### PR TITLE
fix(daemon): recover from stale shell daemon

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -25,6 +25,8 @@ pub mod server;
 pub mod spawn;
 pub mod transport;
 
+pub(crate) const DETECTED_SHELL_ENV: &str = "TTY7_DETECTED_SHELL";
+
 // `pub(crate)` rather than private so a future non-daemon spawn path could reuse
 // the exact same rc-file setup; today `pane` is the only caller.
 pub(crate) mod shell_integration;

--- a/src/daemon/pane.rs
+++ b/src/daemon/pane.rs
@@ -49,11 +49,38 @@ fn default_prog() -> CommandBuilder {
     CommandBuilder::new(crate::core::shells::windows_default_shell())
 }
 
-/// On Unix, defer to `portable-pty`, which launches the user's login shell from
-/// the passwd database (falling back to `/bin/sh`).
+/// On Unix, start from `portable-pty`'s login-shell builder, but switch to an
+/// explicit command when the GUI has already detected the shell that launched
+/// tty7 and forwarded it to the detached daemon. LaunchServices may otherwise
+/// give the daemon a stale config dir and stale `$SHELL`.
 #[cfg(not(windows))]
 fn default_prog() -> CommandBuilder {
-    CommandBuilder::new_default_prog()
+    default_prog_with_override(detected_shell_override())
+}
+
+#[cfg(not(windows))]
+fn default_prog_with_override(shell_override: Option<String>) -> CommandBuilder {
+    let cmd = CommandBuilder::new_default_prog();
+    let portable_shell = cmd.get_shell();
+    if let Some(shell) = shell_override.filter(|shell| shell != &portable_shell) {
+        return CommandBuilder::new(&shell);
+    }
+    cmd
+}
+
+#[cfg(not(windows))]
+fn detected_shell_override() -> Option<String> {
+    let path = std::env::var_os(crate::daemon::DETECTED_SHELL_ENV)?;
+    usable_shell_path(path)
+}
+
+#[cfg(not(windows))]
+fn usable_shell_path(path: std::ffi::OsString) -> Option<String> {
+    let path = PathBuf::from(path);
+    if path.as_os_str().is_empty() || !path.is_file() {
+        return None;
+    }
+    path.into_os_string().into_string().ok()
 }
 
 /// The program name used to detect which shell integration applies for the
@@ -81,6 +108,25 @@ fn choose_shell(
     configured: Option<(String, Vec<String>)>,
 ) -> Option<(String, Vec<String>)> {
     spawn_override.map(|s| (s.program, s.args)).or(configured)
+}
+
+fn apply_shell_integration(
+    cmd: &mut CommandBuilder,
+    resolved_program: &str,
+    integration: &shell_integration::Injection,
+) {
+    // `CommandBuilder::new_default_prog()` preserves the Unix login-shell argv0
+    // shape, but portable-pty intentionally panics if argv is appended to that
+    // sentinel builder. Integrations that need argv (fish `-C`, bash `--rcfile`,
+    // PowerShell flags) must use an explicit command builder first. Env-only zsh
+    // integration keeps the default login-shell path.
+    if integration.force_non_login || (cmd.is_default_prog() && !integration.args.is_empty()) {
+        *cmd = CommandBuilder::new(resolved_program);
+    }
+    cmd.args(&integration.args);
+    for (k, v) in &integration.env {
+        cmd.env(k, v);
+    }
 }
 
 /// Default cap on the replay ring: 8 MiB. Enough to reconstruct a deep screen +
@@ -299,16 +345,7 @@ impl DaemonPane {
             .is_some_and(|(_, args)| !args.is_empty());
         let integration = shell_integration::setup(Some(&resolved_program), has_custom_args);
         if let Some(integration) = &integration {
-            // Bash only takes `--rcfile` as a non-login shell, so rebuild `cmd` as
-            // a plain invocation of the resolved program rather than however
-            // `default_prog()` would otherwise spawn it (a login shell on Unix).
-            if integration.force_non_login {
-                cmd = CommandBuilder::new(&resolved_program);
-            }
-            cmd.args(&integration.args);
-            for (k, v) in &integration.env {
-                cmd.env(k, v);
-            }
+            apply_shell_integration(&mut cmd, &resolved_program, integration);
         }
         let integration_dir = integration.as_ref().and_then(|i| i.dir.clone());
 
@@ -1161,6 +1198,76 @@ mod tests {
         assert_eq!(choose_shell(None, Some(cfg.clone())), Some(cfg));
         // Neither → platform default.
         assert_eq!(choose_shell(None, None), None);
+    }
+
+    #[test]
+    fn arg_based_integration_rebuilds_default_shell_builder() {
+        let mut cmd = CommandBuilder::new_default_prog();
+        let injection = shell_integration::Injection {
+            env: std::collections::HashMap::new(),
+            args: vec!["-C".to_string(), "echo ready".to_string()],
+            force_non_login: false,
+            dir: None,
+        };
+
+        apply_shell_integration(&mut cmd, "/bin/fish", &injection);
+
+        assert!(!cmd.is_default_prog(), "argv can now be appended safely");
+        let argv: Vec<_> = cmd
+            .get_argv()
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(argv, vec!["/bin/fish", "-C", "echo ready"]);
+    }
+
+    #[test]
+    fn env_only_integration_keeps_default_login_shell_builder() {
+        let mut cmd = CommandBuilder::new_default_prog();
+        let mut env = std::collections::HashMap::new();
+        env.insert("ZDOTDIR".to_string(), "/tmp/tty7-zdotdir-test".to_string());
+        let injection = shell_integration::Injection {
+            env,
+            args: Vec::new(),
+            force_non_login: false,
+            dir: None,
+        };
+
+        apply_shell_integration(&mut cmd, "/bin/zsh", &injection);
+
+        assert!(
+            cmd.is_default_prog(),
+            "zsh still launches as the login shell"
+        );
+        assert_eq!(
+            cmd.get_env("ZDOTDIR").and_then(|value| value.to_str()),
+            Some("/tmp/tty7-zdotdir-test")
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn detected_shell_override_uses_explicit_command_builder() {
+        let portable_shell = CommandBuilder::new_default_prog().get_shell();
+        let detected_shell = format!("{portable_shell}-detected");
+        let cmd = default_prog_with_override(Some(detected_shell.clone()));
+
+        assert!(!cmd.is_default_prog());
+        let argv: Vec<_> = cmd
+            .get_argv()
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(argv, vec![detected_shell]);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn no_detected_shell_keeps_portable_login_default() {
+        let cmd = default_prog_with_override(None);
+
+        assert!(cmd.is_default_prog());
+        assert!(!default_shell_name(&cmd).is_empty());
     }
 
     /// A reader that finishes is joined and reported done — the common teardown

--- a/src/daemon/spawn.rs
+++ b/src/daemon/spawn.rs
@@ -15,6 +15,7 @@
 //! Then we poll the endpoint until it's connectable, so the caller can immediately
 //! proceed to connect.
 
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -128,6 +129,13 @@ fn spawn_detached() -> anyhow::Result<()> {
         cmd.arg("--config-dir").arg(dir);
     }
 
+    if let Some(shell) = detect_parent_shell() {
+        // The detached daemon's parent becomes launchd/systemd, so capture the
+        // shell that launched the GUI before detaching and let the pane builder
+        // prefer it over a stale `$SHELL` / passwd login-shell value.
+        cmd.env(crate::daemon::DETECTED_SHELL_ENV, shell);
+    }
+
     // A daemon has no controlling terminal or console: send all three std streams
     // to the null device so nothing inherits the GUI's handles.
     cmd.stdin(Stdio::null())
@@ -143,6 +151,51 @@ fn spawn_detached() -> anyhow::Result<()> {
         Ok(_child) => Ok(()),
         Err(e) => Err(anyhow::anyhow!("failed to spawn daemon process: {e}")),
     }
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn detect_parent_shell() -> Option<PathBuf> {
+    parent_process_path(unsafe { libc::getppid() }).filter(|path| is_supported_shell(path))
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn detect_parent_shell() -> Option<PathBuf> {
+    None
+}
+
+fn is_supported_shell(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "zsh" | "bash" | "fish" | "pwsh" | "powershell" | "powershell.exe" | "pwsh.exe"
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn parent_process_path(pid: libc::pid_t) -> Option<PathBuf> {
+    if pid <= 0 {
+        return None;
+    }
+    let mut buf = [0u8; libc::PROC_PIDPATHINFO_MAXSIZE as usize];
+    // SAFETY: valid buffer, and `proc_pidpath` writes at most `buf.len()` bytes.
+    let len =
+        unsafe { libc::proc_pidpath(pid, buf.as_mut_ptr() as *mut libc::c_void, buf.len() as u32) };
+    if len <= 0 {
+        return None;
+    }
+    Some(PathBuf::from(
+        String::from_utf8_lossy(&buf[..len as usize]).into_owned(),
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn parent_process_path(pid: libc::pid_t) -> Option<PathBuf> {
+    if pid <= 0 {
+        return None;
+    }
+    std::fs::read_link(format!("/proc/{pid}/exe")).ok()
 }
 
 /// Detach the child into its own session/process group so a GUI teardown can't
@@ -189,8 +242,21 @@ fn detach(cmd: &mut Command) {
 // port file with different semantics), so this test only runs on Unix.
 #[cfg(all(test, unix))]
 mod tests {
+    use super::*;
     use std::io::ErrorKind;
     use std::os::unix::net::UnixStream;
+    use std::path::Path;
+
+    #[test]
+    fn supported_shell_detection_matches_shell_basenames_only() {
+        assert!(is_supported_shell(Path::new("/opt/homebrew/bin/fish")));
+        assert!(is_supported_shell(Path::new("/bin/zsh")));
+        assert!(is_supported_shell(Path::new("/usr/bin/bash")));
+        assert!(!is_supported_shell(Path::new(
+            "/Applications/kitty.app/kitty"
+        )));
+        assert!(!is_supported_shell(Path::new("/usr/bin/omp")));
+    }
 
     /// A stale socket file (one nothing is listening on) must be treated as "not
     /// running": connecting to it fails, which is our trigger to clean up + spawn.

--- a/src/terminal/remote.rs
+++ b/src/terminal/remote.rs
@@ -158,6 +158,37 @@ impl RemoteTerminal {
         cwd: Option<PathBuf>,
         shell: Option<ShellSpec>,
     ) -> anyhow::Result<(Self, u64)> {
+        let retry_cwd = cwd.clone();
+        let retry_shell = shell.clone();
+        match Self::spawn_once(size, cell_w, cell_h, cwd, shell) {
+            Ok(term) => Ok(term),
+            Err(first_err) if daemon_disconnected_before_spawn_reply(&first_err) => {
+                // A live-but-old daemon can accept the connection, panic while
+                // handling Spawn, and close before replying. Restart once so an
+                // upgraded GUI cuts over cleanly instead of crashing on a stale
+                // background service.
+                if let Err(restart_err) = crate::daemon::spawn::restart() {
+                    return Err(anyhow::anyhow!(
+                        "daemon disconnected before Spawn reply ({first_err}); restart failed: {restart_err}"
+                    ));
+                }
+                Self::spawn_once(size, cell_w, cell_h, retry_cwd, retry_shell).map_err(|second_err| {
+                    anyhow::anyhow!(
+                        "daemon disconnected before Spawn reply ({first_err}); restarted daemon but Spawn still failed: {second_err}"
+                    )
+                })
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    fn spawn_once(
+        size: TermSize,
+        cell_w: u16,
+        cell_h: u16,
+        cwd: Option<PathBuf>,
+        shell: Option<ShellSpec>,
+    ) -> anyhow::Result<(Self, u64)> {
         let mut stream = connect()?;
         let win = win_size(size, cell_w, cell_h);
 
@@ -745,6 +776,19 @@ impl RemoteTerminal {
     }
 }
 
+fn daemon_disconnected_before_spawn_reply(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause.downcast_ref::<std::io::Error>().is_some_and(|io| {
+            matches!(
+                io.kind(),
+                std::io::ErrorKind::UnexpectedEof
+                    | std::io::ErrorKind::ConnectionReset
+                    | std::io::ErrorKind::BrokenPipe
+            )
+        })
+    })
+}
+
 impl Drop for RemoteTerminal {
     fn drop(&mut self) {
         // Detach (don't kill): the daemon keeps the pane running so a later
@@ -945,6 +989,16 @@ mod tests {
     use super::*;
     use std::io::Write;
     use std::os::unix::net::UnixStream;
+
+    #[test]
+    fn spawn_retry_only_for_daemon_disconnects() {
+        let eof: anyhow::Error =
+            std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "closed").into();
+        assert!(daemon_disconnected_before_spawn_reply(&eof));
+
+        let refused = anyhow::anyhow!("daemon refused Spawn: configured shell missing");
+        assert!(!daemon_disconnected_before_spawn_reply(&refused));
+    }
 
     /// Without a real daemon, drive the reader path directly: a `UnixStream::pair`
     /// stands in for the connection. We hand `RemoteTerminal` one half (as if it


### PR DESCRIPTION
Cherry-picks the stale daemon crash fix only.

- Restarts a stale daemon once when it disconnects before a Spawn reply
- Preserves the detected GUI parent shell for the detached daemon
- Avoids appending shell-integration argv to portable-pty's default-prog builder
- Keeps the PR limited to the original fix content requested for upstream

Verification:
- cargo test -q daemon::pane::tests
- cargo test -q terminal::remote::tests
- cargo test -q