### PR TITLE
fix(shell): detect PATH-installed shells missing from /etc/shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The "+" button now opens a shell picker: tty7 detects the shells installed
-  on this machine (the login shell plus `/etc/shells` on Unix; PowerShell 7,
-  Windows PowerShell, Command Prompt, Git Bash and WSL distributions on
-  Windows) and lists them in a dropdown, so opening a tab in a different shell
+  on this machine (on Unix the login shell, `/etc/shells`, plus well-known
+  shells found on `PATH` — fish, nushell, pwsh and friends installed by
+  Homebrew/nix are never registered in `/etc/shells`; on Windows PowerShell 7,
+  Windows PowerShell, Command Prompt, Git Bash and WSL distributions)
+  and lists them in a dropdown, so opening a tab in a different shell
   no longer requires editing `config.json`. The default entry leads the menu,
   ⌘T / Ctrl+T still opens a default tab in one keystroke, and splitting a pane
   inherits its shell — a fish tab splits into more fish, not back to the

--- a/src/core/shells.rs
+++ b/src/core/shells.rs
@@ -8,7 +8,10 @@
 //! - **Unix**: `/etc/shells` is the system's own inventory — parse it, keep the
 //!   entries that exist, dedupe by basename (the same shell often appears as
 //!   both `/bin/zsh` and `/usr/local/bin/zsh`). The login shell (`$SHELL`) is
-//!   seeded first so it wins its dedupe slot and leads the list.
+//!   seeded first so it wins its dedupe slot and leads the list. Package
+//!   managers don't register what they install there (Homebrew only *suggests*
+//!   adding fish to `/etc/shells`), so a curated set of well-known shells is
+//!   then probed on `PATH` as the catch-all.
 //! - **Windows**: there is no inventory file, so probe each shell's known
 //!   homes: PowerShell 7 across its six-ish install roots, Windows PowerShell
 //!   in System32, cmd via `%ComSpec%`, Git Bash under the Git install, and WSL
@@ -133,14 +136,47 @@ fn unix_shells_from(
     out
 }
 
+/// Shells package managers commonly install *without* registering them in
+/// `/etc/shells` — Homebrew and nix leave that edit to the user, and few make
+/// it, so `/etc/shells` misses e.g. a brew-installed fish entirely. Probed on
+/// `PATH` (the login-shell-enriched one — see `enrich_path_from_login_shell`
+/// in `main` — so Dock launches see Homebrew's prefix too).
+#[cfg_attr(windows, allow(dead_code))]
+const PATH_PROBED_SHELLS: [&str; 5] = ["fish", "nu", "pwsh", "elvish", "xonsh"];
+
+/// Expand [`PATH_PROBED_SHELLS`] into concrete candidate paths, one per
+/// `path_var` directory in `PATH` order. Fed through the same exists + dedupe
+/// pass as the `/etc/shells` entries, so the first directory that actually
+/// holds the shell wins — `which` semantics without spawning anything.
+/// Relative `PATH` entries are skipped: a `./fish` candidate would resolve
+/// somewhere else at every spawn. Pure — the caller supplies `path_var`.
+#[cfg_attr(windows, allow(dead_code))]
+fn path_shell_candidates(path_var: &str) -> Vec<String> {
+    let dirs: Vec<&str> = path_var.split(':').filter(|d| d.starts_with('/')).collect();
+    PATH_PROBED_SHELLS
+        .iter()
+        .flat_map(|name| {
+            dirs.iter()
+                .map(move |dir| format!("{}/{name}", dir.trim_end_matches('/')))
+        })
+        .collect()
+}
+
 #[cfg(unix)]
 fn detect_unix() -> Vec<DetectedShell> {
     // Seed the login shell first so it wins its basename's dedupe slot and
     // leads the list — it also covers shells installed outside /etc/shells
     // (nix/homebrew installs the user pointed $SHELL at without registering).
+    // The PATH probe comes last: registered shells keep their `/etc/shells`
+    // paths, and only the unregistered leftovers (brew fish, nushell, …) are
+    // picked up from `PATH`.
     let login = std::env::var("SHELL").ok().filter(|s| !s.is_empty());
     let etc = std::fs::read_to_string("/etc/shells").unwrap_or_default();
-    let candidates = login.into_iter().chain(parse_etc_shells(&etc));
+    let path_var = std::env::var("PATH").unwrap_or_default();
+    let candidates = login
+        .into_iter()
+        .chain(parse_etc_shells(&etc))
+        .chain(path_shell_candidates(&path_var));
     unix_shells_from(candidates, |p| Path::new(p).is_file())
 }
 
@@ -351,6 +387,45 @@ mod tests {
             vec![
                 DetectedShell::bare("zsh", "/opt/homebrew/bin/zsh"),
                 DetectedShell::bare("bash", "/bin/bash"),
+            ]
+        );
+    }
+
+    #[test]
+    fn path_shell_candidates_expand_dirs_in_order_skipping_relative() {
+        let cands = path_shell_candidates("/opt/homebrew/bin:relative:.:/usr/bin/:");
+        // Per shell, one candidate per *absolute* PATH dir, in PATH order, with
+        // any trailing slash on the dir normalized away.
+        assert_eq!(cands[0], "/opt/homebrew/bin/fish");
+        assert_eq!(cands[1], "/usr/bin/fish");
+        assert!(cands.contains(&"/opt/homebrew/bin/nu".to_string()));
+        assert!(cands.iter().all(|c| c.starts_with('/')));
+        assert_eq!(cands.len(), PATH_PROBED_SHELLS.len() * 2);
+    }
+
+    #[test]
+    fn unregistered_path_shells_are_detected_after_etc_shells() {
+        // A brew-installed fish: absent from /etc/shells (and not the login
+        // shell), present on PATH — must still make the list, after the
+        // registered shells. zsh exists on PATH too but keeps its /etc/shells
+        // slot via the basename dedupe.
+        let etc = ["/bin/zsh".to_string(), "/bin/bash".to_string()];
+        let candidates = etc
+            .into_iter()
+            .chain(path_shell_candidates("/opt/homebrew/bin:/usr/bin"));
+        let exists = |p: &str| {
+            matches!(
+                p,
+                "/bin/zsh" | "/bin/bash" | "/opt/homebrew/bin/fish" | "/usr/bin/zsh"
+            )
+        };
+        let got = unix_shells_from(candidates, exists);
+        assert_eq!(
+            got,
+            vec![
+                DetectedShell::bare("zsh", "/bin/zsh"),
+                DetectedShell::bare("bash", "/bin/bash"),
+                DetectedShell::bare("fish", "/opt/homebrew/bin/fish"),
             ]
         );
     }


### PR DESCRIPTION
## 问题

fish 装了却不在 "+" 下拉菜单里（#18）。

Unix 的 shell 发现（`detect_unix`）只从 `$SHELL` 和 `/etc/shells` 两个来源枚举。但 Homebrew / nix **不会**把安装的 shell 登记进 `/etc/shells`（Homebrew 只在 caveats 里*建议*你手动加 fish，很少有人加）。于是 brew 装的 fish 完全不出现在下拉列表——尽管一旦选中，spawn 和 shell integration 都能正常工作。

本机复现：`/etc/shells` 只有 macOS 原生七件套（bash/csh/dash/ksh/sh/tcsh/zsh），`$SHELL` 是 `/bin/zsh`，fish 在 `/opt/homebrew/bin/fish`——两个来源都覆盖不到，正是 issue 截图里缺 fish 的原因。

对比之下 Windows 路径本就主动探测已知安装位置（PowerShell 7 的多个根、Git Bash、WSL），Unix 路径缺了这一层。

## 修复

给 `detect_unix()` 补第三个候选来源：对一组知名 shell（`fish`、`nu`、`pwsh`、`elvish`、`xonsh`）在 `PATH` 上做 `which` 式解析，排在 `/etc/shells` 条目**之后**。

- 已登记的 shell 保留各自的 `/etc/shells` 路径，靠现有的 basename 去重；只有未登记的（brew fish、nushell…）才从 PATH 补进来。
- 复用现成的 `is_file()` 存在性检查 + 去重，无新分支。
- 用的是 `enrich_path_from_login_shell`（`main.rs` 已有）增强过的 PATH，所以从 Dock 启动、拿不到用户 shell PATH 时也能看到 Homebrew 前缀。
- 跳过 PATH 里的相对路径条目。

## 验证

- 真实环境跑实际的 `detect_shells()`：现在返回 `fish → /opt/homebrew/bin/fish`，排在七个系统 shell 之后。
- 新增 2 个单元测试：`path_shell_candidates` 的 PATH 展开 / 去相对路径，以及 `unregistered_path_shells_are_detected_after_etc_shells`（回归测试，锁定"未登记的 fish 也能检出且排在已登记之后"）。
- shells 模块 8 个测试全过，clippy 干净。

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved shell picker detection so more locally installed shells can appear, including shells installed outside the system shell list.
  * Clarified shell availability on Unix and Windows for more predictable selection.

* **Bug Fixes**
  * Fixed cases where some installed shells were previously missed during discovery.

* **Tests**
  * Added coverage for shell discovery ordering, duplicate handling, and path-based detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->