### PR TITLE
fix(menu): soften context-menu and dropdown row hover to match the palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Context menus and the "+" dropdown now highlight the hovered row with the
+  same soft fill the command palette uses for its selected row, instead of the
+  stock saturated accent that snapped hard against the rest of the UI. The
+  hover text stays at the normal foreground so it reads clearly on the quieter
+  fill.
+
 ## [0.6.0] - 2026-07-08
 
 ### Added

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -99,6 +99,25 @@ pub(crate) fn apply_theme(mut window: Option<&mut Window>, cx: &mut App) {
     // sidebar below.
     t.tokens.popover = Hsla::from(rgb(m.popover)).into();
     t.tokens.popover_foreground = Hsla::from(rgb(m.foreground)).into();
+
+    // Context menus and dropdowns highlight the hovered/selected row from
+    // `tokens.accent` (fill) + `accent_foreground` (text) — see gpui-component's
+    // `MenuItemElement`. Left unset, that highlight falls back to the stock
+    // saturated accent, which snaps hard against this app's soft mix-based
+    // palette (the "生硬" hover). Point it at the same soft fill the command
+    // palette uses for its selected row (`list_active`, mix 0.17) so context
+    // menu, dropdown and palette share one hover language; keep the text at
+    // `foreground` so it stays legible on the low-contrast fill instead of the
+    // stock inverted accent text. The plain `accent`/`accent_foreground` fields
+    // feed the same highlight in the input completion / code-action popovers, so
+    // mirror both the fields and the tokens to keep every menu surface in step.
+    let accent_fill = rgb(m.list_active);
+    let accent_text = color_or(&c.foreground, m.foreground);
+    t.accent = accent_fill.into();
+    t.accent_foreground = accent_text;
+    t.tokens.accent = Hsla::from(accent_fill).into();
+    t.tokens.accent_foreground = accent_text.into();
+
     t.caret = color_or(&c.caret, m.caret);
     t.selection = color_or(&c.selection, m.selection); // text selection highlight
 


### PR DESCRIPTION
gpui-component's `MenuItemElement` highlights the hovered/selected row from `tokens.accent` (fill) + `accent_foreground` (text). tty7's theme never overrode those, so context-menu and dropdown rows fell back to the stock **saturated accent** — a hard highlight out of step with the app's soft `mix(bg, fg, …)` palette. That was the "生硬" hover.

## Change

Point the accent tokens — and the plain `accent` / `accent_foreground` fields the input completion / code-action popovers also read — at `list_active` (`mix 0.17`), the same soft fill the command palette uses for its selected row, and keep the hover text at `foreground` so it stays legible on the low-contrast fill.

Right-click menu, the "+" dropdown and the command palette now share one hover language.

## Scope / safety

- Pure theming change in `src/ui/theme.rs`; no fork edit, no `gpui-component` rebuild.
- Settings segmented controls use button-specific tokens (not `tokens.accent`) — unaffected.
- The command-palette list runs the `active_highlight` path (`list_active`), not the `accent` fallback — unaffected.
- `cargo check` clean; verified in `cargo dev`.

https://claude.ai/code/session_01ABey161AUxhgmJC3PRoYtF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated hover highlighting in context menus and the “+” dropdown to use the same soft selection color as the command palette.
  - Kept hover text at the normal foreground color for better readability and consistency across menu-like UI surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->