### PR TITLE
fix(terminal): stop severing wide Nerd Font prompt glyphs (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Nerd Font prompt icons no longer render sliced off on the right. A non-Mono
+  Nerd Font (and the proportional `➜`/`❯` the OS cascade hands back when nothing
+  in your font list covers them) gives an icon a single-cell *advance* but draws
+  ink up to ~1.9 cells wide, and tty7 clipped every lone glyph to exactly one
+  cell — severing the overflow into the half-icons and cut-off arrow from the
+  report. A single glyph now paints into a two-cell window, so it renders whole
+  (bleeding into the trailing blank the way iTerm2 and Terminal.app do), bounded
+  at two cells so a stray face can't smear across the row. Pairs with the native
+  powerline separators from #19; Mono Nerd Fonts are unchanged. (#17)
+
 - New tabs and splits no longer stall for seconds while a zsh plugin manager
   reinstalls itself. tty7 launches zsh through a throwaway `ZDOTDIR` (so it can
   layer its shell integration on top of your config), but it used to leave

--- a/src/terminal/element.rs
+++ b/src/terminal/element.rs
@@ -687,6 +687,26 @@ fn powerline_path(bounds: Bounds<Pixels>, shape: PowerlineShape) -> gpui::Path<P
     }
 }
 
+/// How wide to clip a solo (single-column) glyph's paint.
+///
+/// A batched run clips to its exact column span, but a lone glyph can be a
+/// symbol whose face paints ink well past the single cell the grid reserved for
+/// it: a non-Mono Nerd Font sets a *one-cell advance* on its icons yet draws up
+/// to ~1.9 cells of ink (measured across Hasklug / Meslo / JetBrainsMono NF),
+/// and the OS cascade serves a proportional `➜`/`❯` the same way. Clipping that
+/// to one cell severs the glyph mid-ink — the incomplete icons and the cut-off
+/// arrow in issue #17.
+///
+/// Advance is no signal here (it reads one cell for those overflowing icons), so
+/// widen every solo glyph's clip to two cells. A glyph that already fits is
+/// untouched — it has no ink to spill — while a symbol that overflows renders
+/// whole, bleeding into a trailing blank the way iTerm2 and Terminal.app do with
+/// non-Mono faces. The two-cell bound keeps a pathological face from smearing a
+/// lone glyph across the row.
+fn solo_clip_width(cell_width: Pixels) -> Pixels {
+    cell_width * 2.
+}
+
 /// Paint glyphs as per-row batched runs where safe, single cells otherwise.
 ///
 /// Merging cells into multi-char `shape_line` runs causes drift whenever a
@@ -735,12 +755,13 @@ fn paint_glyphs(
         let y = geom.origin.y + geom.line_height * (row as f32);
 
         for seg in segment_row(&buf[row_base..row_base + geom.cols]) {
-            let (start, cells, text, force_width) = match seg {
+            let (start, cells, text, force_width, solo) = match seg {
                 RowSeg::Run { start, cells, text } => (
                     start,
                     cells,
                     SharedString::from(text),
                     Some(geom.cell_width),
+                    false,
                 ),
                 // Each wide glyph is pinned to its own two-column slot; the
                 // clip stops an oversized fallback glyph bleeding past the run.
@@ -749,6 +770,7 @@ fn paint_glyphs(
                     cells,
                     SharedString::from(text),
                     Some(geom.cell_width * 2.),
+                    false,
                 ),
                 // Always exactly one column now — anything with a trailing
                 // spacer became a Wide run in `segment_row`. No `force_width`
@@ -764,7 +786,7 @@ fn paint_glyphs(
                         window.paint_path(path, GlyphStyle::of(cell).fg);
                         continue;
                     }
-                    (col, 1, char_string(cell.c), None)
+                    (col, 1, char_string(cell.c), None, true)
                 }
             };
 
@@ -783,10 +805,15 @@ fn paint_glyphs(
                 .shape_line(text, font_size, run_buf, force_width);
 
             let x = geom.origin.x + geom.cell_width * (start as f32);
-            let clip = Bounds::new(
-                point(x, y),
-                size(geom.cell_width * (cells as f32), geom.line_height),
-            );
+            // Batched runs clip to their exact column span; a solo glyph gets a
+            // two-cell window so a symbol/icon face whose ink overflows its cell
+            // isn't severed (see `solo_clip_width` — issue #17).
+            let clip_width = if solo {
+                solo_clip_width(geom.cell_width)
+            } else {
+                geom.cell_width * (cells as f32)
+            };
+            let clip = Bounds::new(point(x, y), size(clip_width, geom.line_height));
             window.with_content_mask(Some(ContentMask { bounds: clip }), |window| {
                 _ = shaped.paint(
                     point(x, y),
@@ -1850,6 +1877,16 @@ mod tests {
                 "{shape:?} does not reach the right cell edge"
             );
         }
+    }
+
+    #[test]
+    fn solo_clip_width_gives_symbols_two_cells() {
+        // A lone symbol glyph paints into a two-cell window so a non-Mono Nerd
+        // Font icon (one-cell advance, ~1.9-cell ink) or a proportional arrow
+        // renders whole instead of severed at the cell edge (issue #17) — the
+        // bound keeps a pathological face from smearing across the row.
+        assert_eq!(solo_clip_width(px(10.)), px(20.));
+        assert_eq!(solo_clip_width(px(9.)), px(18.));
     }
 
     #[test]

--- a/src/terminal/element.rs
+++ b/src/terminal/element.rs
@@ -687,24 +687,30 @@ fn powerline_path(bounds: Bounds<Pixels>, shape: PowerlineShape) -> gpui::Path<P
     }
 }
 
-/// How wide to clip a solo (single-column) glyph's paint.
+/// The width `paint_glyphs` clips a segment's paint to.
 ///
-/// A batched run clips to its exact column span, but a lone glyph can be a
-/// symbol whose face paints ink well past the single cell the grid reserved for
-/// it: a non-Mono Nerd Font sets a *one-cell advance* on its icons yet draws up
-/// to ~1.9 cells of ink (measured across Hasklug / Meslo / JetBrainsMono NF),
-/// and the OS cascade serves a proportional `➜`/`❯` the same way. Clipping that
-/// to one cell severs the glyph mid-ink — the incomplete icons and the cut-off
-/// arrow in issue #17.
+/// A batched `Run`/`Wide` segment clips to its exact column span (`cells`
+/// columns): its glyphs come from faces whose advance matches the cell, so
+/// nothing should spill past that span. A lone `solo` glyph is different — it
+/// can be a symbol whose face paints ink well past the single cell the grid
+/// reserved for it: a non-Mono Nerd Font sets a *one-cell advance* on its icons
+/// yet draws up to ~1.9 cells of ink (measured across Hasklug / Meslo /
+/// JetBrainsMono NF), and the OS cascade serves a proportional `➜`/`❯` the same
+/// way. Clipping that to one cell severs the glyph mid-ink — the incomplete
+/// icons and the cut-off arrow in issue #17.
 ///
-/// Advance is no signal here (it reads one cell for those overflowing icons), so
-/// widen every solo glyph's clip to two cells. A glyph that already fits is
-/// untouched — it has no ink to spill — while a symbol that overflows renders
-/// whole, bleeding into a trailing blank the way iTerm2 and Terminal.app do with
-/// non-Mono faces. The two-cell bound keeps a pathological face from smearing a
-/// lone glyph across the row.
-fn solo_clip_width(cell_width: Pixels) -> Pixels {
-    cell_width * 2.
+/// Advance is no signal there (it reads one cell for exactly those overflowing
+/// icons), so a solo glyph gets a two-cell window instead. A glyph that already
+/// fits is untouched — it has no ink to spill — while a symbol that overflows
+/// renders whole, bleeding into a trailing blank the way iTerm2 and Terminal.app
+/// do with non-Mono faces. The two-cell bound keeps a pathological face from
+/// smearing a lone glyph across the row.
+fn seg_clip_width(solo: bool, cells: usize, cell_width: Pixels) -> Pixels {
+    if solo {
+        cell_width * 2.
+    } else {
+        cell_width * cells as f32
+    }
 }
 
 /// Paint glyphs as per-row batched runs where safe, single cells otherwise.
@@ -807,12 +813,8 @@ fn paint_glyphs(
             let x = geom.origin.x + geom.cell_width * (start as f32);
             // Batched runs clip to their exact column span; a solo glyph gets a
             // two-cell window so a symbol/icon face whose ink overflows its cell
-            // isn't severed (see `solo_clip_width` — issue #17).
-            let clip_width = if solo {
-                solo_clip_width(geom.cell_width)
-            } else {
-                geom.cell_width * (cells as f32)
-            };
+            // isn't severed (see `seg_clip_width` — issue #17).
+            let clip_width = seg_clip_width(solo, cells, geom.cell_width);
             let clip = Bounds::new(point(x, y), size(clip_width, geom.line_height));
             window.with_content_mask(Some(ContentMask { bounds: clip }), |window| {
                 _ = shaped.paint(
@@ -1880,13 +1882,18 @@ mod tests {
     }
 
     #[test]
-    fn solo_clip_width_gives_symbols_two_cells() {
-        // A lone symbol glyph paints into a two-cell window so a non-Mono Nerd
-        // Font icon (one-cell advance, ~1.9-cell ink) or a proportional arrow
-        // renders whole instead of severed at the cell edge (issue #17) — the
-        // bound keeps a pathological face from smearing across the row.
-        assert_eq!(solo_clip_width(px(10.)), px(20.));
-        assert_eq!(solo_clip_width(px(9.)), px(18.));
+    fn seg_clip_width_frees_solo_symbols_but_pins_batched_runs() {
+        let cell = px(10.);
+        // Batched Run/Wide segments clip to their exact column span, so an
+        // oversized fallback glyph can't bleed past the run.
+        assert_eq!(seg_clip_width(false, 1, cell), px(10.));
+        assert_eq!(seg_clip_width(false, 5, cell), px(50.)); // an ASCII run
+        assert_eq!(seg_clip_width(false, 2, cell), px(20.)); // a wide (CJK) glyph
+        // A solo glyph gets a two-cell window instead, so a non-Mono Nerd Font
+        // icon (one-cell advance, ~1.9-cell ink) or a proportional arrow renders
+        // whole instead of severed at the cell edge (issue #17) — the bound keeps
+        // a pathological face from smearing across the row.
+        assert_eq!(seg_clip_width(true, 1, cell), px(20.));
     }
 
     #[test]


### PR DESCRIPTION
## What

Follow-up to #19 for issue #17. Nerd Font prompt icons — and the multiline `➜`/`❯` in the original report — still rendered **sliced off on the right**.

## Root cause

`paint_glyphs` clips every single-column (`Solo`) glyph to **exactly one cell** via a `content_mask`. But a symbol face routinely draws ink *past* that cell:

- A **non-Mono Nerd Font** sets a **one-cell advance** on its icons yet fills up to **~1.9 cells** of ink. Measured on the reporter's font class (`fontTools` bounding boxes, Hasklug Nerd Font Regular, cell = 600 units):
  - `folder`  ink xMax = **1.87×** cell
  - `f303` / gitbranch = **1.67×**
  - `cog` = 1.57×, `save` = 1.46×, `bolt`/`apple` = 1.2–1.25×
- The **OS cascade** serves a proportional `➜` (U+279C) the same way when nothing in the font list covers it — the "severed arrow" in the issue screenshot.

`#19` only swapped *which face* resolves a glyph (bundled Hack fallback); it never touched the clip, so a wide glyph coming from the **primary** font or a wide fallback was still cut. Advance is no signal here — it reads one cell for exactly the icons that overflow.

## Fix

Widen a solo glyph's paint window to **two cells**. A glyph that already fits is untouched (no ink to spill); a symbol that overflows renders **whole**, bleeding into the trailing blank the way iTerm2 / Terminal.app do with non-Mono faces. Bounded at two cells so a pathological face can't smear a lone glyph across the row. Batched `Run`/`Wide` segments keep their exact column-span clip; **Mono Nerd Fonts are pixel-identical**.

```rust
fn solo_clip_width(cell_width: Pixels) -> Pixels { cell_width * 2. }
```

## Verification

Built and driven in-app on Apple Silicon with a non-Mono **"Hasklug Nerd Font"** primary (worst case):

- **Before:** apple / folder / house / cog icons all cut with a hard vertical edge one cell in; pixel-diff of the render before/after my first (advance-based) attempt was empty — confirming advance is the wrong signal.
- **After:** every icon renders whole; a colored powerline prompt (segments + native `E0B0` separators + in-segment apple/clock icons) renders cleanly; **ASCII, CJK, and the Mono-font path are unchanged**.

New unit test `solo_clip_width_gives_symbols_two_cells`; full suite green (390 passed).

Closes #17.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Nerd Font prompt icons and similar single-cell symbols from being clipped or cut off on the right.
  * Improved glyph rendering so icons with slight overflow now display fully without bleeding into neighboring text.
  * Preserved correct rendering for special separator symbols while applying the new clipping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->