### PR TITLE
feat(input): support <C-l> to clear screen

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -39,6 +39,10 @@ pub struct Config {
     pub theme_preset: String,
     /// Optional per-color overrides layered on top of the active preset.
     pub colors: Colors,
+    /// Optional ANSI 0-15 overrides layered on top of the active preset's
+    /// terminal palette. Each field maps to the familiar terminal `colorN`
+    /// slot; `None` keeps the preset's value.
+    pub ansi_colors: AnsiColors,
     /// Optional keybinding overrides: action name (e.g. "NewTab") → keystroke
     /// (e.g. "secondary-t", which is ⌘ on macOS and Ctrl elsewhere). Unknown
     /// actions and unparseable keystrokes are ignored (with a warning) so a bad
@@ -233,6 +237,7 @@ impl Default for Config {
             // depend on ui). Unknown ids fall back to it anyway.
             theme_preset: "light".to_string(),
             colors: Colors::default(),
+            ansi_colors: AnsiColors::default(),
             keybindings: HashMap::new(),
             // `None` → the platform default shell (login shell on Unix,
             // PowerShell 7 / Windows PowerShell on Windows), chosen by the
@@ -282,6 +287,77 @@ pub struct Colors {
     pub popover: Option<String>,
     pub caret: Option<String>,
     pub selection: Option<String>,
+}
+
+/// Optional overrides for terminal ANSI colors 0-15. These correspond to the
+/// standard `color0`…`color15` slots that command-line tools address with SGR
+/// foreground/background colors; unlike [`Colors`], they do not affect UI chrome
+/// or the terminal's default foreground/background.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AnsiColors {
+    pub color0: Option<String>,
+    pub color1: Option<String>,
+    pub color2: Option<String>,
+    pub color3: Option<String>,
+    pub color4: Option<String>,
+    pub color5: Option<String>,
+    pub color6: Option<String>,
+    pub color7: Option<String>,
+    pub color8: Option<String>,
+    pub color9: Option<String>,
+    pub color10: Option<String>,
+    pub color11: Option<String>,
+    pub color12: Option<String>,
+    pub color13: Option<String>,
+    pub color14: Option<String>,
+    pub color15: Option<String>,
+}
+
+impl AnsiColors {
+    pub fn get(&self, index: usize) -> Option<&Option<String>> {
+        match index {
+            0 => Some(&self.color0),
+            1 => Some(&self.color1),
+            2 => Some(&self.color2),
+            3 => Some(&self.color3),
+            4 => Some(&self.color4),
+            5 => Some(&self.color5),
+            6 => Some(&self.color6),
+            7 => Some(&self.color7),
+            8 => Some(&self.color8),
+            9 => Some(&self.color9),
+            10 => Some(&self.color10),
+            11 => Some(&self.color11),
+            12 => Some(&self.color12),
+            13 => Some(&self.color13),
+            14 => Some(&self.color14),
+            15 => Some(&self.color15),
+            _ => None,
+        }
+    }
+
+    pub fn set(&mut self, index: usize, value: Option<String>) {
+        match index {
+            0 => self.color0 = value,
+            1 => self.color1 = value,
+            2 => self.color2 = value,
+            3 => self.color3 = value,
+            4 => self.color4 = value,
+            5 => self.color5 = value,
+            6 => self.color6 = value,
+            7 => self.color7 = value,
+            8 => self.color8 = value,
+            9 => self.color9 = value,
+            10 => self.color10 = value,
+            11 => self.color11 = value,
+            12 => self.color12 = value,
+            13 => self.color13 = value,
+            14 => self.color14 = value,
+            15 => self.color15 = value,
+            _ => {}
+        }
+    }
 }
 
 impl Global for Config {}
@@ -589,6 +665,31 @@ mod tests {
         // A valid override wins over the default.
         let white: Hsla = rgb(0xffffff).into();
         assert_eq!(color_or(&Some("#ffffff".to_string()), 0x000000), white);
+    }
+
+    #[test]
+    fn ansi_color_overrides_parse_and_default_independently() {
+        let cfg: Config =
+            serde_json::from_str(r##"{"ansi_colors":{"color0":"#575279","color15":"123456"}}"##)
+                .unwrap();
+        assert_eq!(
+            cfg.ansi_colors.get(0).and_then(|v| v.as_deref()),
+            Some("#575279")
+        );
+        assert_eq!(
+            cfg.ansi_colors.get(15).and_then(|v| v.as_deref()),
+            Some("123456")
+        );
+        assert!(cfg.ansi_colors.get(1).is_some_and(Option::is_none));
+
+        let mut colors = AnsiColors::default();
+        colors.set(0, Some("#111111".to_string()));
+        colors.set(15, Some("#eeeeee".to_string()));
+        assert_eq!(colors.get(0).and_then(|v| v.as_deref()), Some("#111111"));
+        assert_eq!(colors.get(15).and_then(|v| v.as_deref()), Some("#eeeeee"));
+        colors.set(0, None);
+        assert!(colors.get(0).is_some_and(Option::is_none));
+        assert!(colors.get(16).is_none());
     }
 
     #[test]

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
-use gpui::{Global, Hsla, Rgba, rgb};
+use gpui::{FontFeatures, Global, Hsla, Rgba, rgb};
 use serde::{Deserialize, Serialize};
 
 /// Top-level configuration. Stored as a GPUI global so any view can read it.
@@ -26,6 +26,10 @@ pub struct Config {
     /// Optional distinct face for italic cells. `None` reuses `font_family` with a
     /// synthesized italic slant.
     pub font_family_italic: Option<String>,
+    /// Optional OpenType font features for terminal text. When absent, tty7 keeps
+    /// terminal-safe defaults and disables contextual ligatures; when present,
+    /// this map is passed through to gpui as-is (for example `{ "calt": true }`).
+    pub font_features: Option<FontFeatures>,
     /// Base font size in pixels.
     pub font_size: f32,
     /// Line height as a multiple of the font size (e.g. 1.35 → a 13px font gets
@@ -230,6 +234,7 @@ impl Default for Config {
             ],
             font_family_bold: None,
             font_family_italic: None,
+            font_features: None,
             font_size: 15.0,
             line_height: 1.4,
             theme: "light".to_string(),
@@ -690,6 +695,23 @@ mod tests {
         colors.set(0, None);
         assert!(colors.get(0).is_some_and(Option::is_none));
         assert!(colors.get(16).is_none());
+    }
+
+    #[test]
+    fn font_features_are_optional_and_parse_as_gpui_features() {
+        let cfg: Config =
+            serde_json::from_str(r#"{"font_features":{"calt":true,"liga":1}}"#).unwrap();
+        let features = cfg.font_features.expect("font features should parse");
+        assert_eq!(features.is_calt_enabled(), Some(true));
+        assert!(
+            features
+                .tag_value_list()
+                .iter()
+                .any(|(tag, value)| tag == "liga" && *value == 1)
+        );
+
+        let default_cfg = Config::default();
+        assert!(default_cfg.font_features.is_none());
     }
 
     #[test]

--- a/src/terminal/element.rs
+++ b/src/terminal/element.rs
@@ -151,10 +151,13 @@ fn build_font(base: &Font, bold: bool, italic: bool) -> Font {
         FontStyle::Normal
     };
     // Batched runs shape several chars in one line, where a programming font's
-    // contextual ligatures (`calt`, e.g. Fira Code's "->") would fuse cells into
-    // one glyph and break `force_width`'s one-glyph-per-column snapping. A cell
-    // grid can't ligate — Zed's terminal disables the same feature.
-    f.features = gpui::FontFeatures::disable_ligatures();
+    // contextual ligatures (`calt`, e.g. Fira Code's "->") can fuse cells into
+    // one glyph and stress `force_width`'s one-glyph-per-column snapping. Keep
+    // the terminal-safe default unless the user explicitly configured OpenType
+    // features on the base font.
+    if f.features.tag_value_list().is_empty() {
+        f.features = gpui::FontFeatures::disable_ligatures();
+    }
     f
 }
 
@@ -1894,6 +1897,23 @@ mod tests {
         // whole instead of severed at the cell edge (issue #17) — the bound keeps
         // a pathological face from smearing across the row.
         assert_eq!(seg_clip_width(true, 1, cell), px(20.));
+    }
+
+    #[test]
+    fn build_font_disables_ligatures_unless_features_are_configured() {
+        let font = build_font(&gpui::font("Test"), false, false);
+        assert_eq!(font.features.is_calt_enabled(), Some(false));
+
+        let mut configured = gpui::font("Test");
+        configured.features = serde_json::from_str(r#"{"calt":true,"liga":1}"#).unwrap();
+        let font = build_font(&configured, false, false);
+        assert_eq!(font.features.is_calt_enabled(), Some(true));
+        assert!(
+            font.features
+                .tag_value_list()
+                .iter()
+                .any(|(tag, value)| tag == "liga" && *value == 1)
+        );
     }
 
     #[test]

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -1240,9 +1240,10 @@ impl TerminalView {
 
     /// Apply a readline-style Ctrl chord to the command editor: Ctrl-A/E/B/F
     /// motions (Ctrl-F also accepts the autosuggestion), Ctrl-W/U/K/H deletions
-    /// (each removing the selection first if there is one), Ctrl-R reverse search,
-    /// Ctrl-C interrupt, and Ctrl-D EOF/forward-delete. Unrecognized chords are
-    /// no-ops (the caller swallows every Ctrl combo at the prompt regardless).
+    /// (each removing the selection first if there is one), Ctrl-L clear-screen,
+    /// Ctrl-R reverse search, Ctrl-C interrupt, and Ctrl-D EOF/forward-delete.
+    /// Unrecognized chords are no-ops (the caller swallows every Ctrl combo at
+    /// the prompt regardless).
     fn apply_readline_ctrl(&mut self, key: &str) {
         match key {
             "r" => self.start_reverse_search(),
@@ -1284,6 +1285,11 @@ impl TerminalView {
                 }
             }
             "h" => self.cmd.backspace(),
+            "l" => {
+                // Clear screen belongs to the shell/readline layer: send the
+                // same form-feed byte the raw terminal path emits for Ctrl+L.
+                self.terminal.write(vec![0x0c]);
+            }
             "c" => {
                 // Interrupt: drop the edited line and let the shell draw a
                 // fresh prompt (send ^C, as a real terminal would). zle's own
@@ -4021,6 +4027,44 @@ mod gpui_tests {
                 _ => continue,
             }
         }
+    }
+
+    fn next_input_until_timeout(daemon: &mut UnixStream) -> Option<Vec<u8>> {
+        use std::io::ErrorKind;
+
+        daemon
+            .set_read_timeout(Some(std::time::Duration::from_millis(250)))
+            .unwrap();
+        loop {
+            match ClientMsg::read(daemon) {
+                Ok(ClientMsg::Input(bytes)) => return Some(bytes),
+                Ok(_) => continue,
+                Err(e) if matches!(e.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
+                    return None;
+                }
+                Err(e) => panic!("client socket failed before Input: {e}"),
+            }
+        }
+    }
+
+    #[gpui::test]
+    fn ctrl_l_at_prompt_reaches_the_shell(cx: &mut TestAppContext) {
+        let (window, mut daemon) = harness(cx);
+        window
+            .update(cx, |view, _, cx| {
+                let ctrl_l = gpui::Keystroke {
+                    modifiers: gpui::Modifiers {
+                        control: true,
+                        ..Default::default()
+                    },
+                    key: "l".to_string(),
+                    key_char: None,
+                };
+                view.handle_editor_key(&ctrl_l, cx);
+            })
+            .unwrap();
+
+        assert_eq!(next_input_until_timeout(&mut daemon), Some(vec![0x0c]));
     }
 
     /// Readline's Meta word chords act on the local prompt editor: M-b / M-f

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -73,6 +73,9 @@ pub struct TerminalView {
     /// Optional distinct base face for italic cells (from `font_family_italic`).
     /// `None` → synthesize italic from `font`.
     pub font_italic: Option<Font>,
+    /// User-configured OpenType features for terminal fonts. `None` preserves
+    /// tty7's terminal-safe default (ligatures disabled); `Some` is opt-in.
+    font_features: Option<gpui::FontFeatures>,
     pub font_size: Pixels,
     /// Line height as a multiple of `font_size`; the element turns it into the
     /// concrete row height each frame. Sourced from `Config::line_height`.
@@ -438,14 +441,21 @@ impl TerminalView {
         let fallbacks = fallback_chain(&font_family, &config.font_fallbacks);
         let font_size = px(config.font_size);
         let line_height_mul = config.line_height;
+        let font_features = config.font_features.clone();
         let mut font = gpui::font(font_family);
         font.fallbacks = Some(gpui::FontFallbacks::from_fonts(fallbacks.clone()));
+        if let Some(features) = &font_features {
+            font.features = features.clone();
+        }
         // Optional distinct bold/italic faces, each carrying the same fallback
         // chain so glyph coverage matches the primary face.
         let alt_font = |family: &Option<String>| {
             family.as_ref().map(|f| {
                 let mut af = gpui::font(f.clone());
                 af.fallbacks = Some(gpui::FontFallbacks::from_fonts(fallbacks.clone()));
+                if let Some(features) = &font_features {
+                    af.features = features.clone();
+                }
                 af
             })
         };
@@ -591,6 +601,7 @@ impl TerminalView {
             font,
             font_bold,
             font_italic,
+            font_features,
             font_size,
             line_height_mul,
             cell_width: px(8.),
@@ -1647,6 +1658,9 @@ impl TerminalView {
         let fallbacks = self.font.fallbacks.clone();
         let mut font = gpui::font(family);
         font.fallbacks = fallbacks;
+        if let Some(features) = &self.font_features {
+            font.features = features.clone();
+        }
         self.font = font;
         cx.notify();
     }
@@ -1664,12 +1678,37 @@ impl TerminalView {
         cx.notify();
     }
 
+    /// Apply OpenType features to the live terminal fonts. `None` restores the
+    /// terminal-safe default path, where the renderer disables contextual
+    /// ligatures while building paint faces.
+    pub fn set_font_features(
+        &mut self,
+        features: Option<gpui::FontFeatures>,
+        cx: &mut Context<Self>,
+    ) {
+        self.font_features = features.clone();
+        let apply = |font: &mut Font| {
+            font.features = features.clone().unwrap_or_default();
+        };
+        apply(&mut self.font);
+        if let Some(font) = &mut self.font_bold {
+            apply(font);
+        }
+        if let Some(font) = &mut self.font_italic {
+            apply(font);
+        }
+        cx.notify();
+    }
+
     /// Build an alternate face from a family name, reusing the primary's
     /// fallbacks. `None` → `None` (fall back to synthesizing from `self.font`).
     fn alt_font(&self, family: Option<String>) -> Option<Font> {
         family.map(|f| {
             let mut af = gpui::font(f);
             af.fallbacks = self.font.fallbacks.clone();
+            if let Some(features) = &self.font_features {
+                af.features = features.clone();
+            }
             af
         })
     }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -19,7 +19,7 @@ use crate::daemon::protocol::ShellSpec;
 use crate::terminal::view::{ChildExited, TerminalView};
 use crate::ui::palette::{Command, CommandKind, PaletteEvent, PaletteView};
 use crate::ui::pane::{CloseOutcome, Pane};
-use crate::ui::settings::{ColorKey, SettingsSection, SettingsState};
+use crate::ui::settings::{AnsiColorKey, ColorKey, SettingsSection, SettingsState};
 use crate::ui::theme::{apply_theme, set_menus};
 
 /// Global font-size bounds and step for the live zoom actions.
@@ -540,6 +540,61 @@ impl Tty7App {
         });
         if let Some(state) = picker {
             let default = color_or(&None, key.default_u32(&neutrals));
+            state.update(cx, |s, cx| s.set_value(default, window, cx));
+        }
+        cx.notify();
+    }
+
+    /// Apply a picked ANSI color override and re-paint the terminal palette live.
+    /// `None` clears the slot back to the active preset's ANSI value.
+    pub(crate) fn set_ansi_color_override(
+        &mut self,
+        key: AnsiColorKey,
+        value: Option<gpui::Hsla>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let new = value.map(hsla_to_hex6);
+        let cfg = cx.global_mut::<Config>();
+        if key.get(&cfg.ansi_colors) == &new {
+            return;
+        }
+        key.set(&mut cfg.ansi_colors, new);
+        cfg.save();
+        apply_theme(Some(window), cx);
+        cx.notify();
+    }
+
+    /// Clear one ANSI override back to the active preset default and sync the
+    /// picker swatch to that effective color.
+    pub(crate) fn reset_ansi_color_override(
+        &mut self,
+        key: AnsiColorKey,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        {
+            let cfg = cx.global_mut::<Config>();
+            if key.get(&cfg.ansi_colors).is_none() {
+                return;
+            }
+            key.set(&mut cfg.ansi_colors, None);
+            cfg.save();
+        }
+        apply_theme(Some(window), cx);
+        let default: gpui::Hsla = {
+            let cfg = cx.global::<Config>();
+            let p = crate::ui::presets::by_id(&cfg.theme_preset);
+            let (r, g, b) = p.ansi16[key.0];
+            gpui::rgb((r as u32) << 16 | (g as u32) << 8 | b as u32).into()
+        };
+        let picker = self.active_settings().and_then(|s| {
+            s.ansi_color_pickers
+                .iter()
+                .find(|(k, _)| *k == key)
+                .map(|(_, state)| state.clone())
+        });
+        if let Some(state) = picker {
             state.update(cx, |s, cx| s.set_value(default, window, cx));
         }
         cx.notify();
@@ -1178,6 +1233,7 @@ impl Tty7App {
         let (shell_program_input, shell_args_input, wd_path_input) =
             self.build_shell_inputs(&mut subs, window, cx);
         let color_pickers = self.build_color_pickers(&mut subs, window, cx);
+        let ansi_color_pickers = self.build_ansi_color_pickers(&mut subs, window, cx);
         let scroll_slider = self.build_scroll_slider(&mut subs, window, cx);
 
         self.maximized = None;
@@ -1194,7 +1250,9 @@ impl Tty7App {
                 shell_args_input,
                 wd_path_input,
                 color_pickers,
+                ansi_color_pickers,
                 colors_expanded: false,
+                ansi_colors_expanded: false,
                 scroll_slider,
                 _subs: subs,
             }),
@@ -1388,6 +1446,38 @@ impl Tty7App {
                     move |this, _picker, ev: &ColorPickerEvent, window, cx| {
                         let ColorPickerEvent::Change(value) = ev;
                         this.set_color_override(key, *value, window, cx);
+                    },
+                ));
+                (key, state)
+            })
+            .collect()
+    }
+
+    /// One color picker per terminal ANSI color, seeded with the effective
+    /// current value (override if set, else active preset default).
+    fn build_ansi_color_pickers(
+        &mut self,
+        subs: &mut Vec<Subscription>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Vec<(AnsiColorKey, Entity<ColorPickerState>)> {
+        let cfg = cx.global::<Config>();
+        let theme_preset = cfg.theme_preset.clone();
+        let ansi_colors = cfg.ansi_colors.clone();
+        let preset = crate::ui::presets::by_id(&theme_preset);
+        AnsiColorKey::ALL
+            .iter()
+            .map(|&key| {
+                let (r, g, b) = preset.ansi16[key.0];
+                let default = (r as u32) << 16 | (g as u32) << 8 | b as u32;
+                let effective = color_or(key.get(&ansi_colors), default);
+                let state = cx.new(|cx| ColorPickerState::new(window, cx).default_value(effective));
+                subs.push(cx.subscribe_in(
+                    &state,
+                    window,
+                    move |this, _picker, ev: &ColorPickerEvent, window, cx| {
+                        let ColorPickerEvent::Change(value) = ev;
+                        this.set_ansi_color_override(key, *value, window, cx);
                     },
                 ));
                 (key, state)
@@ -1656,6 +1746,19 @@ impl Tty7App {
             .and_then(|t| t.settings.as_mut())
         {
             s.colors_expanded = !s.colors_expanded;
+        }
+        cx.notify();
+    }
+
+    /// Expand/collapse the ANSI Colors override group in the settings tab's
+    /// Appearance section (no-op elsewhere).
+    pub(crate) fn toggle_settings_ansi_colors(&mut self, cx: &mut Context<Self>) {
+        if let Some(s) = self
+            .tabs
+            .get_mut(self.active)
+            .and_then(|t| t.settings.as_mut())
+        {
+            s.ansi_colors_expanded = !s.ansi_colors_expanded;
         }
         cx.notify();
     }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -10,6 +10,7 @@ use gpui_component::input::{InputEvent, InputState};
 use gpui_component::select::{SearchableVec, SelectEvent, SelectState};
 use gpui_component::slider::{SliderEvent, SliderState};
 use gpui_component::{ActiveTheme as _, IndexPath, TitleBar};
+use std::sync::Arc;
 
 use crate::core::actions::*;
 use crate::core::config::{Config, NewTabPosition, ShellConfig, color_or, hsla_to_hex6};
@@ -100,6 +101,9 @@ pub struct Tty7App {
     /// tracked so the hot-reload observer can diff them like `font_family`.
     pub(crate) font_family_bold: Option<String>,
     pub(crate) font_family_italic: Option<String>,
+    /// Currently-applied OpenType features for terminal fonts. `None` means the
+    /// terminal-safe default (ligatures disabled).
+    pub(crate) font_features: Option<gpui::FontFeatures>,
     /// Keeps the `observe_global::<Config>` subscription alive for the app's
     /// lifetime so external edits to `config.json` (swapped in by the watcher in
     /// `main.rs`) live-apply font size / line height / family. Never read.
@@ -150,6 +154,7 @@ impl Tty7App {
         let font_family = cx.global::<Config>().font_family.clone();
         let font_family_bold = cx.global::<Config>().font_family_bold.clone();
         let font_family_italic = cx.global::<Config>().font_family_italic.clone();
+        let font_features = cx.global::<Config>().font_features.clone();
         // Live-apply hot-reloaded config: the watcher in `main.rs` swaps the
         // `Config` global on every `config.json` change, which fires this. Theme
         // and colors are handled separately by `apply_theme`; here we cover the
@@ -189,6 +194,7 @@ impl Tty7App {
             font_family,
             font_family_bold,
             font_family_italic,
+            font_features,
             _config_watch: config_watch,
             _keystroke_watch: keystroke_watch,
             palette: None,
@@ -597,6 +603,29 @@ impl Tty7App {
         if let Some(state) = picker {
             state.update(cx, |s, cx| s.set_value(default, window, cx));
         }
+        cx.notify();
+    }
+
+    /// Toggle terminal font ligatures through the generic `font_features`
+    /// config. On enables the common programming-font features; off restores
+    /// tty7's terminal-safe default (contextual ligatures disabled).
+    pub(crate) fn set_font_ligatures(&mut self, on: bool, cx: &mut Context<Self>) {
+        let features = on.then(|| {
+            gpui::FontFeatures(Arc::new(vec![
+                ("calt".to_string(), 1),
+                ("liga".to_string(), 1),
+            ]))
+        });
+        self.font_features = features.clone();
+        for tab in &self.tabs {
+            for leaf in tab.pane.leaves() {
+                let features = features.clone();
+                leaf.update(cx, |v, cx| v.set_font_features(features, cx));
+            }
+        }
+        let cfg = cx.global_mut::<Config>();
+        cfg.font_features = features;
+        cfg.save();
         cx.notify();
     }
 
@@ -1580,9 +1609,14 @@ impl Tty7App {
     /// writes it), and — because we never write the global or `save()` from here
     /// — closes the save → watch → reload loop that would otherwise oscillate.
     fn reload_from_config(&mut self, cx: &mut Context<Self>) {
-        let (font_size, line_height, font_family) = {
+        let (font_size, line_height, font_family, font_features) = {
             let cfg = cx.global::<Config>();
-            (cfg.font_size, cfg.line_height, cfg.font_family.clone())
+            (
+                cfg.font_size,
+                cfg.line_height,
+                cfg.font_family.clone(),
+                cfg.font_features.clone(),
+            )
         };
         if font_size != self.font_size {
             self.font_size = font_size;
@@ -1613,6 +1647,15 @@ impl Tty7App {
                 for leaf in tab.pane.leaves() {
                     let family = font_family.clone();
                     leaf.update(cx, |v, cx| v.set_font_family(family, cx));
+                }
+            }
+        }
+        if font_features != self.font_features {
+            self.font_features = font_features.clone();
+            for tab in &self.tabs {
+                for leaf in tab.pane.leaves() {
+                    let features = font_features.clone();
+                    leaf.update(cx, |v, cx| v.set_font_features(features, cx));
                 }
             }
         }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use gpui_component::color_picker::{ColorPicker, ColorPickerState};
 
-use crate::core::config::{Colors, Config, CursorStyle, NewTabPosition, NotifyMode};
+use crate::core::config::{AnsiColors, Colors, Config, CursorStyle, NewTabPosition, NotifyMode};
 use crate::ui::app::{FONT_SIZE_STEP, LINE_HEIGHT_STEP, Tty7App};
 use crate::ui::keymap::default_bindings;
 use crate::ui::presets;
@@ -56,6 +56,49 @@ pub(crate) enum ColorKey {
     Popover,
     Caret,
     Selection,
+}
+
+/// One terminal ANSI color slot (`ansi_colors.color0`…`color15`). These map to
+/// SGR colors that terminal programs request explicitly, separate from the
+/// default foreground/background.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AnsiColorKey(pub(crate) usize);
+
+impl AnsiColorKey {
+    pub(crate) const ALL: [AnsiColorKey; 16] = [
+        AnsiColorKey(0),
+        AnsiColorKey(1),
+        AnsiColorKey(2),
+        AnsiColorKey(3),
+        AnsiColorKey(4),
+        AnsiColorKey(5),
+        AnsiColorKey(6),
+        AnsiColorKey(7),
+        AnsiColorKey(8),
+        AnsiColorKey(9),
+        AnsiColorKey(10),
+        AnsiColorKey(11),
+        AnsiColorKey(12),
+        AnsiColorKey(13),
+        AnsiColorKey(14),
+        AnsiColorKey(15),
+    ];
+
+    fn label(self) -> String {
+        format!("Color {}", self.0)
+    }
+
+    fn id(self) -> String {
+        format!("ansi-color{}", self.0)
+    }
+
+    pub(crate) fn get(self, colors: &AnsiColors) -> &Option<String> {
+        colors.get(self.0).unwrap_or(&colors.color0)
+    }
+
+    pub(crate) fn set(self, colors: &mut AnsiColors, val: Option<String>) {
+        colors.set(self.0, val);
+    }
 }
 
 impl ColorKey {
@@ -169,10 +212,14 @@ pub(crate) struct SettingsState {
     /// order. Each is initialized to the effective color and emits a `Change` that
     /// writes the override + re-applies the theme.
     pub(crate) color_pickers: Vec<(ColorKey, Entity<ColorPickerState>)>,
+    /// One color picker per overridable terminal ANSI color (`ansi_colors.*`).
+    pub(crate) ansi_color_pickers: Vec<(AnsiColorKey, Entity<ColorPickerState>)>,
     /// Whether the Colors override group (Appearance) is expanded. Collapsed by
     /// default: its nine theme-internal slots are power-user surface, and open
     /// they would dwarf the theme/typography settings everyone else came for.
     pub(crate) colors_expanded: bool,
+    /// Whether the ANSI Colors override group (Appearance) is expanded.
+    pub(crate) ansi_colors_expanded: bool,
     /// Mouse-scroll multiplier slider (Terminal section).
     pub(crate) scroll_slider: Entity<SliderState>,
     pub(crate) _subs: Vec<Subscription>,
@@ -434,20 +481,31 @@ impl Tty7App {
         let hover_bg = theme.secondary.opacity(0.6);
         let stepper_bg = theme.secondary.opacity(0.35);
         let font_size = self.font_size;
-        let (font_select, font_bold_select, font_italic_select, color_pickers, colors_expanded) =
-            match self.active_settings() {
-                Some(s) => (
-                    s.font_select.clone(),
-                    s.font_bold_select.clone(),
-                    s.font_italic_select.clone(),
-                    s.color_pickers.clone(),
-                    s.colors_expanded,
-                ),
-                None => return div().into_any_element(),
-            };
-        let cursor_style = cx.global::<Config>().cursor_style;
-        let cursor_blink = cx.global::<Config>().cursor_blink;
-        let colors = cx.global::<Config>().colors.clone();
+        let (
+            font_select,
+            font_bold_select,
+            font_italic_select,
+            color_pickers,
+            colors_expanded,
+            ansi_color_pickers,
+            ansi_colors_expanded,
+        ) = match self.active_settings() {
+            Some(s) => (
+                s.font_select.clone(),
+                s.font_bold_select.clone(),
+                s.font_italic_select.clone(),
+                s.color_pickers.clone(),
+                s.colors_expanded,
+                s.ansi_color_pickers.clone(),
+                s.ansi_colors_expanded,
+            ),
+            None => return div().into_any_element(),
+        };
+        let cfg = cx.global::<Config>();
+        let cursor_style = cfg.cursor_style;
+        let cursor_blink = cfg.cursor_blink;
+        let colors = cfg.colors.clone();
+        let ansi_colors = cfg.ansi_colors.clone();
 
         // Unified −/value/+ stepper plus a quiet Reset.
         let step = move |id: &'static str, glyph: &'static str, divider: bool| {
@@ -638,6 +696,13 @@ impl Tty7App {
             ))
             .child(self.section_rule(cx))
             .child(self.render_colors_group(colors_expanded, color_pickers, &colors, cx))
+            .child(self.section_rule(cx))
+            .child(self.render_ansi_colors_group(
+                ansi_colors_expanded,
+                ansi_color_pickers,
+                &ansi_colors,
+                cx,
+            ))
             .into_any_element()
     }
 
@@ -710,6 +775,89 @@ impl Tty7App {
                     .disabled(!overridden)
                     .on_click(cx.listener(move |this, _, window, cx| {
                         this.reset_color_override(key, window, cx);
+                    })),
+            )
+            .into_any_element();
+        self.settings_row(
+            key.label(),
+            if overridden {
+                "Custom"
+            } else {
+                "Theme default"
+            },
+            control,
+            cx,
+        )
+    }
+
+    /// Terminal ANSI color overrides (`color0`…`color15`), separate from the
+    /// theme's default foreground/background. These are the slots CLI programs
+    /// address explicitly with SGR colors.
+    fn render_ansi_colors_group(
+        &self,
+        expanded: bool,
+        color_pickers: Vec<(AnsiColorKey, Entity<ColorPickerState>)>,
+        colors: &AnsiColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let muted_fg = cx.theme().muted_foreground;
+        let chevron = if expanded {
+            IconName::ChevronDown
+        } else {
+            IconName::ChevronRight
+        };
+        let header = v_flex()
+            .id("ansi-colors-toggle")
+            .gap_1()
+            .cursor_pointer()
+            .on_click(cx.listener(|this, _, _w, cx| this.toggle_settings_ansi_colors(cx)))
+            .child(
+                h_flex()
+                    .items_center()
+                    .gap_1p5()
+                    .child(self.header_text("ANSI Colors", cx))
+                    .child(Icon::new(chevron).small().text_color(muted_fg)),
+            )
+            .child(
+                div()
+                    .text_xs()
+                    .text_color(muted_fg)
+                    .child("Advanced: override terminal color0-color15 slots used by CLI tools."),
+            );
+        Collapsible::new()
+            .open(expanded)
+            .child(header)
+            .content(
+                v_flex().mt_2().children(
+                    color_pickers
+                        .into_iter()
+                        .map(|(key, state)| self.render_ansi_color_row(key, state, colors, cx)),
+                ),
+            )
+            .into_any_element()
+    }
+
+    fn render_ansi_color_row(
+        &self,
+        key: AnsiColorKey,
+        state: Entity<ColorPickerState>,
+        colors: &AnsiColors,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement + use<> {
+        let overridden = key.get(colors).is_some();
+        let control = h_flex()
+            .items_center()
+            .gap_3()
+            .w(px(240.))
+            .child(ColorPicker::new(&state).small())
+            .child(
+                Button::new(SharedString::from(format!("{}-reset", key.id())))
+                    .label("Reset")
+                    .ghost()
+                    .small()
+                    .disabled(!overridden)
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        this.reset_ansi_color_override(key, window, cx);
                     })),
             )
             .into_any_element();

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -504,6 +504,13 @@ impl Tty7App {
         let cfg = cx.global::<Config>();
         let cursor_style = cfg.cursor_style;
         let cursor_blink = cfg.cursor_blink;
+        let font_ligatures = cfg.font_features.as_ref().is_some_and(|features| {
+            features.is_calt_enabled() == Some(true)
+                || features
+                    .tag_value_list()
+                    .iter()
+                    .any(|(tag, value)| tag == "liga" && *value != 0)
+        });
         let colors = cfg.colors.clone();
         let ansi_colors = cfg.ansi_colors.clone();
 
@@ -614,6 +621,10 @@ impl Tty7App {
         let font_family_control = font_dropdown(&font_select);
         let font_bold_control = font_dropdown(&font_bold_select);
         let font_italic_control = font_dropdown(&font_italic_select);
+        let ligature_switch = Switch::new("font-ligatures")
+            .checked(font_ligatures)
+            .on_click(cx.listener(|this, on: &bool, _w, cx| this.set_font_ligatures(*on, cx)))
+            .into_any_element();
 
         let cursor_idx = match cursor_style {
             CursorStyle::Block => 0,
@@ -678,6 +689,12 @@ impl Tty7App {
                 "Italic Font",
                 "Face for italic text; Default synthesizes it from the primary.",
                 font_italic_control,
+                cx,
+            ))
+            .child(self.settings_row(
+                "Font ligatures",
+                "Enable common programming ligature features for terminal text.",
+                ligature_switch,
                 cx,
             ))
             .child(self.section_rule(cx))

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -7,7 +7,8 @@ use gpui::{App, Hsla, Menu, MenuItem, Pixels, Point, Window, point, px, rgb};
 use gpui_component::{Theme, ThemeMode};
 
 use crate::core::actions::*;
-use crate::core::config::{Config, color_or};
+use crate::core::config::{AnsiColors, Config, color_or, parse_hex_color};
+use crate::terminal::palette::ActivePalette;
 use crate::ui::presets;
 
 /// The traffic-light origin, nudged down from the macOS default so the buttons
@@ -78,7 +79,8 @@ pub(crate) fn apply_theme(mut window: Option<&mut Window>, cx: &mut App) {
     // User `colors.*` overrides apply on top of the derived neutrals; a `None`
     // field falls through to the theme.
     let c = cfg.colors.clone();
-    let active = preset.active_palette();
+    let mut active = preset.active_palette();
+    apply_ansi_overrides(&mut active, &cfg.ansi_colors);
 
     Theme::change(mode, window.as_deref_mut(), cx);
     // Publish the terminal palette before borrowing the theme mutably.
@@ -167,6 +169,16 @@ pub(crate) fn apply_theme(mut window: Option<&mut Window>, cx: &mut App) {
     }
 }
 
+fn apply_ansi_overrides(active: &mut ActivePalette, overrides: &AnsiColors) {
+    for i in 0..16 {
+        if let Some(Some(hex)) = overrides.get(i) {
+            if let Some(rgb) = parse_hex_color(hex) {
+                active.ansi16[i] = crate::terminal::palette::hsla_to_rgb(rgb.into());
+            }
+        }
+    }
+}
+
 /// Apply `Config::mouse_hide_while_typing` to GPUI's cursor-hide policy: hide the
 /// pointer while typing when on, never when off. Called at startup and whenever
 /// the config changes (setter + hot-reload) so the switch takes effect live.
@@ -216,3 +228,41 @@ fn sync_native_appearance(dark: bool) {
 
 #[cfg(not(target_os = "macos"))]
 fn sync_native_appearance(_dark: bool) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ansi_overrides_replace_only_valid_slots() {
+        let mut active = presets::by_id("rose_pine_dawn").active_palette();
+        let original0 = active.ansi16[0];
+        let original1 = active.ansi16[1];
+        let original15 = active.ansi16[15];
+        let mut overrides = AnsiColors::default();
+        overrides.color0 = Some("#575279".to_string());
+        overrides.color1 = Some("not-a-color".to_string());
+        overrides.color15 = Some("123456".to_string());
+
+        apply_ansi_overrides(&mut active, &overrides);
+
+        assert_eq!(
+            (active.ansi16[0].r, active.ansi16[0].g, active.ansi16[0].b),
+            (0x57, 0x52, 0x79)
+        );
+        assert_eq!(
+            active.ansi16[1], original1,
+            "malformed overrides are ignored"
+        );
+        assert_eq!(
+            (
+                active.ansi16[15].r,
+                active.ansi16[15].g,
+                active.ansi16[15].b
+            ),
+            (0x12, 0x34, 0x56)
+        );
+        assert_ne!(active.ansi16[0], original0);
+        assert_ne!(active.ansi16[15], original15);
+    }
+}


### PR DESCRIPTION
#32 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable OpenType font features for the terminal (including bold/italic variants).
  * Added Settings controls to override terminal ANSI colors (color0–color15) and toggle font ligatures.
* **Bug Fixes**
  * `Ctrl+L` now reliably clears via the expected terminal form-feed command at the editor prompt.
  * Ligatures are now disabled/enabled based on whether configured font features include ligature tags.
* **Documentation**
  * Clarified supported Ctrl-chord handling at the prompt.
* **Tests**
  * Added/updated tests for `Ctrl+L`, font-feature parsing, ANSI override behavior, and ligature conditional logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->