### PR TITLE
fix(hints): dismiss held-modifier tab badges on window activation flip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The held-⌘ tab-number badges no longer stick on after the window loses key
+  status mid-hold (⌘-Tab, Spotlight, a click into another app). The ⌘ release
+  goes to whatever app is key by then, so the window never saw it; the badges
+  — and any pending reveal — are now dismissed on the activation flip itself.
+
 ## [0.7.0] - 2026-07-10
 
 ### Added

--- a/src/core/session.rs
+++ b/src/core/session.rs
@@ -117,19 +117,40 @@ impl Session {
     }
 }
 
+/// Helpers for every test that touches the on-disk `session.json`. The
+/// config-dir pin is process-wide (`set_config_dir` is first-call-wins), so
+/// the file is process-wide too — any test that reads or writes it must hold
+/// [`lock_session_file`] across the whole read/write sequence, or parallel
+/// tests clobber each other's session.
 #[cfg(test)]
-mod tests {
-    use super::*;
+pub(crate) mod test_support {
+    use std::path::PathBuf;
+    use std::sync::{Mutex, MutexGuard};
+
+    static SESSION_FILE: Mutex<()> = Mutex::new(());
+
+    /// Serialize access to the shared `session.json`.
+    pub(crate) fn lock_session_file() -> MutexGuard<'static, ()> {
+        // A poisoned lock just means another test failed mid-sequence; every
+        // holder rewrites the file from scratch, so the state is still sound.
+        SESSION_FILE.lock().unwrap_or_else(|e| e.into_inner())
+    }
 
     /// Pin the process config dir at a shared temp location so `save`/`load`
     /// (which resolve `session.json` under it) never touch the real `~/.config`.
-    /// `set_config_dir` is first-call-wins; every IO test computes the same path.
-    fn pin_config_dir() -> PathBuf {
+    /// `set_config_dir` is first-call-wins; every caller computes the same path.
+    pub(crate) fn pin_config_dir() -> PathBuf {
         let dir = std::env::temp_dir().join(format!("tty7-covtest-{}", std::process::id()));
         std::fs::create_dir_all(&dir).ok();
         crate::core::config::set_config_dir(dir.clone());
         dir
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::{lock_session_file, pin_config_dir};
+    use super::*;
 
     #[test]
     fn session_json_round_trips_nested_tree() {
@@ -198,6 +219,7 @@ mod tests {
 
     #[test]
     fn save_then_load_recovers_the_session() {
+        let _file = lock_session_file();
         pin_config_dir();
         let session = Session {
             active: 0,

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -114,6 +114,12 @@ pub struct Tty7App {
     /// pre-dispatch) rather than an observer because the terminal consumes
     /// most keys with `stop_propagation`, which suppresses observers. Never read.
     _keystroke_watch: Subscription,
+    /// Keeps the window-activation observer alive: any active-status flip also
+    /// cancels the badges. Deactivating mid-hold (⌘-Tab, Spotlight, a click
+    /// into another app) sends the modifier *release* to whatever app is key
+    /// by then — this window never gets that `ModifiersChanged`, so without
+    /// this the badges stuck on until some later keypress. Never read.
+    _activation_watch: Subscription,
     /// `Some` while the command palette overlay is open; `None` when closed.
     /// The view owns its search input, filtered list and keyboard handling and
     /// emits a `PaletteEvent`; we build the catalog and run the chosen command.
@@ -148,6 +154,20 @@ pub struct Tty7App {
 
 impl Tty7App {
     pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        // Restore the previous session (tab/split layout + each pane's cwd).
+        Self::with_session(Session::load(), window, cx)
+    }
+
+    /// The whole constructor behind `new`, with the saved session injected
+    /// instead of read from disk. The headless tests build the app through
+    /// this seam (a zero-tab session → the home page, no terminal spawned)
+    /// so every subscription and window hook runs exactly as in production
+    /// without touching `~/.config` or a daemon.
+    pub(crate) fn with_session(
+        session: Option<Session>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
         // Font size from config (borrow ends before the mutable theme apply).
         let font_size = cx.global::<Config>().font_size;
         let line_height = cx.global::<Config>().line_height;
@@ -166,15 +186,23 @@ impl Tty7App {
         let keystroke_watch = cx.intercept_keystrokes(move |_ev, _window, cx| {
             let _ = this.update(cx, |this, cx| this.dismiss_mod_hint(cx));
         });
+        // Losing key status mid-hold (⌘-Tab, Spotlight, a click into another
+        // app) means the modifier release is delivered elsewhere and never
+        // reaches this window — the activation flip is the only signal left,
+        // so treat it like a release. Dismissing on *both* flips also keeps a
+        // reveal scheduled just before the switch from popping the badges up
+        // in a window the user already left.
+        let activation_watch = cx.observe_window_activation(window, |this, _window, cx| {
+            this.dismiss_mod_hint(cx);
+        });
         // Paint the configured color theme (defaults to a light one) and build
         // the menu bar.
         apply_theme(Some(window), cx);
         set_menus(cx);
-        // Try to restore the previous session (tab/split layout + each pane's
-        // cwd). A session with zero tabs is a real state — the user quit from
+        // A session with zero tabs is a real state — the user quit from
         // the home page — and restores back to it; only a *missing/unreadable*
         // session (first run) falls back to spawning a default terminal.
-        let (tabs, active) = match Session::load() {
+        let (tabs, active) = match session {
             // First run (no session file): the very first terminal has no
             // predecessor to inherit from, so start in the app's current
             // directory (None → default behavior).
@@ -197,6 +225,7 @@ impl Tty7App {
             font_features,
             _config_watch: config_watch,
             _keystroke_watch: keystroke_watch,
+            _activation_watch: activation_watch,
             palette: None,
             palette_sub: None,
             closed: Vec::new(),

--- a/src/ui/hints.rs
+++ b/src/ui/hints.rs
@@ -132,9 +132,8 @@ mod gpui_tests {
         // Inject the zero-tab session (the persisted home-page state) so the
         // app builds without spawning a terminal — and without reading the
         // on-disk `session.json`.
-        let window = cx.add_window(|window, cx| {
-            Tty7App::with_session(Some(Session::default()), window, cx)
-        });
+        let window =
+            cx.add_window(|window, cx| Tty7App::with_session(Some(Session::default()), window, cx));
         // `add_window` alone doesn't make this the platform's active window,
         // and `deactivate_window` below is a no-op on a non-active one — so
         // activate it for real, like the OS does when the app opens.

--- a/src/ui/hints.rs
+++ b/src/ui/hints.rs
@@ -3,10 +3,12 @@
 //! Hold the bare `secondary` modifier (⌘ on macOS, Ctrl on Windows/Linux) for
 //! a beat and every tab chip shows its switch digit (1…9 — the held modifier
 //! itself is implied).
-//! Releasing the modifier, adding another modifier, or pressing any real key
-//! (a chord like ⌘C) hides them immediately — the chord dismissal lives in
-//! the keystroke interceptor registered in `Tty7App::new`, which fires even
-//! for keys the terminal consumes.
+//! Releasing the modifier, adding another modifier, pressing any real key
+//! (a chord like ⌘C), or the window changing active status all hide them
+//! immediately — the chord dismissal lives in the keystroke interceptor
+//! registered in `Tty7App::new` (it fires even for keys the terminal
+//! consumes), and the activation dismissal in the observer beside it (a
+//! window that deactivates mid-hold never receives the release).
 //!
 //! The trigger is a *hold*, not a chord: ⌘+Tab is reserved by macOS for the
 //! system app switcher and never reaches the app.
@@ -77,9 +79,11 @@ impl Tty7App {
 
     /// Hide the badges and invalidate any pending reveal. Called on every real
     /// keypress (the interceptor in `Tty7App::new`) so a chord like ⌘C never
-    /// shows them, and re-arming requires releasing and holding ⌘ afresh —
-    /// which doubles as the stuck-state guard if the window ever misses a
-    /// release (e.g. ⌘-tabbing away and back).
+    /// shows them, and on every window-activation flip (the observer next to
+    /// it) because deactivating mid-hold — ⌘-Tab, Spotlight, a click into
+    /// another app — sends the modifier release to whatever app is key by
+    /// then, so this window would otherwise show the badges forever.
+    /// Re-arming always requires releasing and holding ⌘ afresh.
     pub(crate) fn dismiss_mod_hint(&mut self, cx: &mut Context<Self>) {
         self.mod_hint_gen = self.mod_hint_gen.wrapping_add(1);
         if self.mod_hint_badges {
@@ -100,5 +104,108 @@ mod tests {
     fn tab_badge_label_is_the_bare_digit() {
         assert_eq!(tab_badge_label(0), "1");
         assert_eq!(tab_badge_label(8), "9");
+    }
+}
+
+/// gpui-harness tests: a real (headless) App + Window around a `Tty7App`
+/// restored to the zero-tab home page — no terminal panes, so no daemon —
+/// with the modifiers listener, the reveal timer, and the window-activation
+/// wiring running exactly as in production.
+#[cfg(test)]
+mod gpui_tests {
+    use crate::core::config::Config;
+    use crate::core::session::Session;
+    use crate::ui::app::Tty7App;
+    use gpui::{Modifiers, TestAppContext, VisualTestContext, WindowHandle};
+
+    fn harness(cx: &mut TestAppContext) -> (WindowHandle<Tty7App>, VisualTestContext) {
+        // The badge reveal is a real `smol::Timer` on smol's reactor thread —
+        // outside the deterministic executor — so waiting on it parks the
+        // test thread, exactly what `allow_parking` exists for.
+        cx.executor().allow_parking();
+        cx.update(|cx| {
+            // Same globals `main` installs: the component theme and the
+            // user config.
+            gpui_component::init(cx);
+            cx.set_global(Config::default());
+        });
+        // Inject the zero-tab session (the persisted home-page state) so the
+        // app builds without spawning a terminal — and without reading the
+        // on-disk `session.json`.
+        let window = cx.add_window(|window, cx| {
+            Tty7App::with_session(Some(Session::default()), window, cx)
+        });
+        // `add_window` alone doesn't make this the platform's active window,
+        // and `deactivate_window` below is a no-op on a non-active one — so
+        // activate it for real, like the OS does when the app opens.
+        window
+            .update(cx, |_, window, _| window.activate_window())
+            .unwrap();
+        cx.background_executor.run_until_parked();
+        let vcx = VisualTestContext::from_window(window.into(), cx);
+        (window, vcx)
+    }
+
+    fn badges_shown(window: &WindowHandle<Tty7App>, cx: &mut TestAppContext) -> bool {
+        window
+            .update(cx, |app, _, _| app.mod_hint_badges)
+            .expect("the app window stays open")
+    }
+
+    /// The reveal timer is real time (~200ms), so poll — bounded — until the
+    /// badges land.
+    fn wait_for_badges(window: &WindowHandle<Tty7App>, cx: &mut TestAppContext) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            cx.background_executor.run_until_parked();
+            if badges_shown(window, cx) {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "badges never appeared within 5s of the bare-secondary hold"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
+    /// Regression: ⌘-Tab, Spotlight, or a click into another app steals key
+    /// status mid-hold, so the ⌘ release lands in the other app and this
+    /// window never sees the `ModifiersChanged`. The activation flip is the
+    /// only signal left — it must dismiss the badges, or they stick until
+    /// some later keypress.
+    #[gpui::test]
+    fn deactivation_dismisses_visible_badges(cx: &mut TestAppContext) {
+        let (window, mut vcx) = harness(cx);
+        vcx.simulate_modifiers_change(Modifiers::secondary_key());
+        wait_for_badges(&window, cx);
+
+        // The window deactivates with the modifier still down; its eventual
+        // release is delivered to whatever app is key by then, not to us.
+        vcx.deactivate_window();
+
+        assert!(
+            !badges_shown(&window, cx),
+            "deactivation must dismiss the badges — the modifier release will never reach this window"
+        );
+    }
+
+    /// Same steal, faster: the modifier goes down and the window deactivates
+    /// within the reveal delay. The pending timer must not pop the badges up
+    /// in a window the user has already left.
+    #[gpui::test]
+    fn deactivation_cancels_a_pending_reveal(cx: &mut TestAppContext) {
+        let (window, mut vcx) = harness(cx);
+        vcx.simulate_modifiers_change(Modifiers::secondary_key());
+        vcx.deactivate_window();
+
+        // Give the now-stale reveal timer ample real time to fire.
+        std::thread::sleep(std::time::Duration::from_millis(400));
+        cx.background_executor.run_until_parked();
+
+        assert!(
+            !badges_shown(&window, cx),
+            "a reveal scheduled before deactivation must not fire after it"
+        );
     }
 }


### PR DESCRIPTION
## Problem

Hold ⌘ and the tab chips show their switch digits. Release ⌘ — they should hide. But if the window loses key status **mid-hold** (⌘-Tab to another app, ⌘-Space Spotlight, ⌘-clicking another window), the eventual ⌘ release is delivered to whatever app is key by then. This window never receives that `ModifiersChanged`, and the only remaining dismissal path was "some later keypress in tty7" — so with mouse-only use the badges stuck on screen indefinitely.

A nastier variant: press ⌘ and switch away *within* the 200ms reveal delay — the pending timer then popped the badges up in a window the user had already left, and they stuck the same way.

## Fix

Register an `observe_window_activation` observer in `Tty7App::new` that calls `dismiss_mod_hint` on every active-status flip. Deactivation is the last signal the window gets before the release goes elsewhere, so treat it like a release: hide the badges and invalidate any pending reveal (the generation counter both share).

## Tests

Two headless gpui regression tests drive the real wiring end to end:

- `Tty7App` now builds through a `with_session` seam — injecting a zero-tab session restores the home page, so the app constructs with every subscription and window hook live but no terminal/daemon spawned.
- The harness activates the test window for real (`add_window` alone doesn't, which makes `deactivate_window` a silent no-op — the tests were red for the wrong reason until then).
- `deactivation_dismisses_visible_badges`: bare-⌘ hold → badges appear (real ~200ms `smol::Timer`) → window deactivates → badges gone.
- `deactivation_cancels_a_pending_reveal`: hold, deactivate within the delay, wait past it → badges never appear.

Also: `session.json` IO tests now serialize on a shared lock (`session::test_support`) — the pinned config dir is process-wide, so parallel tests writing the same file could clobber each other.

Both red without the fix, green with it; full suite 399/399.