### PR TITLE
feat(links): add file path links

### DIFF
--- a/src/daemon/pane.rs
+++ b/src/daemon/pane.rs
@@ -423,7 +423,8 @@ impl DaemonPane {
         // client didn't pass an explicit cwd (tab-inherit / session restore still
         // win). Inherit → `forced` is `None`, so we keep the fallback as before.
         let forced = crate::core::config::working_directory_base();
-        if let Some(dir) = cwd.or(forced).or(fallback) {
+        let initial_cwd = cwd.or(forced).or(fallback);
+        if let Some(dir) = &initial_cwd {
             cmd.cwd(dir);
         }
         // Advertise a widely-available terminfo + truecolor.
@@ -457,7 +458,7 @@ impl DaemonPane {
             ring: VecDeque::new(),
             subscriber: None,
             subscriber_epoch: 0,
-            cwd: None,
+            cwd: initial_cwd,
             shell: ShellState::default(),
             size,
             alive: true,
@@ -1925,6 +1926,21 @@ mod tests {
         );
         // A live pane replays no exit; the reader thread reports that live.
         assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn attach_replays_initial_cwd_even_before_shell_reports_osc7() {
+        let mut st = test_state(true);
+        st.cwd = Some(PathBuf::from("/Users/alice/clone/tty7"));
+
+        let (tx, rx) = mpsc::channel();
+        attach_subscriber(&mut st, tx);
+
+        assert!(matches!(rx.try_recv(), Ok(DaemonMsg::Size(_))));
+        assert!(matches!(rx.try_recv(), Ok(DaemonMsg::Snapshot(_))));
+        assert!(
+            matches!(rx.try_recv(), Ok(DaemonMsg::Cwd(p)) if p == PathBuf::from("/Users/alice/clone/tty7"))
+        );
     }
 
     /// Regression: attaching to a pane whose child already exited must replay

--- a/src/terminal/element.rs
+++ b/src/terminal/element.rs
@@ -1177,7 +1177,8 @@ impl TerminalElement {
             let clicks = ev.click_count;
             view.update(cx, |v, cx| {
                 // Cmd+click opens a URL under the cursor.
-                if mods.platform && button == MouseButton::Left && v.open_link_at(col, row, cx) {
+                let link_modifier = mods.platform || v.link_modifier_down();
+                if link_modifier && button == MouseButton::Left && v.open_link_at(col, row, cx) {
                     return;
                 }
                 // Report to the app when in mouse-tracking mode (Shift forces
@@ -1227,7 +1228,8 @@ impl TerminalElement {
                         if !mods.shift {
                             v.mouse_motion(col, row, &mods);
                         }
-                        v.hover_link_at(col, row, cx);
+                        let include_files = mods.platform || v.link_modifier_down();
+                        v.hover_link_at(col, row, include_files, cx);
                     } else {
                         v.clear_hovered_link(cx);
                     }

--- a/src/terminal/search.rs
+++ b/src/terminal/search.rs
@@ -3,6 +3,8 @@
 //! the match list, step between matches) and the search-bar UI. Also hosts
 //! `url_at`, the cursor-to-URL probe used for Cmd+click link opening.
 
+use std::path::{Path, PathBuf};
+
 use alacritty_terminal::grid::Dimensions;
 use alacritty_terminal::index::{Boundary, Column, Direction, Line, Point, Side};
 use alacritty_terminal::term::search::{Match, RegexSearch};
@@ -17,6 +19,23 @@ use super::view::TerminalView;
 /// query (e.g. one character) against a large scrollback from producing an
 /// unbounded list and stalling the recompute.
 const MAX_MATCHES: usize = 10_000;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum LinkTarget {
+    Url(String),
+    File {
+        path: PathBuf,
+        line: Option<u32>,
+        column: Option<u32>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct LinkMatch {
+    pub start: usize,
+    pub end: usize,
+    pub target: LinkTarget,
+}
 
 /// State backing the Cmd+F search bar. The query text, caret, selection, IME
 /// composition and in-field editing keys are all owned by `input` (a
@@ -312,8 +331,27 @@ impl TerminalView {
 /// Detect a bare URL spanning column `col` within a line's text. Splits on
 /// whitespace and accepts tokens starting with a known scheme (or `www.`),
 /// trimming trailing punctuation that's usually not part of the link.
+#[cfg(test)]
 pub(super) fn url_at(text: &str, col: usize) -> Option<String> {
     url_span_at(text, col).map(|(_, _, url)| url)
+}
+
+pub(super) fn link_at(
+    text: &str,
+    col: usize,
+    cwd: Option<&Path>,
+    include_files: bool,
+) -> Option<LinkMatch> {
+    if let Some((start, end, url)) = url_span_at(text, col) {
+        return Some(LinkMatch {
+            start,
+            end,
+            target: LinkTarget::Url(url),
+        });
+    }
+    include_files
+        .then(|| file_span_at(text, col, cwd))
+        .flatten()
 }
 
 /// Like [`url_at`] but also reports the inclusive column span `[start, end]` the
@@ -397,6 +435,184 @@ pub(super) fn url_span_at(text: &str, col: usize) -> Option<(usize, usize, Strin
     } else {
         None
     }
+}
+
+fn file_span_at(text: &str, col: usize, cwd: Option<&Path>) -> Option<LinkMatch> {
+    let (start, end, token) = non_ws_token_at(text, col)?;
+    let (start, mut end, mut token) = trim_file_token(start, end, token);
+    if token.is_empty() {
+        return None;
+    }
+
+    let mut location = split_file_location(&token);
+    if location.line.is_none() && token.ends_with(':') {
+        token.pop();
+        end = end.saturating_sub(1);
+        location = split_file_location(&token);
+    }
+
+    let path = resolve_existing_file(&location.path, cwd)?;
+    (start..=end).contains(&col).then_some(LinkMatch {
+        start,
+        end,
+        target: LinkTarget::File {
+            path,
+            line: location.line,
+            column: location.column,
+        },
+    })
+}
+
+fn non_ws_token_at(text: &str, col: usize) -> Option<(usize, usize, String)> {
+    let chars: Vec<char> = text.chars().collect();
+    if col >= chars.len() || chars[col].is_whitespace() {
+        return None;
+    }
+
+    let mut start = col;
+    while start > 0 && !chars[start - 1].is_whitespace() {
+        start -= 1;
+    }
+    let mut end = col;
+    while end + 1 < chars.len() && !chars[end + 1].is_whitespace() {
+        end += 1;
+    }
+    Some((start, end, chars[start..=end].iter().collect()))
+}
+
+fn trim_file_token(mut start: usize, mut end: usize, mut token: String) -> (usize, usize, String) {
+    while token
+        .chars()
+        .next()
+        .is_some_and(|c| matches!(c, '(' | '[' | '<' | '\'' | '"' | '{' | '`'))
+    {
+        token.remove(0);
+        start += 1;
+    }
+    while token
+        .chars()
+        .next_back()
+        .is_some_and(is_file_trailing_punct)
+    {
+        token.pop();
+        end = end.saturating_sub(1);
+    }
+    (start, end, token)
+}
+
+fn is_file_trailing_punct(c: char) -> bool {
+    matches!(
+        c,
+        ')' | ']'
+            | '}'
+            | '.'
+            | ','
+            | ';'
+            | '\''
+            | '"'
+            | '>'
+            | '`'
+            | '）'
+            | '］'
+            | '】'
+            | '》'
+            | '」'
+            | '。'
+            | '，'
+            | '；'
+    )
+}
+
+struct FileLocation {
+    path: String,
+    line: Option<u32>,
+    column: Option<u32>,
+}
+
+fn split_file_location(token: &str) -> FileLocation {
+    let Some((prefix, last)) = strip_numeric_suffix(token) else {
+        return FileLocation {
+            path: token.to_string(),
+            line: None,
+            column: None,
+        };
+    };
+    if let Some((path, line)) = strip_numeric_suffix(prefix) {
+        FileLocation {
+            path: path.to_string(),
+            line: Some(line),
+            column: Some(last),
+        }
+    } else {
+        FileLocation {
+            path: prefix.to_string(),
+            line: Some(last),
+            column: None,
+        }
+    }
+}
+
+fn strip_numeric_suffix(token: &str) -> Option<(&str, u32)> {
+    let (prefix, suffix) = token.rsplit_once(':')?;
+    if prefix.is_empty() || suffix.is_empty() || !suffix.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    let value = suffix.parse().ok()?;
+    Some((prefix, value))
+}
+
+fn resolve_existing_file(path: &str, cwd: Option<&Path>) -> Option<PathBuf> {
+    if path.is_empty() {
+        return None;
+    }
+    let path = expand_home(path, cwd)?;
+    let candidate = if path.is_absolute() {
+        path
+    } else {
+        cwd?.join(path)
+    };
+    candidate.is_file().then_some(candidate)
+}
+
+fn expand_home(path: &str, cwd: Option<&Path>) -> Option<PathBuf> {
+    if path == "~" {
+        return home_dir(cwd);
+    }
+    if let Some(rest) = path.strip_prefix("~/").or_else(|| path.strip_prefix("~\\")) {
+        return home_dir(cwd).map(|home| home.join(rest));
+    }
+    Some(PathBuf::from(path))
+}
+
+fn home_dir(cwd: Option<&Path>) -> Option<PathBuf> {
+    if let Some(home) = cwd.and_then(home_from_cwd) {
+        return Some(home);
+    }
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .filter(|home| !home.is_empty())
+        .map(PathBuf::from)
+}
+
+#[cfg(unix)]
+fn home_from_cwd(cwd: &Path) -> Option<PathBuf> {
+    let mut components = cwd.components();
+    let root = components.next()?;
+    let base = components.next()?;
+    let user = components.next()?;
+    let base = base.as_os_str().to_str()?;
+    matches!(base, "Users" | "home").then(|| {
+        let mut home = PathBuf::new();
+        home.push(root.as_os_str());
+        home.push(base);
+        home.push(user.as_os_str());
+        home
+    })
+}
+
+#[cfg(not(unix))]
+fn home_from_cwd(_cwd: &Path) -> Option<PathBuf> {
+    None
 }
 
 /// Trim trailing punctuation a URL gets glued to in prose — `.,;:'"` and `>` plus
@@ -713,5 +929,121 @@ mod tests {
         assert_eq!(url_at("...", 1), None);
         // A plain word starting like a scheme but not one.
         assert_eq!(url_at("httpsomething", 3), None);
+    }
+
+    fn temp_file(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("tty7-link-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temporary link-test dir");
+        let path = dir.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create temporary parent dir");
+        }
+        std::fs::write(&path, b"").expect("create temporary file");
+        path
+    }
+
+    fn assert_file_link(
+        line: &str,
+        col: usize,
+        cwd: &Path,
+        expected_path: &Path,
+        expected_line: Option<u32>,
+        expected_column: Option<u32>,
+    ) {
+        let link = link_at(line, col, Some(cwd), true).expect("file link under cursor");
+        match link.target {
+            LinkTarget::File { path, line, column } => {
+                assert_eq!(path, expected_path);
+                assert_eq!(line, expected_line);
+                assert_eq!(column, expected_column);
+            }
+            LinkTarget::Url(url) => panic!("expected file link, got URL {url}"),
+        }
+    }
+
+    #[test]
+    fn link_at_detects_relative_file_paths_from_cwd() {
+        let path = temp_file("src/main.rs");
+        let cwd = path.parent().and_then(Path::parent).unwrap();
+
+        assert_file_link(
+            "error src/main.rs:10:2 failed",
+            8,
+            cwd,
+            &path,
+            Some(10),
+            Some(2),
+        );
+
+        let link = link_at("error src/main.rs:10:2 failed", 8, Some(cwd), true)
+            .expect("file link under cursor");
+        assert_eq!((link.start, link.end), (6, 21));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn tilde_expansion_prefers_home_inferred_from_the_pane_cwd() {
+        let cwd = Path::new("/Users/alice/clone/tty7");
+        assert_eq!(
+            expand_home("~/clone/tty7/src/main.rs", Some(cwd)),
+            Some(PathBuf::from("/Users/alice/clone/tty7/src/main.rs"))
+        );
+    }
+
+    #[test]
+    fn link_at_detects_absolute_file_paths_and_single_line_suffix() {
+        let path = temp_file("absolute.log");
+        let line = format!("open {}:42 now", path.display());
+        let col = line.chars().position(|c| c == '/').unwrap_or(5);
+
+        assert_file_link(&line, col, Path::new("/"), &path, Some(42), None);
+    }
+
+    #[test]
+    fn link_at_trims_wrappers_and_trailing_punctuation_around_file_paths() {
+        let path = temp_file("wrapped/src/lib.rs");
+        let cwd = path.parent().and_then(Path::parent).unwrap();
+        let line = "see (src/lib.rs:7), now";
+
+        let link = link_at(line, 7, Some(cwd), true).expect("wrapped file link");
+        assert_eq!((link.start, link.end), (5, 16));
+        match link.target {
+            LinkTarget::File {
+                path: got,
+                line,
+                column,
+            } => {
+                assert_eq!(got, path);
+                assert_eq!(line, Some(7));
+                assert_eq!(column, None);
+            }
+            LinkTarget::Url(url) => panic!("expected file link, got URL {url}"),
+        }
+    }
+
+    #[test]
+    fn link_at_rejects_missing_files_and_file_detection_can_be_disabled() {
+        let cwd = std::env::temp_dir();
+
+        assert_eq!(link_at("missing src/nope.rs:1", 9, Some(&cwd), true), None);
+        assert_eq!(link_at("missing src/nope.rs:1", 9, Some(&cwd), false), None);
+
+        let path = temp_file("disabled.rs");
+        let line = format!("open {}", path.display());
+        assert!(link_at(&line, 6, Some(&cwd), false).is_none());
+    }
+
+    #[test]
+    fn link_at_keeps_url_detection_ahead_of_file_detection() {
+        let url = "https://example.com/src/main.rs";
+        let link = link_at(url, 10, Some(Path::new("/")), true).expect("URL link");
+        assert_eq!(
+            link,
+            LinkMatch {
+                start: 0,
+                end: url.len() - 1,
+                target: LinkTarget::Url(url.to_string()),
+            }
+        );
     }
 }

--- a/src/terminal/search.rs
+++ b/src/terminal/search.rs
@@ -328,14 +328,16 @@ impl TerminalView {
     }
 }
 
-/// Detect a bare URL spanning column `col` within a line's text. Splits on
-/// whitespace and accepts tokens starting with a known scheme (or `www.`),
-/// trimming trailing punctuation that's usually not part of the link.
+/// Test-only convenience over [`url_span_at`]: just the resolved address.
 #[cfg(test)]
 pub(super) fn url_at(text: &str, col: usize) -> Option<String> {
     url_span_at(text, col).map(|(_, _, url)| url)
 }
 
+/// Detect a link spanning column `col` within a line's text: a bare URL
+/// always (see [`url_span_at`]), plus an existing file path when
+/// `include_files` — URL detection wins when both would match. `cwd` anchors
+/// relative paths and `~` expansion.
 pub(super) fn link_at(
     text: &str,
     col: usize,
@@ -354,9 +356,11 @@ pub(super) fn link_at(
         .flatten()
 }
 
-/// Like [`url_at`] but also reports the inclusive column span `[start, end]` the
-/// URL token occupies in `text`. Used to underline the link on hover, where we
-/// need the exact cells to highlight, not just the resolved address.
+/// Detect a bare URL spanning column `col` within a line's text. Splits on
+/// whitespace and accepts tokens starting with a known scheme (or `www.`),
+/// trimming trailing punctuation that's usually not part of the link. Also
+/// reports the inclusive column span `[start, end]` the URL token occupies in
+/// `text`, used to underline the exact cells on hover.
 pub(super) fn url_span_at(text: &str, col: usize) -> Option<(usize, usize, String)> {
     let chars: Vec<char> = text.chars().collect();
     if col >= chars.len() {

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -23,7 +23,7 @@ use super::highlight::{self, TokenKind};
 use super::hold::{GapHold, Verdict};
 use super::remote::RemoteTerminal;
 use super::reverse_search::{self, ReverseSearch};
-use super::search::SearchState;
+use super::search::{LinkTarget, SearchState};
 use super::typeahead::{RawInput, Typeahead};
 use crate::core::actions::{
     CloseActiveTab, NewTab, SendBackTab, SendTab, SplitDown, SplitRight, ToggleMaximizePane,
@@ -114,6 +114,15 @@ pub struct TerminalView {
     /// Last cell reported to the PTY in mouse-tracking mode, used to suppress
     /// duplicate motion reports while dragging within a single cell.
     last_mouse_cell: Option<(usize, usize)>,
+    /// Last cell the pointer hovered over locally. Kept separate from
+    /// `last_mouse_cell`, which belongs to terminal mouse-reporting protocol
+    /// state and must not be disturbed by local link affordances.
+    last_hover_cell: Option<(usize, usize)>,
+    /// Whether the platform modifier (⌘ on macOS) is currently held, as reported
+    /// by the window-level modifier listener. Mouse events can lag or omit this
+    /// state while a mouse-tracking TUI is foreground, so link hover must not
+    /// depend solely on each move event's modifier snapshot.
+    link_modifier_down: bool,
     /// Fractional line debt carried between wheel events on the quantized
     /// paths (mouse-tracking reports, alternate-scroll arrow keys), where the
     /// app consumes whole lines. Trackpads report pixel deltas well under a
@@ -728,6 +737,8 @@ impl TerminalView {
             title: "tty7".to_string(),
             marked_text: String::new(),
             last_mouse_cell: None,
+            last_hover_cell: None,
+            link_modifier_down: false,
             scroll_debt: 0.,
             scroll_frac: 0.,
             search: None,
@@ -2859,8 +2870,8 @@ impl TerminalView {
         }
     }
 
-    /// Open the URL under the given cell, if any (OSC 8 hyperlink or a plain URL
-    /// detected in the row text). Returns true if a URL was opened.
+    /// Open the link under the given cell, if any (OSC 8 hyperlink, plain URL or
+    /// existing file path detected in the row text). Returns true if one opened.
     pub fn open_link_at(&self, col: usize, row: usize, cx: &mut Context<Self>) -> bool {
         if !cx.global::<Config>().link_url {
             return false;
@@ -2882,31 +2893,43 @@ impl TerminalView {
             return true;
         }
 
-        // 2) Fall back to detecting a bare URL in the row's text.
+        // 2) Fall back to detecting a bare URL or file path in the row's text.
         let mut text = String::with_capacity(cols);
         for c in 0..cols {
             text.push(term.grid()[line][Column(c)].c);
         }
         drop(term);
-        if let Some(url) = super::search::url_at(&text, col) {
-            cx.open_url(&url);
-            return true;
+        let cwd = self.cwd();
+        if let Some(link) = super::search::link_at(&text, col, cwd.as_deref(), true) {
+            match link.target {
+                LinkTarget::Url(url) => cx.open_url(&url),
+                LinkTarget::File { path, .. } => open_file_path(&path),
+            }
+            true
+        } else {
+            false
         }
-        false
     }
 
     /// Update the remembered hovered link for the screen cell `(col, row)` and
     /// repaint if it changed. Returns whether a link sits under the cursor, so the
     /// element can switch to a pointing-hand cursor. Cheap on the common case: any
     /// non-URL cell resolves to `None` and bails.
-    pub fn hover_link_at(&mut self, col: usize, row: usize, cx: &mut Context<Self>) -> bool {
+    pub fn hover_link_at(
+        &mut self,
+        col: usize,
+        row: usize,
+        include_files: bool,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        self.last_hover_cell = Some((col, row));
         // URL detection off → never underline or switch to the pointing hand,
         // and drop any underline a prior hover left behind.
         if !cx.global::<Config>().link_url {
             self.clear_hovered_link(cx);
             return false;
         }
-        let next = self.link_span_at(col, row);
+        let next = self.link_span_at(col, row, include_files);
         if next != self.hovered_link {
             self.hovered_link = next;
             cx.notify();
@@ -2914,19 +2937,32 @@ impl TerminalView {
         self.hovered_link.is_some()
     }
 
+    pub fn refresh_link_hover(&mut self, include_files: bool, cx: &mut Context<Self>) -> bool {
+        self.link_modifier_down = include_files;
+        let Some((col, row)) = self.last_hover_cell else {
+            return false;
+        };
+        self.hover_link_at(col, row, include_files, cx)
+    }
+
+    pub fn link_modifier_down(&self) -> bool {
+        self.link_modifier_down
+    }
+
     /// Forget any hovered link (mouse left the grid, or moved onto plain text),
     /// repainting to drop the underline.
     pub fn clear_hovered_link(&mut self, cx: &mut Context<Self>) {
+        self.last_hover_cell = None;
         if self.hovered_link.take().is_some() {
             cx.notify();
         }
     }
 
     /// Resolve the link span at screen cell `(col, row)`: an OSC 8 hyperlink (the
-    /// contiguous run of cells sharing the same target) or a bare URL token in the
-    /// row text. Mirrors [`open_link_at`](Self::open_link_at)'s detection so the
-    /// underline always covers exactly what a Cmd+click would open.
-    fn link_span_at(&self, col: usize, row: usize) -> Option<HoveredLink> {
+    /// contiguous run of cells sharing the same target), a bare URL token, or an
+    /// existing file path in the row text. Mirrors [`open_link_at`](Self::open_link_at)'s
+    /// detection so the underline covers exactly what a Cmd+click would open.
+    fn link_span_at(&self, col: usize, row: usize, include_files: bool) -> Option<HoveredLink> {
         let term = self.terminal.term.lock();
         let display_offset = term.grid().display_offset() as i32;
         let line = Line(row as i32 - display_offset);
@@ -2959,17 +2995,18 @@ impl TerminalView {
             });
         }
 
-        // 2) Bare URL detected in the row's text.
+        // 2) Bare URL or file path detected in the row's text.
         let mut text = String::with_capacity(cols);
         for c in 0..cols {
             text.push(term.grid()[line][Column(c)].c);
         }
         drop(term);
-        let (start, end, _url) = super::search::url_span_at(&text, col)?;
+        let cwd = self.cwd();
+        let link = super::search::link_at(&text, col, cwd.as_deref(), include_files)?;
         Some(HoveredLink {
             line: line.0,
-            start,
-            end,
+            start: link.start,
+            end: link.end,
         })
     }
 
@@ -3827,6 +3864,19 @@ fn select_end_copy(enabled: bool, grid: bool, editor: bool) -> SelectEndCopy {
         (true, true, _) => SelectEndCopy::Grid,
         (true, false, true) => SelectEndCopy::Editor,
         (true, false, false) => SelectEndCopy::None,
+    }
+}
+
+fn open_file_path(path: &std::path::Path) {
+    let opener = if cfg!(target_os = "macos") {
+        "open"
+    } else if cfg!(windows) {
+        "explorer"
+    } else {
+        "xdg-open"
+    };
+    if let Err(e) = std::process::Command::new(opener).arg(path).spawn() {
+        log::warn!("failed to open {}: {e}", path.display());
     }
 }
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -194,6 +194,11 @@ impl Tty7App {
         // in a window the user already left.
         let activation_watch = cx.observe_window_activation(window, |this, _window, cx| {
             this.dismiss_mod_hint(cx);
+            // The panes' link-modifier tracking loses the release the same
+            // way, and a stale "⌘ held" is worse than missing badges: a
+            // plain unmodified click would open links. Treat the flip as a
+            // release; holding ⌘ again re-arms it via `on_modifiers_changed`.
+            this.set_link_modifier(false, cx);
         });
         // Paint the configured color theme (defaults to a light one) and build
         // the menu bar.

--- a/src/ui/hints.rs
+++ b/src/ui/hints.rs
@@ -44,14 +44,7 @@ impl Tty7App {
         cx: &mut Context<Self>,
     ) {
         let m = &ev.modifiers;
-        let command_down = m.platform;
-        if let Some(tab) = self.tabs.get(self.active) {
-            for leaf in tab.pane.leaves() {
-                leaf.update(cx, |view, cx| {
-                    view.refresh_link_hover(command_down, cx);
-                });
-            }
-        }
+        self.set_link_modifier(m.platform, cx);
 
         // Mirror `on_key_down`'s chord test: reject the other platform-ish key
         // (⌃ on macOS, Win/Super elsewhere), Alt, and Shift, so only the bare
@@ -84,6 +77,22 @@ impl Tty7App {
             });
         })
         .detach();
+    }
+
+    /// Push the platform-modifier state down to every pane's link tracking.
+    /// Every tab, not just the active one: `on_modifiers_changed` only fires on
+    /// the frontmost window state, so a background tab that saw "⌘ down" but
+    /// never the matching release would keep a stale `true` — and a stale
+    /// `true` makes a plain, unmodified click open links (see
+    /// `TerminalView::link_modifier_down`).
+    pub(crate) fn set_link_modifier(&mut self, down: bool, cx: &mut Context<Self>) {
+        for tab in &self.tabs {
+            for leaf in tab.pane.leaves() {
+                leaf.update(cx, |view, cx| {
+                    view.refresh_link_hover(down, cx);
+                });
+            }
+        }
     }
 
     /// Hide the badges and invalidate any pending reveal. Called on every real

--- a/src/ui/hints.rs
+++ b/src/ui/hints.rs
@@ -44,6 +44,15 @@ impl Tty7App {
         cx: &mut Context<Self>,
     ) {
         let m = &ev.modifiers;
+        let command_down = m.platform;
+        if let Some(tab) = self.tabs.get(self.active) {
+            for leaf in tab.pane.leaves() {
+                leaf.update(cx, |view, cx| {
+                    view.refresh_link_hover(command_down, cx);
+                });
+            }
+        }
+
         // Mirror `on_key_down`'s chord test: reject the other platform-ish key
         // (⌃ on macOS, Win/Super elsewhere), Alt, and Shift, so only the bare
         // secondary hold shows the badges.


### PR DESCRIPTION
## Summary

- add Cmd-click support for local file paths in terminal output
- resolve relative file paths against the pane cwd and expand `~/...` from the pane home when possible
- keep file-path hover tied to the platform modifier so plain mouse movement does not over-detect paths
- replay a pane's initial cwd immediately so relative paths work before the shell emits OSC 7

## Details

This keeps the existing URL behavior and extends the same link pipeline to file paths:

- OSC 8 hyperlinks still take priority.
- Plain URLs still resolve before file paths.
- Existing local files can be detected as absolute paths, relative paths, and `~/...` paths.
- `path:line` and `path:line:column` are parsed, while opening currently delegates to the system file opener.

For mouse-tracking TUIs, the platform modifier is now tracked from modifier-change events and reused by mouse hover/click handling. This avoids relying only on each mouse-move event's modifier snapshot.

## Testing

- `cargo fmt --check`
- `cargo test terminal::search`
- `cargo test daemon::pane::tests::attach_replays_initial_cwd_even_before_shell_reports_osc7`
- `cargo check`
- `cargo test`

## Effect

https://github.com/user-attachments/assets/64521dff-2da6-48e8-b884-331be95b0442
