### PR TITLE
fix(ui): stop the title-bar strip from clipping the Windows close button

### DIFF
--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -183,10 +183,16 @@ impl Tty7App {
         // `viewport - 80` reaches the true right edge and the strip's own `pr`
         // sets the "⋯" inset; other platforms put the window controls on the
         // *right*, so keep the strip narrower to clear them.
+        //
+        // The non-macOS reserve must cover everything the TitleBar lays out
+        // *beside* the strip, or the strip overruns the bar and shoves the native
+        // close button off the corner: 12px of `TitleBar` left padding + the three
+        // 34px window-control tiles (─ ▢ ✕ = 102px) = 114px. Undershooting it (the
+        // old 100px) left the strip ~14px too wide, clipping the "✕".
         let strip_w = if cfg!(target_os = "macos") {
             (window.viewport_size().width - px(80.)).max(px(160.))
         } else {
-            (window.viewport_size().width - px(100.)).max(px(140.))
+            (window.viewport_size().width - px(114.)).max(px(140.))
         };
         // The "+" and the right-edge overflow "⋯" (30px each), their surrounding
         // gaps, and the strip's own left/right padding all live *outside* the


### PR DESCRIPTION
## Problem

On Windows, the overflow `⋯` menu added in #57 pushed the native close button `✕` off the rounded window corner — it renders clipped (`⋯ ─ ▢ ✕`, with the `✕` past the corner).

## Cause

The tab strip derives an explicit width from the viewport so its right edge (where the `⋯` is pinned) tracks the window. On Windows it reserved only **100px** for what the `TitleBar` lays out beside it. gpui-component's `TitleBar` actually places **12px left padding + three 34px caption tiles (─ ▢ ✕ = 102px) = 114px**. The 14px shortfall let the strip overrun the bar; the window controls render last, so the overflow clipped the `✕`.

## Fix

Reserve the full **114px** on non-macOS so the strip's right edge meets the window controls exactly. The strip's own right padding keeps the `⋯` inset from the minimize button. macOS is unchanged (80px for the left-side traffic lights, no right-side controls).

One-line change in `src/ui/tab_strip.rs` (`100 → 114`) plus an explanatory comment.

## Testing

Built and ran `cargo dev` on Windows 11; the `✕` now sits fully inside the corner with a clean gap to the `⋯`, and the right edge still tracks the window on resize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)