### PR TITLE
fix(ui): trim the first tab's left gap flush to the traffic-light reserve

### DIFF
--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -527,7 +527,7 @@ impl Tty7App {
             // inside the width. `pr_2` (8px) sets the "⋯"'s gap from the right edge
             // — the original tight inset, which now holds steady on resize since
             // `strip_w` keeps the right edge tracking the window.
-            .pl_2()
+            .pl_0()
             .pr_2()
             // On Windows/Linux the window controls (─ ▢ ✕) sit on the right, right
             // where the "⋯" lands; give it extra right breathing room there so it


### PR DESCRIPTION
The first tab sat too far from the window's left edge. The left gutter was three stacked layers of padding:

| Layer | Value | Source |
|---|---|---|
| TitleBar left padding (macOS traffic-light reserve) | 80px | `title_bar.rs` (fork) |
| strip's `.pl_2()` | +8px | `tab_strip.rs` |
| chip's own `.pl_3()` (inner padding) | +12px | `tab_strip.rs` |

So the first tab's **fill** started at 88px and its **label** at 100px — noticeably more than native macOS tabs, which sit right behind the traffic lights (~65–70px).

**Change:** drop the strip's leading padding from `.pl_2()` to `.pl_0()` so the first chip starts flush against the 80px traffic-light reserve.

- Fill left edge: 88px → **80px**
- Label start: 100px → **92px**

The right side is unaffected: `strip_w` and `.pr_2()` still pin the overflow `⋯` to the window's right edge. The chip's `.pl_3()` is every tab's text inset, so it stays untouched.

Verified locally with `cargo dev` — the traffic-light-to-first-tab spacing reads normally.