### PR TITLE
feat(ui): tab title follows the active pane

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -97,14 +97,17 @@ impl Tab {
         Self { pane, name: None }
     }
 
-    /// The title of the tab's representative terminal (its first leaf), used to
-    /// derive both the tab label and its context icon. Empty when there's no
-    /// terminal or no title yet.
-    pub(crate) fn leaf_title(&self, cx: &App) -> String {
-        self.pane
-            .first_leaf()
-            .map(|l| l.read(cx).title.clone())
-            .unwrap_or_default()
+    /// The title used to derive the tab label. With a `window`, this is the
+    /// *focused* pane's title (falling back to the first leaf when nothing in
+    /// the tab holds focus) so the label tracks the pane you're working in;
+    /// without one (e.g. the command palette, which has no window), it's the
+    /// first leaf. Empty when there's no terminal or no title yet.
+    pub(crate) fn leaf_title(&self, window: Option<&Window>, cx: &App) -> String {
+        let leaf = match window {
+            Some(window) => self.pane.focused_or_first(window, cx),
+            None => self.pane.first_leaf(),
+        };
+        leaf.map(|l| l.read(cx).title.clone()).unwrap_or_default()
     }
 }
 
@@ -1509,7 +1512,7 @@ impl Tty7App {
         if self.tabs.get(index).is_none() {
             return;
         }
-        let current = self.tab_label(&self.tabs[index], index, cx);
+        let current = self.tab_label(&self.tabs[index], index, Some(&*window), cx);
         let input = cx.new(|cx| InputState::new(window, cx).default_value(current));
         input.update(cx, |state, cx| state.focus(window, cx));
         let subs = vec![cx.subscribe_in(
@@ -1564,7 +1567,7 @@ impl Tty7App {
             if i == self.active {
                 continue;
             }
-            let label = self.tab_label(tab, i, cx);
+            let label = self.tab_label(tab, i, None, cx);
             commands.push(Command {
                 title: format!("Switch to Tab: {label}"),
                 kind: CommandKind::ActivateTab(i),

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -75,7 +75,7 @@ impl Tty7App {
 
         for (i, tab) in self.tabs.iter().enumerate() {
             let is_active = i == active;
-            let label = self.tab_label(tab, i, cx);
+            let label = self.tab_label(tab, i, Some(window), cx);
             // Filter by the search box; matching is on the visible label. The row
             // keeps its real index `i`, so activate/close/move still hit the right
             // tab even when the list is narrowed.

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -149,15 +149,23 @@ impl Render for DragTab {
 impl Tty7App {
     /// The display label for a tab: the user-set name if present, otherwise the
     /// focused terminal's title (shortened), falling back to
-    /// "Session N" when there's no title yet.
-    pub(crate) fn tab_label(&self, tab: &Tab, index: usize, cx: &App) -> String {
+    /// "Session N" when there's no title yet. Pass `window` so the label tracks
+    /// the focused pane in a split; `None` (no window available) uses the first
+    /// leaf.
+    pub(crate) fn tab_label(
+        &self,
+        tab: &Tab,
+        index: usize,
+        window: Option<&Window>,
+        cx: &App,
+    ) -> String {
         if let Some(name) = tab.name.as_ref() {
             let trimmed = name.trim();
             if !trimmed.is_empty() {
                 return trimmed.to_string();
             }
         }
-        let raw = tab.leaf_title(cx);
+        let raw = tab.leaf_title(window, cx);
         let label = short_title(&raw);
         if label.trim().is_empty() {
             format!("Session {}", index + 1)
@@ -298,7 +306,7 @@ impl Tty7App {
                 break;
             }
             let is_active = i == active;
-            let label = self.tab_label(tab, i, cx);
+            let label = self.tab_label(tab, i, Some(window), cx);
 
             // Inline rename input for this tab, if it's the one being renamed.
             let rename_input = self


### PR DESCRIPTION
## What

The tab label derived from a terminal's title always read the tab's **first** (left/top) leaf pane, regardless of which pane held focus. In a split tab this meant the label kept showing the left pane's title even while you worked in another pane.

This makes the label track the **focused** pane instead — matching iTerm2 / ghostty / kitty — falling back to the first leaf when nothing in the tab is focused.

## How

- `Tab::leaf_title` and `Tty7App::tab_label` now take `Option<&Window>`.
- With a window (tab strip, sidebar, inline rename) the title resolves via `pane.focused_or_first(window, cx)`.
- The command palette has no window, so it passes `None` and keeps the first-leaf title for its "Switch to Tab" list.
- A user-set tab name still wins over the derived title, unchanged.

## Test

`cargo check` + `cargo test --bin tty7 tab` pass. Manually verified in `cargo dev`: split a tab, give the panes different terminal titles, and the label switches as focus moves between them.