### PR TITLE
feat(ssh): support Unix GSSAPI auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pkg-config cmake clang libxkbcommon-dev \
             libxkbcommon-x11-dev libfontconfig1-dev libfreetype6-dev \
-            libwayland-dev libx11-dev libxcb1-dev libzstd-dev libssl-dev
+            libwayland-dev libx11-dev libxcb1-dev libzstd-dev libssl-dev \
+            libkrb5-dev
+          echo "LIBGSSAPI_IMPL=mit" >> "$GITHUB_ENV"
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,8 @@ jobs:
           sudo apt-get install -y pkg-config cmake clang libxkbcommon-dev \
             libxkbcommon-x11-dev libfontconfig1-dev libfreetype6-dev \
             libwayland-dev libx11-dev libxcb1-dev libzstd-dev libssl-dev \
-            libfuse2 file imagemagick
+            libkrb5-dev libfuse2 file imagemagick
+          echo "LIBGSSAPI_IMPL=mit" >> "$GITHUB_ENV"
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5357,7 +5357,7 @@ dependencies = [
 [[package]]
 name = "pageant"
 version = "0.2.1"
-source = "git+https://github.com/ayamir/russh?branch=gssapi-with-mic#0d1d073350ed823069252075cbf3db9672d5b490"
+source = "git+https://github.com/ayamir/russh?rev=0d1d073350ed823069252075cbf3db9672d5b490#0d1d073350ed823069252075cbf3db9672d5b490"
 dependencies = [
  "base16ct",
  "byteorder",
@@ -6533,7 +6533,7 @@ dependencies = [
 [[package]]
 name = "russh"
 version = "0.62.2"
-source = "git+https://github.com/ayamir/russh?branch=gssapi-with-mic#0d1d073350ed823069252075cbf3db9672d5b490"
+source = "git+https://github.com/ayamir/russh?rev=0d1d073350ed823069252075cbf3db9672d5b490#0d1d073350ed823069252075cbf3db9672d5b490"
 dependencies = [
  "aes 0.9.1",
  "aws-lc-rs",
@@ -6604,7 +6604,7 @@ dependencies = [
 [[package]]
 name = "russh-cryptovec"
 version = "0.62.0"
-source = "git+https://github.com/ayamir/russh?branch=gssapi-with-mic#0d1d073350ed823069252075cbf3db9672d5b490"
+source = "git+https://github.com/ayamir/russh?rev=0d1d073350ed823069252075cbf3db9672d5b490#0d1d073350ed823069252075cbf3db9672d5b490"
 dependencies = [
  "log",
  "nix 0.31.3",
@@ -6635,7 +6635,7 @@ dependencies = [
 [[package]]
 name = "russh-util"
 version = "0.52.0"
-source = "git+https://github.com/ayamir/russh?branch=gssapi-with-mic#0d1d073350ed823069252075cbf3db9672d5b490"
+source = "git+https://github.com/ayamir/russh?rev=0d1d073350ed823069252075cbf3db9672d5b490#0d1d073350ed823069252075cbf3db9672d5b490"
 dependencies = [
  "chrono",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4151,6 +4151,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgssapi"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e440a6151f5ef06571612e4121709aed90cfc0c40f8161f9090c71656758086d"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytes",
+ "libgssapi-sys",
+]
+
+[[package]]
+name = "libgssapi-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5103ac4557eacd36ff678b654b943f8966d3db9688fbd180a0b4c5464759ce17"
+dependencies = [
+ "bindgen",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5336,8 +5357,7 @@ dependencies = [
 [[package]]
 name = "pageant"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3a5ae18f65a85c67a77d18d42d3606c07948e3c17c1e5f74852b26589e88a5"
+source = "git+https://github.com/ayamir/russh?branch=gssapi-with-mic#0d1d073350ed823069252075cbf3db9672d5b490"
 dependencies = [
  "base16ct",
  "byteorder",
@@ -6513,8 +6533,7 @@ dependencies = [
 [[package]]
 name = "russh"
 version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6c3c1dd0a9ad3a9915a2f6e907d158f9a7e9ac32ddc772b003faafc027d9a8"
+source = "git+https://github.com/ayamir/russh?branch=gssapi-with-mic#0d1d073350ed823069252075cbf3db9672d5b490"
 dependencies = [
  "aes 0.9.1",
  "aws-lc-rs",
@@ -6585,8 +6604,7 @@ dependencies = [
 [[package]]
 name = "russh-cryptovec"
 version = "0.62.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aec6cb630dbe85d72ffd7bcd95f07e1bd69f9f270ee8adfa1afe443a6331438"
+source = "git+https://github.com/ayamir/russh?branch=gssapi-with-mic#0d1d073350ed823069252075cbf3db9672d5b490"
 dependencies = [
  "log",
  "nix 0.31.3",
@@ -6617,8 +6635,7 @@ dependencies = [
 [[package]]
 name = "russh-util"
 version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6"
+source = "git+https://github.com/ayamir/russh?branch=gssapi-with-mic#0d1d073350ed823069252075cbf3db9672d5b490"
 dependencies = [
  "chrono",
  "tokio",
@@ -8475,6 +8492,7 @@ dependencies = [
  "gpui_platform",
  "keyring",
  "libc",
+ "libgssapi",
  "log",
  "memchr",
  "notify 8.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ memchr = "2"
 # only libc users left, both Unix-only — so the dep is Unix-only too.
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+libgssapi = "0.11"
 
 # The Windows GUI⇄daemon transport is loopback TCP, which (unlike a Unix socket)
 # any local process can connect to — so the daemon authenticates each connection
@@ -196,6 +197,10 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1"
 smallvec = "1"
 smol = "2"
+
+[patch.crates-io]
+# Temporary until upstream russh releases gssapi-with-mic client auth support.
+russh = { git = "https://github.com/ayamir/russh", branch = "gssapi-with-mic" }
 
 [workspace.lints.clippy]
 dbg_macro = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,8 +199,12 @@ smallvec = "1"
 smol = "2"
 
 [patch.crates-io]
-# Temporary until upstream russh releases gssapi-with-mic client auth support.
-russh = { git = "https://github.com/ayamir/russh", branch = "gssapi-with-mic" }
+# Temporary until upstream russh releases gssapi-with-mic client auth support
+# (https://github.com/Eugeny/russh/pull/737) — remove this patch and take the
+# crates.io release once it lands. Pinned to an exact rev (never a branch):
+# russh is the SSH protocol layer handling user credentials, and a moving
+# branch on a third-party fork could change what `cargo update` builds.
+russh = { git = "https://github.com/ayamir/russh", rev = "0d1d073350ed823069252075cbf3db9672d5b490" }
 
 [workspace.lints.clippy]
 dbg_macro = "deny"

--- a/src/core/ssh_profile.rs
+++ b/src/core/ssh_profile.rs
@@ -180,6 +180,8 @@ pub enum AuthMode {
     /// order (the default).
     #[default]
     Auto,
+    /// GSSAPI with MIC only (Kerberos-style SSO).
+    Gssapi,
     /// Password only (saved, then prompted).
     Password,
     /// Public-key only.
@@ -658,6 +660,10 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&AuthMode::KeyboardInteractive).unwrap(),
             "\"keyboard-interactive\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AuthMode::Gssapi).unwrap(),
+            "\"gssapi\""
         );
         let m: AuthMode = serde_json::from_str("\"agent\"").unwrap();
         assert_eq!(m, AuthMode::Agent);

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -171,6 +171,7 @@ pub struct LoopbackForwardInfo {
 pub enum SshAuthMode {
     #[default]
     Auto,
+    Gssapi,
     Password,
     PublicKey,
     Agent,

--- a/src/daemon/ssh/auth.rs
+++ b/src/daemon/ssh/auth.rs
@@ -1,8 +1,9 @@
 //! The authentication flow for a native SSH connection.
 //!
 //! Ordering follows the Tabby reference (brief §2): a leading `none` probe (which
-//! also learns the server's remaining methods), then — for `Auto` — publickey,
-//! agent, password, keyboard-interactive; a non-`Auto` mode restricts attempts to
+//! also learns the server's remaining methods), then — for `Auto` — gssapi-with-mic
+//! (matching OpenSSH's default preference), publickey, agent, password,
+//! keyboard-interactive; a non-`Auto` mode restricts attempts to
 //! that one family. The server's advertised remaining-methods set gates which
 //! families are worth trying and is refreshed after each failure (only when the
 //! server actually sends a non-empty set). Passwords/passphrases come from the
@@ -184,11 +185,14 @@ impl GssapiAuthenticator for GssapiClient {
                 mic: Some(mic.to_vec()),
             })
         } else {
+            // An incomplete context that produced no token to send is a stalled
+            // exchange; claiming completion here would send the server a MIC-less
+            // exchange-complete it will reject with an opaque failure. Error out
+            // instead so the real cause reaches the user.
             let Some(token) = output else {
-                return Ok(GssapiStep::Complete {
-                    token: None,
-                    mic: None,
-                });
+                return Err(GssapiAuthError::Other(
+                    "gssapi context stalled: incomplete with no output token".to_string(),
+                ));
             };
             Ok(GssapiStep::Continue {
                 token: token.to_vec(),

--- a/src/daemon/ssh/auth.rs
+++ b/src/daemon/ssh/auth.rs
@@ -9,13 +9,14 @@
 //! spec (pre-resolved from the keychain by the GUI) or, failing that, from the
 //! [`PromptBroker`]. Secrets are never logged.
 
+use std::net::IpAddr;
 use std::sync::Arc;
 
 use russh::client::{AuthResult, Handle, KeyboardInteractiveAuthResponse};
 use russh::keys::agent::AgentIdentity;
 use russh::keys::agent::client::AgentClient;
 use russh::keys::{Algorithm, HashAlg, PrivateKeyWithHashAlg, PublicKey};
-use russh::{MethodKind, MethodSet};
+use russh::{GssapiAuthenticator, GssapiStep, MethodKind, MethodSet};
 
 use crate::daemon::protocol::{AuthPromptKind, AuthResponse, KiPrompt, NativeSshSpec, SshAuthMode};
 
@@ -53,6 +54,7 @@ pub async fn authenticate(
             continue;
         }
         let outcome = match family {
+            MethodKind::GssapiWithMic => try_gssapi(handle, spec).await,
             MethodKind::PublicKey => try_publickeys(handle, spec, broker).await,
             MethodKind::KeyboardInteractive => try_keyboard_interactive(handle, spec, broker).await,
             MethodKind::Password => try_password(handle, spec, broker).await,
@@ -89,10 +91,12 @@ pub async fn authenticate(
 fn method_order(mode: SshAuthMode) -> Vec<MethodKind> {
     match mode {
         SshAuthMode::Auto => vec![
+            MethodKind::GssapiWithMic,
             MethodKind::PublicKey,
             MethodKind::Password,
             MethodKind::KeyboardInteractive,
         ],
+        SshAuthMode::Gssapi => vec![MethodKind::GssapiWithMic],
         SshAuthMode::PublicKey | SshAuthMode::Agent => vec![MethodKind::PublicKey],
         SshAuthMode::Password => vec![MethodKind::Password],
         SshAuthMode::KeyboardInteractive => vec![MethodKind::KeyboardInteractive],
@@ -114,6 +118,301 @@ fn failed(reason: impl Into<String>) -> Outcome {
         reason: Some(reason.into()),
     }
 }
+
+const KRB5_DER_OID: &[u8] = b"\x06\x09\x2a\x86\x48\x86\xf7\x12\x01\x02\x02";
+
+#[cfg(unix)]
+struct GssapiClient {
+    ctx: libgssapi::context::ClientCtx,
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+enum GssapiAuthError {
+    Send(russh::SendError),
+    Gssapi(libgssapi::error::Error),
+    Other(String),
+}
+
+#[cfg(unix)]
+impl std::fmt::Display for GssapiAuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GssapiAuthError::Send(_) => write!(f, "send error"),
+            GssapiAuthError::Gssapi(e) => write!(f, "{e}"),
+            GssapiAuthError::Other(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+#[cfg(unix)]
+impl From<russh::SendError> for GssapiAuthError {
+    fn from(value: russh::SendError) -> Self {
+        GssapiAuthError::Send(value)
+    }
+}
+
+#[cfg(unix)]
+impl From<libgssapi::error::Error> for GssapiAuthError {
+    fn from(value: libgssapi::error::Error) -> Self {
+        GssapiAuthError::Gssapi(value)
+    }
+}
+
+#[cfg(unix)]
+impl GssapiAuthenticator for GssapiClient {
+    type Error = GssapiAuthError;
+
+    async fn gssapi_step(
+        &mut self,
+        selected_mechanism: Vec<u8>,
+        input_token: Option<Vec<u8>>,
+        mic_data: Vec<u8>,
+    ) -> Result<GssapiStep, Self::Error> {
+        use libgssapi::context::SecurityContext;
+
+        if input_token.is_none() && selected_mechanism != KRB5_DER_OID {
+            return Err(GssapiAuthError::Other(
+                "server selected an unsupported gssapi mechanism".to_string(),
+            ));
+        }
+        let output = self.ctx.step(input_token.as_deref(), None)?;
+        if self.ctx.is_complete() {
+            let mic = self.ctx.get_mic(&mic_data)?;
+            Ok(GssapiStep::Complete {
+                token: output.map(|buf| buf.to_vec()),
+                mic: Some(mic.to_vec()),
+            })
+        } else {
+            let Some(token) = output else {
+                return Ok(GssapiStep::Complete {
+                    token: None,
+                    mic: None,
+                });
+            };
+            Ok(GssapiStep::Continue {
+                token: token.to_vec(),
+            })
+        }
+    }
+}
+
+async fn try_gssapi(handle: &mut Handle<ClientHandler>, spec: &NativeSshSpec) -> Outcome {
+    #[cfg(unix)]
+    {
+        use libgssapi::context::{ClientCtx, CtxFlags};
+        use libgssapi::name::Name;
+        use libgssapi::oid::{GSS_MECH_KRB5, GSS_NT_HOSTBASED_SERVICE};
+
+        let service_hosts = gssapi_service_hosts(&spec.host).await;
+        let mut tried = Vec::new();
+        let mut errors = Vec::new();
+        let mut last_remaining = None;
+        let mut saw_rejection = false;
+
+        for service_host in service_hosts {
+            let service = format!("host@{service_host}");
+            tried.push(service.clone());
+            let name = match Name::new(service.as_bytes(), Some(GSS_NT_HOSTBASED_SERVICE)) {
+                Ok(name) => name,
+                Err(e) => {
+                    errors.push(format!("{service}: target name error: {e}"));
+                    continue;
+                }
+            };
+            let mut client = GssapiClient {
+                ctx: ClientCtx::new(
+                    None,
+                    name,
+                    CtxFlags::GSS_C_MUTUAL_FLAG | CtxFlags::GSS_C_INTEG_FLAG,
+                    Some(GSS_MECH_KRB5),
+                ),
+            };
+
+            match handle
+                .authenticate_gssapi_with_mic(&spec.user, vec![KRB5_DER_OID.to_vec()], &mut client)
+                .await
+            {
+                Ok(AuthResult::Success) => return Outcome::Authenticated,
+                Ok(AuthResult::Failure {
+                    remaining_methods, ..
+                }) => {
+                    saw_rejection = true;
+                    let can_retry = remaining_methods.is_empty()
+                        || remaining_methods.contains(&MethodKind::GssapiWithMic);
+                    last_remaining = Some(remaining_methods);
+                    if !can_retry {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    errors.push(format!("{service}: {e}"));
+                    break;
+                }
+            }
+        }
+
+        let tried = tried.join(", ");
+        if saw_rejection {
+            return Outcome::Failed {
+                remaining_methods: last_remaining,
+                reason: Some(format!("gssapi rejected (tried {tried})")),
+            };
+        }
+        if errors.is_empty() {
+            failed(format!("gssapi auth error (tried {tried})"))
+        } else {
+            failed(format!(
+                "gssapi auth error (tried {tried}): {}",
+                errors.join("; ")
+            ))
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (handle, spec);
+        failed("gssapi auth is only implemented on Unix")
+    }
+}
+
+#[cfg(unix)]
+async fn gssapi_service_hosts(host: &str) -> Vec<String> {
+    let host = host.to_string();
+    let fallback = host.clone();
+    tokio::task::spawn_blocking(move || gssapi_service_hosts_blocking(&host))
+        .await
+        .unwrap_or_else(|_| vec![fallback])
+}
+
+#[cfg(unix)]
+fn gssapi_service_hosts_blocking(host: &str) -> Vec<String> {
+    gssapi_service_hosts_with_lookup(host, reverse_lookup_addr)
+}
+
+#[cfg(unix)]
+fn gssapi_service_hosts_with_lookup(
+    host: &str,
+    reverse_lookup: impl FnOnce(IpAddr) -> Option<String>,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    out.push(host.to_string());
+    if let Ok(ip) = host.parse::<IpAddr>()
+        && let Some(name) = reverse_lookup(ip).map(|name| name.trim_end_matches('.').to_string())
+        && !name.is_empty()
+    {
+        out.push(name);
+    }
+    out.dedup();
+    out
+}
+
+#[cfg(unix)]
+fn reverse_lookup_addr(ip: IpAddr) -> Option<String> {
+    match ip {
+        IpAddr::V4(ip) => reverse_lookup_v4(ip),
+        IpAddr::V6(ip) => reverse_lookup_v6(ip),
+    }
+}
+
+#[cfg(unix)]
+fn reverse_lookup_v4(ip: std::net::Ipv4Addr) -> Option<String> {
+    let mut addr: libc::sockaddr_in = unsafe { std::mem::zeroed() };
+    set_sockaddr_in_len(&mut addr);
+    addr.sin_family = libc::AF_INET as _;
+    addr.sin_addr = libc::in_addr {
+        s_addr: u32::from_ne_bytes(ip.octets()),
+    };
+    reverse_lookup_sockaddr(
+        &addr as *const libc::sockaddr_in as *const libc::sockaddr,
+        std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
+    )
+}
+
+#[cfg(unix)]
+fn reverse_lookup_v6(ip: std::net::Ipv6Addr) -> Option<String> {
+    let mut addr: libc::sockaddr_in6 = unsafe { std::mem::zeroed() };
+    set_sockaddr_in6_len(&mut addr);
+    addr.sin6_family = libc::AF_INET6 as _;
+    addr.sin6_addr = libc::in6_addr {
+        s6_addr: ip.octets(),
+    };
+    reverse_lookup_sockaddr(
+        &addr as *const libc::sockaddr_in6 as *const libc::sockaddr,
+        std::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t,
+    )
+}
+
+#[cfg(unix)]
+fn reverse_lookup_sockaddr(addr: *const libc::sockaddr, len: libc::socklen_t) -> Option<String> {
+    const NI_MAXHOST_FALLBACK: usize = 1025;
+    let mut host = [0 as libc::c_char; NI_MAXHOST_FALLBACK];
+    let rc = unsafe {
+        libc::getnameinfo(
+            addr,
+            len,
+            host.as_mut_ptr(),
+            host.len() as libc::socklen_t,
+            std::ptr::null_mut(),
+            0,
+            libc::NI_NAMEREQD,
+        )
+    };
+    if rc != 0 {
+        return None;
+    }
+    let name = unsafe { std::ffi::CStr::from_ptr(host.as_ptr()) }
+        .to_string_lossy()
+        .into_owned();
+    (!name.is_empty()).then_some(name)
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+#[cfg(unix)]
+fn set_sockaddr_in_len(addr: &mut libc::sockaddr_in) {
+    addr.sin_len = std::mem::size_of::<libc::sockaddr_in>() as u8;
+}
+
+#[cfg(not(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+)))]
+#[cfg(unix)]
+fn set_sockaddr_in_len(_addr: &mut libc::sockaddr_in) {}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+#[cfg(unix)]
+fn set_sockaddr_in6_len(addr: &mut libc::sockaddr_in6) {
+    addr.sin6_len = std::mem::size_of::<libc::sockaddr_in6>() as u8;
+}
+
+#[cfg(not(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+)))]
+#[cfg(unix)]
+fn set_sockaddr_in6_len(_addr: &mut libc::sockaddr_in6) {}
 
 /// Try identity files (unless mode is `Agent`) then the ssh-agent (unless mode is
 /// `PublicKey`), in that order.
@@ -518,13 +817,45 @@ mod tests {
             vec![MethodKind::KeyboardInteractive]
         );
         assert_eq!(
+            method_order(SshAuthMode::Gssapi),
+            vec![MethodKind::GssapiWithMic]
+        );
+        assert_eq!(
             method_order(SshAuthMode::Auto),
             vec![
+                MethodKind::GssapiWithMic,
                 MethodKind::PublicKey,
                 MethodKind::Password,
                 MethodKind::KeyboardInteractive
             ]
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn gssapi_service_hosts_keep_original_host_before_reverse_dns() {
+        let hosts = gssapi_service_hosts_with_lookup("10.37.108.28", |_| {
+            Some("n37-108-028.byted.org.".into())
+        });
+        assert_eq!(
+            hosts,
+            vec![
+                "10.37.108.28".to_string(),
+                "n37-108-028.byted.org".to_string()
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn gssapi_service_hosts_dedup_reverse_dns() {
+        let hosts = gssapi_service_hosts_with_lookup("example.com", |_| {
+            panic!("non-ip hosts should not trigger reverse lookup")
+        });
+        assert_eq!(hosts, vec!["example.com".to_string()]);
+
+        let hosts = gssapi_service_hosts_with_lookup("10.0.0.1", |_| Some("10.0.0.1".into()));
+        assert_eq!(hosts, vec!["10.0.0.1".to_string()]);
     }
 
     #[test]

--- a/src/daemon/ssh/mod.rs
+++ b/src/daemon/ssh/mod.rs
@@ -547,4 +547,40 @@ mod tests {
             ConnectionKey::from_spec(&with_jump)
         );
     }
+
+    #[test]
+    #[ignore = "requires a live SSH server and local GSSAPI credentials"]
+    fn live_gssapi_connects_and_opens_a_channel() {
+        let host = std::env::var("TTY7_LIVE_SSH_HOST").expect("TTY7_LIVE_SSH_HOST");
+        let user = std::env::var("TTY7_LIVE_SSH_USER").expect("TTY7_LIVE_SSH_USER");
+        let port = std::env::var("TTY7_LIVE_SSH_PORT")
+            .ok()
+            .and_then(|p| p.parse::<u16>().ok())
+            .unwrap_or(22);
+
+        let mut spec = base_spec();
+        spec.host = host;
+        spec.user = user;
+        spec.port = port;
+        spec.auth_mode = SshAuthMode::Gssapi;
+        spec.connect_timeout_s = Some(10);
+        // Prove GSSAPI itself without requiring a GUI host-key prompt or mutating
+        // the user's known_hosts from this live test.
+        spec.verify_host_keys = false;
+
+        let manager = SshManager::global();
+        let broker = PromptBroker::new(Box::new(|_| true));
+        manager.runtime.block_on(async {
+            let (conn, reused) = manager
+                .open_connection(&spec, &broker)
+                .await
+                .expect("native GSSAPI connection");
+            assert!(!reused);
+            conn.open_session_channel()
+                .await
+                .expect("open session channel");
+            conn.mark_dead();
+            manager.evict_connection(conn.key());
+        });
+    }
 }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -1929,10 +1929,11 @@ impl Tty7App {
 
         let auth_idx = match form.auth {
             AuthMode::Auto => 0,
-            AuthMode::Password => 1,
-            AuthMode::PublicKey => 2,
-            AuthMode::Agent => 3,
-            AuthMode::KeyboardInteractive => 4,
+            AuthMode::Gssapi => 1,
+            AuthMode::Password => 2,
+            AuthMode::PublicKey => 3,
+            AuthMode::Agent => 4,
+            AuthMode::KeyboardInteractive => 5,
         };
         let header = h_flex()
             .items_center()
@@ -2004,16 +2005,17 @@ impl Tty7App {
                 "Authentication method. Auto tries every applicable method.",
                 self.segmented(
                     "ssh-form-auth",
-                    &["Auto", "Password", "Key", "Agent", "2FA"],
+                    &["Auto", "GSSAPI", "Password", "Key", "Agent", "2FA"],
                     auth_idx,
                     cx,
                     |this, ix, _w, cx| {
                         if let Some(f) = this.ssh_form_mut() {
                             f.auth = match ix {
                                 0 => AuthMode::Auto,
-                                1 => AuthMode::Password,
-                                2 => AuthMode::PublicKey,
-                                3 => AuthMode::Agent,
+                                1 => AuthMode::Gssapi,
+                                2 => AuthMode::Password,
+                                3 => AuthMode::PublicKey,
+                                4 => AuthMode::Agent,
                                 _ => AuthMode::KeyboardInteractive,
                             };
                             cx.notify();

--- a/src/ui/ssh_connect.rs
+++ b/src/ui/ssh_connect.rs
@@ -308,6 +308,7 @@ fn build_spec_inner(
 fn map_auth_mode(auth: AuthMode) -> SshAuthMode {
     match auth {
         AuthMode::Auto => SshAuthMode::Auto,
+        AuthMode::Gssapi => SshAuthMode::Gssapi,
         AuthMode::Password => SshAuthMode::Password,
         AuthMode::PublicKey => SshAuthMode::PublicKey,
         AuthMode::Agent => SshAuthMode::Agent,


### PR DESCRIPTION
## Summary

Add native SSH `gssapi-with-mic` authentication support for the connection manager.

This lets tty7 connect to Kerberos/GSSAPI-only SSH servers through the native russh session engine instead of requiring users to fall back to a shell-launched system `ssh`.

## Changes

- Add a `GSSAPI` auth mode to saved SSH profiles and the settings UI
- Try `gssapi-with-mic` first when auth mode is `Auto`
- Add a Unix `libgssapi` authenticator that drives russh's `GssapiAuthenticator` trait
- Request the mutual-authentication and integrity flags expected by OpenSSH-style GSSAPI server configurations
- For IP-literal hosts, try the original `host@IP` service first and then a PTR hostname fallback for environments where host principals are registered under canonical names
- Temporarily patch russh to the upstream GSSAPI branch until the protocol support lands in a released russh version
- Add an ignored live integration test for real SSH servers with local GSSAPI redentials

## Notes

The russh protocol support is proposed upstream in: https://github.com/Eugeny/russh/pull/738

This tty7 PR keeps platform Kerberos/GSSAPI integration on the tty7 side while russh owns the SSH protocol exchange.

## Verification

```text
cargo fmt --check
cargo test auth_mode_kebab_case_serialization
cargo test method_order_restricts_by_mode
cargo test gssapi_service_hosts
cargo check
```

`cargo check` passed with the existing future-incompatibility warning for transitive dependencies.
