### PR TITLE
fix(settings): keep theme panel on-screen on narrow windows

### DIFF
--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -726,10 +726,15 @@ impl Tty7App {
         // bypasses the shared padded, single-scroll wrapper (which would otherwise
         // give the whole section one outer scrollbar and no definite height for the
         // columns to fill) and is dropped in flush instead.
+        // A `flex_1` pane still defaults to `min-width: auto`, so on a narrow
+        // window it refuses to shrink below its content's intrinsic width and
+        // shoves the fixed 300px theme panel (and its close `×`) off the right
+        // edge. `min_w_0` lets the pane yield so the panel stays fully on-screen.
         let content_pane = if section == SettingsSection::Ssh {
             v_flex()
                 .id("settings-content")
                 .flex_1()
+                .min_w_0()
                 .h_full()
                 .bg(background)
                 .child(content)
@@ -737,6 +742,7 @@ impl Tty7App {
             v_flex()
                 .id("settings-content")
                 .flex_1()
+                .min_w_0()
                 .h_full()
                 .bg(background)
                 .overflow_y_scroll()


### PR DESCRIPTION
## Problem

On Windows, the theme picker panel''s close **×** (top-right of the panel) gets clipped by the window''s right edge on narrower windows.

## Root cause

The settings root is a flex row: `sidebar (flex_shrink_0)` + `content_pane (flex_1)` + `theme_panel (300px, flex_shrink_0)`. A `flex_1` item still defaults to `min-width: auto`, so when the window isn''t wide enough the content pane refuses to shrink below its content''s intrinsic width and shoves the fixed-width theme panel — and its close `×` — partly off the right edge, where it''s clipped. It surfaces on Windows because that''s where the window happened to be narrow enough to trip the overflow; the mechanism is platform-independent.

## Fix

Add `min_w_0()` to both content-pane branches (the shared/Appearance pane and the SSH master-detail pane) so the pane yields and the 300px panel always stays fully on-screen. This matches the existing shrinkable `flex_1` + `min_w_0` pattern already used in the tab strip, panes, and search bar. No platform-specific branches; behaviour is unchanged on wide windows (macOS/Linux included) and only kicks in when the row would otherwise overflow.

## Testing

- `cargo check` passes.
- Verified the app builds and launches (`cargo dev`); the theme panel close `×` stays clear of the right edge, including when the window is narrowed.