### PR TITLE
feat(terminal): splitting an SSH pane opens another SSH pane

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1404,8 +1404,25 @@ impl Tty7App {
         // split was opened with an explicit pick (a WSL/fish tab splits into
         // more WSL/fish, not back to the default).
         let cwd = target.read(cx).cwd();
-        let shell = target.read(cx).shell_spec();
-        let new = new_terminal(self.font_size, cwd, None, shell, window, cx);
+        // Splitting a native-SSH pane opens another SSH pane on the same
+        // connection rather than dropping back to a local shell. Re-resolve the
+        // persisted (secret-free) spec from its saved profile so keychain
+        // secrets are re-applied, mirroring the reconnect path.
+        let ssh_spec = target.read(cx).ssh_spec();
+        let new = if let Some(spec) = ssh_spec {
+            let resolved = crate::ui::ssh_connect::resolve_persisted_ssh_spec(spec, cx);
+            match new_terminal_native(self.font_size, cwd, resolved, window, cx) {
+                Ok(view) => view,
+                Err(e) => {
+                    log::error!("native SSH split spawn failed: {e}");
+                    window.push_notification(format!("SSH connection failed: {e}"), cx);
+                    return;
+                }
+            }
+        } else {
+            let shell = target.read(cx).shell_spec();
+            new_terminal(self.font_size, cwd, None, shell, window, cx)
+        };
         if let Some(tab) = self.tabs.get_mut(self.active) {
             if tab.pane.split_leaf(&target, axis, new.clone()) {
                 self.maximized = None;


### PR DESCRIPTION
Splitting a pane inside a live native-SSH session used to spawn a **local** shell instead of staying on the remote host.

## Cause

`split()` only inherited the parent pane's `cwd` and `shell_spec`. For a native-SSH pane `shell_spec` is `None` (the SSH context lives in `ssh_spec`), so the new leaf always went through the local `new_terminal(...)` path and fell back to the default local shell — with the remote `cwd` string handed to a local shell that then falls back to the home dir when the path does not exist locally.

## Fix

In `split()`, check the target pane's `ssh_spec()`:

- **SSH pane** → re-resolve the persisted (secret-free) spec via `resolve_persisted_ssh_spec` so keychain secrets are re-applied from the saved profile (the same re-hydration the reconnect path uses), then spawn the new leaf with `new_terminal_native(...)` on the same connection. A spawn error logs and shows a notification instead of panicking.
- **Local pane** → unchanged: inherit `shell_spec` and spawn a local shell as before.

## Notes

- Reuses the existing reconnect re-hydration (`resolve_persisted_ssh_spec`), so auth mode / jump-host chain carry over correctly.
- The new pane is a fresh SSH session on the same profile, not a shared channel — the daemon rebuilds the profile's preconfigured forwards on connect, consistent with reconnect / restore.
- Local-pane split behavior is untouched.