### PR TITLE
fix(terminal): shift the grid up when wrapped input overflows the bottom

### DIFF
--- a/src/terminal/element.rs
+++ b/src/terminal/element.rs
@@ -1181,6 +1181,7 @@ impl TerminalElement {
                 return;
             }
             let (col, row, left) = geom.pos_to_cell(ev.position);
+            let raw_row = geom.pos_to_row_raw(ev.position);
             let mods = ev.modifiers;
             let button = ev.button;
             let clicks = ev.click_count;
@@ -1199,7 +1200,8 @@ impl TerminalElement {
                 // A left click/double-click/triple-click on the command-editor
                 // line drives its caret/selection instead of a (meaningless)
                 // terminal selection over it.
-                if button == MouseButton::Left && v.editor_click(col, row, clicks, mods.shift, cx) {
+                if button == MouseButton::Left && v.editor_click(col, raw_row, clicks, mods.shift, cx)
+                {
                     return;
                 }
                 if button == MouseButton::Left {
@@ -1211,6 +1213,7 @@ impl TerminalElement {
         let view = self.view.clone();
         window.on_mouse_event(move |ev: &MouseMoveEvent, _phase, window, cx| {
             let (col, row, left) = geom.pos_to_cell(ev.position);
+            let raw_row = geom.pos_to_row_raw(ev.position);
             let mods = ev.modifiers;
             let Some(button) = ev.pressed_button else {
                 // No button down: detect a link under the cursor so it underlines.
@@ -1252,7 +1255,7 @@ impl TerminalElement {
                 }
                 // A drag that began on the command-editor line extends its
                 // selection rather than the terminal's.
-                if button == MouseButton::Left && v.editor_drag(col, row, cx) {
+                if button == MouseButton::Left && v.editor_drag(col, raw_row, cx) {
                     return;
                 }
                 if button == MouseButton::Left {
@@ -1393,10 +1396,16 @@ impl Element for TerminalElement {
         // the next older row (the "sliver"). Mouse mapping stays consistent
         // automatically: `pos_to_cell` measures from this shifted origin.
         let frac = self.view.read(cx).scroll_frac.clamp(0., 1.);
+        // While the command editor's wrapped input would spill past the bottom
+        // row, the whole grid shifts up by that many lines — the top rows are
+        // clipped by the content mask and the overlay's wrapped tail lands in
+        // the vacated strip, emulating the scroll an echoing shell would do.
+        // Mouse mapping follows automatically via the shifted origin.
+        let input_shift = self.view.read(cx).input_scroll_rows();
         let geom = CellGeom {
             origin: point(
                 bounds.origin.x,
-                bounds.origin.y + prepaint.line_height * frac,
+                bounds.origin.y + prepaint.line_height * (frac - input_shift as f32),
             ),
             cell_width: prepaint.cell_width,
             line_height: prepaint.line_height,
@@ -1599,6 +1608,16 @@ impl CellGeom {
             ((ly / self.line_height.as_f32()).floor() as usize).min(self.rows.saturating_sub(1));
         let left = (colf - colf.floor()) <= 0.5;
         (col, row, left)
+    }
+
+    /// The row under `pos` without `pos_to_cell`'s bottom clamp. While the
+    /// input overlay shifts the grid up, its wrapped rows extend past
+    /// `rows - 1` into the vacated strip; the command editor needs those raw
+    /// rows so clicks and drags land on the right wrapped line. (Terminal
+    /// consumers — selection, mouse reports — keep the clamped row.)
+    fn pos_to_row_raw(&self, pos: Point<Pixels>) -> usize {
+        let ly = (pos.y - self.origin.y).as_f32().max(0.);
+        (ly / self.line_height.as_f32()).floor() as usize
     }
 }
 

--- a/src/terminal/element.rs
+++ b/src/terminal/element.rs
@@ -1200,7 +1200,8 @@ impl TerminalElement {
                 // A left click/double-click/triple-click on the command-editor
                 // line drives its caret/selection instead of a (meaningless)
                 // terminal selection over it.
-                if button == MouseButton::Left && v.editor_click(col, raw_row, clicks, mods.shift, cx)
+                if button == MouseButton::Left
+                    && v.editor_click(col, raw_row, clicks, mods.shift, cx)
                 {
                     return;
                 }

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -5102,7 +5102,9 @@ fn input_overlay_rows(
 /// the caret's row never scrolls off the top when the input is taller than
 /// the whole screen.
 fn input_overflow_shift(crow: usize, caret_vrow: usize, visual_rows: usize, rows: usize) -> usize {
-    (crow + visual_rows).saturating_sub(rows).min(crow + caret_vrow)
+    (crow + visual_rows)
+        .saturating_sub(rows)
+        .min(crow + caret_vrow)
 }
 
 fn wrapped_click_index(
@@ -5179,8 +5181,8 @@ mod tests {
         SelectEndCopy, WheelRoute, clipboard_paste_text, display_width, drag_scroll_step,
         encode_mouse, fallback_chain, fig_icon_emoji, fig_icon_glyph, focus_report_bytes,
         input_overflow_shift, input_overlay_rows, menu_layout, paste_bytes, select_end_copy,
-        shell_escape_path, smooth_scroll_step,
-        trim_trailing_spaces, wheel_route, wrapped_click_index,
+        shell_escape_path, smooth_scroll_step, trim_trailing_spaces, wheel_route,
+        wrapped_click_index,
     };
     use alacritty_terminal::term::TermMode;
     use gpui::{ClipboardEntry, ClipboardItem, ExternalPaths, Modifiers};

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -2606,6 +2606,44 @@ impl TerminalView {
         (row >= 0).then_some((row as usize, col))
     }
 
+    /// How many rows the whole surface — grid and input overlay together —
+    /// shifts up so a wrapped command at a bottom-of-screen prompt stays
+    /// visible, emulating the scroll the shell itself would perform if the
+    /// input were echoed. `element::paint` raises the grid origin by this many
+    /// lines (clipping the top rows) and `render_input_bar` anchors the same
+    /// rows higher, so the wrapped tail lands in the vacated strip. Zero
+    /// whenever nothing overflows, while scrolled into history (the overlay is
+    /// off-screen anyway and the view shouldn't fight the user's scroll), or
+    /// in reverse-search mode (a single fixed row).
+    pub(super) fn input_scroll_rows(&self) -> usize {
+        if !self.input_active() || self.reverse_search.is_some() {
+            return 0;
+        }
+        let Some((crow, ccol)) = self.cursor_cell() else {
+            return 0;
+        };
+        let (rows, cols, offset) = {
+            let term = self.terminal.term.lock();
+            (
+                term.screen_lines(),
+                term.columns(),
+                term.grid().display_offset(),
+            )
+        };
+        if offset != 0 {
+            return 0;
+        }
+        let chars: Vec<char> = self.cmd.text().chars().collect();
+        let (visual_rows, caret_vrow) = input_overlay_rows(
+            &chars,
+            self.cmd.cursor(),
+            &self.marked_text,
+            ccol,
+            cols.max(1),
+        );
+        input_overflow_shift(crow, caret_vrow, visual_rows, rows)
+    }
+
     /// Handle a left click while the command editor is live: if it lands on the
     /// input line, move the caret to the clicked position and report `true` (so
     /// the caller skips starting a terminal text-selection). The line is rendered
@@ -3846,7 +3884,13 @@ impl TerminalView {
     fn render_input_bar(&self, cx: &mut Context<Self>) -> impl IntoElement + use<> {
         let (crow, ccol) = self.cursor_cell().unwrap_or((0, 0));
         let cx_left = px(GRID_PAD_X) + self.cell_width * (ccol as f32);
-        let cy_top = px(GRID_PAD_Y) + self.line_height * (crow as f32);
+        // The overlay rides the same upward shift `element::paint` applies to
+        // the grid when the wrapped input would spill past the bottom, so its
+        // first line keeps hugging the (shifted) prompt row. May go negative
+        // when the input is taller than the screen — the parent's
+        // `overflow_hidden` clips the rows that scroll off the top.
+        let shift = self.input_scroll_rows();
+        let cy_top = px(GRID_PAD_Y) + self.line_height * (crow as f32 - shift as f32);
 
         // Reverse-search mode replaces the line with a `(reverse-i-search)` prompt
         // showing the query and the selected match; the ranked candidates float
@@ -4111,6 +4155,10 @@ impl TerminalView {
             return None;
         }
         let (srow, scol) = self.cursor_cell()?;
+        // Anchor rows are *visual*: when the overflowing input shifts the whole
+        // surface up (`input_scroll_rows`), the menu must follow the shifted
+        // input row, not the unshifted grid row.
+        let srow = srow.saturating_sub(self.input_scroll_rows());
 
         // Decide how many rows to show and whether to drop the menu below the input
         // row or flip it above — based on the room actually available in the grid,
@@ -5019,6 +5067,44 @@ fn input_char_positions(
     (positions, r, c)
 }
 
+/// Visual size of the rendered input overlay: how many wrapped rows it
+/// occupies and which of them carries the caret. Mirrors `render_input_bar`'s
+/// layout: the IME pre-edit is inserted at the caret, and a one-cell caret
+/// slot trails the buffer when the caret sits at the end (wrapping to a fresh
+/// row when the content exactly fills its last one). The ghost autosuggestion
+/// is deliberately excluded — the screen shouldn't scroll to reveal a
+/// suggestion the user hasn't accepted.
+fn input_overlay_rows(
+    chars: &[char],
+    cursor: usize,
+    marked: &str,
+    scol: usize,
+    cols: usize,
+) -> (usize, usize) {
+    let mut merged: Vec<char> = Vec::with_capacity(chars.len() + marked.len());
+    let cursor = cursor.min(chars.len());
+    merged.extend_from_slice(&chars[..cursor]);
+    merged.extend(marked.chars());
+    merged.extend_from_slice(&chars[cursor..]);
+    let (positions, r, c) = input_char_positions(&merged, scol, cols);
+    let end_row = if cursor >= chars.len() && marked.is_empty() && c >= cols {
+        r + 1
+    } else {
+        r
+    };
+    let caret_vrow = positions.get(cursor).map_or(end_row, |&(pr, _, _)| pr);
+    (end_row + 1, caret_vrow)
+}
+
+/// Rows the grid (and the input overlay riding on it) must shift up so the
+/// wrapped command editor stays visible when the prompt sits near the bottom:
+/// enough that the overlay's last row lands on the last grid row — capped so
+/// the caret's row never scrolls off the top when the input is taller than
+/// the whole screen.
+fn input_overflow_shift(crow: usize, caret_vrow: usize, visual_rows: usize, rows: usize) -> usize {
+    (crow + visual_rows).saturating_sub(rows).min(crow + caret_vrow)
+}
+
 fn wrapped_click_index(
     chars: &[char],
     scol: usize,
@@ -5092,7 +5178,8 @@ mod tests {
     use super::{
         SelectEndCopy, WheelRoute, clipboard_paste_text, display_width, drag_scroll_step,
         encode_mouse, fallback_chain, fig_icon_emoji, fig_icon_glyph, focus_report_bytes,
-        menu_layout, paste_bytes, select_end_copy, shell_escape_path, smooth_scroll_step,
+        input_overflow_shift, input_overlay_rows, menu_layout, paste_bytes, select_end_copy,
+        shell_escape_path, smooth_scroll_step,
         trim_trailing_spaces, wheel_route, wrapped_click_index,
     };
     use alacritty_terminal::term::TermMode;
@@ -5618,6 +5705,42 @@ mod tests {
         // Indices: 0='a', 1='\n', 2='\n', 3='b'. Row 1 holds the second newline.
         assert_eq!(click("a\n\nb", 4, 80, 3, 1), Some(2));
         assert_eq!(click("a\n\nb", 4, 80, 0, 2), Some(3)); // 'b' on row 2
+    }
+
+    #[test]
+    fn input_overlay_rows_counts_wraps_slot_marked_and_newlines() {
+        let rows = |text: &str, cursor: usize, marked: &str, scol: usize, cols: usize| {
+            let chars: Vec<char> = text.chars().collect();
+            input_overlay_rows(&chars, cursor, marked, scol, cols)
+        };
+        // Empty input: just the caret slot on the prompt row.
+        assert_eq!(rows("", 0, "", 3, 8), (1, 0));
+        // 10 chars after a 6-col prompt in an 8-col grid fill rows 0..=1
+        // exactly, so the end-of-line caret slot wraps to row 2.
+        assert_eq!(rows("aaaaaaaaaa", 10, "", 6, 8), (3, 2));
+        // Same content with the caret in the middle: no trailing slot beyond
+        // the content, and the caret sits on the char's own row.
+        assert_eq!(rows("aaaaaaaaaa", 3, "", 6, 8), (2, 1));
+        // A hard newline is its own break; caret at the end lands on row 1.
+        assert_eq!(rows("ab\ncd", 5, "", 0, 8), (2, 1));
+        // IME pre-edit is inserted at the caret and counts its display width:
+        // the two-cell 漢 doesn't fit in the last column of row 0, so it wraps
+        // whole — pulling the caret's row down with it.
+        assert_eq!(rows("ab", 1, "漢", 6, 8), (2, 1));
+    }
+
+    #[test]
+    fn input_overflow_shift_keeps_the_tail_and_caret_visible() {
+        // Fits: a 3-row input anchored at row 5 of a 22-row grid.
+        assert_eq!(input_overflow_shift(5, 2, 3, 22), 0);
+        // Spills one row past the bottom → shift up by one.
+        assert_eq!(input_overflow_shift(20, 2, 3, 22), 1);
+        // Taller than the whole screen, caret at the end: shift so the last
+        // row lands on the last grid row (caret stays visible with it).
+        assert_eq!(input_overflow_shift(21, 29, 30, 22), 29);
+        // Same giant input with the caret back on its first row: the cap
+        // stops the caret row from scrolling off the top.
+        assert_eq!(input_overflow_shift(21, 0, 30, 22), 21);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

While the local command editor is active, keystrokes never reach the grid — they accumulate in the in-memory buffer and render as an absolutely-positioned overlay anchored at the prompt row. Since nothing is written to the emulator, its scroll-on-wrap never fires, and the overlay itself had no logic to stay on-screen: a multi-line command typed at a bottom-of-screen prompt grew downward past the window edge, and its wrapped tail (including the caret) was clipped by the surface's `overflow_hidden`.

## Fix

Emulate the scroll an echoing shell would perform, as one uniform visual shift:

- `input_scroll_rows()` computes how many rows the wrapped overlay spills past the last grid row, capped so the caret's row never scrolls off the top when the input is taller than the whole screen. It returns 0 while scrolled into history (don't fight the user's scrollback) and in reverse-search mode (single fixed row).
- `element::paint` raises the whole grid origin by that many lines (same mechanism as the existing sub-line `scroll_frac` shift): the top rows clip under the content mask, and the vacated strip at the bottom is exactly where the overlay's wrapped tail lands. Mouse mapping follows automatically via the shifted origin.
- `render_input_bar` anchors the overlay at the shifted prompt row, so the typed text keeps hugging the (now higher) prompt; the completion menu follows the same shifted anchor.
- Editor clicks/drags map through a new unclamped row lookup (`pos_to_row_raw`) so wrapped rows past the old bottom row remain clickable; terminal consumers (selection, mouse reports) keep the clamped row.

On Enter the command is echoed and the grid scrolls for real by the same number of rows, so the handoff is visually seamless.

## Layout math

`input_overlay_rows()` mirrors `render_input_bar`'s layout exactly (IME pre-edit inserted at the caret, the trailing caret slot wrapping to a fresh row when content exactly fills its last row, wide-glyph-aware via the shared `input_char_positions`). The ghost autosuggestion is deliberately excluded — the screen shouldn't scroll to reveal a suggestion the user hasn't accepted.

## Testing

- Unit tests for `input_overlay_rows` (wraps, trailing caret slot, hard newlines, wide-char IME pre-edit) and `input_overflow_shift` (fits / spills one row / taller-than-screen with caret at both ends).
- Full suite: 683 passed.