### PR TITLE
feat(agents): per-agent hook integrations with install state in Settings

### DIFF
--- a/src/core/agent_hooks.rs
+++ b/src/core/agent_hooks.rs
@@ -226,7 +226,12 @@ impl HookAgent {
         match self {
             HookAgent::Claude => claude_settings_path(),
             HookAgent::Codex => Some(home_dir()?.join(".codex").join("hooks.json")),
-            HookAgent::Copilot => Some(home_dir()?.join(".copilot").join("hooks").join(OWNED_FILE_STEM_JSON)),
+            HookAgent::Copilot => Some(
+                home_dir()?
+                    .join(".copilot")
+                    .join("hooks")
+                    .join(OWNED_FILE_STEM_JSON),
+            ),
             HookAgent::OpenCode => Some(
                 xdg_config_dir()?
                     .join("opencode")
@@ -883,7 +888,11 @@ mod tests {
             Some("permission-request")
         );
         assert_eq!(
-            effective_event("copilot", "notification", r#"{"type":"elicitation_dialog"}"#),
+            effective_event(
+                "copilot",
+                "notification",
+                r#"{"type":"elicitation_dialog"}"#
+            ),
             Some("permission-request")
         );
         assert_eq!(
@@ -943,7 +952,12 @@ mod tests {
     /// generated file carries its ownership marker and this binary's path.
     #[test]
     fn owned_file_contents_carry_marker_and_exe() {
-        let exe = std::env::current_exe().unwrap().display().to_string();
+        // The exe path is embedded inside JSON / JS string literals, so look
+        // for its string-escaped form — on Windows the raw path's backslashes
+        // appear as `\\` in the generated content.
+        let exe_raw = std::env::current_exe().unwrap().display().to_string();
+        let exe_json = serde_json::to_string(&exe_raw).unwrap();
+        let exe = exe_json.trim_matches('"').to_string();
 
         let copilot = copilot_hooks_json().expect("copilot content builds");
         let parsed: serde_json::Value = serde_json::from_str(&copilot).expect("valid JSON");

--- a/src/core/agent_hooks.rs
+++ b/src/core/agent_hooks.rs
@@ -1,21 +1,22 @@
 //! Agent-side hook integration: the emitter behind `tty7 agent-hook …` and the
-//! installer that wires it into Claude Code's `settings.json`.
+//! per-agent installers that wire it into each CLI agent's own hook surface.
 //!
 //! The rich agent-status channel ([`crate::core::cli_agent`]) needs the agent
-//! itself to say what it's doing. For Claude Code that is its hooks system:
-//! each lifecycle hook runs `tty7 agent-hook claude <event>`, which reads the
-//! hook's JSON payload from stdin and writes one sentinel OSC 777 sequence to
-//! the controlling terminal (`/dev/tty`) — where tty7's daemon-side sniffer
-//! picks it up and folds it into the pane's session state. The same idea can
-//! ship as a Claude *plugin*; a hook + our own binary needs no plugin
-//! marketplace and no jq.
+//! itself to say what it's doing. Each supported agent exposes that
+//! differently — Claude Code and Codex take a declarative hooks map, Copilot
+//! auto-loads JSON hook files from a directory, OpenCode loads JS plugins, Pi
+//! loads TS extensions — but every integration bottoms out in the same tiny
+//! emitter: `tty7 agent-hook <agent> <event>` reads the hook's JSON payload
+//! from stdin and writes one sentinel OSC 777 sequence to the controlling
+//! terminal, where tty7's daemon-side sniffer picks it up and folds it into
+//! the pane's session state.
 //!
 //! Emission is gated on the `TTY7` environment variable (injected into every
-//! shell tty7 spawns), so hooks installed globally stay silent when Claude
+//! shell tty7 spawns), so hooks installed globally stay silent when an agent
 //! runs in another terminal.
 
 use std::io::Read as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::core::cli_agent::AGENT_EVENT_SENTINEL;
 
@@ -30,19 +31,38 @@ const MAX_STDIN: u64 = 64 * 1024;
 /// Entry point for the `tty7 agent-hook <agent> <event>` subcommand: read the
 /// hook's JSON payload from stdin, build the sentinel event, and write it to
 /// the controlling terminal. Always exits quietly — a hook that fails must
-/// never break the agent's own flow (Claude Code surfaces nonzero exits).
+/// never break the agent's own flow (agents surface nonzero exits).
 pub fn run_agent_hook(agent: &str, event: &str) {
     // Not inside tty7 (or a remote shell): stay silent, so globally-installed
     // hooks don't leak escape sequences into other terminals.
     if std::env::var_os(TTY7_ENV_MARKER).is_none() {
         return;
     }
-    // Hook payload: Claude Code writes {"session_id": …, "message": …, …} and
-    // closes stdin. Absent/malformed input still emits the bare event — the
-    // state machine works without ids or messages.
+    // Hook payload: the agent writes JSON ({"session_id": …, "message": …, …})
+    // and closes stdin. Absent/malformed input still emits the bare event —
+    // the state machine works without ids or messages.
     let mut input = String::new();
     let _ = std::io::stdin().take(MAX_STDIN).read_to_string(&mut input);
+    let Some(event) = effective_event(agent, event, &input) else {
+        return;
+    };
     write_to_controlling_tty(&build_hook_sequence(agent, event, &input));
+}
+
+/// The sentinel event one hook invocation maps onto, or `None` to stay silent.
+/// Most hooks pass their event through; the exception is Copilot's single
+/// `notification` hook, which fires for *every* notification type — only
+/// permission/elicitation prompts are the amber "needs you" moment, so those
+/// are escalated to `permission-request` and everything else is dropped
+/// rather than parroted as a block.
+fn effective_event<'a>(agent: &str, event: &'a str, stdin_json: &str) -> Option<&'a str> {
+    if agent == "copilot" && event == "notification" {
+        if stdin_json.contains("permission_prompt") || stdin_json.contains("elicitation_dialog") {
+            return Some("permission-request");
+        }
+        return None;
+    }
+    Some(event)
 }
 
 /// Build the sentinel OSC sequence for one hook invocation — the pure core of
@@ -137,23 +157,223 @@ fn write_to_controlling_tty(_bytes: &[u8]) -> bool {
 }
 
 // ---------------------------------------------------------------------------
-// Claude Code installer.
+// Integrations: one installer per agent that exposes a hook surface.
 // ---------------------------------------------------------------------------
 
-/// The Claude Code hook events we subscribe to, and the sentinel event each
-/// maps onto. `Notification` covers both "needs permission" and "waiting for
-/// input" — exactly the Waiting state.
-const CLAUDE_HOOK_EVENTS: [(&str, &str); 5] = [
-    ("SessionStart", "session-start"),
-    ("UserPromptSubmit", "prompt-submit"),
-    ("Notification", "notification"),
-    ("Stop", "stop"),
-    ("SessionEnd", "session-end"),
-];
+/// The agents tty7 can wire its rich-status channel into. Each carries a
+/// different install mechanism (see [`install_hooks`]); the emitter side is
+/// identical for all of them. Gemini/Aider/… are recognized in the sidebar
+/// but have no hook surface to install into, so they are not listed here.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum HookAgent {
+    /// Hooks map merged into `~/.claude/settings.json` (or
+    /// `$CLAUDE_CONFIG_DIR/settings.json`).
+    Claude,
+    /// Hooks map merged into `~/.codex/hooks.json`, plus the one-time
+    /// `codex features enable hooks` feature flag.
+    Codex,
+    /// A tty7-owned hook file in `~/.copilot/hooks/` (Copilot auto-loads
+    /// every JSON file there).
+    Copilot,
+    /// A tty7-owned JS plugin in `~/.config/opencode/plugins/`.
+    OpenCode,
+    /// A tty7-owned TS extension in `~/.pi/agent/extensions/tty7/`.
+    Pi,
+}
 
-/// Substring that identifies a hook entry as ours, for idempotent
-/// install/upgrade (an entry containing it is replaced, never duplicated).
-const HOOK_MARKER: &str = "agent-hook claude";
+impl HookAgent {
+    pub const ALL: [HookAgent; 5] = [
+        HookAgent::Claude,
+        HookAgent::Codex,
+        HookAgent::Copilot,
+        HookAgent::OpenCode,
+        HookAgent::Pi,
+    ];
+
+    /// The `agent` slug in hook commands and sentinel events — matches
+    /// [`crate::core::cli_agent::CLIAgent::slug`] so events brand the pane.
+    pub fn slug(self) -> &'static str {
+        match self {
+            HookAgent::Claude => "claude",
+            HookAgent::Codex => "codex",
+            HookAgent::Copilot => "copilot",
+            HookAgent::OpenCode => "opencode",
+            HookAgent::Pi => "pi",
+        }
+    }
+
+    /// User-facing name for the settings row.
+    pub fn display_name(self) -> &'static str {
+        match self {
+            HookAgent::Claude => "Claude Code",
+            HookAgent::Codex => "Codex",
+            HookAgent::Copilot => "Copilot CLI",
+            HookAgent::OpenCode => "OpenCode",
+            HookAgent::Pi => "Pi",
+        }
+    }
+
+    /// The file the integration installs into, `~`-abbreviated for display.
+    pub fn target_display(self) -> String {
+        match self.target_path() {
+            Some(p) => abbreviate_home(&p),
+            None => "~ (home directory unresolved)".to_string(),
+        }
+    }
+
+    /// The file this agent's integration lives in.
+    fn target_path(self) -> Option<PathBuf> {
+        match self {
+            HookAgent::Claude => claude_settings_path(),
+            HookAgent::Codex => Some(home_dir()?.join(".codex").join("hooks.json")),
+            HookAgent::Copilot => Some(home_dir()?.join(".copilot").join("hooks").join(OWNED_FILE_STEM_JSON)),
+            HookAgent::OpenCode => Some(
+                xdg_config_dir()?
+                    .join("opencode")
+                    .join("plugins")
+                    .join(OWNED_FILE_STEM_JS),
+            ),
+            HookAgent::Pi => Some(
+                home_dir()?
+                    .join(".pi")
+                    .join("agent")
+                    .join("extensions")
+                    .join("tty7")
+                    .join("index.ts"),
+            ),
+        }
+    }
+
+    /// Substring that identifies a hook entry / owned file as tty7's, for
+    /// idempotent install/upgrade and ownership-guarded uninstall. Every
+    /// generated command and file embeds `agent-hook <slug>` verbatim.
+    fn marker(self) -> String {
+        format!("agent-hook {}", self.slug())
+    }
+}
+
+/// Install state of one agent's tty7 hooks, as shown in Settings → Agents.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum HooksState {
+    /// No tty7 hook entry / file anywhere.
+    NotInstalled,
+    /// The integration is present and points at this binary.
+    Installed,
+    /// tty7 wrote it, but it points at a different tty7 binary (the app
+    /// moved/updated, or it was installed from another build) or is missing a
+    /// piece — the hooks fire into the wrong or a vanished executable. A
+    /// reinstall rewrites it in place.
+    Outdated,
+}
+
+/// Read one agent's install state from disk. An unreadable or malformed
+/// target reports `NotInstalled` — the same "nothing usable there" answer the
+/// installer would start from.
+pub fn hooks_state(agent: HookAgent) -> HooksState {
+    let Some(path) = agent.target_path() else {
+        return HooksState::NotInstalled;
+    };
+    match agent {
+        HookAgent::Claude => hook_map_state(&path, agent, CLAUDE_HOOK_EVENTS),
+        HookAgent::Codex => hook_map_state(&path, agent, CODEX_HOOK_EVENTS),
+        HookAgent::Copilot | HookAgent::OpenCode | HookAgent::Pi => {
+            let Some(expected) = owned_file_content(agent) else {
+                return HooksState::NotInstalled;
+            };
+            owned_file_state(&path, &expected, &agent.marker())
+        }
+    }
+}
+
+/// Install (or rewrite in place) one agent's tty7 hooks. Idempotent: existing
+/// tty7 entries/files are replaced, never duplicated, and anything
+/// user-authored is left untouched. Returns a short human-readable summary.
+pub fn install_hooks(agent: HookAgent) -> anyhow::Result<String> {
+    let path = agent
+        .target_path()
+        .ok_or_else(|| anyhow::anyhow!("cannot resolve home directory"))?;
+    match agent {
+        HookAgent::Claude => {
+            hook_map_install(&path, agent, CLAUDE_HOOK_EVENTS)?;
+            Ok(format!(
+                "Claude Code hooks installed in {} — restart running claude sessions to pick them up",
+                path.display()
+            ))
+        }
+        HookAgent::Codex => {
+            hook_map_install(&path, agent, CODEX_HOOK_EVENTS)?;
+            // Codex only reads hooks.json once the hooks feature flag is on.
+            // Best-effort: the file install above is complete and correct
+            // either way, so a missing codex binary downgrades to advice
+            // instead of failing the install.
+            let summary = format!("Codex hooks installed in {}", path.display());
+            Ok(match enable_codex_hooks_feature() {
+                Ok(()) => summary,
+                Err(e) => format!(
+                    "{summary} — couldn't run `codex features enable hooks` ({e}); run it once manually"
+                ),
+            })
+        }
+        HookAgent::Copilot | HookAgent::OpenCode | HookAgent::Pi => {
+            let content = owned_file_content(agent)
+                .ok_or_else(|| anyhow::anyhow!("cannot resolve tty7's own executable path"))?;
+            owned_file_install(&path, &content, &agent.marker())?;
+            Ok(format!(
+                "{} integration installed at {}",
+                agent.display_name(),
+                path.display()
+            ))
+        }
+    }
+}
+
+/// Remove one agent's tty7 hooks, leaving user-authored hooks and settings
+/// untouched. Ownership-guarded: only entries/files carrying the tty7 marker
+/// are ever removed.
+pub fn uninstall_hooks(agent: HookAgent) -> anyhow::Result<String> {
+    let path = agent
+        .target_path()
+        .ok_or_else(|| anyhow::anyhow!("cannot resolve home directory"))?;
+    match agent {
+        HookAgent::Claude | HookAgent::Codex => hook_map_uninstall(&path, agent),
+        HookAgent::Copilot | HookAgent::OpenCode | HookAgent::Pi => {
+            owned_file_uninstall(&path, &agent.marker())
+        }
+    }
+}
+
+/// Startup keeper: rewrite any integration that is installed but stale (see
+/// [`HooksState::Outdated`]) so hooks keep pointing at a real tty7 after the
+/// app moves or updates. Release builds only — a debug build auto-claiming
+/// the hooks would steal them from the installed app on every dev launch
+/// (installing *from* a dev build stays possible, just explicit). Returns how
+/// many integrations were refreshed.
+pub fn refresh_hooks_at_launch() -> usize {
+    if cfg!(debug_assertions) {
+        return 0;
+    }
+    let mut refreshed = 0;
+    for agent in HookAgent::ALL {
+        if hooks_state(agent) != HooksState::Outdated {
+            continue;
+        }
+        match install_hooks(agent) {
+            Ok(summary) => {
+                refreshed += 1;
+                log::info!("refreshed stale agent hooks: {summary}");
+            }
+            Err(e) => log::warn!(
+                "could not refresh stale {} hooks: {e}",
+                agent.display_name()
+            ),
+        }
+    }
+    refreshed
+}
+
+// ---------------------------------------------------------------------------
+// Shared: paths and the hook command line.
+// ---------------------------------------------------------------------------
 
 /// Claude Code's user settings file: `$CLAUDE_CONFIG_DIR/settings.json`,
 /// defaulting to `~/.claude/settings.json`.
@@ -175,24 +395,105 @@ fn home_dir() -> Option<PathBuf> {
     }
 }
 
-/// The hook command line written into Claude's settings — this binary, by
-/// absolute path, so it works regardless of PATH. Quoted because macOS app
-/// paths ("/Applications/…") can carry spaces.
-fn hook_command(event: &str) -> Option<String> {
-    let exe = std::env::current_exe().ok()?;
-    Some(format!("\"{}\" agent-hook claude {event}", exe.display()))
+/// `$XDG_CONFIG_HOME`, defaulting to `~/.config` (OpenCode's config root).
+fn xdg_config_dir() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("XDG_CONFIG_HOME").filter(|d| !d.is_empty()) {
+        return Some(PathBuf::from(dir));
+    }
+    Some(home_dir()?.join(".config"))
 }
 
-/// Install (or upgrade) the tty7 hooks in Claude Code's `settings.json`,
-/// preserving everything else in the file. Idempotent: entries carrying
-/// [`HOOK_MARKER`] are rewritten in place (e.g. after the binary moved);
-/// user-defined hooks on the same events are left untouched. Returns a short
-/// human-readable summary for the caller to toast.
-pub fn install_claude_hooks() -> anyhow::Result<String> {
-    let path =
-        claude_settings_path().ok_or_else(|| anyhow::anyhow!("cannot resolve home directory"))?;
+/// Abbreviate the user's home-directory prefix to `~` for display.
+fn abbreviate_home(path: &Path) -> String {
+    if let Some(home) = home_dir()
+        && let Ok(rest) = path.strip_prefix(&home)
+    {
+        return format!("~/{}", rest.display());
+    }
+    path.display().to_string()
+}
 
-    let mut root: serde_json::Value = match std::fs::read_to_string(&path) {
+/// The hook command line written into an agent's config — this binary, by
+/// absolute path, so it works regardless of PATH. Quoted because macOS app
+/// paths ("/Applications/…") can carry spaces. `event` is one of tty7's
+/// kebab-case sentinel events, passed straight through by the emitter.
+fn hook_command(agent: HookAgent, event: &str) -> Option<String> {
+    let exe = std::env::current_exe().ok()?;
+    Some(format!(
+        "\"{}\" agent-hook {} {event}",
+        exe.display(),
+        agent.slug()
+    ))
+}
+
+/// Owned-file names, shared by path resolution and tests.
+const OWNED_FILE_STEM_JSON: &str = "tty7.json";
+const OWNED_FILE_STEM_JS: &str = "tty7.js";
+
+// ---------------------------------------------------------------------------
+// Hooks-map installer (Claude Code, Codex): a JSON object with a top-level
+// `"hooks"` key mapping event names to entry lists; tty7 owns exactly one
+// marker-carrying entry per event and never touches the rest of the file.
+// ---------------------------------------------------------------------------
+
+/// Claude Code's hook events and the sentinel event each maps onto.
+/// `Notification` covers both "needs permission" and "waiting for input" —
+/// exactly the Waiting state.
+const CLAUDE_HOOK_EVENTS: &[(&str, &str)] = &[
+    ("SessionStart", "session-start"),
+    ("UserPromptSubmit", "prompt-submit"),
+    ("Notification", "notification"),
+    ("Stop", "stop"),
+    ("SessionEnd", "session-end"),
+];
+
+/// Codex's hook events (`~/.codex/hooks.json`, Claude-shaped). Codex is
+/// turn-level only: no Notification hook, and no SessionEnd — the pane's
+/// foreground detection clears the badge when Codex exits.
+const CODEX_HOOK_EVENTS: &[(&str, &str)] = &[
+    ("SessionStart", "session-start"),
+    ("UserPromptSubmit", "prompt-submit"),
+    ("Stop", "stop"),
+];
+
+fn hook_map_state(path: &Path, agent: HookAgent, events: &[(&str, &str)]) -> HooksState {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return HooksState::NotInstalled;
+    };
+    let Ok(root) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return HooksState::NotInstalled;
+    };
+    let marker = agent.marker();
+    let (mut any, mut complete) = (false, true);
+    for (hook_event, tty7_event) in events {
+        let ours = root
+            .get("hooks")
+            .and_then(|h| h.get(hook_event))
+            .and_then(|e| e.as_array())
+            .and_then(|list| list.iter().find_map(|m| marker_command(m, &marker)));
+        match ours {
+            Some(cmd) => {
+                any = true;
+                if Some(cmd) != hook_command(agent, tty7_event).as_deref() {
+                    complete = false;
+                }
+            }
+            None => complete = false,
+        }
+    }
+    match (any, complete) {
+        (false, _) => HooksState::NotInstalled,
+        (true, true) => HooksState::Installed,
+        (true, false) => HooksState::Outdated,
+    }
+}
+
+/// Merge tty7's hook entries into the file at `path`, preserving everything
+/// else. Idempotent: entries carrying the agent's marker are rewritten in
+/// place (e.g. after the binary moved); user-defined hooks on the same events
+/// are left untouched.
+fn hook_map_install(path: &Path, agent: HookAgent, events: &[(&str, &str)]) -> anyhow::Result<()> {
+    let mut root: serde_json::Value = match std::fs::read_to_string(path) {
         Ok(text) => serde_json::from_str(&text).map_err(|e| {
             anyhow::anyhow!(
                 "{} is not valid JSON ({e}); not touching it",
@@ -221,19 +522,20 @@ pub fn install_claude_hooks() -> anyhow::Result<String> {
         ));
     }
 
-    for (claude_event, tty7_event) in CLAUDE_HOOK_EVENTS {
-        let command = hook_command(tty7_event)
+    let marker = agent.marker();
+    for (hook_event, tty7_event) in events {
+        let command = hook_command(agent, tty7_event)
             .ok_or_else(|| anyhow::anyhow!("cannot resolve tty7's own executable path"))?;
         let entries = hooks
             .as_object_mut()
             .unwrap()
-            .entry(claude_event)
+            .entry(*hook_event)
             .or_insert_with(|| serde_json::json!([]));
         let Some(list) = entries.as_array_mut() else {
             continue; // malformed user config on this event; leave it alone
         };
         // Drop any previous tty7 entry (stale exe path), then append ours.
-        list.retain(|matcher| !matcher_contains_marker(matcher));
+        list.retain(|matcher| marker_command(matcher, &marker).is_none());
         list.push(serde_json::json!({
             "hooks": [{ "type": "command", "command": command }]
         }));
@@ -242,46 +544,273 @@ pub fn install_claude_hooks() -> anyhow::Result<String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    crate::core::config::write_atomic(&path, serde_json::to_string_pretty(&root)?.as_bytes())?;
+    crate::core::config::write_atomic(path, serde_json::to_string_pretty(&root)?.as_bytes())?;
+    Ok(())
+}
+
+/// Remove every tty7 hook entry from the file, leaving user-defined hooks and
+/// all other settings untouched. Sweeps *all* hook events (not just the ones
+/// we currently subscribe to) so entries left by an older tty7 with a
+/// different event set are cleaned up too.
+fn hook_map_uninstall(path: &Path, agent: HookAgent) -> anyhow::Result<String> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok("Nothing installed; nothing to remove".to_string());
+        }
+        Err(e) => return Err(anyhow::anyhow!("read {}: {e}", path.display())),
+    };
+    let mut root: serde_json::Value = serde_json::from_str(&text).map_err(|e| {
+        anyhow::anyhow!(
+            "{} is not valid JSON ({e}); not touching it",
+            path.display()
+        )
+    })?;
+
+    let marker = agent.marker();
+    let mut removed = 0;
+    if let Some(hooks) = root.get_mut("hooks").and_then(|h| h.as_object_mut()) {
+        for entries in hooks.values_mut() {
+            if let Some(list) = entries.as_array_mut() {
+                let before = list.len();
+                list.retain(|matcher| marker_command(matcher, &marker).is_none());
+                removed += before - list.len();
+            }
+        }
+        // Drop event lists we emptied; a user's own hooks keep their event key.
+        hooks.retain(|_, entries| entries.as_array().is_none_or(|list| !list.is_empty()));
+    }
+    if removed == 0 {
+        return Ok("No tty7 hooks found; nothing to remove".to_string());
+    }
+    crate::core::config::write_atomic(path, serde_json::to_string_pretty(&root)?.as_bytes())?;
     Ok(format!(
-        "Claude Code hooks installed in {} — restart running claude sessions to pick them up",
+        "{} hooks removed from {}",
+        agent.display_name(),
         path.display()
     ))
 }
 
-/// Whether the tty7 hooks are already present in Claude Code's settings (all
-/// five events carry a marker entry).
-pub fn claude_hooks_installed() -> bool {
-    let Some(path) = claude_settings_path() else {
-        return false;
-    };
-    let Ok(text) = std::fs::read_to_string(&path) else {
-        return false;
-    };
-    let Ok(root) = serde_json::from_str::<serde_json::Value>(&text) else {
-        return false;
-    };
-    CLAUDE_HOOK_EVENTS.iter().all(|(claude_event, _)| {
-        root.get("hooks")
-            .and_then(|h| h.get(claude_event))
-            .and_then(|e| e.as_array())
-            .is_some_and(|list| list.iter().any(matcher_contains_marker))
-    })
-}
-
-/// Whether one matcher entry (`{"matcher": …, "hooks": [{"command": …}]}`)
-/// carries a tty7 hook command.
-fn matcher_contains_marker(matcher: &serde_json::Value) -> bool {
+/// The tty7 hook command inside one matcher entry
+/// (`{"matcher": …, "hooks": [{"command": …}]}`), if it carries one.
+fn marker_command<'a>(matcher: &'a serde_json::Value, marker: &str) -> Option<&'a str> {
     matcher
         .get("hooks")
-        .and_then(|h| h.as_array())
-        .is_some_and(|hooks| {
-            hooks.iter().any(|h| {
-                h.get("command")
-                    .and_then(|c| c.as_str())
-                    .is_some_and(|c| c.contains(HOOK_MARKER))
-            })
+        .and_then(|h| h.as_array())?
+        .iter()
+        .find_map(|h| {
+            h.get("command")
+                .and_then(|c| c.as_str())
+                .filter(|c| c.contains(marker))
         })
+}
+
+/// Turn Codex's hooks feature flag on (`[features] hooks = true`), which gates
+/// whether `~/.codex/hooks.json` is read at all. Runs the codex CLI itself so
+/// the flag lands wherever the installed version keeps it; probes the common
+/// install locations first because the GUI's PATH is often minimal. Uninstall
+/// deliberately leaves the flag on — other tools' hooks may rely on it.
+fn enable_codex_hooks_feature() -> Result<(), String> {
+    let candidates = [
+        PathBuf::from("/opt/homebrew/bin/codex"),
+        PathBuf::from("/usr/local/bin/codex"),
+    ]
+    .into_iter()
+    .chain(home_dir().map(|h| h.join(".local/bin/codex")))
+    .find(|p| p.exists());
+    let program = candidates.unwrap_or_else(|| PathBuf::from("codex"));
+    match std::process::Command::new(&program)
+        .args(["features", "enable", "hooks"])
+        .output()
+    {
+        Ok(out) if out.status.success() => Ok(()),
+        Ok(out) => Err(format!(
+            "codex exited with {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        )),
+        Err(e) => Err(format!("{}: {e}", program.display())),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Owned-file installer (Copilot, OpenCode, Pi): tty7 writes a whole file it
+// owns outright, identified by the marker. Install refuses to clobber a file
+// tty7 didn't write; uninstall only ever deletes a marker-carrying file.
+// ---------------------------------------------------------------------------
+
+/// The exact file content for an owned-file agent, deterministic so state
+/// detection can byte-compare (drift ⇒ `Outdated`). `None` when tty7's own
+/// executable path can't resolve.
+fn owned_file_content(agent: HookAgent) -> Option<String> {
+    match agent {
+        HookAgent::Copilot => copilot_hooks_json(),
+        HookAgent::OpenCode => opencode_plugin_js(),
+        HookAgent::Pi => pi_extension_ts(),
+        HookAgent::Claude | HookAgent::Codex => None,
+    }
+}
+
+fn owned_file_state(path: &Path, expected: &str, marker: &str) -> HooksState {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return HooksState::NotInstalled;
+    };
+    if contents == expected {
+        HooksState::Installed
+    } else if contents.contains(marker) {
+        // tty7 wrote it (the marker survives), but from another binary or an
+        // older version of the content.
+        HooksState::Outdated
+    } else {
+        HooksState::NotInstalled
+    }
+}
+
+fn owned_file_install(path: &Path, content: &str, marker: &str) -> anyhow::Result<()> {
+    // Refuse to clobber a user-authored file at the managed path, symmetric
+    // with uninstall's ownership guard.
+    if let Ok(existing) = std::fs::read_to_string(path)
+        && !existing.contains(marker)
+    {
+        return Err(anyhow::anyhow!(
+            "{} exists but wasn't written by tty7; not touching it",
+            path.display()
+        ));
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    crate::core::config::write_atomic(path, content.as_bytes())?;
+    Ok(())
+}
+
+fn owned_file_uninstall(path: &Path, marker: &str) -> anyhow::Result<String> {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok("Nothing installed; nothing to remove".to_string());
+        }
+        Err(e) => return Err(anyhow::anyhow!("read {}: {e}", path.display())),
+    };
+    if !contents.contains(marker) {
+        return Err(anyhow::anyhow!(
+            "{} wasn't written by tty7; not touching it",
+            path.display()
+        ));
+    }
+    std::fs::remove_file(path)?;
+    // Pi's extension lives in its own directory; sweep it if now empty so
+    // uninstall leaves no husk (ignore failure — a non-empty dir is the
+    // user's).
+    if let Some(parent) = path.parent()
+        && parent.file_name().is_some_and(|n| n == "tty7")
+    {
+        let _ = std::fs::remove_dir(parent);
+    }
+    Ok(format!("Removed {}", path.display()))
+}
+
+/// Copilot hook file (`~/.copilot/hooks/tty7.json`): Copilot auto-loads every
+/// JSON file in that directory, so tty7 owns its own file and never touches
+/// the user's. Event names are Copilot's camelCase vocabulary; each runs the
+/// emitter with the sentinel event it maps onto. `notification` is passed
+/// through and filtered in the emitter (see [`effective_event`]).
+fn copilot_hooks_json() -> Option<String> {
+    let cmd = |event: &str| hook_command(HookAgent::Copilot, event);
+    let hook = |event: &str, timeout: u32| {
+        Some(serde_json::json!([{ "type": "command", "bash": cmd(event)?, "timeoutSec": timeout }]))
+    };
+    let root = serde_json::json!({
+        "version": 1,
+        "hooks": {
+            "sessionStart": hook("session-start", 5)?,
+            "userPromptSubmitted": hook("prompt-submit", 5)?,
+            "agentStop": hook("stop", 10)?,
+            "sessionEnd": hook("session-end", 5)?,
+            "notification": hook("notification", 5)?,
+        }
+    });
+    serde_json::to_string_pretty(&root).ok()
+}
+
+/// OpenCode plugin (`~/.config/opencode/plugins/tty7.js`). OpenCode has no
+/// declarative hooks — its extensibility surface is JS plugins auto-loaded
+/// from that directory — so the plugin bridges its events onto the same
+/// emitter every other agent's hooks run. Inert outside tty7 (both the JS
+/// guard and the emitter check `TTY7`).
+fn opencode_plugin_js() -> Option<String> {
+    // The command prefix as a JS string literal (JSON string escaping is
+    // valid JS), completed with the event name at call time.
+    let prefix = serde_json::to_string(&format!(
+        "{} ",
+        hook_command(HookAgent::OpenCode, "")?.trim_end()
+    ))
+    .ok()?;
+    Some(format!(
+        r#"// tty7 agent-hook opencode bridge — generated by tty7, do not edit.
+// Bridges OpenCode plugin events onto `tty7 agent-hook opencode <event>`,
+// which is inert outside tty7 (gated on the TTY7 env var).
+export const Tty7Presence = async ({{ $ }}) => {{
+  if (!process.env["TTY7"]) return {{}}
+  const cmd = {prefix}
+  const emit = (event) => $`sh -c ${{cmd + event}}`.quiet().nothrow()
+
+  // Plugin load = the agent is running in this pane.
+  await emit("session-start")
+
+  return {{
+    dispose: async () => {{
+      await emit("session-end")
+    }},
+    "tool.execute.before": async () => {{
+      await emit("prompt-submit")
+    }},
+    "permission.ask": async () => {{
+      await emit("permission-request")
+    }},
+    event: async ({{ event }}) => {{
+      if (event.type === "session.idle") {{
+        await emit("stop")
+      }} else if (event.type === "permission.replied") {{
+        await emit("prompt-submit")
+      }}
+    }},
+  }}
+}}
+"#
+    ))
+}
+
+/// Pi extension (`~/.pi/agent/extensions/tty7/index.ts`). Pi auto-loads TS
+/// extensions from per-directory `index.ts` files; this one forwards Pi's
+/// lifecycle events to the emitter. Inert outside tty7 (both the TS guard and
+/// the emitter check `TTY7`).
+fn pi_extension_ts() -> Option<String> {
+    let exe = serde_json::to_string(&std::env::current_exe().ok()?.display().to_string()).ok()?;
+    Some(format!(
+        r#"/* tty7 agent-hook pi bridge — generated by tty7, do not edit. */
+import type {{ ExtensionAPI }} from "@mariozechner/pi-coding-agent";
+import {{ spawnSync }} from "node:child_process";
+
+const EXE = {exe};
+
+function emit(event: string): void {{
+  try {{
+    spawnSync(EXE, ["agent-hook", "pi", event], {{ stdio: ["ignore", "ignore", "ignore"] }});
+  }} catch {{}}
+}}
+
+export default function (pi: ExtensionAPI) {{
+  if (!process.env["TTY7"]) return;
+  // Extension load = the agent is running in this pane; Pi has no separate
+  // session-start event.
+  emit("session-start");
+  pi.on("agent_start", () => emit("prompt-submit"));
+  pi.on("agent_end", () => emit("stop"));
+  pi.on("session_shutdown", () => emit("session-end"));
+}}
+"#
+    ))
 }
 
 #[cfg(test)]
@@ -315,6 +844,60 @@ mod tests {
         assert_eq!(ev.session_id, None);
     }
 
+    /// Every event name any installer writes must be one the daemon's parser
+    /// accepts — a typo here would install hooks that emit into the void.
+    #[test]
+    fn every_installed_event_parses_as_a_sentinel_kind() {
+        use crate::core::cli_agent::parse_agent_event;
+
+        let mut events: Vec<&str> = CLAUDE_HOOK_EVENTS
+            .iter()
+            .chain(CODEX_HOOK_EVENTS)
+            .map(|(_, e)| *e)
+            .collect();
+        // Owned-file integrations embed their events in generated source.
+        events.extend([
+            "prompt-submit",
+            "permission-request",
+            "stop",
+            "session-end",
+            "session-start",
+        ]);
+        for event in events {
+            let seq = build_hook_sequence("codex", event, "{}");
+            let ev = parse_agent_event(&seq[2..seq.len() - 1])
+                .unwrap_or_else(|| panic!("event {event:?} must parse"));
+            // Round-trip sanity: serde derives kebab-case names from the enum.
+            let kind_json = serde_json::to_value(ev.kind).unwrap();
+            assert_eq!(kind_json, serde_json::Value::String(event.to_string()));
+        }
+    }
+
+    /// Copilot's catch-all `notification` hook is filtered in the emitter:
+    /// permission/elicitation prompts escalate to `permission-request`, and
+    /// everything else stays silent instead of masquerading as a block.
+    #[test]
+    fn copilot_notifications_filter_to_permission_requests() {
+        assert_eq!(
+            effective_event("copilot", "notification", r#"{"type":"permission_prompt"}"#),
+            Some("permission-request")
+        );
+        assert_eq!(
+            effective_event("copilot", "notification", r#"{"type":"elicitation_dialog"}"#),
+            Some("permission-request")
+        );
+        assert_eq!(
+            effective_event("copilot", "notification", r#"{"type":"turn_summary"}"#),
+            None
+        );
+        // Other agents and events pass through untouched.
+        assert_eq!(
+            effective_event("claude", "notification", "{}"),
+            Some("notification")
+        );
+        assert_eq!(effective_event("copilot", "stop", "{}"), Some("stop"));
+    }
+
     /// The controlling-tty fallback (`ancestor_tty_device`) is what makes the
     /// hook work at all: Claude Code runs hooks detached from the controlling
     /// terminal, so `/dev/tty` fails and we must reach the agent's tty via the
@@ -339,27 +922,112 @@ mod tests {
         let ours = serde_json::json!({
             "hooks": [{ "type": "command", "command": "\"/x/tty7\" agent-hook claude stop" }]
         });
-        assert!(matcher_contains_marker(&ours));
+        assert!(marker_command(&ours, "agent-hook claude").is_some());
+        // Another agent's entry in the same file is not ours.
+        assert!(marker_command(&ours, "agent-hook codex").is_none());
         let theirs = serde_json::json!({
             "hooks": [{ "type": "command", "command": "afplay /System/Library/Sounds/Glass.aiff" }]
         });
-        assert!(!matcher_contains_marker(&theirs));
-        assert!(!matcher_contains_marker(&serde_json::json!({})));
+        assert!(marker_command(&theirs, "agent-hook claude").is_none());
+        assert!(marker_command(&serde_json::json!({}), "agent-hook claude").is_none());
     }
 
     #[test]
     fn hook_command_quotes_the_exe_path() {
-        let cmd = hook_command("stop").expect("current_exe resolves in tests");
+        let cmd = hook_command(HookAgent::Claude, "stop").expect("current_exe resolves in tests");
         assert!(cmd.starts_with('"'));
         assert!(cmd.ends_with("agent-hook claude stop"));
     }
 
-    /// Full install → verify → re-install round trip against a scratch
-    /// settings file (`CLAUDE_CONFIG_DIR` is honored, so the test never
-    /// touches the real `~/.claude`). Serialized with the env-var lock other
-    /// env-mutating tests use… none exists for this var, so the test sets it
-    /// once and relies on `cargo test` threads not racing the same var (only
-    /// this test touches CLAUDE_CONFIG_DIR).
+    /// Owned-file content sanity: valid/parseable where applicable, and every
+    /// generated file carries its ownership marker and this binary's path.
+    #[test]
+    fn owned_file_contents_carry_marker_and_exe() {
+        let exe = std::env::current_exe().unwrap().display().to_string();
+
+        let copilot = copilot_hooks_json().expect("copilot content builds");
+        let parsed: serde_json::Value = serde_json::from_str(&copilot).expect("valid JSON");
+        for event in [
+            "sessionStart",
+            "userPromptSubmitted",
+            "agentStop",
+            "sessionEnd",
+            "notification",
+        ] {
+            assert!(
+                parsed["hooks"][event][0]["bash"]
+                    .as_str()
+                    .is_some_and(|c| c.contains("agent-hook copilot")),
+                "copilot {event} carries the emitter"
+            );
+        }
+        assert!(copilot.contains(&exe));
+
+        let opencode = opencode_plugin_js().expect("opencode content builds");
+        assert!(opencode.contains("agent-hook opencode"));
+        assert!(opencode.contains(&exe));
+        assert!(opencode.contains(r#"process.env["TTY7"]"#));
+
+        let pi = pi_extension_ts().expect("pi content builds");
+        assert!(pi.contains("agent-hook pi"));
+        assert!(pi.contains(&exe));
+        assert!(pi.contains(r#"process.env["TTY7"]"#));
+    }
+
+    /// Owned-file lifecycle against a scratch path: install → Installed,
+    /// drift → Outdated, foreign file → refused, uninstall → gone.
+    #[test]
+    fn owned_file_round_trip_and_ownership_guard() {
+        let dir = std::env::temp_dir().join(format!("tty7-owned-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("tty7.json");
+        let marker = "agent-hook copilot";
+        let content = copilot_hooks_json().unwrap();
+
+        assert_eq!(
+            owned_file_state(&path, &content, marker),
+            HooksState::NotInstalled
+        );
+        owned_file_install(&path, &content, marker).expect("fresh install succeeds");
+        assert_eq!(
+            owned_file_state(&path, &content, marker),
+            HooksState::Installed
+        );
+
+        // Drift (e.g. written by an older tty7 or another binary) reads as
+        // Outdated, and a reinstall heals it.
+        std::fs::write(&path, content.replace(marker, "agent-hook copilot --old")).unwrap();
+        assert_eq!(
+            owned_file_state(&path, &content, marker),
+            HooksState::Outdated
+        );
+        owned_file_install(&path, &content, marker).expect("reinstall over our own file");
+        assert_eq!(
+            owned_file_state(&path, &content, marker),
+            HooksState::Installed
+        );
+
+        // A user-authored file at the managed path is never clobbered or
+        // deleted.
+        std::fs::write(&path, "// my own hooks, hands off").unwrap();
+        assert!(owned_file_install(&path, &content, marker).is_err());
+        assert!(owned_file_uninstall(&path, marker).is_err());
+
+        // Restore ours, then uninstall removes it; a second uninstall no-ops.
+        std::fs::write(&path, &content).unwrap();
+        owned_file_uninstall(&path, marker).expect("uninstall succeeds");
+        assert!(!path.exists());
+        owned_file_uninstall(&path, marker).expect("uninstall is idempotent");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Full install → verify → re-install → outdated → uninstall round trip
+    /// for the hooks-map installer, against a scratch settings file
+    /// (`CLAUDE_CONFIG_DIR` is honored, so the test never touches the real
+    /// `~/.claude`). One test on purpose: it is the only place
+    /// CLAUDE_CONFIG_DIR is mutated, so `cargo test` threads never race the
+    /// env var.
     #[test]
     fn install_is_idempotent_and_preserves_user_hooks() {
         let dir = std::env::temp_dir().join(format!("tty7-hooks-test-{}", std::process::id()));
@@ -380,19 +1048,21 @@ mod tests {
         // SAFETY: test-only env mutation; no other test reads this var.
         unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", &dir) };
 
-        assert!(!claude_hooks_installed());
-        install_claude_hooks().expect("install succeeds");
-        assert!(claude_hooks_installed());
+        assert_eq!(hooks_state(HookAgent::Claude), HooksState::NotInstalled);
+        install_hooks(HookAgent::Claude).expect("install succeeds");
+        assert_eq!(hooks_state(HookAgent::Claude), HooksState::Installed);
 
         // Install again: no duplicates.
-        install_claude_hooks().expect("re-install succeeds");
+        install_hooks(HookAgent::Claude).expect("re-install succeeds");
         let root: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&settings).unwrap()).unwrap();
         // User settings and user hooks survive.
         assert_eq!(root["model"], "opus");
         let stop = root["hooks"]["Stop"].as_array().unwrap();
         assert_eq!(
-            stop.iter().filter(|m| matcher_contains_marker(m)).count(),
+            stop.iter()
+                .filter(|m| marker_command(m, "agent-hook claude").is_some())
+                .count(),
             1,
             "exactly one tty7 entry after two installs"
         );
@@ -404,14 +1074,46 @@ mod tests {
         // All five events are wired.
         for (event, _) in CLAUDE_HOOK_EVENTS {
             assert!(
-                root["hooks"][event]
+                root["hooks"][*event]
                     .as_array()
                     .unwrap()
                     .iter()
-                    .any(matcher_contains_marker),
+                    .any(|m| marker_command(m, "agent-hook claude").is_some()),
                 "{event} carries the tty7 hook"
             );
         }
+
+        // A tty7 entry rewritten to another binary's path reads as Outdated —
+        // the state the launch-time refresh keys on — and a reinstall heals it.
+        let healthy = std::fs::read_to_string(&settings).unwrap();
+        std::fs::write(
+            &settings,
+            healthy.replace("agent-hook claude stop", "agent-hook claude stop --stale"),
+        )
+        .unwrap();
+        assert_eq!(hooks_state(HookAgent::Claude), HooksState::Outdated);
+        install_hooks(HookAgent::Claude).expect("reinstall over an outdated entry succeeds");
+        assert_eq!(hooks_state(HookAgent::Claude), HooksState::Installed);
+
+        // Uninstall removes exactly our entries: the user's Stop hook and their
+        // other settings survive, and the emptied event keys are dropped.
+        uninstall_hooks(HookAgent::Claude).expect("uninstall succeeds");
+        assert_eq!(hooks_state(HookAgent::Claude), HooksState::NotInstalled);
+        let root: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&settings).unwrap()).unwrap();
+        assert_eq!(root["model"], "opus");
+        let stop = root["hooks"]["Stop"].as_array().unwrap();
+        assert!(
+            stop.iter()
+                .any(|m| m.to_string().contains("afplay ding.aiff")),
+            "the user's own Stop hook survives uninstall"
+        );
+        assert!(
+            root["hooks"].get("SessionStart").is_none(),
+            "an event list that held only the tty7 hook is dropped"
+        );
+        // Nothing left to remove: a second uninstall is a no-op, not an error.
+        uninstall_hooks(HookAgent::Claude).expect("uninstall is idempotent");
 
         // SAFETY: restore for any later test relying on the default path.
         unsafe { std::env::remove_var("CLAUDE_CONFIG_DIR") };

--- a/src/main.rs
+++ b/src/main.rs
@@ -334,6 +334,16 @@ fn main() {
             // if so, Settings → About surfaces a download prompt. Fails soft and
             // is a no-op when `check_for_updates` is disabled.
             crate::core::update::spawn_check(cx);
+            // If any agent's installed hooks point at a moved/stale tty7
+            // binary (the app updated or relocated since they were
+            // installed), rewrite them in place — off the startup path, since
+            // it reads (and rarely writes) the agents' config files. No-op in
+            // debug builds and when hooks are absent or already current.
+            cx.background_executor()
+                .spawn(async {
+                    crate::core::agent_hooks::refresh_hooks_at_launch();
+                })
+                .detach();
             keymap::init(cx);
 
             cx.spawn(async move |cx| {

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -2096,8 +2096,10 @@ impl Tty7App {
                 // Synchronous file edit; report the outcome as a toast either
                 // way. Installing over an existing install just refreshes the
                 // entries (e.g. after the tty7 binary moved) — say so.
-                let refreshed = crate::core::agent_hooks::claude_hooks_installed();
-                match crate::core::agent_hooks::install_claude_hooks() {
+                use crate::core::agent_hooks::{HookAgent, HooksState};
+                let refreshed =
+                    crate::core::agent_hooks::hooks_state(HookAgent::Claude) != HooksState::NotInstalled;
+                match crate::core::agent_hooks::install_hooks(HookAgent::Claude) {
                     Ok(summary) if refreshed => crate::terminal::notify_desktop(
                         Some("tty7"),
                         &format!("Refreshed: {summary}"),
@@ -2107,6 +2109,11 @@ impl Tty7App {
                         Some("tty7"),
                         &format!("Claude Code hook install failed: {e}"),
                     ),
+                }
+                // Keep an open Settings → Agents page truthful about what just
+                // happened behind its back.
+                if let Some(s) = self.settings.as_mut() {
+                    s.agent_hooks_states = Self::agent_hooks_snapshot();
                 }
             }
             // Handled inside `PaletteView` (opens a sub-list); these never emit a
@@ -2279,6 +2286,8 @@ impl Tty7App {
             rebinding_note: None,
             ssh_form: None,
             ssh_detail: crate::ui::settings::SshDetail::None,
+            agent_hooks_states: Self::agent_hooks_snapshot(),
+            agent_hooks_note: None,
             _subs: subs,
         });
         // Land the caret in the search box so Settings opens ready to type/filter
@@ -2910,6 +2919,64 @@ impl Tty7App {
             // Leaving the Keybindings page abandons any in-progress capture, so
             // the interceptor doesn't keep swallowing keys off-screen.
             s.recording = None;
+            // Entering Agents re-reads the hook install states, so edits made
+            // behind the panel's back (another tty7, a hand edit) show up.
+            if target == SettingsSection::Agents {
+                s.agent_hooks_states = Self::agent_hooks_snapshot();
+            }
+        }
+        cx.notify();
+    }
+
+    /// Every hook-capable agent paired with its current on-disk install state,
+    /// in the order the Agents section lists them.
+    fn agent_hooks_snapshot()
+    -> Vec<(crate::core::agent_hooks::HookAgent, crate::core::agent_hooks::HooksState)> {
+        crate::core::agent_hooks::HookAgent::ALL
+            .into_iter()
+            .map(|agent| (agent, crate::core::agent_hooks::hooks_state(agent)))
+            .collect()
+    }
+
+    /// Settings → Agents: install (or rewrite in place) one agent's hooks,
+    /// then fold the outcome back into the panel — status row + note line.
+    pub(crate) fn settings_install_agent_hooks(
+        &mut self,
+        agent: crate::core::agent_hooks::HookAgent,
+        cx: &mut Context<Self>,
+    ) {
+        let result = crate::core::agent_hooks::install_hooks(agent);
+        self.finish_agent_hooks_action(agent, result, cx);
+    }
+
+    /// Settings → Agents: remove one agent's tty7 hooks (user hooks survive).
+    pub(crate) fn settings_uninstall_agent_hooks(
+        &mut self,
+        agent: crate::core::agent_hooks::HookAgent,
+        cx: &mut Context<Self>,
+    ) {
+        let result = crate::core::agent_hooks::uninstall_hooks(agent);
+        self.finish_agent_hooks_action(agent, result, cx);
+    }
+
+    /// Shared tail of the Agents-section hook actions: re-read the on-disk
+    /// states (the ground truth, whatever the action just did) and surface the
+    /// action's own summary or error as the note under that agent's row.
+    fn finish_agent_hooks_action(
+        &mut self,
+        agent: crate::core::agent_hooks::HookAgent,
+        result: anyhow::Result<String>,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(s) = self.settings.as_mut() {
+            s.agent_hooks_states = Self::agent_hooks_snapshot();
+            s.agent_hooks_note = Some((
+                agent,
+                match result {
+                    Ok(summary) => summary,
+                    Err(e) => format!("Failed: {e}"),
+                },
+            ));
         }
         cx.notify();
     }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -2097,8 +2097,8 @@ impl Tty7App {
                 // way. Installing over an existing install just refreshes the
                 // entries (e.g. after the tty7 binary moved) — say so.
                 use crate::core::agent_hooks::{HookAgent, HooksState};
-                let refreshed =
-                    crate::core::agent_hooks::hooks_state(HookAgent::Claude) != HooksState::NotInstalled;
+                let refreshed = crate::core::agent_hooks::hooks_state(HookAgent::Claude)
+                    != HooksState::NotInstalled;
                 match crate::core::agent_hooks::install_hooks(HookAgent::Claude) {
                     Ok(summary) if refreshed => crate::terminal::notify_desktop(
                         Some("tty7"),
@@ -2930,8 +2930,10 @@ impl Tty7App {
 
     /// Every hook-capable agent paired with its current on-disk install state,
     /// in the order the Agents section lists them.
-    fn agent_hooks_snapshot()
-    -> Vec<(crate::core::agent_hooks::HookAgent, crate::core::agent_hooks::HooksState)> {
+    fn agent_hooks_snapshot() -> Vec<(
+        crate::core::agent_hooks::HookAgent,
+        crate::core::agent_hooks::HooksState,
+    )> {
         crate::core::agent_hooks::HookAgent::ALL
             .into_iter()
             .map(|agent| (agent, crate::core::agent_hooks::hooks_state(agent)))

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -49,6 +49,7 @@ pub(crate) enum SettingsSection {
     Terminal,
     Shell,
     Ssh,
+    Agents,
     WindowTabs,
     Keybindings,
     About,
@@ -63,6 +64,7 @@ impl SettingsSection {
             SettingsSection::Terminal => "settings:terminal",
             SettingsSection::Shell => "settings:shell",
             SettingsSection::Ssh => "settings:ssh",
+            SettingsSection::Agents => "settings:agents",
             SettingsSection::WindowTabs => "settings:window-tabs",
             SettingsSection::Keybindings => "settings:keybindings",
             SettingsSection::About => "settings:about",
@@ -211,6 +213,32 @@ fn settings_search_entries() -> &'static [SearchEntry] {
             title: "Verify host keys",
             keywords: "ssh security known_hosts fingerprint mitm host key verification",
         },
+        // Agents
+        SearchEntry {
+            section: Agents,
+            title: "Claude Code hooks",
+            keywords: "agent integration install uninstall status rich session working waiting sidebar badge claude",
+        },
+        SearchEntry {
+            section: Agents,
+            title: "Codex hooks",
+            keywords: "agent integration install openai codex",
+        },
+        SearchEntry {
+            section: Agents,
+            title: "Copilot CLI hooks",
+            keywords: "agent integration install github copilot",
+        },
+        SearchEntry {
+            section: Agents,
+            title: "OpenCode plugin",
+            keywords: "agent integration install opencode",
+        },
+        SearchEntry {
+            section: Agents,
+            title: "Pi extension",
+            keywords: "agent integration install pi",
+        },
         // Window & Tabs
         SearchEntry {
             section: WindowTabs,
@@ -338,6 +366,16 @@ pub(crate) struct SettingsState {
     /// edit form); `None` shows the empty state (the "pick a profile" hint plus
     /// the two global security toggles).
     pub(crate) ssh_detail: SshDetail,
+    /// Install state of each agent's hook integration (Agents section), in
+    /// [`crate::core::agent_hooks::HookAgent::ALL`] order. Cached — captured
+    /// when the panel opens, re-read when the section is selected, and updated
+    /// after each install/uninstall — so rendering never touches the agents'
+    /// config files.
+    pub(crate) agent_hooks_states:
+        Vec<(crate::core::agent_hooks::HookAgent, crate::core::agent_hooks::HooksState)>,
+    /// Outcome of the last Agents-section hook action (install summary or
+    /// error), shown under that agent's row. Replaced by the next action.
+    pub(crate) agent_hooks_note: Option<(crate::core::agent_hooks::HookAgent, String)>,
     pub(crate) _subs: Vec<Subscription>,
 }
 
@@ -647,6 +685,7 @@ impl Tty7App {
                 IconName::SquareTerminal,
             ))
             .child(nav_item("SSH", SettingsSection::Ssh, IconName::Globe))
+            .child(nav_item("Agents", SettingsSection::Agents, IconName::Bot))
             .child(nav_item(
                 "Window & Tabs",
                 SettingsSection::WindowTabs,
@@ -712,6 +751,7 @@ impl Tty7App {
             SettingsSection::Terminal => self.render_settings_terminal(cx),
             SettingsSection::Shell => self.render_settings_shell(cx),
             SettingsSection::Ssh => self.render_settings_ssh(cx),
+            SettingsSection::Agents => self.render_settings_agents(cx),
             SettingsSection::WindowTabs => self.render_settings_window_tabs(cx),
             SettingsSection::Keybindings => self.render_settings_keybindings(cx),
             SettingsSection::About => self.render_settings_about(cx),
@@ -2744,6 +2784,90 @@ impl Tty7App {
                 cx,
             ))
             .into_any_element()
+    }
+
+    /// Agents section: one row per hook-capable agent — install state + actions
+    /// per row, copy kept terse.
+    fn render_settings_agents(&self, cx: &mut Context<Self>) -> AnyElement {
+        use crate::core::agent_hooks::{HookAgent, HooksState};
+
+        let theme = cx.theme();
+        let (foreground, muted_fg) = (theme.foreground, theme.muted_foreground);
+        let (success, warning) = (theme.success, theme.warning);
+        let (states, note) = match self.active_settings() {
+            Some(s) => (s.agent_hooks_states.clone(), s.agent_hooks_note.clone()),
+            None => (Vec::new(), None),
+        };
+
+        let mut page = v_flex().child(self.section_intro(
+            "Agents",
+            "Hook integrations give panes running these agents live session status \
+             (working / waiting / done) in the sidebar. Only active inside tty7.",
+            cx,
+        ));
+        for (i, (agent, state)) in states.into_iter().enumerate() {
+            // Status: a colored dot + one word; the dot is the only color on
+            // the page, so state reads at a glance.
+            let (dot_color, status_text) = match state {
+                HooksState::NotInstalled => (muted_fg, "Not installed"),
+                HooksState::Installed => (success, "Installed"),
+                HooksState::Outdated => (warning, "Outdated — points at another tty7"),
+            };
+            // The primary action reads as what it will *do* from this state.
+            let primary_label = match state {
+                HooksState::NotInstalled => "Install",
+                HooksState::Installed => "Reinstall",
+                HooksState::Outdated => "Update",
+            };
+            let row_note = note
+                .as_ref()
+                .filter(|(for_agent, _)| *for_agent == agent)
+                .map(|(_, text)| text.clone());
+
+            let control = v_flex()
+                .gap_2()
+                .child(
+                    h_flex()
+                        .gap_2()
+                        .items_center()
+                        .child(div().size_2().rounded_full().bg(dot_color))
+                        .child(div().text_sm().text_color(foreground).child(status_text)),
+                )
+                .child(
+                    h_flex()
+                        .gap_2()
+                        .child(
+                            Button::new(("agent-hooks-install", i))
+                                .label(primary_label)
+                                .small()
+                                .on_click(cx.listener(move |this, _, _w, cx| {
+                                    this.settings_install_agent_hooks(agent, cx)
+                                })),
+                        )
+                        .when(state != HooksState::NotInstalled, |row| {
+                            row.child(
+                                Button::new(("agent-hooks-uninstall", i))
+                                    .label("Uninstall")
+                                    .small()
+                                    .on_click(cx.listener(move |this, _, _w, cx| {
+                                        this.settings_uninstall_agent_hooks(agent, cx)
+                                    })),
+                            )
+                        }),
+                )
+                .when_some(row_note, |col, text| {
+                    col.child(div().text_xs().text_color(muted_fg).child(text))
+                })
+                .into_any_element();
+
+            page = page.child(self.settings_row(
+                agent.display_name(),
+                agent.target_display(),
+                control,
+                cx,
+            ));
+        }
+        page.into_any_element()
     }
 
     /// Window & Tabs section: the app window's lifecycle and tab placement.

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -371,8 +371,10 @@ pub(crate) struct SettingsState {
     /// when the panel opens, re-read when the section is selected, and updated
     /// after each install/uninstall — so rendering never touches the agents'
     /// config files.
-    pub(crate) agent_hooks_states:
-        Vec<(crate::core::agent_hooks::HookAgent, crate::core::agent_hooks::HooksState)>,
+    pub(crate) agent_hooks_states: Vec<(
+        crate::core::agent_hooks::HookAgent,
+        crate::core::agent_hooks::HooksState,
+    )>,
     /// Outcome of the last Agents-section hook action (install summary or
     /// error), shown under that agent's row. Replaced by the next action.
     pub(crate) agent_hooks_note: Option<(crate::core::agent_hooks::HookAgent, String)>,


### PR DESCRIPTION
## Summary

Generalizes the Claude Code hook install into a per-agent integration layer. Every integration feeds the same `tty7 agent-hook <agent> <event>` emitter (gated on the `TTY7` env var, silent in other terminals), so panes running these agents get live session status — working / waiting-for-you / done — in the sidebar.

| Agent | Installs into | Mechanism |
|---|---|---|
| Claude Code | `~/.claude/settings.json` | tty7-marked entries merged into the hooks map |
| Codex | `~/.codex/hooks.json` | same hooks-map merge, plus `codex features enable hooks` (best-effort; advises a manual run when the CLI is missing) |
| Copilot CLI | `~/.copilot/hooks/tty7.json` | tty7-owned hook file (the directory is auto-loaded) |
| OpenCode | `~/.config/opencode/plugins/tty7.js` | tty7-owned JS plugin bridging plugin events onto the emitter |
| Pi | `~/.pi/agent/extensions/tty7/index.ts` | tty7-owned TS extension bridging lifecycle events onto the emitter |

## Design

- **Two installer shapes.** Hooks-map agents (Claude Code, Codex) get marker-carrying entries merged in place — user hooks and unrelated settings are never touched, and uninstall removes only tty7's entries. Owned-file agents (Copilot, OpenCode, Pi) get a whole file tty7 owns: byte-compared for drift (`Outdated`), and both install and uninstall refuse to touch a file tty7 didn't write.
- **Emitter-side filtering.** Copilot's single `notification` hook fires for every notification type; only permission/elicitation prompts escalate to `permission-request`, the rest stay silent instead of masquerading as a block.
- **Settings → Agents.** New section with one row per agent: install state (not installed / installed / outdated — outdated means the hooks point at a different tty7 binary) plus Install / Reinstall / Update / Uninstall.
- **Launch refresh.** Release builds rewrite any integration whose hooks point at a moved/stale tty7 binary; debug builds never auto-claim hooks, so a dev build can't steal them from the installed app.
- **Protocol unchanged.** The daemon's sentinel-event vocabulary already covered `permission-request` / `question-asked`; no wire changes.

## Testing

- `cargo test`: 681 passed (4 new), including install → outdated → reinstall → uninstall round trips for both installer shapes, ownership guards, emitter filtering, and a check that every installed event name parses back into the daemon's event vocabulary.
- Manually exercised the Settings → Agents flow in an isolated dev instance (`CLAUDE_CONFIG_DIR` pointed at a scratch dir): install writes the expected hooks, reinstall is idempotent, state reporting matches the file on disk.