### PR TITLE
fix(agent-hooks): skip stdin read when it is a tty

### DIFF
--- a/src/core/agent_hooks.rs
+++ b/src/core/agent_hooks.rs
@@ -15,7 +15,7 @@
 //! shell tty7 spawns), so hooks installed globally stay silent when an agent
 //! runs in another terminal.
 
-use std::io::Read as _;
+use std::io::{IsTerminal as _, Read as _};
 use std::path::{Path, PathBuf};
 
 use crate::core::cli_agent::AGENT_EVENT_SENTINEL;
@@ -40,9 +40,14 @@ pub fn run_agent_hook(agent: &str, event: &str) {
     }
     // Hook payload: the agent writes JSON ({"session_id": …, "message": …, …})
     // and closes stdin. Absent/malformed input still emits the bare event —
-    // the state machine works without ids or messages.
+    // the state machine works without ids or messages. A tty stdin means the
+    // spawner inherited the pane's terminal instead of piping a payload (e.g.
+    // OpenCode's plugin runner, issue #88); reading it would block forever on
+    // an EOF that never comes and swallow the user's keystrokes, so skip it.
     let mut input = String::new();
-    let _ = std::io::stdin().take(MAX_STDIN).read_to_string(&mut input);
+    if !std::io::stdin().is_terminal() {
+        let _ = std::io::stdin().take(MAX_STDIN).read_to_string(&mut input);
+    }
     let Some(event) = effective_event(agent, event, &input) else {
         return;
     };


### PR DESCRIPTION
## Problem

Installing the OpenCode hook left OpenCode with a blank screen on startup inside tty7 (#88).

## Root cause

The `tty7 agent-hook <agent> <event>` emitter reads its JSON payload from stdin until EOF. That contract assumes the spawner pipes a payload and closes the stream, which is how Claude Code / Codex / Copilot invoke hooks. The generated OpenCode plugin instead spawns the emitter via Bun's shell (`$`), whose child inherits **the pane's tty as stdin**. A tty never reaches EOF, so:

1. the emitter blocked forever in `read_to_string`,
2. the plugin's `await emit("session-start")` never resolved,
3. OpenCode's startup stalled before the TUI ever drew — and the hung read also swallowed the user's keystrokes.

## Fix

Skip the stdin read when stdin is a terminal (`std::io::IsTerminal`, cross-platform). A bare event without `session_id`/`message` is already a supported payload, and this hardens the emitter for every agent, not just OpenCode — any future integration that inherits the tty can no longer hang.

## Verification

Reproduced with a pty whose stdin is held open (no EOF):

- **Before**: `TTY7=1 tty7 agent-hook opencode session-start` hangs until killed by `timeout`.
- **After**: emits the OSC 777 sentinel immediately and exits 0.
- **Regression check** (piped payload, Claude Code style): `echo '{...}' | tty7 agent-hook claude notification` still includes `session_id`/`message` in the emitted event.
- `cargo build`, `cargo clippy --all-targets`, `cargo test agent_hooks` (9 tests) all pass.

## Notes for affected users

No plugin reinstall needed — the plugin invokes the binary by path, so upgrading tty7 fixes it in place. Until then, the workaround is Settings → Agents → OpenCode → Uninstall.

Fixes #88