### PR TITLE
fix(sidebar): limit the diff overlay toggle to the +N/-N counts

### DIFF
--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -93,9 +93,11 @@ impl Tty7App {
             // branch, then the working-tree diff as green `+N` / red `−N`
             // badges — a per-session branch row. Built here so the row can
             // grow to fit it (a non-repo pane keeps the compact two-line row).
-            // The line is also the diff overlay's toggle: the cwd it probes is
-            // the same one the status resolved through, so overlay and badge
-            // always describe the same repo.
+            // The `+N`/`−N` counts are also the diff overlay's toggle: the cwd
+            // they probe is the same one the status resolved through, so
+            // overlay and badge always describe the same repo. Only the counts
+            // are the click target — the icon and branch name stay part of the
+            // row, so clicking them activates the tab like anywhere else.
             let git_cwd = tab
                 .pane
                 .focused_or_first(window, cx)
@@ -108,24 +110,6 @@ impl Tty7App {
                     .gap_1p5()
                     .text_xs()
                     .text_color(cx.theme().muted_foreground)
-                    // Click to peek the full diff in an overlay over the
-                    // terminal — without activating this row's tab, which is
-                    // the point: glance at another session's changes while
-                    // staying where you are. Quiet until hovered (the line
-                    // brightens and shows a pointer), so the rail stays calm.
-                    .when_some(git_cwd, |line, cwd| {
-                        line.cursor_pointer()
-                            .hover(|s| s.text_color(cx.theme().foreground))
-                            .on_mouse_down(
-                                MouseButton::Left,
-                                cx.listener(move |this, _: &MouseDownEvent, window, cx| {
-                                    // Swallow the press so the row/label
-                                    // handlers don't also activate the tab.
-                                    cx.stop_propagation();
-                                    this.toggle_diff_overlay(cwd.clone(), window, cx);
-                                }),
-                            )
-                    })
                     .child(
                         gpui::svg()
                             .path("icons/git-branch.svg")
@@ -138,22 +122,45 @@ impl Tty7App {
                     .child(div().flex_1().min_w_0().truncate().child(g.branch.clone()));
                 // Diff counts in plain (not bold) coloured text — a quiet
                 // green/red readout, not a loud badge, so a big `+1590` doesn't
-                // dominate the row.
-                if g.added > 0 {
-                    line = line.child(
-                        div()
-                            .flex_shrink_0()
-                            .text_color(cx.theme().success)
-                            .child(format!("+{}", g.added)),
-                    );
-                }
-                if g.removed > 0 {
-                    line = line.child(
-                        div()
-                            .flex_shrink_0()
-                            .text_color(cx.theme().danger)
-                            .child(format!("−{}", g.removed)),
-                    );
+                // dominate the row. Click them to peek the full diff in an
+                // overlay over the terminal — without activating this row's
+                // tab, which is the point: glance at another session's changes
+                // while staying where you are. The pointer cursor alone marks
+                // the hot spot, so the rail stays calm.
+                if g.added > 0 || g.removed > 0 {
+                    let mut counts = h_flex()
+                        .id(("sidebar-diff", i))
+                        .flex_shrink_0()
+                        .items_center()
+                        .gap_1p5()
+                        .when_some(git_cwd, |counts, cwd| {
+                            counts
+                                .cursor_pointer()
+                                .on_mouse_down(
+                                    MouseButton::Left,
+                                    cx.listener(move |this, _: &MouseDownEvent, window, cx| {
+                                        // Swallow the press so the row/label
+                                        // handlers don't also activate the tab.
+                                        cx.stop_propagation();
+                                        this.toggle_diff_overlay(cwd.clone(), window, cx);
+                                    }),
+                                )
+                        });
+                    if g.added > 0 {
+                        counts = counts.child(
+                            div()
+                                .text_color(cx.theme().success)
+                                .child(format!("+{}", g.added)),
+                        );
+                    }
+                    if g.removed > 0 {
+                        counts = counts.child(
+                            div()
+                                .text_color(cx.theme().danger)
+                                .child(format!("−{}", g.removed)),
+                        );
+                    }
+                    line = line.child(counts);
                 }
                 line
             });


### PR DESCRIPTION
## Problem

Clicking anywhere on a sidebar row's git line — the branch icon, the branch name, or the diff counts — toggled the working-tree diff overlay. In practice the whole lower half of a tab row opened the overlay, when a click there should just activate the tab.

## Change

- Only the `+N`/`−N` diff readout is the overlay's click target now (pointer cursor marks the hot spot; no hover text-style change).
- The branch icon and name fall through to the row's normal handler, so clicking them activates the tab like anywhere else on the row.
- A clean tree renders no counts, hence no click target — there is no diff to peek at anyway.