### PR TITLE
style(ui): macOS Sonoma-style popup panels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ dependencies = [
 [[package]]
 name = "gpui-component"
 version = "0.5.2"
-source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#9484cf99c89ac7bbce7af063c329925a6576409b"
+source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#ff8af959b759a5c554a243fbae5ca78ce1cdf5e5"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2972,7 +2972,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-assets"
 version = "0.5.1"
-source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#9484cf99c89ac7bbce7af063c329925a6576409b"
+source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#ff8af959b759a5c554a243fbae5ca78ce1cdf5e5"
 dependencies = [
  "anyhow",
  "gpui",
@@ -2986,7 +2986,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-macros"
 version = "0.5.1"
-source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#9484cf99c89ac7bbce7af063c329925a6576409b"
+source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#ff8af959b759a5c554a243fbae5ca78ce1cdf5e5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/ui/palette.rs
+++ b/src/ui/palette.rs
@@ -481,9 +481,13 @@ impl ListDelegate for PaletteDelegate {
         Some(
             ListItem::new(ix.row)
                 .selected(Some(ix) == self.selected)
-                // Tighter than the stock row: smaller text + compact vertical
-                // padding so the palette reads dense, like the terminal itself.
-                .py_1()
+                // Fixed-height, dense rows (see `PALETTE_ROW_H`: the card's
+                // list viewport is sized to a whole number of rows). The 5px
+                // side margin + 6px radius turn the highlight into the same
+                // inset pill the context menu / dropdown use.
+                .h(px(PALETTE_ROW_H))
+                .mx(px(5.))
+                .rounded(px(6.))
                 .text_sm()
                 .child(row),
         )
@@ -664,6 +668,12 @@ impl PaletteView {
 
 impl EventEmitter<PaletteEvent> for PaletteView {}
 
+/// Fixed command-row height (see `render_item`). The list viewport must hold a
+/// whole number of rows, or the card's bottom edge cuts the last one mid-height.
+const PALETTE_ROW_H: f32 = 30.;
+/// Rows visible before the list scrolls.
+const PALETTE_VISIBLE_ROWS: f32 = 12.;
+
 impl Render for PaletteView {
     /// The centered overlay: a dim full-window scrim plus the command card. The
     /// card just frames gpui-component's `List`, which renders its own search
@@ -672,25 +682,32 @@ impl Render for PaletteView {
         let theme = cx.theme();
         let (background, border, popover) = (theme.background, theme.border, theme.popover);
 
+        // The list viewport holds exactly `PALETTE_VISIBLE_ROWS` fixed-height
+        // rows plus the list's own 4px top padding (`py_1` below, which scrolls
+        // with the content) — any other height leaves the last visible row cut
+        // mid-height at the card's bottom edge. The card wraps its content (no
+        // max_h of its own) and adds `pb_1` so that row still clears the
+        // rounded corners.
+        let list_max_h = px(PALETTE_ROW_H * PALETTE_VISIBLE_ROWS + 4.);
         let card = v_flex()
             .w(px(560.))
-            .max_h(px(440.))
             .bg(popover)
             .border_1()
             .border_color(border)
-            .rounded_lg()
-            .shadow_lg()
+            // 10px radius + the floatier shadow match the context menu /
+            // dropdown panel (see the fork's `PopupMenu`).
+            .rounded(px(10.))
+            .shadow_xl()
             .overflow_hidden()
-            // `py_1` (not `p_1`): the row padding is vertical only, so the
-            // selected row's fill runs edge to edge — the same flat, full-bleed
-            // highlight the context menu, new-tab dropdown and completion popup
-            // use. The 4px top/bottom inset keeps the first/last row clear of the
-            // card's rounded corners.
+            .pb_1()
+            // `py_1` (not `p_1`): the search input keeps its full-bleed width;
+            // the rows inset themselves into rounded pills (see `render_item`),
+            // Spotlight-style, matching the context menu's highlight language.
             .child(
                 List::new(&self.list)
                     .search_placeholder(self.search_placeholder())
                     .py_1()
-                    .max_h(px(440.)),
+                    .max_h(list_max_h),
             );
 
         // Full-window scrim; clicking the empty area dismisses the palette (the


### PR DESCRIPTION
## What

对齐所有弹层（右键菜单 / `…` 下拉 / 新建 tab 选单 / command palette）到 macOS Sonoma 的菜单语言。配色不变，只改几何。

| 面 | 之前 | 现在 |
|---|---|---|
| **菜单高亮** | 平铺全宽色条 | 5px 内缩的 6px 圆角胶囊 |
| **菜单面板** | 8px 圆角、`shadow_lg` | 10px 圆角、`shadow_xl`、13px 字号 |
| **分隔线** | 通栏 | 两端内缩（macOS 式） |
| **Palette 搜索行** | 与列表行同高同字号 | 加高 + 15px 字号（Spotlight 式） |
| **Palette 行** | padding 撑高、可被底边拦腰截断 | 固定 30px 高的内缩胶囊；视口 = 12 整行，底边永远落在整行上 |

## How

- **fork 侧**（`l0ng-ai/gpui-component` `tty7` 分支，经 `Cargo.lock` bump 引入）
  - `562341a` — `PopupMenu`：胶囊高亮、5px 面板内边距、内缩分隔线、10px 圆角、去掉试过的半透明底（GPUI 弹层无背景模糊，半透明只会透出终端文字）
  - `ff8af95` — `List`：非 Small 尺寸的搜索行加高（`py_1p5`）+ 15px 查询文字
- **tty7 侧**
  - `palette.rs`：卡片对齐菜单面板；行固定高度；`PALETTE_VISIBLE_ROWS` 常量控制可见行数，视口高度按整行数计算，卡片不再自设 `max_h`

## Verify

Dev 实例（独立 `--config-dir`）人工验收：右键菜单、`…` 下拉、⌘P palette 亮色主题下逐一核对；palette 底部整行收边确认无截断。