### PR TITLE
fix(agent-status): recover from Waiting once an approved tool completes

### DIFF
--- a/src/core/agent_hooks.rs
+++ b/src/core/agent_hooks.rs
@@ -448,11 +448,15 @@ const OWNED_FILE_STEM_JS: &str = "tty7.js";
 
 /// Claude Code's hook events and the sentinel event each maps onto.
 /// `Notification` covers both "needs permission" and "waiting for input" —
-/// exactly the Waiting state.
+/// exactly the Waiting state. `PostToolUse` is the way *back*: Claude has no
+/// "permission replied" hook, so the first tool that completes after the user
+/// approves is the signal that the turn is moving again (state machine flips
+/// Waiting → Working on it, and ignores it otherwise).
 const CLAUDE_HOOK_EVENTS: &[(&str, &str)] = &[
     ("SessionStart", "session-start"),
     ("UserPromptSubmit", "prompt-submit"),
     ("Notification", "notification"),
+    ("PostToolUse", "tool-complete"),
     ("Stop", "stop"),
     ("SessionEnd", "session-end"),
 ];

--- a/src/core/cli_agent.rs
+++ b/src/core/cli_agent.rs
@@ -498,6 +498,19 @@ impl AgentSessionState {
                     self.message = ev.message.clone();
                 }
             }
+            // A tool call finished. Only meaningful as the recovery edge out
+            // of a block: the user answered the permission prompt / question,
+            // the approved tool ran, so the turn is moving again — no agent
+            // emits an explicit "permission replied" signal here, so the next
+            // tool completion is that signal. Guarded on Waiting so the steady
+            // stream of completions during normal work is a no-op and can
+            // never overwrite Done between turns.
+            AgentEventKind::ToolComplete => {
+                if self.status == AgentStatus::Waiting {
+                    self.status = AgentStatus::Working;
+                    self.message = None;
+                }
+            }
             AgentEventKind::Stop => {
                 self.status = AgentStatus::Done;
                 self.message = ev.message.clone();
@@ -514,9 +527,9 @@ impl AgentSessionState {
 
 /// The event vocabulary of the sentinel protocol (`"event"` in the JSON).
 /// Deliberately a superset of what any one agent emits: Claude Code hooks map
-/// onto session-start / prompt-submit / notification / stop / session-end,
-/// while permission-request / question-asked are there for agents (Codex,
-/// OpenCode plugins) that can distinguish them.
+/// onto session-start / prompt-submit / notification / tool-complete / stop /
+/// session-end, while permission-request / question-asked are there for
+/// agents (Codex, OpenCode plugins) that can distinguish them.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum AgentEventKind {
@@ -524,6 +537,7 @@ pub enum AgentEventKind {
     PromptSubmit,
     PermissionRequest,
     QuestionAsked,
+    ToolComplete,
     Notification,
     Stop,
     SessionEnd,
@@ -778,7 +792,23 @@ mod tests {
         assert_eq!(s.status, AgentStatus::Waiting);
         assert!(s.message.as_deref().unwrap().contains("permission"));
 
+        // The user approved: the granted tool runs to completion, and that
+        // completion is the "back to work" edge — amber flips back to blue
+        // instead of lingering for the rest of the turn.
+        s.apply_event(&ev(AgentEventKind::ToolComplete, None, None));
+        assert_eq!(s.status, AgentStatus::Working);
+        assert_eq!(s.message, None, "the stale permission prompt is cleared");
+
+        // Tool completions during normal work are a no-op, not state churn.
+        s.apply_event(&ev(AgentEventKind::ToolComplete, None, None));
+        assert_eq!(s.status, AgentStatus::Working);
+
         s.apply_event(&ev(AgentEventKind::Stop, None, None));
+        assert_eq!(s.status, AgentStatus::Done);
+
+        // A straggler tool-complete after the turn ended must not resurrect
+        // Working and hide the unread green dot.
+        s.apply_event(&ev(AgentEventKind::ToolComplete, None, None));
         assert_eq!(s.status, AgentStatus::Done);
 
         // A Notification arriving BETWEEN turns (while Done) is Claude Code's

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -2818,7 +2818,7 @@ impl Tty7App {
             let (dot_color, status_text) = match state {
                 HooksState::NotInstalled => (muted_fg, "Not installed"),
                 HooksState::Installed => (success, "Installed"),
-                HooksState::Outdated => (warning, "Outdated — points at another tty7"),
+                HooksState::Outdated => (warning, "Outdated — installed by another tty7 version"),
             };
             // The primary action reads as what it will *do* from this state.
             let primary_label = match state {


### PR DESCRIPTION
## Problem

After approving a Claude Code permission prompt mid-turn, the tab/sidebar status dot stayed **amber (Waiting) for the rest of the turn** even though the agent was clearly working again.

Root cause: the state machine had no edge out of `Waiting` back to `Working`. Claude Code has no "permission replied" hook, and we only installed SessionStart / UserPromptSubmit / Notification / Stop / SessionEnd — so nothing fired between "user approved" and the next `Stop`.

## Fix

Same shape as Warp's `ToolComplete` transition (guarded, event-driven, no timers):

- **Hook table** — install `PostToolUse` for Claude, mapped to a new `tool-complete` sentinel event. The first tool that finishes after approval is the "turn is moving again" signal.
- **State machine** — `ToolComplete` flips `Waiting → Working` and clears the stale permission message. Guarded on `Waiting`: completions during normal work are a no-op, and a straggler event after `Stop` can't overwrite `Done` (won't hide the green unread dot).
- **Settings copy** — `Outdated` now also means "missing a newly added hook", not just a stale exe path, so the label is reworded to "installed by another tty7 version".

## Compatibility

- Old daemon + new hooks: unknown `tool-complete` event is dropped by the parser (by design).
- New daemon + old hooks: behaves exactly as before.
- Existing installs show **Outdated** in Settings → Agents with an **Update** button that merges the new hook in.

## Tests

State-machine test now covers: approve → first tool completes → back to `Working`; `ToolComplete` is a no-op while `Working`; `ToolComplete` after `Stop` keeps `Done`. The installer/parser consistency test picks up the new event automatically. 717 passed.