### PR TITLE
feat(tabs): double-click on tab zooms window instead of renaming

### DIFF
--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -209,16 +209,13 @@ impl Tty7App {
                     )
                     // Branch + diff line, when the pane sits in a git repo.
                     .children(git_line)
-                    // Single click activates; double click starts a rename.
+                    // Click activates. (Renaming lives in the context menu,
+                    // matching the strip — no double-click rename.)
                     .on_mouse_down(
                         MouseButton::Left,
-                        cx.listener(move |this, ev: &MouseDownEvent, window, cx| {
+                        cx.listener(move |this, _: &MouseDownEvent, window, cx| {
                             cx.stop_propagation();
-                            if ev.click_count >= 2 {
-                                this.start_rename(i, window, cx);
-                            } else {
-                                this.activate(i, window, cx);
-                            }
+                            this.activate(i, window, cx);
                         }),
                     )
                     // Drag the row by its label to reorder it (shared `DragTab`).

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -393,8 +393,9 @@ impl Tty7App {
         let has_cwd = cwd.is_some();
         let mut menu = menu.min_w(px(200.));
 
-        // Rename — the same inline edit a label double-click starts, given a
-        // discoverable entry point.
+        // Rename — the inline label edit's only entry point (a label
+        // double-click zooms the window instead, like the rest of the
+        // titlebar).
         menu = menu.item(PopupMenuItem::new("Rename Tab").on_click({
             let app = app.clone();
             move |_, window, cx| {
@@ -593,16 +594,18 @@ impl Tty7App {
                     // from the type, not from colour alone.
                     .when(is_active, |d| d.font_weight(FontWeight::MEDIUM))
                     .child(label)
-                    // Single click activates; double click starts a rename.
+                    // Single click activates; double click zooms the window,
+                    // same as the rest of the titlebar. (Renaming lives in the
+                    // context menu.)
                     .on_mouse_down(
                         MouseButton::Left,
                         cx.listener(move |this, ev: &MouseDownEvent, window, cx| {
-                            // Swallow the event so it never reaches the enclosing
-                            // TitleBar, whose double-click handler would otherwise
-                            // zoom/maximize the window on a rename double-click.
+                            // Swallow the event — on Windows the chip's `occlude()`
+                            // means it would never reach the TitleBar anyway, so we
+                            // forward the double-click zoom explicitly instead.
                             cx.stop_propagation();
                             if ev.click_count >= 2 {
-                                this.start_rename(i, window, cx);
+                                window.titlebar_double_click();
                             } else {
                                 this.activate(i, window, cx);
                             }


### PR DESCRIPTION
## What

- Double-clicking a tab label in the title-bar strip now zooms/maximizes the window (via `window.titlebar_double_click()`), matching the behavior of the rest of the titlebar, instead of starting an inline rename.
- The sidebar's double-click rename is removed as well for consistency — a click simply activates the tab.
- Renaming stays available through the tab context menu's **Rename Tab** item, now its single entry point.

## Why

With rename bound to double-click, the tab strip was the one part of the titlebar where double-clicking did not zoom the window. The zoom is forwarded explicitly rather than via event propagation because on Windows the chip's `occlude()` hitbox prevents the event from ever reaching the `TitleBar`.

## Testing

- `cargo check` / `cargo build` pass.
- Manually verified in an isolated dev instance: double-click on a strip tab zooms the window, sidebar double-click only activates, and context-menu **Rename Tab** still opens the inline editor.