### PR TITLE
fix(tray): redesign macOS menu bar glyph for legibility

### DIFF
--- a/assets/tray.svg
+++ b/assets/tray.svg
@@ -1,0 +1,5 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <rect x="11" y="21" width="98" height="78" rx="18" fill="none" stroke="#000" stroke-width="9"/>
+  <path d="M34 48 L50 61 L34 74" fill="none" stroke="#000" stroke-width="9" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="60" y1="76" x2="82" y2="76" stroke="#000" stroke-width="9" stroke-linecap="round"/>
+</svg>

--- a/src/ui/tray/icon.rs
+++ b/src/ui/tray/icon.rs
@@ -2,7 +2,7 @@
 //! own SVG path only yields a tinted alpha mask, so the tray draws its own).
 //!
 //! Two states per platform:
-//! - macOS: the outline terminal glyph (`logo.svg`) as a *template* image —
+//! - macOS: the outline terminal glyph (`tray.svg`) as a *template* image —
 //!   the system recolors its alpha for light/dark menu bars. Attention swaps
 //!   to a non-template variant: the glyph recolored to a mid-grey that reads
 //!   on both bar appearances, plus an amber badge (template images can't
@@ -23,7 +23,7 @@ pub(super) struct RgbaImage {
 }
 
 #[cfg(target_os = "macos")]
-const GLYPH_SVG: &[u8] = include_bytes!("../../../assets/logo.svg");
+const GLYPH_SVG: &[u8] = include_bytes!("../../../assets/tray.svg");
 #[cfg(not(target_os = "macos"))]
 const GLYPH_SVG: &[u8] = include_bytes!("../../../assets/app-icon.svg");
 


### PR DESCRIPTION
Redesigns the macOS menu bar (tray) glyph: a dedicated `tray.svg` drawn for 18pt, replacing the reused `logo.svg` that rendered as an illegible blob.

| | Before | After |
|---|---|---|
| Source asset | `logo.svg` (app logo reused) | `assets/tray.svg`, drawn for menu-bar size |
| Glyph | Window outline + title-bar rule + colored cursor block | Window outline + prompt chevron `>` + underscore `_` |
| Legibility at 18pt | Title-bar rule and cursor flatten into a card/wallet shape; template mode kills the cursor color | Bold single-weight strokes, reads as a terminal at a glance |

## Why

macOS renders the tray icon as a template image, so color is discarded and only alpha coverage survives. `logo.svg` depends on its orange cursor and a 0.7-opacity title-bar rule for meaning — both degrade badly at menu-bar size. `logo.svg` itself is untouched (the tray was its only code consumer); Windows/Linux keep `app-icon.svg`.

## Testing

- `cargo test ui::tray` — all 8 tests pass (render size/coverage, attention badge diff, recolor/alpha invariants).
- Rasterized the new glyph at 36px (the tray render size) and 240px with resvg/rsvg to confirm legibility.
