### PR TITLE
feat(nightly): unattended nightly build channel with prerelease-aware update check

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,190 @@
+name: Nightly
+
+# Unattended nightly channel: build `main` every night, stamp a pre-release
+# CalVer version (<next-stable>-nightly.<YYYYMMDD>), and publish everything to
+# a single rolling `nightly` prerelease. Stable releases (release.yml) are
+# untouched; the update checker ignores prereleases via /releases/latest.
+
+on:
+  schedule:
+    - cron: "0 18 * * *" # 18:00 UTC = 02:00 Beijing
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: nightly
+  cancel-in-progress: false
+
+jobs:
+  # Decide whether tonight needs a build, and compute the version once.
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      build: ${{ steps.plan.outputs.build }}
+      version: ${{ steps.plan.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history + tags — needed for the skip check and version math
+
+      - id: plan
+        run: |
+          # Skip when HEAD is already published: last night's nightly points at
+          # it (main hasn't moved) or a stable tag does (tonight would just
+          # rebuild the release under a nightly name).
+          if git tag --points-at HEAD | grep -qE '^(nightly$|v[0-9])'; then
+            echo "nothing new since the last published build — skipping"
+            echo "build=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Nightly version = next stable patch + date suffix, so semver
+          # ordering lands between the previous and the next stable release:
+          # 26.7.0 < 26.7.1-nightly.20260716 < 26.7.1.
+          LAST=$(git tag -l 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          BASE=${LAST#v}
+          NEXT="${BASE%.*}.$(( ${BASE##*.} + 1 ))"
+          VERSION="${NEXT}-nightly.$(date -u +%Y%m%d)"
+          echo "building $VERSION from ${GITHUB_SHA::7}"
+          echo "build=true" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  # Mirrors release.yml's build matrix; keep the two in sync when editing.
+  build:
+    needs: plan
+    if: needs.plan.outputs.build == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14
+            os: macos
+            arch: arm64
+            target: aarch64-apple-darwin
+          - runner: macos-15-intel
+            os: macos
+            arch: x86_64
+            target: x86_64-apple-darwin
+          - runner: windows-latest
+            os: windows
+            arch: x86_64
+            target: x86_64-pc-windows-msvc
+          - runner: ubuntu-latest
+            os: linux
+            arch: x86_64
+            target: x86_64-unknown-linux-gnu
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout tty7
+        uses: actions/checkout@v4
+        with:
+          path: tty7
+
+      # Everything versioned — the binary (CARGO_PKG_VERSION), asset names,
+      # DMG plist, Inno installer — reads Cargo.toml, so stamping it here is
+      # the only edit needed. Cargo.lock is left alone: cargo refreshes the
+      # root package's own lock entry automatically, without network access.
+      - name: Stamp nightly version
+        working-directory: tty7
+        shell: bash
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: |
+          awk -v ver="$VERSION" '!done && /^version = /{ $0 = "version = \"" ver "\""; done = 1 } { print }' \
+            Cargo.toml > Cargo.toml.tmp
+          mv Cargo.toml.tmp Cargo.toml
+          grep -m1 '^version' Cargo.toml
+
+      - name: Install Linux system dependencies
+        if: matrix.os == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config cmake clang libxkbcommon-dev \
+            libxkbcommon-x11-dev libfontconfig1-dev libfreetype6-dev \
+            libwayland-dev libx11-dev libxcb1-dev libzstd-dev libssl-dev \
+            libkrb5-dev libfuse2 file imagemagick
+          echo "LIBGSSAPI_IMPL=mit" >> "$GITHUB_ENV"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tty7
+
+      - name: Build
+        working-directory: tty7
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Bundle macOS DMG
+        if: matrix.os == 'macos'
+        working-directory: tty7
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: bash .github/scripts/bundle-macos.sh "${{ matrix.target }}" "${{ matrix.arch }}"
+
+      - name: Package Linux tarball
+        if: matrix.os == 'linux'
+        working-directory: tty7
+        run: bash .github/scripts/bundle-linux.sh "${{ matrix.target }}" "${{ matrix.arch }}"
+
+      - name: Package Linux AppImage
+        if: matrix.os == 'linux'
+        working-directory: tty7
+        run: bash .github/scripts/bundle-appimage.sh "${{ matrix.target }}" "${{ matrix.arch }}"
+
+      - name: Package Windows installer + zip
+        if: matrix.os == 'windows'
+        working-directory: tty7
+        shell: pwsh
+        run: '& ./.github/scripts/bundle-windows.ps1 "${{ matrix.target }}" "${{ matrix.arch }}"'
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nightly-${{ matrix.os }}-${{ matrix.arch }}
+          path: tty7/dist/*
+          if-no-files-found: error
+
+  # Single publish step after all platforms succeed, so the rolling release is
+  # always complete — a failed platform means tonight's nightly is skipped
+  # entirely and users keep yesterday's, never a partial asset set.
+  publish:
+    needs: [plan, build]
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      VERSION: ${{ needs.plan.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Update rolling nightly release
+        run: |
+          # Move the tag first so the release object follows it to this SHA.
+          git push -f origin "$GITHUB_SHA:refs/tags/nightly"
+
+          TITLE="Nightly $VERSION"
+          NOTES="Automated nightly build of \`main\` @ ${GITHUB_SHA::7} ($(date -u +%F)). Rolling prerelease — assets are replaced every night; for the latest stable release see https://github.com/${GITHUB_REPOSITORY}/releases/latest."
+
+          if gh release view nightly >/dev/null 2>&1; then
+            # Old assets carry the previous version in their names, so clear
+            # them out instead of relying on --clobber's same-name matching.
+            gh release view nightly --json assets -q '.assets[].name' |
+              xargs -r -I{} gh release delete-asset nightly {} -y
+            gh release edit nightly --prerelease --title "$TITLE" --notes "$NOTES"
+          else
+            gh release create nightly --prerelease --title "$TITLE" --notes "$NOTES"
+          fi
+          gh release upload nightly dist/* --clobber

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -179,12 +179,18 @@ jobs:
           NOTES="Automated nightly build of \`main\` @ ${GITHUB_SHA::7} ($(date -u +%F)). Rolling prerelease — assets are replaced every night; for the latest stable release see https://github.com/${GITHUB_REPOSITORY}/releases/latest."
 
           if gh release view nightly >/dev/null 2>&1; then
-            # Old assets carry the previous version in their names, so clear
-            # them out instead of relying on --clobber's same-name matching.
-            gh release view nightly --json assets -q '.assets[].name' |
-              xargs -r -I{} gh release delete-asset nightly {} -y
             gh release edit nightly --prerelease --title "$TITLE" --notes "$NOTES"
           else
             gh release create nightly --prerelease --title "$TITLE" --notes "$NOTES"
           fi
+
+          # Upload before deleting: date-suffixed names never collide across
+          # nights, so both sets briefly coexist — if an upload dies midway,
+          # yesterday's complete nightly is still intact.
           gh release upload nightly dist/* --clobber
+
+          # Now prune the previous night's assets (anything we didn't upload).
+          gh release view nightly --json assets -q '.assets[].name' |
+            while read -r name; do
+              [ -e "dist/$name" ] || gh release delete-asset nightly "$name" -y
+            done

--- a/src/core/update.rs
+++ b/src/core/update.rs
@@ -383,6 +383,13 @@ mod tests {
         assert!(!is_update_available("v26.7.0", "26.7.1-nightly.20260716"));
         // A stable binary is never downgraded to a pre-release of itself.
         assert!(!is_update_available("v26.7.1-rc.1", "26.7.1"));
+        // Nightly-to-nightly is deliberately not an update: pre-releases with
+        // the same core compare equal, and the check only ever sees
+        // /releases/latest, which is never a pre-release anyway.
+        assert!(!is_update_available(
+            "26.7.1-nightly.20260717",
+            "26.7.1-nightly.20260716"
+        ));
     }
 
     #[test]

--- a/src/core/update.rs
+++ b/src/core/update.rs
@@ -287,17 +287,25 @@ async fn fetch_latest_version() -> Result<String> {
     Ok(release.tag_name)
 }
 
-/// Parse a version string into a `(major, minor, patch)` triple, tolerating a
-/// leading `v` and ignoring any pre-release / build suffix (`-rc.1`, `+build`).
-/// Missing minor/patch components read as `0`. Returns `None` if the numeric
-/// core doesn't parse — the caller treats that as "don't prompt".
-fn parse_version(s: &str) -> Option<(u64, u64, u64)> {
+/// Parse a version string into a `(major, minor, patch, is_release)` tuple,
+/// tolerating a leading `v`. Missing minor/patch components read as `0`.
+/// Returns `None` if the numeric core doesn't parse — the caller treats that
+/// as "don't prompt".
+///
+/// The trailing `is_release` flag implements semver's pre-release ordering
+/// through plain tuple comparison: a `-nightly.20260716` (or `-rc.1`) suffix
+/// makes it `false`, which sorts *below* the same core with `true` — so a
+/// nightly binary counts as older than the stable release it previews, and the
+/// prompt fires when that stable ships. Finer ordering *between* pre-releases
+/// isn't needed: the check only ever compares against `/releases/latest`,
+/// which never returns a pre-release. Build metadata (`+ci`) is ignored, as
+/// semver says it should be.
+fn parse_version(s: &str) -> Option<(u64, u64, u64, bool)> {
     let trimmed = s.trim();
     // Strip a single optional `v` prefix. `strip_prefix` (not `trim_start_matches`)
     // so a doubled `vv0.3.1` fails to parse instead of silently losing the extra v.
     let core = trimmed.strip_prefix('v').unwrap_or(trimmed);
-    // A pre-release/build tag (`0.4.0-rc.1`, `0.4.0+ci`) compares by its release
-    // core here; we don't ship pre-releases, so finer ordering isn't worth it.
+    let is_release = !core.split('+').next().unwrap_or(core).contains('-');
     let core = core.split(['-', '+']).next().unwrap_or(core);
     let mut parts = core.split('.');
     let major = parts.next()?.parse().ok()?;
@@ -308,7 +316,7 @@ fn parse_version(s: &str) -> Option<(u64, u64, u64)> {
     if parts.next().is_some() {
         return None;
     }
-    Some((major, minor, patch))
+    Some((major, minor, patch, is_release))
 }
 
 /// Whether `latest` names a strictly newer version than `current`. If either
@@ -327,15 +335,20 @@ mod tests {
 
     #[test]
     fn parses_versions_with_and_without_prefix() {
-        assert_eq!(parse_version("v0.3.1"), Some((0, 3, 1)));
-        assert_eq!(parse_version("0.3.1"), Some((0, 3, 1)));
-        assert_eq!(parse_version(" 1.2.0 "), Some((1, 2, 0)));
+        assert_eq!(parse_version("v0.3.1"), Some((0, 3, 1, true)));
+        assert_eq!(parse_version("0.3.1"), Some((0, 3, 1, true)));
+        assert_eq!(parse_version(" 1.2.0 "), Some((1, 2, 0, true)));
         // Missing components default to zero.
-        assert_eq!(parse_version("v2"), Some((2, 0, 0)));
-        assert_eq!(parse_version("v2.5"), Some((2, 5, 0)));
-        // Pre-release / build metadata is ignored down to the release core.
-        assert_eq!(parse_version("v0.4.0-rc.1"), Some((0, 4, 0)));
-        assert_eq!(parse_version("0.4.0+ci.7"), Some((0, 4, 0)));
+        assert_eq!(parse_version("v2"), Some((2, 0, 0, true)));
+        assert_eq!(parse_version("v2.5"), Some((2, 5, 0, true)));
+        // A pre-release suffix keeps the core but sorts below the release…
+        assert_eq!(parse_version("v0.4.0-rc.1"), Some((0, 4, 0, false)));
+        assert_eq!(
+            parse_version("26.7.1-nightly.20260716"),
+            Some((26, 7, 1, false))
+        );
+        // …while build metadata alone is still a release.
+        assert_eq!(parse_version("0.4.0+ci.7"), Some((0, 4, 0, true)));
         // Garbage yields None.
         assert_eq!(parse_version("nightly"), None);
         assert_eq!(parse_version(""), None);
@@ -351,6 +364,8 @@ mod tests {
         assert!(is_update_available("v0.3.1", "0.3.0"));
         assert!(is_update_available("v1.0.0", "0.9.9"));
         assert!(is_update_available("0.4.0", "0.3.99"));
+        // CalVer jump over the old 0.x tags still orders correctly.
+        assert!(is_update_available("v26.7.0", "0.17.0"));
     }
 
     #[test]
@@ -358,6 +373,16 @@ mod tests {
         assert!(!is_update_available("v0.3.0", "0.3.0"));
         assert!(!is_update_available("v0.2.9", "0.3.0"));
         assert!(!is_update_available("0.3.0", "0.3.1"));
+    }
+
+    #[test]
+    fn nightly_binaries_prompt_when_their_stable_ships() {
+        // A nightly previews the next stable: same core, sorts below it.
+        assert!(is_update_available("v26.7.1", "26.7.1-nightly.20260716"));
+        // …but the stable it was built *after* is not an update.
+        assert!(!is_update_available("v26.7.0", "26.7.1-nightly.20260716"));
+        // A stable binary is never downgraded to a pre-release of itself.
+        assert!(!is_update_available("v26.7.1-rc.1", "26.7.1"));
     }
 
     #[test]


### PR DESCRIPTION
Adds an unattended nightly build channel: a scheduled workflow builds `main` every night into a single rolling `nightly` prerelease, and the in-app update check learns semver pre-release ordering so nightly binaries prompt correctly.

| | Before | After |
|---|---|---|
| Nightly builds | None — users wait for the next stable release | Built from `main` every night (18:00 UTC), published to one rolling `nightly` prerelease |
| Nightly versioning | — | `<next stable patch>-nightly.<YYYYMMDD>` (e.g. `26.7.1-nightly.20260716`), stamped into `Cargo.toml` in CI only, never committed |
| Releases page | Stable releases only | Unchanged for stable; a single `nightly` prerelease whose tag/assets are replaced each night (no wezterm-style timestamp pile-up) |
| Update prompt, stable users | Checks `/releases/latest` | Unchanged — that endpoint ignores prereleases, so nightly never triggers prompts |
| Update prompt, nightly users | `26.7.1-nightly.x` parsed as `26.7.1` → no prompt when stable `26.7.1` ships | Pre-release sorts below the same-core stable (per semver), so the prompt fires when the previewed stable is released |

## How the workflow works

```mermaid
flowchart LR
    plan["plan\nskip if main unmoved\nor HEAD already tagged;\ncompute version"] --> build["build ×4\nrelease.yml matrix,\nversion stamped pre-build"]
    build --> publish["publish (all-or-nothing)\nforce-move nightly tag,\nreplace all assets"]
```

- **Skip logic**: no build when the `nightly` tag still points at HEAD (nothing landed) or a stable `v*` tag points at HEAD (tonight would just rebuild the release).
- **Version stamping**: everything versioned (binary, asset names, DMG plist, Inno installer) reads `Cargo.toml`, so one awk edit in CI covers all of it. `Cargo.lock` is untouched — cargo refreshes the root package entry itself, offline.
- **All-or-nothing publish**: assets upload in a single job after all four platforms succeed. One failed platform skips the night entirely; users keep the previous complete nightly instead of getting a partial asset set.
- The build matrix and bundle scripts are shared with `release.yml`; a comment in both marks them as keep-in-sync.

## Testing

- `cargo test --bin tty7 core::update` — 6/6 pass, including new cases: nightly binary prompts on its stable release, does not prompt for the stable it was built after, and a stable binary is never "downgraded" to a pre-release of itself.
- `nightly.yml` YAML-validated; version-derivation shell logic exercised locally against the real tag list.
- Verified Inno Setup uses `AppVersion` (free-form string), so the `-nightly.<date>` suffix is safe on Windows packaging.
