### PR TITLE
fix(nightly): upload only packaged artifacts, not dist/ intermediates

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -147,10 +147,18 @@ jobs:
         shell: pwsh
         run: '& ./.github/scripts/bundle-windows.ps1 "${{ matrix.target }}" "${{ matrix.arch }}"'
 
+      # Same glob list as release.yml's Release step: the bundle scripts leave
+      # intermediates in dist/ (tty7.app, entitlements.plist, the Windows
+      # staging dir) that must not reach the release assets.
       - uses: actions/upload-artifact@v4
         with:
           name: nightly-${{ matrix.os }}-${{ matrix.arch }}
-          path: tty7/dist/*
+          path: |
+            tty7/dist/*.dmg
+            tty7/dist/*.tar.gz
+            tty7/dist/*.zip
+            tty7/dist/*-setup.exe
+            tty7/dist/*.AppImage
           if-no-files-found: error
 
   # Single publish step after all platforms succeed, so the rolling release is


### PR DESCRIPTION
First manual run of the nightly workflow (#114) failed in `publish`: `gh release upload dist/*` hit `read dist/tty7.app: is a directory`. The bundle scripts leave intermediates in `dist/` — `tty7.app` and `entitlements.plist` on macOS, the zip staging directory on Windows — and the nightly artifact upload swept them all in with `tty7/dist/*`.

| | Before | After |
|---|---|---|
| Artifact upload glob | `tty7/dist/*` (includes `.app` dir, plist, staging dir) | Same five-suffix glob list as `release.yml`'s Release step (`*.dmg`, `*.tar.gz`, `*.zip`, `*-setup.exe`, `*.AppImage`) |
| `publish` job | Fails on the `tty7.app` directory; nightly release left empty | Uploads exactly the packaged assets |

All four platform builds (including macOS notarization with the `-nightly.` version suffix) already passed in the failed run — only the asset sweep was wrong.

## Testing

- YAML-validated.
- Verified each matrix job still matches ≥1 glob, so `if-no-files-found: error` stays meaningful (macOS → dmg, Linux → tar.gz + AppImage, Windows → zip + setup.exe).
