### PR TITLE
feat(tabs): add Mark as Unread to the tab context menu

### DIFF
--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -247,6 +247,13 @@ pub struct TerminalView {
     /// while this is true, so a result you've already seen stops nagging. Blue
     /// (working) / amber (waiting) are unaffected — they track live state.
     agent_result_unread: bool,
+    /// One-shot guard for a manual "Mark as Unread" on the pane the dismissed
+    /// context menu is about to refocus: closing the menu returns window focus
+    /// to that pane, and the resulting focus-in would instantly clear the mark
+    /// the user just made. Armed by [`mark_agent_result_unread`]
+    /// (Self::mark_agent_result_unread); the next focus-in consumes it instead
+    /// of clearing, so the mark survives until the user genuinely comes back.
+    keep_unread_on_focus: bool,
     /// The cwd this pane's git line reads from (and last scheduled a probe
     /// for), so the poll loop only reprobes when the working directory
     /// actually changes. The snapshot itself lives in the process-wide
@@ -824,8 +831,14 @@ impl TerminalView {
                 view.focused = true;
                 view.cursor_visible = true;
                 // Looking at the pane marks its finished turn read, so the tab
-                // avatar's green Done dot clears.
-                view.agent_result_unread = false;
+                // avatar's green Done dot clears — unless this focus-in is
+                // just the context menu handing focus back after a manual
+                // "Mark as Unread" (the one-shot guard eats it).
+                if view.keep_unread_on_focus {
+                    view.keep_unread_on_focus = false;
+                } else {
+                    view.agent_result_unread = false;
+                }
                 view.report_focus_change(true);
                 cx.notify();
             }),
@@ -944,6 +957,7 @@ impl TerminalView {
             agent_turn_started: None,
             agent_was_rich: false,
             agent_result_unread: false,
+            keep_unread_on_focus: false,
             git_status_cwd: None,
             cmd: CmdEditor::new(),
             typeahead: Typeahead::new(),
@@ -1026,6 +1040,16 @@ impl TerminalView {
     /// for any `Done`.
     pub fn agent_result_unread(&self) -> bool {
         self.agent_result_unread
+    }
+
+    /// Re-flag this pane's finished turn as unread — the tab context menu's
+    /// "Mark as Unread". `refocus_incoming` is true for the pane the dismissed
+    /// menu is about to hand window focus back to (the active tab's focused
+    /// leaf): that focus-in is the menu closing, not the user reading the
+    /// result, so it must not clear the mark it just made.
+    pub fn mark_agent_result_unread(&mut self, refocus_incoming: bool) {
+        self.agent_result_unread = true;
+        self.keep_unread_on_focus = refocus_incoming;
     }
 
     /// The git snapshot for this pane's cwd (branch + working-tree diff), for
@@ -2549,9 +2573,13 @@ impl TerminalView {
         match status {
             Some(AgentStatus::Done) if prev != Some(AgentStatus::Done) => {
                 self.agent_result_unread = !self.focused;
+                self.keep_unread_on_focus = false;
             }
             Some(AgentStatus::Done) => {}
-            _ => self.agent_result_unread = false,
+            _ => {
+                self.agent_result_unread = false;
+                self.keep_unread_on_focus = false;
+            }
         }
 
         let rich = session.as_ref().is_some_and(|s| s.rich);

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -2471,6 +2471,30 @@ impl Tty7App {
         }
     }
 
+    /// "Mark as Unread" (tab context menu): re-flag every finished (`Done`)
+    /// agent turn in the tab as unread, so the avatar's green dot swells back
+    /// into its count badge until the user next looks at those panes. The
+    /// active tab's focus target is told the dismissed menu is about to hand
+    /// focus back to it, so that focus-in doesn't immediately re-read the mark
+    /// (see `TerminalView::mark_agent_result_unread`).
+    pub(crate) fn mark_tab_unread(&mut self, index: usize, cx: &mut Context<Self>) {
+        use crate::core::cli_agent::AgentStatus;
+        let Some(tab) = self.tabs.get(index) else {
+            return;
+        };
+        let refocus = (index == self.active).then(|| tab.focus_target()).flatten();
+        for leaf in tab.pane.leaves() {
+            let refocus_incoming = refocus.as_ref() == Some(&leaf);
+            leaf.update(cx, |view, cx| {
+                if view.agent_session().map(|s| s.status) == Some(AgentStatus::Done) {
+                    view.mark_agent_result_unread(refocus_incoming);
+                    cx.notify();
+                }
+            });
+        }
+        cx.notify();
+    }
+
     /// The cwd of the tab's label-driving terminal (focused leaf, else first) —
     /// what the tab context menu's "Copy Working Directory" copies and "New
     /// Worktree Tab" derives the repo from.

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -403,6 +403,27 @@ impl Tty7App {
             }
         }));
 
+        // Mark as Unread — re-arm the avatar's green Done badge so a result
+        // you want to revisit nags again. Only agent tabs get the entry, and
+        // only a settled (`Done`) tab has a finished turn to mark; a busier
+        // status (working/waiting) owns the dot anyway, so the entry disables
+        // rather than promising a badge that can't show yet.
+        let tab = this.tabs.get(index);
+        if tab.is_some_and(|t| t.agent(cx).is_some()) {
+            let done = tab.and_then(|t| t.agent_status(cx))
+                == Some(crate::core::cli_agent::AgentStatus::Done);
+            menu = menu.item(
+                PopupMenuItem::new("Mark as Unread")
+                    .disabled(!done)
+                    .on_click({
+                        let app = app.clone();
+                        move |_, _window, cx| {
+                            let _ = app.update(cx, |this, cx| this.mark_tab_unread(index, cx));
+                        }
+                    }),
+            );
+        }
+
         // Worktree: an isolated checkout of this tab's repo on a fresh branch,
         // opened as a new tab — parallel-agent fuel. Only offered when the
         // tab's cwd actually sits in a git repository (a filesystem-only


### PR DESCRIPTION
Adds a **Mark as Unread** entry to the tab context menu (title-bar chips and sidebar rows share the same menu), so a finished agent result you want to revisit can be re-flagged after you've already looked at it.

| | Before | After |
|---|---|---|
| Re-flag a finished agent turn | Impossible — focusing the pane clears the unread badge for good | Right-click tab → **Mark as Unread** re-arms the count badge on the avatar's green Done dot |
| Menu on a plain shell tab | — | No new entry (agent tabs only) |
| Menu while the agent is working/waiting | — | Entry shown but disabled — the badge only renders in the `Done` state, so marking would promise nothing visible |
| Marking the *active* tab | — | Badge survives the menu closing; it clears the next time you come back to the pane |

**Why the one-shot focus guard:** dismissing the context menu hands window focus back to the pane it was on, and the pane's `focus-in` handler is exactly what clears `agent_result_unread`. Without a guard, "Mark as Unread" on the active tab would be undone the instant the menu closes. `mark_tab_unread` arms `keep_unread_on_focus` on the active tab's focus target only; the menu-close focus-in consumes the guard instead of clearing, and any later genuine visit (blur → focus) reads the mark as usual. Agent status transitions (a new turn starting, etc.) reset the guard so it can't leak into unrelated focus changes.

## Testing

- `cargo check` / `cargo build` clean.
- Manually accepted in an isolated dev instance (`--config-dir` scratch): run an agent turn to `Done`, mark the tab unread → the badge re-appears and survives the menu closing; revisiting the pane clears it; shell tabs show no entry; a working agent tab shows it disabled.
