### PR TITLE
feat(theme): follow the OS appearance with separate light/dark themes

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -19,6 +19,7 @@
 - **Command palette** <kbd>⌘ P</kbd> · scrollback search <kbd>⌘ F</kbd>
 - **⌘-click links** · desktop notifications · copy on select (opt-in, Settings → Terminal → Clipboard)
 - **Eight themes, plus your own** — YAML seed themes with solid, gradient, or image backgrounds; iTerm2 `.itermcolors` import; in-app color editor with a background-image picker
+- **Sync with system** — Settings → Appearance; pick separate light and dark themes and tty7 follows the OS appearance live (`theme_follow_system`, `theme_preset_light` / `theme_preset_dark` in `config.json`)
 - **Window opacity & blur** — Settings → Appearance → Window; applies to every theme, *Follow theme* returns to the theme's own `opacity` / `blur`
 - **CJK / IME input**
 

--- a/docs/features.zh-CN.md
+++ b/docs/features.zh-CN.md
@@ -19,6 +19,7 @@
 - **命令面板** <kbd>⌘ P</kbd> · 回滚搜索 <kbd>⌘ F</kbd>
 - **⌘ 点击打开链接** · 桌面通知 · 划选即复制（可选，设置 → 终端 → 剪贴板）
 - **8 套主题，也能自定义** — YAML 种子主题，背景支持纯色、渐变或图片；可导入 iTerm2 `.itermcolors`；应用内颜色编辑器带背景图选择
+- **跟随系统外观** — 设置 → Appearance；分别选好浅色和深色主题，tty7 随系统深浅模式实时切换（`config.json` 中的 `theme_follow_system`、`theme_preset_light` / `theme_preset_dark`）
 - **窗口透明与模糊** — 设置 → Appearance → Window；对所有主题生效，*Follow theme* 恢复主题自带的 `opacity` / `blur`
 - **CJK / 输入法输入**
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -852,6 +852,27 @@ mod tests {
     }
 
     #[test]
+    fn theme_follow_system_defaults_and_round_trips() {
+        // Old configs (no follow-system keys) must land on off + the built-in
+        // light/dark pair, so nothing changes until the user opts in.
+        let cfg: Config = serde_json::from_str(r#"{"theme_preset":"dracula"}"#).unwrap();
+        assert!(!cfg.theme_follow_system);
+        assert_eq!(cfg.theme_preset_light, "light");
+        assert_eq!(cfg.theme_preset_dark, "dark");
+        assert_eq!(cfg.theme_preset, "dracula");
+
+        let mut cfg = Config::default();
+        cfg.theme_follow_system = true;
+        cfg.theme_preset_light = "one_light".to_string();
+        cfg.theme_preset_dark = "dracula".to_string();
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: Config = serde_json::from_str(&json).unwrap();
+        assert!(back.theme_follow_system);
+        assert_eq!(back.theme_preset_light, "one_light");
+        assert_eq!(back.theme_preset_dark, "dracula");
+    }
+
+    #[test]
     fn font_features_are_optional_and_parse_as_gpui_features() {
         let cfg: Config =
             serde_json::from_str(r#"{"font_features":{"calt":true,"liga":1}}"#).unwrap();

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -42,6 +42,18 @@ pub struct Config {
     /// `~/.config/tty7/themes/*`); unknown ids fall back to the default theme. The
     /// native chrome is forced to match the theme's light/dark brightness.
     pub theme_preset: String,
+    /// Follow the OS light/dark appearance. When `true` the active theme is
+    /// resolved from `theme_preset_light` / `theme_preset_dark` by the current
+    /// system appearance (switching live when the OS mode flips) and
+    /// `theme_preset` is ignored; the native chrome follows the OS instead of
+    /// being pinned to the theme.
+    pub theme_follow_system: bool,
+    /// Theme id used while `theme_follow_system` is on and the OS is in light
+    /// mode. Same registry/fallback rules as `theme_preset`.
+    pub theme_preset_light: String,
+    /// Theme id used while `theme_follow_system` is on and the OS is in dark
+    /// mode. Same registry/fallback rules as `theme_preset`.
+    pub theme_preset_dark: String,
     /// Global window-opacity override, 0.2–1.0. `None` (the default) follows the
     /// active theme's own `opacity`; when set it applies to every theme, so a
     /// chosen translucency survives theme switches.
@@ -431,6 +443,11 @@ impl Default for Config {
             // The default theme id (mirrors `ui::presets::DEFAULT_ID`; core can't
             // depend on ui). Unknown ids fall back to it anyway.
             theme_preset: "light".to_string(),
+            theme_follow_system: false,
+            // The built-in light/dark pair; each side is user-swappable in
+            // Settings once "sync with system" is on.
+            theme_preset_light: "light".to_string(),
+            theme_preset_dark: "dark".to_string(),
             window_opacity: None,
             window_blur: None,
             keybindings: HashMap::new(),

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -303,6 +303,10 @@ pub struct Tty7App {
     /// the same repo shows the just-refreshed branch/diff line, not a stale
     /// per-row copy. Never read.
     _git_status_watch: Subscription,
+    /// Keeps the window-appearance observer alive: while
+    /// `Config::theme_follow_system` is on, an OS light/dark flip re-resolves
+    /// the theme slot and repaints. Never read.
+    _appearance_watch: Subscription,
     /// `Some` while the command palette overlay is open; `None` when closed.
     /// The view owns its search input, filtered list and keyboard handling and
     /// emits a `PaletteEvent`; we build the catalog and run the chosen command.
@@ -534,6 +538,24 @@ impl Tty7App {
             // release; holding ⌘ again re-arms it via `on_modifiers_changed`.
             this.set_link_modifier(false, cx);
         });
+        // Follow OS light/dark flips live: while "sync with system" is on, an
+        // appearance change re-resolves the theme slot and repaints. While it's
+        // off the appearance only ever changes because `apply_theme` pinned it
+        // to the theme — skip, or the pin would re-trigger a redundant apply.
+        let this = cx.weak_entity();
+        let appearance_watch = window.observe_window_appearance(move |window, cx| {
+            if !cx.global::<Config>().theme_follow_system {
+                return;
+            }
+            apply_theme(Some(window), cx);
+            let _ = this.update(cx, |this, cx| {
+                // The editor targets the on-screen theme, and with no global
+                // override the opacity slider follows it — keep both in step.
+                this.rebuild_theme_editor(window, cx);
+                this.sync_window_opacity_slider(window, cx);
+                cx.notify();
+            });
+        });
         // Paint the configured color theme (defaults to a light one) and build
         // the menu bar.
         apply_theme(Some(window), cx);
@@ -578,6 +600,7 @@ impl Tty7App {
             _keystroke_watch: keystroke_watch,
             _activation_watch: activation_watch,
             _git_status_watch: git_status_watch,
+            _appearance_watch: appearance_watch,
             palette: None,
             palette_sub: None,
             closed: Vec::new(),
@@ -1079,8 +1102,89 @@ impl Tty7App {
 
     /// Switch the active color theme by id, repaint, and persist the choice so
     /// it survives a restart. The theme carries its own dark/light brightness.
+    /// While the system is being followed, the choice lands in the slot for the
+    /// *current* OS appearance (the theme visibly on screen changes either way).
     pub(crate) fn set_preset(&mut self, id: &str, window: &mut Window, cx: &mut Context<Self>) {
-        cx.global_mut::<Config>().theme_preset = id.to_string();
+        let dark_now = crate::ui::theme::system_dark(cx);
+        let cfg = cx.global_mut::<Config>();
+        if !cfg.theme_follow_system {
+            cfg.theme_preset = id.to_string();
+        } else if dark_now {
+            cfg.theme_preset_dark = id.to_string();
+        } else {
+            cfg.theme_preset_light = id.to_string();
+        }
+        self.after_theme_change(window, cx);
+    }
+
+    /// Set the theme for one follow-system slot explicitly (the Light / Dark
+    /// cards in Settings). Only visibly changes anything when that slot is the
+    /// one currently on screen; either way the choice is persisted.
+    pub(crate) fn set_slot_preset(
+        &mut self,
+        dark_slot: bool,
+        id: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let cfg = cx.global_mut::<Config>();
+        if dark_slot {
+            cfg.theme_preset_dark = id.to_string();
+        } else {
+            cfg.theme_preset_light = id.to_string();
+        }
+        self.after_theme_change(window, cx);
+    }
+
+    /// Turn "sync with system appearance" on/off (the Appearance switch).
+    /// Flipping it never visibly changes the theme by itself: turning it on
+    /// seeds the slot matching the manual theme's own brightness with that
+    /// theme, and turning it off adopts whatever is on screen as the manual
+    /// choice.
+    pub(crate) fn set_theme_follow_system(
+        &mut self,
+        on: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if on {
+            let manual = cx.global::<Config>().theme_preset.clone();
+            let manual_dark = crate::ui::presets::by_id(cx, &manual).dark;
+            let cfg = cx.global_mut::<Config>();
+            cfg.theme_follow_system = true;
+            if manual_dark {
+                cfg.theme_preset_dark = manual;
+            } else {
+                cfg.theme_preset_light = manual;
+            }
+        } else {
+            // Resolve while following is still on (the pin is released, so
+            // this reads the real OS appearance).
+            let effective = crate::ui::theme::effective_preset_id(cx);
+            let cfg = cx.global_mut::<Config>();
+            cfg.theme_follow_system = false;
+            cfg.theme_preset = effective;
+        }
+        self.after_theme_change(window, cx);
+        // Re-aim an open picker panel at a slot that exists in the new mode —
+        // after the apply above, so `system_dark` reads the unpinned OS value.
+        let slot = if on {
+            if crate::ui::theme::system_dark(cx) {
+                crate::ui::settings::ThemeSlot::Dark
+            } else {
+                crate::ui::settings::ThemeSlot::Light
+            }
+        } else {
+            crate::ui::settings::ThemeSlot::Manual
+        };
+        if let Some(s) = self.active_settings_mut() {
+            s.theme_panel_slot = slot;
+        }
+    }
+
+    /// The shared tail of every theme-selection change: repaint, persist, and
+    /// keep the dependent Settings widgets in step.
+    fn after_theme_change(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         apply_theme(Some(window), cx);
         set_menus(cx);
         cx.global::<Config>().save();
@@ -1092,10 +1196,21 @@ impl Tty7App {
         cx.notify();
     }
 
-    /// Show/hide the theme picker panel beside the Appearance page.
-    pub(crate) fn toggle_theme_panel(&mut self, cx: &mut Context<Self>) {
+    /// Show/hide the theme picker panel beside the Appearance page. Clicking
+    /// the card whose slot the open panel already targets closes it; clicking
+    /// another card re-aims the open panel at that slot.
+    pub(crate) fn toggle_theme_panel(
+        &mut self,
+        slot: crate::ui::settings::ThemeSlot,
+        cx: &mut Context<Self>,
+    ) {
         if let Some(s) = self.active_settings_mut() {
-            s.theme_panel_open = !s.theme_panel_open;
+            if s.theme_panel_open && s.theme_panel_slot == slot {
+                s.theme_panel_open = false;
+            } else {
+                s.theme_panel_open = true;
+                s.theme_panel_slot = slot;
+            }
             cx.notify();
         }
     }
@@ -1121,7 +1236,7 @@ impl Tty7App {
     /// and open the color editor on it. This is the entry point for customizing a
     /// read-only built-in (or an imported iTerm scheme).
     pub(crate) fn fork_active_theme(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let id = cx.global::<Config>().theme_preset.clone();
+        let id = crate::ui::theme::effective_preset_id(cx);
         let theme = crate::ui::presets::by_id(cx, &id);
         match crate::ui::presets::fork_to_file(&theme) {
             Ok(new_id) => {
@@ -1142,7 +1257,7 @@ impl Tty7App {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let id = cx.global::<Config>().theme_preset.clone();
+        let id = crate::ui::theme::effective_preset_id(cx);
         let mut theme = crate::ui::presets::by_id(cx, &id);
         if !theme.editable() {
             return;
@@ -1184,7 +1299,7 @@ impl Tty7App {
     /// set, else the active theme's own value, else fully opaque.
     pub(crate) fn effective_window_opacity(cx: &App) -> f32 {
         let config = cx.global::<Config>();
-        let theme = crate::ui::presets::by_id(cx, &config.theme_preset);
+        let theme = crate::ui::presets::by_id(cx, &crate::ui::theme::effective_preset_id(cx));
         config.window_opacity.or(theme.opacity).unwrap_or(1.0)
     }
 
@@ -1311,7 +1426,7 @@ impl Tty7App {
         if self.settings.is_none() {
             return;
         }
-        let id = cx.global::<Config>().theme_preset.clone();
+        let id = crate::ui::theme::effective_preset_id(cx);
         let theme = crate::ui::presets::by_id(cx, &id);
         if !theme.editable() {
             if let Some(s) = self.settings.as_mut() {
@@ -3010,6 +3125,7 @@ impl Tty7App {
             window_opacity_slider,
             theme_editor: None,
             theme_panel_open: false,
+            theme_panel_slot: crate::ui::settings::ThemeSlot::Manual,
             theme_search,
             recording: None,
             rebinding_note: None,

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1137,10 +1137,11 @@ impl Tty7App {
     }
 
     /// Turn "sync with system appearance" on/off (the Appearance switch).
-    /// Flipping it never visibly changes the theme by itself: turning it on
-    /// seeds the slot matching the manual theme's own brightness with that
-    /// theme, and turning it off adopts whatever is on screen as the manual
-    /// choice.
+    /// Turning it off never visibly changes the theme: whatever is on screen
+    /// is adopted as the manual choice. Turning it on seeds the slot matching
+    /// the manual theme's own brightness with that theme — so the look only
+    /// changes when the OS is currently in the *other* mode, where switching
+    /// to that mode's slot is exactly what the feature promises.
     pub(crate) fn set_theme_follow_system(
         &mut self,
         on: bool,

--- a/src/ui/palette.rs
+++ b/src/ui/palette.rs
@@ -21,7 +21,6 @@ use gpui_component::{
 
 use uuid::Uuid;
 
-use crate::core::config::Config;
 use crate::core::ssh_profile::parse_quick_connect;
 
 /// What a command actually does. Most variants map to an existing `Tty7App`
@@ -234,7 +233,7 @@ impl Command {
     /// preset. The active theme is marked with a check so the list doubles as a
     /// "which theme am I on?" indicator.
     pub fn theme_commands(cx: &App) -> Vec<Command> {
-        let active = cx.global::<Config>().theme_preset.clone();
+        let active = crate::ui::theme::effective_preset_id(cx);
         crate::ui::presets::all(cx)
             .into_iter()
             .enumerate()

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -94,7 +94,7 @@ fn settings_search_entries() -> &'static [SearchEntry] {
         SearchEntry {
             section: Appearance,
             title: "Theme",
-            keywords: "appearance color colours scheme dark light palette background foreground accent",
+            keywords: "appearance color colours scheme dark light palette background foreground accent sync system os auto follow",
         },
         SearchEntry {
             section: Appearance,
@@ -364,8 +364,11 @@ pub(crate) struct SettingsState {
     /// theme is read-only (a built-in / import) or the system is being followed.
     pub(crate) theme_editor: Option<ThemeEditor>,
     /// Whether the theme picker panel is open beside the content pane
-    /// (Appearance section only). Toggled from the "Current theme" card.
+    /// (Appearance section only). Toggled from the theme card(s).
     pub(crate) theme_panel_open: bool,
+    /// Which theme choice the open picker panel writes to (see [`ThemeSlot`]).
+    /// Set by the card that opened the panel.
+    pub(crate) theme_panel_slot: ThemeSlot,
     /// Live filter for the theme picker panel's list.
     pub(crate) theme_search: Entity<InputState>,
     /// `Some` while a Keybindings row is capturing a new shortcut: the action
@@ -401,6 +404,16 @@ pub(crate) struct SettingsState {
     /// error), shown under that agent's row. Replaced by the next action.
     pub(crate) agent_hooks_note: Option<(crate::core::agent_hooks::HookAgent, String)>,
     pub(crate) _subs: Vec<Subscription>,
+}
+
+/// The theme choice a picker card / the picker panel targets. `Manual` is the
+/// single `Config::theme_preset` (sync-with-system off); `Light` / `Dark` are
+/// the two follow-system slots (`Config::theme_preset_light` / `_dark`).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ThemeSlot {
+    Manual,
+    Light,
+    Dark,
 }
 
 /// The SSH section's right-pane selection (see [`SettingsState::ssh_detail`]).
@@ -1191,7 +1204,7 @@ impl Tty7App {
                 "Pick a color theme. Each one sets its own light or dark look.",
                 cx,
             ))
-            .child(self.render_current_theme(cx))
+            .child(self.render_theme_selection(cx))
             // Custom-theme management (duplicate / edit colors / open folder) is
             // *about* themes, so it lives with the picker rather than stranded at
             // the foot of the page after Cursor.
@@ -1266,7 +1279,7 @@ impl Tty7App {
         };
         let config = cx.global::<Config>();
         let overridden = config.window_opacity.is_some() || config.window_blur.is_some();
-        let theme = presets::by_id(cx, &config.theme_preset.clone());
+        let theme = presets::by_id(cx, &crate::ui::theme::effective_preset_id(cx));
         let opacity = Tty7App::effective_window_opacity(cx);
         let blur = cx.global::<Config>().window_blur.unwrap_or(theme.blur);
 
@@ -1349,7 +1362,7 @@ impl Tty7App {
 
             // The theme's current image, for the filename label and the
             // opacity readout (the slider owns its own thumb position).
-            let theme = presets::by_id(cx, &cx.global::<Config>().theme_preset.clone());
+            let theme = presets::by_id(cx, &crate::ui::theme::effective_preset_id(cx));
             let image = theme.image.clone();
             let image_name = image.as_ref().map(|i| {
                 i.path
@@ -3277,11 +3290,39 @@ impl Tty7App {
             )
     }
 
-    /// The compact "Current theme" card on the Appearance page: a preview of the
-    /// active theme beside its kind (built-in vs custom) and light/dark mode,
-    /// its name, and its six chromatic ANSI swatches; the whole row a click
-    /// target that opens the picker panel on the right.
-    fn render_current_theme(&self, cx: &mut Context<Self>) -> AnyElement {
+    /// The theme choice block on the Appearance page: the "Sync with system"
+    /// switch, then either the single manual-theme card or — while following
+    /// the OS — one card per light/dark slot.
+    fn render_theme_selection(&self, cx: &mut Context<Self>) -> AnyElement {
+        let follow = cx.global::<Config>().theme_follow_system;
+        let follow_switch = Switch::new("theme-follow-system")
+            .checked(follow)
+            .on_click(cx.listener(|this, on: &bool, window, cx| {
+                this.set_theme_follow_system(*on, window, cx)
+            }))
+            .into_any_element();
+        let root = v_flex().child(self.settings_row(
+            "Sync with system",
+            "Follow the OS appearance with separate light and dark themes.",
+            follow_switch,
+            cx,
+        ));
+        if follow {
+            root.child(self.render_theme_card(ThemeSlot::Light, cx))
+                .child(self.render_theme_card(ThemeSlot::Dark, cx))
+                .into_any_element()
+        } else {
+            root.child(self.render_theme_card(ThemeSlot::Manual, cx))
+                .into_any_element()
+        }
+    }
+
+    /// One compact theme card: a preview of the slot's theme beside its caption
+    /// (kind + light/dark mode for the manual card, the slot's role for the
+    /// follow-system cards), its name, and its six chromatic ANSI swatches; the
+    /// whole row a click target that opens the picker panel on the right,
+    /// aimed at this slot.
+    fn render_theme_card(&self, slot: ThemeSlot, cx: &mut Context<Self>) -> AnyElement {
         let theme = cx.theme();
         let border = theme.border;
         let foreground = theme.foreground;
@@ -3289,15 +3330,35 @@ impl Tty7App {
         let hover_bg = theme.secondary.opacity(0.5);
         let surface = theme.secondary.opacity(0.28);
 
-        let active_id = cx.global::<Config>().theme_preset.clone();
+        let config = cx.global::<Config>();
+        let (card_id, active_id) = match slot {
+            ThemeSlot::Manual => ("theme-card-manual", config.theme_preset.clone()),
+            ThemeSlot::Light => ("theme-card-light", config.theme_preset_light.clone()),
+            ThemeSlot::Dark => ("theme-card-dark", config.theme_preset_dark.clone()),
+        };
         let active = presets::by_id(cx, &active_id);
         let name = active.name.clone();
-        let mode = if active.dark { "Dark" } else { "Light" };
         // A user file (duplicated or dropped in the themes folder) vs a built-in.
         let kind = if active.path.is_some() {
             "Custom"
         } else {
             "Built-in"
+        };
+        let caption = match slot {
+            ThemeSlot::Manual => {
+                let mode = if active.dark { "Dark" } else { "Light" };
+                format!("{kind} · {mode}")
+            }
+            // The slot cards are captioned by their role; the one matching the
+            // current OS appearance is the theme actually on screen.
+            ThemeSlot::Light if !crate::ui::theme::system_dark(cx) => {
+                format!("Light mode · {kind} · Active")
+            }
+            ThemeSlot::Light => format!("Light mode · {kind}"),
+            ThemeSlot::Dark if crate::ui::theme::system_dark(cx) => {
+                format!("Dark mode · {kind} · Active")
+            }
+            ThemeSlot::Dark => format!("Dark mode · {kind}"),
         };
         // The six chromatic ANSI slots (red…cyan) as tiny swatches — the part of
         // a theme the mini preview's few bars can't show, and what actually
@@ -3311,15 +3372,17 @@ impl Tty7App {
                 .bg(rgb(to_u32(active.ansi16[i])))
         }));
         let preview = self.theme_preview(&active);
-        let open = self.active_settings().is_some_and(|s| s.theme_panel_open);
+        let open = self
+            .active_settings()
+            .is_some_and(|s| s.theme_panel_open && s.theme_panel_slot == slot);
 
         div()
-            .id("current-theme")
+            .id(card_id)
             .mt_1()
             .mb_2()
             .w_full()
             .cursor_pointer()
-            .on_click(cx.listener(|this, _, _w, cx| this.toggle_theme_panel(cx)))
+            .on_click(cx.listener(move |this, _, _w, cx| this.toggle_theme_panel(slot, cx)))
             .child(
                 h_flex()
                     .items_center()
@@ -3338,12 +3401,7 @@ impl Tty7App {
                     .child(
                         v_flex()
                             .gap_0p5()
-                            .child(
-                                div()
-                                    .text_xs()
-                                    .text_color(muted_fg)
-                                    .child(format!("{kind} · {mode}")),
-                            )
+                            .child(div().text_xs().text_color(muted_fg).child(caption))
                             .child(
                                 div()
                                     .text_sm()
@@ -3379,13 +3437,33 @@ impl Tty7App {
         // as its own surface rather than an extension of the page.
         let bg = theme.sidebar;
 
-        let active_id = cx.global::<Config>().theme_preset.clone();
-        let (search, query) = match self.active_settings() {
+        let (search, query, slot) = match self.active_settings() {
             Some(s) => (
                 s.theme_search.clone(),
                 s.theme_search.read(cx).value().trim().to_lowercase(),
+                s.theme_panel_slot,
             ),
             None => return div().into_any_element(),
+        };
+        let config = cx.global::<Config>();
+        // Guard against a slot that no longer exists in the current mode (the
+        // sync switch flipped while the panel was open re-aims it, but stale
+        // state must still render something sensible).
+        let slot = match (config.theme_follow_system, slot) {
+            (false, _) => ThemeSlot::Manual,
+            (true, ThemeSlot::Manual) => {
+                if crate::ui::theme::system_dark(cx) {
+                    ThemeSlot::Dark
+                } else {
+                    ThemeSlot::Light
+                }
+            }
+            (true, s) => s,
+        };
+        let active_id = match slot {
+            ThemeSlot::Manual => config.theme_preset.clone(),
+            ThemeSlot::Light => config.theme_preset_light.clone(),
+            ThemeSlot::Dark => config.theme_preset_dark.clone(),
         };
 
         let header = h_flex()
@@ -3414,7 +3492,11 @@ impl Tty7App {
             .pb_3()
             .text_xs()
             .text_color(muted_fg)
-            .child("Change your current theme.");
+            .child(match slot {
+                ThemeSlot::Manual => "Change your current theme.",
+                ThemeSlot::Light => "Choose the theme for light mode.",
+                ThemeSlot::Dark => "Choose the theme for dark mode.",
+            });
 
         // Plain text input, the same shape the Shell section uses — our own
         // field, not a bespoke pill. The Input fills its parent, but a percent
@@ -3483,8 +3565,10 @@ impl Tty7App {
                                 s.child(Icon::new(IconName::Check).small().text_color(foreground))
                             }),
                     )
-                    .on_click(cx.listener(move |this, _, window, cx| {
-                        this.set_preset(&click_id, window, cx)
+                    .on_click(cx.listener(move |this, _, window, cx| match slot {
+                        ThemeSlot::Manual => this.set_preset(&click_id, window, cx),
+                        ThemeSlot::Light => this.set_slot_preset(false, &click_id, window, cx),
+                        ThemeSlot::Dark => this.set_slot_preset(true, &click_id, window, cx),
                     })),
             );
         }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -360,8 +360,8 @@ pub(crate) struct SettingsState {
     /// Global window-opacity slider (Appearance's Window section). Shows the
     /// effective value; dragging sets the config override.
     pub(crate) window_opacity_slider: Entity<SliderState>,
-    /// The color editor for the active editable theme, or `None` when the active
-    /// theme is read-only (a built-in / import) or the system is being followed.
+    /// The color editor for the effective (on-screen) theme, or `None` when
+    /// that theme is read-only (a built-in / import).
     pub(crate) theme_editor: Option<ThemeEditor>,
     /// Whether the theme picker panel is open beside the content pane
     /// (Appearance section only). Toggled from the theme card(s).

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -87,12 +87,37 @@ pub(crate) fn window_background(bg: &presets::ActiveBackground) -> Background {
     }
 }
 
+/// Whether the OS is currently in dark mode, as gpui reports it. Only
+/// meaningful while the native appearance isn't pinned (see
+/// [`sync_native_appearance`]) — a pinned appearance reports the pin, not the
+/// OS setting, which is why callers gate on `Config::theme_follow_system`.
+pub(crate) fn system_dark(cx: &App) -> bool {
+    matches!(
+        cx.window_appearance(),
+        gpui::WindowAppearance::Dark | gpui::WindowAppearance::VibrantDark
+    )
+}
+
+/// The id of the theme that should be on screen right now: the light/dark
+/// slot matching the OS appearance while `Config::theme_follow_system` is on,
+/// otherwise the manual `Config::theme_preset`.
+pub(crate) fn effective_preset_id(cx: &App) -> String {
+    let config = cx.global::<Config>();
+    if !config.theme_follow_system {
+        config.theme_preset.clone()
+    } else if system_dark(cx) {
+        config.theme_preset_dark.clone()
+    } else {
+        config.theme_preset_light.clone()
+    }
+}
+
 /// The background appearance the window should be *created* with: Blurred when
 /// the effective theme wants blur, otherwise Transparent — never Opaque, so the
 /// opacity slider works live (see the comment in [`apply_theme`]).
 pub(crate) fn background_appearance(cx: &App) -> WindowBackgroundAppearance {
     let config = cx.global::<Config>();
-    let theme = presets::by_id(cx, &config.theme_preset);
+    let theme = presets::by_id(cx, &effective_preset_id(cx));
     if config.window_blur.unwrap_or(theme.blur) {
         WindowBackgroundAppearance::Blurred
     } else {
@@ -100,15 +125,23 @@ pub(crate) fn background_appearance(cx: &App) -> WindowBackgroundAppearance {
     }
 }
 
-/// Paint gpui-component's `Theme` from the active color theme (selected by
-/// `Config::theme_preset`). The theme's inferred `dark` brightness picks the
+/// Paint gpui-component's `Theme` from the active color theme (resolved by
+/// [`effective_preset_id`]). The theme's inferred `dark` brightness picks the
 /// component `ThemeMode`; every shell surface is then derived from the theme's
 /// background/foreground (see `Theme::neutrals`). Also publishes the
 /// terminal-facing palette as the `ActivePalette` global so the renderer matches,
 /// and applies the theme's window opacity/blur.
 pub(crate) fn apply_theme(mut window: Option<&mut Window>, cx: &mut App) {
+    let follow = cx.global::<Config>().theme_follow_system;
+    // While following the OS the native pin must be released *before* the
+    // theme is resolved: `effective_preset_id` reads the system appearance
+    // through `effectiveAppearance`, which keeps reporting the pinned value
+    // until the pin is cleared.
+    if follow {
+        sync_native_appearance(None);
+    }
+    let theme = presets::by_id(cx, &effective_preset_id(cx));
     let config = cx.global::<Config>();
-    let theme = presets::by_id(cx, &config.theme_preset.clone());
     let mode = if theme.dark {
         ThemeMode::Dark
     } else {
@@ -120,8 +153,12 @@ pub(crate) fn apply_theme(mut window: Option<&mut Window>, cx: &mut App) {
     let opacity = config.window_opacity.or(theme.opacity).filter(|o| *o < 1.0);
     let blur = config.window_blur.unwrap_or(theme.blur);
     // Force the native macOS chrome (traffic lights, system menus, scrollbars)
-    // into the theme's own light/dark mode regardless of the OS setting.
-    sync_native_appearance(theme.dark);
+    // into the theme's own light/dark mode regardless of the OS setting —
+    // only while *not* following the OS, where the chrome should track the
+    // system (and pinning would blind `system_dark` to OS flips).
+    if !follow {
+        sync_native_appearance(Some(theme.dark));
+    }
     let m = theme.neutrals();
     let active = theme.active_palette();
 
@@ -278,8 +315,9 @@ pub(crate) fn apply_cursor_hide_mode(cx: &mut App) {
     cx.set_cursor_hide_mode(mode);
 }
 
-/// Force the macOS app appearance to match the active theme's light/dark mode
-/// instead of following the OS `Appearance` setting.
+/// Pin the macOS app appearance to the active theme's light/dark mode
+/// (`Some(dark)`), or release the pin so it follows the OS `Appearance`
+/// setting again (`None`, used while `Config::theme_follow_system` is on).
 ///
 /// macOS draws the native traffic-light buttons according to the window's
 /// effective appearance. With a dark tty7 theme on a light-mode macOS, the
@@ -289,7 +327,7 @@ pub(crate) fn apply_cursor_hide_mode(cx: &mut App) {
 /// no setter, so we pin `NSApplication.appearance` ourselves via AppKit. This
 /// also keeps system menus, context menus and scrollbars in the right mode.
 #[cfg(target_os = "macos")]
-fn sync_native_appearance(dark: bool) {
+fn sync_native_appearance(dark: Option<bool>) {
     use objc2::MainThreadMarker;
     use objc2_app_kit::{
         NSAppearance, NSAppearanceNameAqua, NSAppearanceNameDarkAqua, NSApplication,
@@ -300,18 +338,20 @@ fn sync_native_appearance(dark: bool) {
     let Some(mtm) = MainThreadMarker::new() else {
         return;
     };
-    // SAFETY: reading the framework-provided appearance-name statics.
-    let name = unsafe {
-        if dark {
-            NSAppearanceNameDarkAqua
-        } else {
-            NSAppearanceNameAqua
-        }
-    };
-    if let Some(appearance) = NSAppearance::appearanceNamed(name) {
-        NSApplication::sharedApplication(mtm).setAppearance(Some(&appearance));
-    }
+    let appearance = dark.and_then(|dark| {
+        // SAFETY: reading the framework-provided appearance-name statics.
+        let name = unsafe {
+            if dark {
+                NSAppearanceNameDarkAqua
+            } else {
+                NSAppearanceNameAqua
+            }
+        };
+        NSAppearance::appearanceNamed(name)
+    });
+    // `None` here means "inherit from the system" — the AppKit way to unpin.
+    NSApplication::sharedApplication(mtm).setAppearance(appearance.as_deref());
 }
 
 #[cfg(not(target_os = "macos"))]
-fn sync_native_appearance(_dark: bool) {}
+fn sync_native_appearance(_dark: Option<bool>) {}


### PR DESCRIPTION
Adds a **Sync with system** mode: pick separate light and dark themes and tty7 follows the OS appearance live. Closes #107.

| | Before | After |
|---|---|---|
| OS switches light/dark | Nothing happens; theme stays fixed | With sync on, the theme flips live to the matching slot |
| Native chrome (traffic lights, menus) | Always pinned to the theme's brightness | Pinned only while sync is off; follows the OS while sync is on |
| Settings → Appearance | One "Current theme" card | "Sync with system" switch; when on, one card per light/dark slot, each opening the picker aimed at that slot |
| Picking a theme while syncing (palette / ⌘P, fork) | — | Writes the slot matching the current OS appearance |
| Turning the switch on/off | — | On: seeds the slot matching the manual theme's brightness. Off: adopts the on-screen theme as the manual choice. Round-trip stable |
| `config.json` | `theme_preset` | + `theme_follow_system`, `theme_preset_light`, `theme_preset_dark` (old configs unchanged: sync defaults off) |

This mirrors the design used by VS Code / Zed / Ghostty / iTerm2: two user-picked slots rather than fixed light/dark pairings, since themes have no natural counterparts across families.

```mermaid
flowchart LR
    A[Config] -->|sync off| B[theme_preset]
    A -->|sync on| C{OS appearance}
    C -->|light| D[theme_preset_light]
    C -->|dark| E[theme_preset_dark]
    F[observe_window_appearance] -->|OS mode flips| G[apply_theme]
    B & D & E --> G
```

Key implementation detail: `apply_theme` previously always pinned `NSApplication.appearance` to the theme's brightness, which would blind the OS-appearance reads. While syncing, the pin is released *before* resolving the theme (`effectiveAppearance` reports the pinned value until then); while not syncing, the pin is applied as before and the appearance observer bails early, so the pin and the observer cannot feed back into each other.

## Testing

- `cargo test` — 751 passed; new round-trip/default test for the three config fields (old configs deserialize with sync off and the built-in light/dark pair).
- Manual, isolated dev instance (`--config-dir`, macOS): seeded `one_light`/`dracula` slots with sync on; verified the Appearance UI (switch + two slot cards with Active marker, picker panel aimed per slot) and a live OS light→dark flip switching the window to Dracula, then restored.
