### PR TITLE
test(daemon): poll for the child's exec before asserting its path

### DIFF
--- a/src/daemon/spawn.rs
+++ b/src/daemon/spawn.rs
@@ -528,6 +528,10 @@ mod tests {
     /// match — this is what keeps a stale pidfile with a recycled pid from
     /// getting an innocent process killed. Driven with a real `sleep` child:
     /// alive, path readable, basename `sleep` ≠ the test binary's.
+    ///
+    /// `spawn` returns after the fork, possibly before the child has exec'd —
+    /// until then its executable path still reads as *this* test binary — so
+    /// the path assertions poll until the exec is visible.
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn reap_guard_rejects_a_live_process_of_another_executable() {
@@ -538,11 +542,19 @@ mod tests {
         let pid = child.id() as libc::pid_t;
 
         assert!(process_alive(pid), "the sleep child is alive and ours");
-        assert_eq!(
-            process_path(pid).and_then(|p| p.file_name().map(|n| n.to_os_string())),
-            Some("sleep".into()),
-            "process_path resolves an arbitrary pid, not just our parent"
-        );
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let basename = process_path(pid).and_then(|p| p.file_name().map(|n| n.to_os_string()));
+            if basename == Some("sleep".into()) {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "process_path resolves an arbitrary pid, not just our parent \
+                 (still {basename:?} after 5s)"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
         assert!(
             !process_matches_own_exe(pid),
             "sleep must not match the test binary; matching here would mean the reap could kill it"


### PR DESCRIPTION
Fixes the flaky `reap_guard_rejects_a_live_process_of_another_executable` test that intermittently failed the Linux CI job on `main` (runs 29549626571, 29560431777, 29563049775).

| | Before | After |
|---|---|---|
| Path assertion | Immediately after `spawn`, asserts `process_path(pid)` basename is `sleep` | Polls `process_path` every 10ms (up to 5s) until the basename reads `sleep`, then proceeds |
| Failure message | Generic assert-eq mismatch | Reports the last-seen basename after the 5s timeout |

## Why

`Command::spawn` returns after the fork, possibly before the child has exec'd `sleep`. Until the exec, `/proc/<pid>/exe` (and `proc_pidpath` on macOS) still resolves to the test binary itself, so the immediate assertion races the child's exec. CI logs confirm it:

```
  left: Some("tty7-5d711132de6ade81")   <- the test binary, pre-exec
 right: Some("sleep")
```

The window is only visible on loaded CI runners; locally the exec wins essentially every time. The three original assertions (alive, path resolves, no match against our own exe) all keep their meaning — the guard-rejection assert still runs against the exec'd `sleep` process.

## Testing

- `cargo test --bin tty7 daemon::spawn::tests::` — all 8 tests pass locally (macOS).
