### PR TITLE
fix(settings): keep Agents rows aligned and notes terse

### DIFF
--- a/src/core/agent_hooks.rs
+++ b/src/core/agent_hooks.rs
@@ -432,7 +432,9 @@ pub fn hooks_state(agent: HookAgent) -> HooksState {
 
 /// Install (or rewrite in place) one agent's tty7 hooks. Idempotent: existing
 /// tty7 entries/files are replaced, never duplicated, and anything
-/// user-authored is left untouched. Returns a short human-readable summary.
+/// user-authored is left untouched. Returns a terse summary meant for the
+/// settings row's note line — the row already shows the agent and target
+/// path, so the summary never repeats them.
 pub fn install_hooks(agent: HookAgent) -> anyhow::Result<String> {
     let path = agent
         .target_path()
@@ -440,10 +442,7 @@ pub fn install_hooks(agent: HookAgent) -> anyhow::Result<String> {
     match agent {
         HookAgent::Claude => {
             hook_map_install(&path, agent, CLAUDE_HOOK_EVENTS)?;
-            Ok(format!(
-                "Claude Code hooks installed in {} — restart running claude sessions to pick them up",
-                path.display()
-            ))
+            Ok("Installed".to_string())
         }
         HookAgent::Codex => {
             hook_map_install(&path, agent, CODEX_HOOK_EVENTS)?;
@@ -451,11 +450,10 @@ pub fn install_hooks(agent: HookAgent) -> anyhow::Result<String> {
             // Best-effort: the file install above is complete and correct
             // either way, so a missing codex binary downgrades to advice
             // instead of failing the install.
-            let summary = format!("Codex hooks installed in {}", path.display());
             Ok(match enable_codex_hooks_feature() {
-                Ok(()) => summary,
+                Ok(()) => "Installed".to_string(),
                 Err(e) => format!(
-                    "{summary} — couldn't run `codex features enable hooks` ({e}); run it once manually"
+                    "Installed, but couldn't run `codex features enable hooks` ({e}) — run it once manually"
                 ),
             })
         }
@@ -463,11 +461,7 @@ pub fn install_hooks(agent: HookAgent) -> anyhow::Result<String> {
             let content = owned_file_content(agent)
                 .ok_or_else(|| anyhow::anyhow!("cannot resolve tty7's own executable path"))?;
             owned_file_install(&path, &content, &agent.marker())?;
-            Ok(format!(
-                "{} integration installed at {}",
-                agent.display_name(),
-                path.display()
-            ))
+            Ok("Installed".to_string())
         }
     }
 }
@@ -505,7 +499,11 @@ pub fn refresh_hooks_at_launch() -> usize {
         match install_hooks(agent) {
             Ok(summary) => {
                 refreshed += 1;
-                log::info!("refreshed stale agent hooks: {summary}");
+                log::info!(
+                    "refreshed stale {} hooks at {}: {summary}",
+                    agent.display_name(),
+                    agent.target_display()
+                );
             }
             Err(e) => log::warn!(
                 "could not refresh stale {} hooks: {e}",
@@ -733,11 +731,7 @@ fn hook_map_uninstall(path: &Path, agent: HookAgent) -> anyhow::Result<String> {
         return Ok("No tty7 hooks found; nothing to remove".to_string());
     }
     crate::core::config::write_atomic(path, serde_json::to_string_pretty(&root)?.as_bytes())?;
-    Ok(format!(
-        "{} hooks removed from {}",
-        agent.display_name(),
-        path.display()
-    ))
+    Ok("Removed".to_string())
 }
 
 /// The tty7 hook command inside one matcher entry
@@ -856,7 +850,7 @@ fn owned_file_uninstall(path: &Path, marker: &str) -> anyhow::Result<String> {
     {
         let _ = std::fs::remove_dir(parent);
     }
-    Ok(format!("Removed {}", path.display()))
+    Ok("Removed".to_string())
 }
 
 /// Copilot hook file (`~/.copilot/hooks/tty7.json`): Copilot auto-loads every

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -3031,7 +3031,7 @@ impl Tty7App {
             let (dot_color, status_text) = match state {
                 HooksState::NotInstalled => (muted_fg, "Not installed"),
                 HooksState::Installed => (success, "Installed"),
-                HooksState::Outdated => (warning, "Outdated — installed by another tty7 version"),
+                HooksState::Outdated => (warning, "Outdated"),
             };
             // The primary action reads as what it will *do* from this state.
             let primary_label = match state {
@@ -3044,8 +3044,11 @@ impl Tty7App {
                 .filter(|(for_agent, _)| *for_agent == agent)
                 .map(|(_, text)| text.clone());
 
+            // items_end: the whole stack shares the row's right edge, so
+            // status, buttons, and note line up across every agent row.
             let control = v_flex()
                 .gap_2()
+                .items_end()
                 .child(
                     h_flex()
                         .gap_2()
@@ -3075,8 +3078,18 @@ impl Tty7App {
                             )
                         }),
                 )
+                // Width-capped so a long note (error text) wraps instead of
+                // inflating the shrink-proof control column and crushing the
+                // label to zero width.
                 .when_some(row_note, |col, text| {
-                    col.child(div().text_xs().text_color(muted_fg).child(text))
+                    col.child(
+                        div()
+                            .max_w_80()
+                            .text_xs()
+                            .text_right()
+                            .text_color(muted_fg)
+                            .child(text),
+                    )
                 })
                 .into_any_element();
 


### PR DESCRIPTION
Fixes the Settings → Agents rows collapsing after Install/Reinstall: the outcome note (agent name + full target path) sat inside the row's shrink-proof control column, inflated it past the 640px content cap, and crushed the label column to zero width — the row title rendered one character per line.

| | Before | After |
|---|---|---|
| Action outcome note | `Claude Code hooks installed in /Users/…/settings.json — restart running claude sessions to pick them up`, repeating what the row already shows | `Installed` / `Removed` |
| Note placement | Unconstrained width inside the `flex_shrink_0` control column — a long path blew the column up and squeezed the title into a vertical strip | Under the buttons, width-capped (`max_w_80`), right-aligned; long error text wraps instead of expanding the column |
| Right-column alignment | Status dot/text and buttons started at a different x per row | `items_end` — status, buttons, and note share one right edge across all agent rows |
| Outdated status | `Outdated — installed by another tty7 version` | `Outdated` (the Update button says what to do) |
| Launch-refresh log | Path lived in the reused summary string | Log line carries agent name + target path itself: `refreshed stale <agent> hooks at <path>: Installed` |

The Codex install summary keeps its one exception: when `codex features enable hooks` fails, the note still tells the user to run it manually.

## Testing

- `cargo test agent_hooks` — 9 passed (no test asserted the old summary strings).
- Manual: isolated dev instance (`--config-dir` + scratch `CLAUDE_CONFIG_DIR`), clicked Install/Reinstall/Uninstall on the Claude Code row — note stays terse and right-aligned, label column no longer collapses; rows with mixed states (Installed / Not installed / Outdated) share one right edge.
- `code-reviewer` agent pass on the diff: no correctness findings; its one diagnosability note (log line lost the path) is addressed in the last table row.
