### PR TITLE
fix(windows): align the titlebar ... with the window-control rhythm

### DIFF
--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -897,9 +897,13 @@ impl Tty7App {
             .pl_0()
             .pr_2()
             // On Windows/Linux the window controls (─ ▢ ✕) sit on the right, right
-            // where the "⋯" lands; give it extra right breathing room there so it
-            // reads as a menu affordance, not a fourth window control.
-            .when(!cfg!(target_os = "macos"), |this| this.pr_3())
+            // where the "⋯" lands, so its inset has to match *their* rhythm: the
+            // 34px tiles put consecutive glyph centres 34px apart, and the "⋯"
+            // centre sits `15 + pr + 17` from the minimise glyph. `pr_1` (4px)
+            // lands at 36px — reading as part of the same row, with just enough
+            // slack to not be mistaken for a fourth window control. The old
+            // `pr_3` (12px) made it 44px, visibly adrift from the group.
+            .when(!cfg!(target_os = "macos"), |this| this.pr_1())
             .min_w_0()
             .child(chips)
             // In sidebar mode the rail owns "New Tab" (a "+" in its own top bar),


### PR DESCRIPTION
## Problem

On Windows the overflow `⋯` button sat noticeably further from the minimise button than the three native window controls sit from each other.

## Cause

The window controls are 34px tiles, so consecutive glyph centres are **34px** apart. The `⋯` was inset with `pr_3` (12px), putting its centre `15 + 12 + 17` = **44px** from the minimise glyph. That 10px overshoot read as the button drifting off the group rather than as intentional separation.

The extra padding was deliberate (so `⋯` would not be mistaken for a fourth window control) — just overshot.

## Fix

`pr_3` → `pr_1` (4px), landing the centre at **36px**.

## Verified

Built and launched the app on Windows 11 (1.5x display), screenshotted the title bar and measured dark-pixel glyph clusters:

```
⋯  -> —  : centres 54.5 physical px
—  -> □  : centres 51
□  -> ×  : centres 51
```

54.5 / 1.5 ≈ 36 logical px vs 34 for the native controls — within ~2px of the rhythm, with a hair of slack left.

## Notes

- macOS unaffected: its controls live on the left, and the `pr_2` base still applies.
- The `strip_w` 114px reserve is untouched — this padding is inside the strip box, so shrinking it only shifts the `⋯` right and gives the chip row 8px more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)