### PR TITLE
fix(ui): Codex black-field avatar and 22pt macOS tray icon

### DIFF
--- a/src/core/cli_agent.rs
+++ b/src/core/cli_agent.rs
@@ -184,13 +184,13 @@ impl CLIAgent {
     }
 
     /// Brand accent (0xRRGGBB) for the tab chip's agent dot. Chosen for legibility
-    /// on both light and dark themes rather than exact brand black/white — a pure
-    /// black or white dot vanishes against one theme, so vendors whose mark is
-    /// monochrome (Codex/OpenAI, Cursor) get a recognizable mid-tone hue instead.
+    /// on both light and dark themes rather than exact brand black/white. A pure
+    /// black or white dot vanishes against one theme, so monochrome vendors get
+    /// a recognizable mid-tone hue instead; Codex keeps its black field.
     pub fn accent_rgb(self) -> u32 {
         match self {
             CLIAgent::Claude => 0xD97757,      // Claude terracotta
-            CLIAgent::Codex => 0x10A37F,       // OpenAI green (black mark reads as this)
+            CLIAgent::Codex => 0x000000,       // Codex black field
             CLIAgent::Gemini => 0x4285F4,      // Google blue
             CLIAgent::Aider => 0x14B8A6,       // teal
             CLIAgent::Amp => 0xF34E3F,         // Amp red
@@ -761,6 +761,11 @@ mod tests {
             assert!(a.accent_rgb() <= 0xFFFFFF);
             assert_eq!(CLIAgent::from_slug(a.slug()), Some(a));
         }
+    }
+
+    #[test]
+    fn codex_avatar_uses_its_black_brand_field() {
+        assert_eq!(CLIAgent::Codex.accent_rgb(), 0x000000);
     }
 
     #[test]

--- a/src/ui/tray/icon.rs
+++ b/src/ui/tray/icon.rs
@@ -27,9 +27,9 @@ const GLYPH_SVG: &[u8] = include_bytes!("../../../assets/tray.svg");
 #[cfg(not(target_os = "macos"))]
 const GLYPH_SVG: &[u8] = include_bytes!("../../../assets/app-icon.svg");
 
-/// Physical pixel size. macOS forces the NSImage to 18 pt in the status bar
-/// regardless of pixel size (see tray-icon's macOS backend), so 36 px renders
-/// crisp on retina. Windows tray slots are 16–32 px; 32 downsamples cleanly.
+/// Physical pixel size. On macOS the bitmap is 36 px (retina-crisp at 18 pt);
+/// native.rs then overrides the NSImage to 22 pt so the glyph fills the menu
+/// bar. Windows tray slots are 16–32 px; 32 downsamples cleanly.
 #[cfg(target_os = "macos")]
 const SIZE: u32 = 36;
 #[cfg(not(target_os = "macos"))]

--- a/src/ui/tray/native.rs
+++ b/src/ui/tray/native.rs
@@ -75,10 +75,7 @@ impl Backend {
                         // scales proportionally from its 96×96 viewBox.
                         let target_h: f64 = 22.0;
                         let aspect = nsimage.size().width / nsimage.size().height;
-                        nsimage.setSize(objc2_foundation::NSSize::new(
-                            target_h * aspect,
-                            target_h,
-                        ));
+                        nsimage.setSize(objc2_foundation::NSSize::new(target_h * aspect, target_h));
                     }
                 }
             }

--- a/src/ui/tray/native.rs
+++ b/src/ui/tray/native.rs
@@ -62,6 +62,27 @@ impl Backend {
                 return None;
             }
         };
+
+        // tray-icon hardcodes the NSImage height to 18 pt; override to a
+        // larger size so the glyph fills more of the menu bar. The bitmap
+        // itself is already rendered at `icon::SIZE` px (retina-ready).
+        #[cfg(target_os = "macos")]
+        if let Some(status_item) = tray.ns_status_item() {
+            if let Some(mtm) = objc2::MainThreadMarker::new() {
+                if let Some(button) = status_item.button(mtm) {
+                    if let Some(nsimage) = button.image() {
+                        // 22 pt matches the macOS menu bar height; the glyph
+                        // scales proportionally from its 96×96 viewBox.
+                        let target_h: f64 = 22.0;
+                        let aspect = nsimage.size().width / nsimage.size().height;
+                        nsimage.setSize(objc2_foundation::NSSize::new(
+                            target_h * aspect,
+                            target_h,
+                        ));
+                    }
+                }
+            }
+        }
         Some(Self {
             tray,
             #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
Use Codex's actual black brand field for its tab avatar, and enlarge the macOS tray icon from 18 pt to 22 pt.

## Before / After

| | Before | After |
|---|---|---|
| Codex tab avatar color | `#10A37F` (OpenAI green) | `#000000` (Codex black field) |
| macOS tray icon size | 18 pt (hardcoded by tray-icon) | 22 pt, fills the menu bar |

## Why

- **Codex avatar**: Codex is a distinct product from the OpenAI API. Its brand mark is monochrome black; the old green was an artifact of grouping it under OpenAI's corporate color.
- **Tray icon**: the `tray-icon` crate hardcodes the NSImage height to 18 pt, leaving the glyph visibly smaller than neighboring menu bar icons. `native.rs` now overrides the NSImage size to 22 pt after the tray is built; the bitmap was already rendered at 36 px, so it stays retina-crisp.

## Testing

- `cargo test codex_avatar_uses_its_black_brand_field` — passes; other brand tests unaffected
- Manual: launched an isolated dev instance side by side with the installed app — dev tray icon renders larger and crisp at 22 pt