### PR TITLE
feat(agent): carry launch flags onto session resume commands

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -34,7 +34,7 @@ it never wraps or replaces the agent.
 - **Status dot** — working (blue) / needs your input (amber) / done (green), driven by agent-reported events over an OSC channel; run *Agent: Install Claude Code Hooks* from the palette to wire Claude Code up
 - **Notifications** — "needs your permission…" the moment an agent blocks on you, and "finished after Ns" per turn, honoring your notification policy
 - **Branch at a glance** — each sidebar row shows its pane's git branch and working-tree diff (`+N −M`), refreshed on `cd` and when a command finishes
-- **Session resume** — panes lost to a reboot re-launch their agent conversation (`claude --resume …`) on restore (`restore_agent_sessions`, on by default)
+- **Session resume** — panes lost to a reboot re-launch their agent conversation on restore, carrying the original launch flags (`claude --dangerously-skip-permissions --resume …`) (`restore_agent_sessions`, on by default)
 - **Context feed** — palette commands send the current selection or the repo's `git diff` to the running agent as a ready-made prompt
 - **Tray icon** — a system tray / menu bar item that flips to an attention state the moment any agent needs your input; its menu lists every agent pane (brand avatar + status dot, click to reveal), switches the notification policy, and offers *Quit and Stop Daemon* alongside the plain session-keeping quit (`show_tray_icon`, on by default)
 

--- a/docs/features.zh-CN.md
+++ b/docs/features.zh-CN.md
@@ -33,7 +33,7 @@ Aider、Amp、OpenCode 等约 17 个）并在其外围加功能 —— 绝不包
 - **状态点** —— 工作中（蓝）/ 等你输入（琥珀）/ 完成（绿），由 agent 自己上报的 OSC 事件驱动；在命令面板运行 *Agent: Install Claude Code Hooks* 一键接通 Claude Code
 - **通知** —— agent 卡在等你批准的那一刻弹 "needs your permission…"，每轮结束弹 "finished after Ns"，遵循你的通知策略
 - **一眼看分支** —— 侧栏每行显示该 pane 的 git 分支和工作区改动（`+N −M`），`cd` 或命令跑完时自动刷新
-- **会话恢复** —— 重启后无法重连的 pane 会自动续上 agent 对话（`claude --resume …`；`restore_agent_sessions`，默认开启）
+- **会话恢复** —— 重启后无法重连的 pane 会自动续上 agent 对话，并带上原始启动 flags（`claude --dangerously-skip-permissions --resume …`；`restore_agent_sessions`，默认开启）
 - **上下文回填** —— 面板命令把当前选区或仓库 `git diff` 打包成 prompt 直接喂给正在跑的 agent
 - **托盘图标** —— 系统托盘 / 菜单栏常驻图标，任何 agent 等你输入时立即切换为提醒态；菜单列出所有 agent pane（品牌头像 + 状态点，点击直达）、可切换通知策略，并在保留会话的普通退出之外提供 *Quit and Stop Daemon*（`show_tray_icon`，默认开启）
 

--- a/src/core/cli_agent.rs
+++ b/src/core/cli_agent.rs
@@ -161,7 +161,18 @@ impl CLIAgent {
     /// native session id, or `None` for agents without a known resume flag.
     /// The id is what the agent reported in its `session-start` event (see
     /// [`AgentEvent`]); commands mirror cmux's per-agent resume table.
-    pub fn resume_command(self, session_id: &str) -> Option<String> {
+    ///
+    /// `launch_argv` is the argv the agent was originally launched with, when
+    /// the daemon observed one. Its flags (`--dangerously-skip-permissions`,
+    /// `--model …`) are carried onto the resume command so the restored
+    /// session runs in the same mode the user picked — verbatim only when the
+    /// whole tail passes the conservative shell-safety gate; otherwise the
+    /// bare table command still resumes, just without the flags.
+    pub fn resume_command(
+        self,
+        session_id: &str,
+        launch_argv: Option<&[String]>,
+    ) -> Option<String> {
         // Ids come from the agent's own events, but they still land on a shell
         // command line — refuse anything that isn't a plain token so a
         // malicious/corrupt id can't smuggle shell syntax.
@@ -172,15 +183,133 @@ impl CLIAgent {
         {
             return None;
         }
+        // The user's launch flags, pre-joined with a leading space so they
+        // splice into the format strings below; empty when none survive.
+        let flags = launch_argv
+            .and_then(|argv| self.replay_flags(argv))
+            .map(|flags| {
+                flags.iter().fold(String::new(), |mut s, f| {
+                    s.push(' ');
+                    s.push_str(f);
+                    s
+                })
+            })
+            .unwrap_or_default();
         match self {
-            CLIAgent::Claude => Some(format!("claude --resume {session_id}")),
-            CLIAgent::Codex => Some(format!("codex resume {session_id}")),
-            CLIAgent::Gemini => Some(format!("gemini --resume {session_id}")),
-            CLIAgent::OpenCode => Some(format!("opencode --session {session_id}")),
-            CLIAgent::Amp => Some(format!("amp threads continue {session_id}")),
-            CLIAgent::Cursor => Some(format!("cursor-agent --resume {session_id}")),
+            CLIAgent::Claude => Some(format!("claude{flags} --resume {session_id}")),
+            // Codex resumes via a subcommand that accepts the interactive
+            // options after the positional id (`codex resume [OPTIONS]
+            // [SESSION_ID]`).
+            CLIAgent::Codex => Some(format!("codex resume {session_id}{flags}")),
+            CLIAgent::Gemini => Some(format!("gemini{flags} --resume {session_id}")),
+            CLIAgent::OpenCode => Some(format!("opencode{flags} --session {session_id}")),
+            // Amp's global options (`--dangerously-allow-all`, …) are accepted
+            // by the `threads continue` subcommand (verified: unknown options
+            // are a parse error, globals pass).
+            CLIAgent::Amp => Some(format!("amp threads continue {session_id}{flags}")),
+            CLIAgent::Cursor => Some(format!("cursor-agent{flags} --resume {session_id}")),
+            // Copilot CLI: `copilot --resume <sessionId>` (`-r` shorthand) —
+            // the one hooks-covered agent that was missing from this table.
+            CLIAgent::Copilot => Some(format!("copilot{flags} --resume {session_id}")),
             _ => None,
         }
+    }
+
+    /// The launch-flag tail of `argv` worth replaying on a resume command, or
+    /// `None` to resume bare. Deliberately conservative: anything ambiguous
+    /// falls back to no flags rather than a corrupted command line.
+    ///
+    /// - The tail is everything after the token that names this agent (the
+    ///   launcher itself, or the script path in an interpreter-wrapped argv);
+    ///   leading `VAR=value` env assignments are skipped first so they can't
+    ///   mis-anchor (`CLAUDE_CONFIG_DIR=/opt/claude claude …`). No naming
+    ///   token at all (custom wrapper rules) → no flags.
+    /// - Stale session-targeting flags (`--resume old-id`, `--continue`, a
+    ///   re-launched `codex resume <id>`) are stripped — the new id must win.
+    /// - Every surviving token must be a plain shell-safe word, the first must
+    ///   be a `-` flag, and no two bare words may run consecutively — a bare
+    ///   word is only acceptable as the value directly behind a flag; anything
+    ///   else is a positional prompt that must not re-submit itself into the
+    ///   resumed session. Any violation drops the whole tail.
+    fn replay_flags(self, argv: &[String]) -> Option<Vec<String>> {
+        let names_self = |token: &str| {
+            token.split(['/', '\\']).any(|seg| {
+                CLIAgent::match_token(&base_stem(seg).to_ascii_lowercase()) == Some(self)
+            })
+        };
+        let argv = &argv[argv.iter().take_while(|t| is_env_assignment(t)).count()..];
+        let named = argv.iter().position(|t| names_self(t))?;
+        let mut tail: Vec<&str> = argv[named + 1..].iter().map(String::as_str).collect();
+
+        // A relaunched `codex resume <old-id>`: drop the subcommand and its id
+        // so they don't replay as a positional prompt.
+        if self == CLIAgent::Codex && tail.first() == Some(&"resume") {
+            tail.remove(0);
+            if tail.first().is_some_and(|t| !t.starts_with('-')) {
+                tail.remove(0);
+            }
+        }
+
+        // Session-targeting flags whose old value must not survive; each is
+        // stripped together with one following non-flag value token (harmless
+        // for the value-less ones — anything trailing them is positional).
+        let stale: &[&str] = match self {
+            CLIAgent::Claude => &[
+                "--resume",
+                "-r",
+                "--continue",
+                "-c",
+                "--session-id",
+                "--from-pr",
+            ],
+            CLIAgent::Gemini | CLIAgent::Cursor => &["--resume", "-r"],
+            CLIAgent::Copilot => &["--resume", "-r", "--continue", "-c"],
+            CLIAgent::OpenCode => &["--session", "-s", "--continue", "-c"],
+            // `--last` targets "the most recent session" and would contradict
+            // the explicit id we inject.
+            CLIAgent::Codex => &["--last"],
+            _ => &[],
+        };
+        let mut i = 0;
+        while i < tail.len() {
+            let t = tail[i];
+            if stale.contains(&t)
+                || stale
+                    .iter()
+                    .any(|f| f.len() > 2 && t.starts_with(&format!("{f}=")))
+            {
+                tail.remove(i);
+                if i < tail.len() && !tail[i].starts_with('-') {
+                    tail.remove(i);
+                }
+            } else {
+                i += 1;
+            }
+        }
+
+        // The safety gate: plain tokens only, and a flag-shaped tail — every
+        // bare word must sit directly behind a `-` flag (its value slot); the
+        // first token being bare, or two bare words in a row, is a positional
+        // prompt and drops the whole tail. (A single bare word behind a
+        // boolean flag is indistinguishable from a flag value and slips
+        // through — the residual ambiguity of not knowing each flag's arity.)
+        let safe = |t: &str| {
+            !t.is_empty()
+                && t.bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b"-_=./,:@+~".contains(&b))
+        };
+        if !tail.iter().all(|t| safe(t)) {
+            return None;
+        }
+        let mut prev_was_flag = false;
+        for t in &tail {
+            let is_flag = t.starts_with('-');
+            if !is_flag && !prev_was_flag {
+                return None;
+            }
+            prev_was_flag = is_flag;
+        }
+        Some(tail.into_iter().map(String::from).collect())
     }
 
     /// Brand accent (0xRRGGBB) for the tab chip's agent dot. Chosen for legibility
@@ -479,6 +608,16 @@ pub struct AgentSessionState {
     /// key its own `--resume` flag takes — persisted for restore.
     #[serde(default)]
     pub session_id: Option<String>,
+    /// The argv the agent was launched with, as the daemon observed it (the
+    /// foreground process-table poll on Unix, the shell integration's typed
+    /// `133;C` capture on Windows). Persisted alongside the session id so
+    /// restore can carry the user's launch flags
+    /// (`--dangerously-skip-permissions`, `--model …`) onto the resume
+    /// command — see [`CLIAgent::resume_command`]. Not touched by
+    /// [`apply_event`](Self::apply_event); the daemon stamps it from the
+    /// identity-detection side.
+    #[serde(default)]
+    pub launch_argv: Option<Vec<String>>,
     /// Whether this state came from the rich sentinel channel (hooks
     /// installed) rather than the opaque OSC 9/777 fallback. Rich state drives
     /// turn-level notifications; fallback state only paints the dot (the
@@ -1003,19 +1142,173 @@ mod tests {
     #[test]
     fn resume_commands_are_shell_safe() {
         assert_eq!(
-            CLIAgent::Claude.resume_command("abc-123").as_deref(),
+            CLIAgent::Claude.resume_command("abc-123", None).as_deref(),
             Some("claude --resume abc-123")
         );
         assert_eq!(
-            CLIAgent::Codex.resume_command("th_read.9").as_deref(),
+            CLIAgent::Codex.resume_command("th_read.9", None).as_deref(),
             Some("codex resume th_read.9")
         );
         // No resume flag known → None.
-        assert_eq!(CLIAgent::Aider.resume_command("abc"), None);
+        assert_eq!(CLIAgent::Aider.resume_command("abc", None), None);
         // An id carrying shell syntax is refused outright.
-        assert_eq!(CLIAgent::Claude.resume_command("abc; rm -rf /"), None);
-        assert_eq!(CLIAgent::Claude.resume_command("$(boom)"), None);
-        assert_eq!(CLIAgent::Claude.resume_command(""), None);
+        assert_eq!(CLIAgent::Claude.resume_command("abc; rm -rf /", None), None);
+        assert_eq!(CLIAgent::Claude.resume_command("$(boom)", None), None);
+        assert_eq!(CLIAgent::Claude.resume_command("", None), None);
+    }
+
+    #[test]
+    fn resume_carries_launch_flags() {
+        let argv = |parts: &[&str]| parts.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+
+        // The headline case: the user's mode flags survive the restart.
+        assert_eq!(
+            CLIAgent::Claude
+                .resume_command(
+                    "abc-123",
+                    Some(&argv(&["claude", "--dangerously-skip-permissions"]))
+                )
+                .as_deref(),
+            Some("claude --dangerously-skip-permissions --resume abc-123")
+        );
+        // Value-taking flags ride along whole.
+        assert_eq!(
+            CLIAgent::Claude
+                .resume_command("abc", Some(&argv(&["claude", "--model", "opus"])))
+                .as_deref(),
+            Some("claude --model opus --resume abc")
+        );
+        // Interpreter-wrapped launch: flags start after the token naming the
+        // agent, and the table's launcher name is what replays.
+        assert_eq!(
+            CLIAgent::Claude
+                .resume_command(
+                    "abc",
+                    Some(&argv(&[
+                        "node",
+                        "/x/node_modules/@anthropic-ai/claude-code/cli.js",
+                        "--dangerously-skip-permissions",
+                    ]))
+                )
+                .as_deref(),
+            Some("claude --dangerously-skip-permissions --resume abc")
+        );
+        // A stale session-targeting flag is stripped — the new id must win.
+        assert_eq!(
+            CLIAgent::Claude
+                .resume_command(
+                    "new-id",
+                    Some(&argv(&["claude", "--resume", "old-id", "--model", "opus"]))
+                )
+                .as_deref(),
+            Some("claude --model opus --resume new-id")
+        );
+        // Codex resumes via its subcommand, flags after the positional id; a
+        // relaunched `codex resume <old>` sheds the old subcommand + id.
+        assert_eq!(
+            CLIAgent::Codex
+                .resume_command("id-1", Some(&argv(&["codex", "--yolo"])))
+                .as_deref(),
+            Some("codex resume id-1 --yolo")
+        );
+        assert_eq!(
+            CLIAgent::Codex
+                .resume_command("id-2", Some(&argv(&["codex", "resume", "id-1", "--yolo"])))
+                .as_deref(),
+            Some("codex resume id-2 --yolo")
+        );
+        // Anything shell-unsafe or positional-shaped drops the WHOLE tail —
+        // resume still works, just bare.
+        assert_eq!(
+            CLIAgent::Claude
+                .resume_command(
+                    "abc",
+                    Some(&argv(&["claude", "--allowedTools", "Bash(git:*)"]))
+                )
+                .as_deref(),
+            Some("claude --resume abc")
+        );
+        assert_eq!(
+            CLIAgent::Claude
+                .resume_command("abc", Some(&argv(&["claude", "fix-the-bug"])))
+                .as_deref(),
+            Some("claude --resume abc")
+        );
+        // A leading env assignment doesn't mis-anchor the flag tail.
+        assert_eq!(
+            CLIAgent::Claude
+                .resume_command(
+                    "abc",
+                    Some(&argv(&[
+                        "CLAUDE_CONFIG_DIR=/opt/claude",
+                        "claude",
+                        "--dangerously-skip-permissions",
+                    ]))
+                )
+                .as_deref(),
+            Some("claude --dangerously-skip-permissions --resume abc")
+        );
+        // Two consecutive bare words = a positional prompt, not a flag value —
+        // it must not re-submit itself into the resumed session.
+        assert_eq!(
+            CLIAgent::Claude
+                .resume_command(
+                    "abc",
+                    Some(&argv(&["claude", "--model", "opus", "review", "this"]))
+                )
+                .as_deref(),
+            Some("claude --resume abc")
+        );
+        // Codex `--last` targets "most recent" and would contradict the
+        // explicit id → stripped.
+        assert_eq!(
+            CLIAgent::Codex
+                .resume_command(
+                    "id-3",
+                    Some(&argv(&["codex", "resume", "--last", "--yolo"]))
+                )
+                .as_deref(),
+            Some("codex resume id-3 --yolo")
+        );
+        // No token names the agent (custom wrapper rule) → bare.
+        assert_eq!(
+            CLIAgent::Claude
+                .resume_command(
+                    "abc",
+                    Some(&argv(&["cc", "--dangerously-skip-permissions"]))
+                )
+                .as_deref(),
+            Some("claude --resume abc")
+        );
+        // Amp: global mode flags ride after the `threads continue` positional.
+        assert_eq!(
+            CLIAgent::Amp
+                .resume_command("t-1", Some(&argv(&["amp", "--dangerously-allow-all"])))
+                .as_deref(),
+            Some("amp threads continue t-1 --dangerously-allow-all")
+        );
+        // A relaunch via `amp threads continue …` is subcommand-shaped, not
+        // flag-shaped → bare (the gate rejects the leading bare word).
+        assert_eq!(
+            CLIAgent::Amp
+                .resume_command("t-2", Some(&argv(&["amp", "threads", "continue", "t-1"])))
+                .as_deref(),
+            Some("amp threads continue t-2")
+        );
+        // Copilot resumes by flag, stale session targeting stripped.
+        assert_eq!(
+            CLIAgent::Copilot
+                .resume_command(
+                    "s-9",
+                    Some(&argv(&["copilot", "--resume", "s-1", "--allow-all-tools"]))
+                )
+                .as_deref(),
+            Some("copilot --allow-all-tools --resume s-9")
+        );
+        assert_eq!(
+            CLIAgent::Copilot.resume_command("s-9", None).as_deref(),
+            Some("copilot --resume s-9")
+        );
     }
 
     #[test]

--- a/src/core/session.rs
+++ b/src/core/session.rs
@@ -54,6 +54,12 @@ pub enum SessionPane {
         agent: Option<crate::core::cli_agent::CLIAgent>,
         #[serde(default)]
         agent_session_id: Option<String>,
+        /// The argv the agent was launched with, as the daemon observed it —
+        /// lets the resume command carry the user's launch flags
+        /// (`--dangerously-skip-permissions`, …) instead of resuming bare.
+        /// `None` for old sessions or when nothing was captured.
+        #[serde(default)]
+        agent_launch_argv: Option<Vec<String>>,
     },
     /// A split of two subtrees along `axis`, with `a` taking `ratio` of space.
     Split {
@@ -192,6 +198,7 @@ mod tests {
                         ssh_spec: None,
                         agent: None,
                         agent_session_id: None,
+                        agent_launch_argv: None,
                     },
                 },
                 SessionTab {
@@ -206,6 +213,7 @@ mod tests {
                             ssh_spec: None,
                             agent: None,
                             agent_session_id: None,
+                            agent_launch_argv: None,
                         }),
                         b: Box::new(SessionPane::Leaf {
                             cwd: Some(PathBuf::from("/tmp")),
@@ -213,6 +221,7 @@ mod tests {
                             ssh_spec: None,
                             agent: None,
                             agent_session_id: None,
+                            agent_launch_argv: None,
                         }),
                     },
                 },
@@ -244,6 +253,10 @@ mod tests {
             ssh_spec: None,
             agent: Some(crate::core::cli_agent::CLIAgent::Claude),
             agent_session_id: Some("abc-123".into()),
+            agent_launch_argv: Some(vec![
+                "claude".into(),
+                "--dangerously-skip-permissions".into(),
+            ]),
         };
         let back: SessionPane =
             serde_json::from_str(&serde_json::to_string(&leaf).unwrap()).unwrap();
@@ -251,10 +264,20 @@ mod tests {
             SessionPane::Leaf {
                 agent,
                 agent_session_id,
+                agent_launch_argv,
                 ..
             } => {
                 assert_eq!(agent, Some(crate::core::cli_agent::CLIAgent::Claude));
                 assert_eq!(agent_session_id.as_deref(), Some("abc-123"));
+                assert_eq!(
+                    agent_launch_argv.as_deref(),
+                    Some(
+                        &[
+                            "claude".to_string(),
+                            "--dangerously-skip-permissions".to_string()
+                        ][..]
+                    )
+                );
             }
             _ => panic!("expected leaf"),
         }
@@ -266,6 +289,7 @@ mod tests {
             SessionPane::Leaf {
                 agent: None,
                 agent_session_id: None,
+                agent_launch_argv: None,
                 ..
             }
         ));
@@ -305,6 +329,7 @@ mod tests {
                     ssh_spec: None,
                     agent: None,
                     agent_session_id: None,
+                    agent_launch_argv: None,
                 },
             }],
         };

--- a/src/daemon/pane.rs
+++ b/src/daemon/pane.rs
@@ -468,6 +468,11 @@ struct PaneState {
     /// the foreground `argv` (same process-table poll as `remote`). `None` when
     /// no known agent runs — see [`crate::core::cli_agent`].
     agent: Option<crate::core::cli_agent::CLIAgent>,
+    /// The argv the detected agent was launched with, held here until a rich
+    /// session exists to stamp it into (the sentinel events that create the
+    /// session can land before the first argv poll, and vice versa). Cleared
+    /// with the chip. See [`stamp_launch_argv`].
+    agent_argv: Option<Vec<String>>,
     /// The rich agent-session status (idle/working/waiting/done + native
     /// session id), folded from the sentinel OSC events the agent's hooks emit
     /// (with an opaque OSC 9/777 fallback). Cleared when the agent exits.
@@ -503,8 +508,9 @@ struct ForegroundProbes {
     /// process group) — "no opinion", never applied, so it can't wipe an agent
     /// identified another way (sentinel events, the Windows `133;C;<cmd>`
     /// mark). `Some(answer)` is a real poll result; its inner `None` ("polled,
-    /// no agent") clears the chip.
-    agent: Box<dyn Fn() -> Option<Option<crate::core::cli_agent::CLIAgent>> + Send>,
+    /// no agent") clears the chip. A detected agent travels with the `argv` it
+    /// was identified from, kept for flag carry-over on session resume.
+    agent: Box<dyn Fn() -> Option<Option<(crate::core::cli_agent::CLIAgent, Vec<String>)>> + Send>,
 }
 
 /// The local-PTY backend: the same handles `DaemonPane` has always owned.
@@ -669,6 +675,7 @@ impl DaemonPane {
             remote: spawn.remote.clone(),
             agent: None,
             agent_session: None,
+            agent_argv: None,
             alive: true,
         }));
         let shutting_down = Arc::new(AtomicBool::new(false));
@@ -777,6 +784,7 @@ impl DaemonPane {
             // agent detection never runs for it.
             agent: None,
             agent_session: None,
+            agent_argv: None,
             alive: true,
         }));
         let shutting_down = Arc::new(AtomicBool::new(false));
@@ -1736,7 +1744,8 @@ fn apply_signals(st: &mut PaneState, signals: SniffSignals) {
         if shell_mark_capture_changed(&st.shell, &shell) {
             apply_agent(
                 st,
-                agent_from_shell_mark(&shell, crate::core::config::agent_commands_cached()),
+                agent_from_shell_mark(&shell, crate::core::config::agent_commands_cached())
+                    .map(|agent| (agent, Vec::new())),
             );
         }
         st.shell = shell.clone();
@@ -1774,6 +1783,12 @@ fn agent_from_shell_mark(
     shell: &ShellState,
     custom: &std::collections::HashMap<String, String>,
 ) -> Option<crate::core::cli_agent::CLIAgent> {
+    // Identity only — deliberately NOT a launch-argv source for resume flag
+    // carry-over. The `133;C` capture is terminal *output* (any program can
+    // print the OSC and forge it), and forged flags would ride an
+    // auto-executed resume command on the next restore; the Unix argv comes
+    // from the process table and has no such problem. Windows sessions
+    // therefore resume bare.
     shell
         .command
         .as_deref()
@@ -1827,6 +1842,16 @@ fn apply_agent_signals(
         sess.message = Some(body);
     }
 
+    // A session the events just created starts without the launch argv the
+    // identity poll captured — seed it so resume gets the flags no matter
+    // which side observed the pane first. Updates keep flowing through
+    // [`stamp_launch_argv`].
+    if let (Some(sess), Some(argv)) = (&mut st.agent_session, &st.agent_argv)
+        && sess.launch_argv.is_none()
+    {
+        sess.launch_argv = Some(argv.clone());
+    }
+
     if st.agent_session != before
         && let Some(sub) = &st.subscriber
     {
@@ -1854,8 +1879,19 @@ fn apply_remote_context(st: &mut PaneState, remote: Option<RemoteContext>) {
     st.remote = remote;
 }
 
-fn apply_agent(st: &mut PaneState, agent: Option<crate::core::cli_agent::CLIAgent>) {
+fn apply_agent(
+    st: &mut PaneState,
+    detected: Option<(crate::core::cli_agent::CLIAgent, Vec<String>)>,
+) {
+    let (agent, argv) = match detected {
+        Some((agent, argv)) => (Some(agent), Some(argv)),
+        None => (None, None),
+    };
     if st.agent == agent {
+        // Same chip, but the observed argv can still be news: the sentinel
+        // events may have branded the pane before the first argv poll, or the
+        // user relaunched the agent with different flags.
+        stamp_launch_argv(st, argv);
         return;
     }
     // The agent leaving the foreground ends its session: clear the rich state
@@ -1868,10 +1904,38 @@ fn apply_agent(st: &mut PaneState, agent: Option<crate::core::cli_agent::CLIAgen
             let _ = sub.send(DaemonMsg::AgentStatus(None));
         }
     }
+    if agent.is_none() {
+        st.agent_argv = None;
+    }
     if let Some(sub) = &st.subscriber {
         let _ = sub.send(DaemonMsg::Agent(agent));
     }
     st.agent = agent;
+    stamp_launch_argv(st, argv);
+}
+
+/// Record the detected agent's launch argv and mirror it into the rich session
+/// state (pushing the change to the client) when one exists — resume-after-
+/// restart reads it from there. `None` (a poll that saw no argv) and an empty
+/// argv (Windows mark detection, identity without a trustworthy argv) never
+/// wipe a captured value; the chip clearing in [`apply_agent`] does that.
+fn stamp_launch_argv(st: &mut PaneState, argv: Option<Vec<String>>) {
+    let Some(argv) = argv else { return };
+    if argv.is_empty() {
+        return;
+    }
+    if st.agent_argv.as_ref() == Some(&argv) {
+        return;
+    }
+    st.agent_argv = Some(argv.clone());
+    if let Some(sess) = &mut st.agent_session
+        && sess.launch_argv.as_ref() != Some(&argv)
+    {
+        sess.launch_argv = Some(argv);
+        if let Some(sub) = &st.subscriber {
+            let _ = sub.send(DaemonMsg::AgentStatus(st.agent_session.clone()));
+        }
+    }
 }
 
 /// Whether a foreground command — not the shell itself — currently owns the
@@ -1938,14 +2002,16 @@ fn foreground_remote_context(_master: &Mutex<Box<dyn MasterPty + Send>>) -> Opti
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 fn foreground_agent(
     master: &Mutex<Box<dyn MasterPty + Send>>,
-) -> Option<Option<crate::core::cli_agent::CLIAgent>> {
+) -> Option<Option<(crate::core::cli_agent::CLIAgent, Vec<String>)>> {
     let detect = || {
         let pid = master.lock().ok().and_then(|m| m.process_group_leader())?;
         let argv = crate::daemon::remote::foreground_argv(pid)?;
-        crate::core::cli_agent::CLIAgent::detect_from_argv_with(
+        let agent = crate::core::cli_agent::CLIAgent::detect_from_argv_with(
             &argv,
             crate::core::config::agent_commands_cached(),
-        )
+        )?;
+        // The argv rides along: resume-after-restart replays its flags.
+        Some((agent, argv))
     };
     Some(detect())
 }
@@ -1957,7 +2023,7 @@ fn foreground_agent(
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
 fn foreground_agent(
     _master: &Mutex<Box<dyn MasterPty + Send>>,
-) -> Option<Option<crate::core::cli_agent::CLIAgent>> {
+) -> Option<Option<(crate::core::cli_agent::CLIAgent, Vec<String>)>> {
     None
 }
 
@@ -2305,10 +2371,16 @@ mod tests {
         let _ = child.kill();
         let _ = child.wait();
 
+        let (agent, argv) = detected.expect("agent detected from live PTY child");
         assert_eq!(
-            detected,
-            Some(crate::core::cli_agent::CLIAgent::Codex),
+            agent,
+            crate::core::cli_agent::CLIAgent::Codex,
             "a live PTY child with argv[0]=codex must be detected as Codex"
+        );
+        assert_eq!(
+            argv.first().map(String::as_str),
+            Some("codex"),
+            "the observed argv rides along with the detection"
         );
     }
 
@@ -3150,6 +3222,7 @@ mod tests {
             remote: None,
             agent: None,
             agent_session: None,
+            agent_argv: None,
             alive,
         }
     }
@@ -3246,6 +3319,7 @@ mod tests {
             status: AgentStatus::Working,
             message: None,
             session_id: Some("sid".into()),
+            launch_argv: None,
             rich: true,
             cwd: None,
         });

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -1575,6 +1575,10 @@ mod tests {
                 status: crate::core::cli_agent::AgentStatus::Waiting,
                 message: Some("Claude needs your permission to use Bash".into()),
                 session_id: Some("abc-123".into()),
+                launch_argv: Some(vec![
+                    "claude".into(),
+                    "--dangerously-skip-permissions".into(),
+                ]),
                 rich: true,
                 cwd: Some("/repo/.claude/worktrees/fix-x".into()),
             })),

--- a/src/terminal/remote.rs
+++ b/src/terminal/remote.rs
@@ -2340,6 +2340,7 @@ mod tests {
             status: AgentStatus::Waiting,
             message: Some("Claude needs your permission".into()),
             session_id: Some("sid-1".into()),
+            launch_argv: None,
             rich: true,
             cwd: None,
         }))

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -4572,9 +4572,12 @@ fn pane_to_session(pane: &Pane, cx: &App) -> SessionPane {
                 ssh_spec: view.ssh_spec(),
                 // The running agent + its native session id (when its hooks
                 // reported one), so a pane the daemon loses can resume the
-                // agent conversation instead of just reopening a shell.
+                // agent conversation instead of just reopening a shell. The
+                // observed launch argv rides along so the resume command keeps
+                // the user's flags (`--dangerously-skip-permissions`, …).
                 agent: view.agent(),
                 agent_session_id: view.agent_session().and_then(|s| s.session_id),
+                agent_launch_argv: view.agent_session().and_then(|s| s.launch_argv),
             }
         }
         Pane::Split {
@@ -4596,6 +4599,7 @@ fn pane_to_session(pane: &Pane, cx: &App) -> SessionPane {
             ssh_spec: None,
             agent: None,
             agent_session_id: None,
+            agent_launch_argv: None,
         },
     }
 }
@@ -4665,6 +4669,7 @@ fn session_to_pane(
             ssh_spec,
             agent,
             agent_session_id,
+            agent_launch_argv,
         } => {
             // Only restore the pane id when the daemon confirms it's still live;
             // a stale id (daemon restarted, pane killed) falls back to a spawn.
@@ -4696,7 +4701,7 @@ fn session_to_pane(
             if restore.is_none()
                 && cx.global::<Config>().restore_agent_sessions
                 && let (Some(agent), Some(id)) = (agent, agent_session_id)
-                && let Some(cmd) = agent.resume_command(id)
+                && let Some(cmd) = agent.resume_command(id, agent_launch_argv.as_deref())
             {
                 view.read(cx).run_command_line(&cmd);
             }

--- a/src/ui/home.rs
+++ b/src/ui/home.rs
@@ -187,6 +187,7 @@ mod tests {
             ssh_spec: None,
             agent: None,
             agent_session_id: None,
+            agent_launch_argv: None,
         }
     }
 


### PR DESCRIPTION
Session resume after a restart now replays the agent's original launch flags instead of a bare hardcoded command.

| | Before | After |
|---|---|---|
| Restore a dead pane that ran `claude --dangerously-skip-permissions` | `claude --resume <id>` — flags silently dropped | `claude --dangerously-skip-permissions --resume <id>` |
| Launch flags with values (`--model opus`, `-c key=value`) | Dropped | Carried verbatim |
| Interpreter-wrapped launch (`node …/claude-code/cli.js --flags`) | Dropped | Flags found after the agent-naming token, replayed on the table launcher |
| Relaunch shapes (`claude --resume old`, `codex resume old --yolo`, `copilot -r old`) | n/a | Stale session-targeting flags stripped; the new id wins |
| Ambiguous / unsafe tails (positional prompts, quoted args, shell metacharacters) | n/a | Whole tail dropped — resume still fires, bare |
| Copilot CLI | No resume entry (its hooks already report a session id) | `copilot --resume <id>` |
| Amp | Bare `amp threads continue <id>` | Global flags carried (`threads continue` verified to accept them; unknown options are a parse error) |
| Windows (`133;C` typed-command capture) | Identity detection only | Unchanged — identity only, still resumes bare (see security note) |

## Why

The daemon's 0.5 s foreground poll already reads the agent process's full `argv` for identity detection and then discarded it. Keeping it costs nothing and is the only trustworthy source of the user's launch mode; without it, a restored `--dangerously-skip-permissions` session comes back re-prompting for every permission.

## How

```mermaid
sequenceDiagram
    participant P as daemon poll (process table)
    participant S as PaneState
    participant C as client (AgentSessionState)
    participant F as session file
    participant R as restore

    P->>S: detect agent + argv (0.5 s poll)
    Note over S: agent_argv held until a rich<br/>session exists (either order works)
    S->>C: AgentStatus{launch_argv} (stamped / seeded)
    C->>F: Leaf{agent, session_id, agent_launch_argv}
    F->>R: dead pane → resume_command(id, argv)
    Note over R: gated flag tail spliced into<br/>the per-agent resume command
```

- `AgentSessionState.launch_argv` and the session `Leaf.agent_launch_argv` are `#[serde(default)]` — old⇄new protocol peers and old session files round-trip cleanly.
- `CLIAgent::resume_command(id, launch_argv)` splices a flag tail behind a conservative gate: plain shell-safe tokens only (alnum + `-_=./,:@+~`), first token must be a `-` flag, no two consecutive bare words (a bare word is only acceptable as the value directly behind a flag — anything else is a positional prompt that must not re-submit itself). Leading `VAR=value` env assignments are skipped before anchoring. Any violation falls back to the bare table command.
- Per-agent stale-flag stripping (`--resume/-r/--continue/-c/--session-id/--from-pr` for Claude, `--last` for Codex, etc.) so an old session target never contradicts the injected id.

## Security

The Windows `133;C` typed-command capture is terminal *output* — any program can print the OSC and forge it. Forged flags on an auto-executed resume command would be a real escalation (e.g. `--mcp-config` pointing at an attacker-controlled file), so the capture contributes agent *identity* only and never feeds flag carry-over. The Unix argv comes from the process table and has no such problem. The session id itself was already charset-gated; that gate is unchanged.

Known accepted limits: custom wrapper commands (`agent_commands` rules) expose no real flags → bare resume; a single bare word behind a boolean flag is indistinguishable from a flag value and rides along (no per-flag arity table).

## Testing

- New unit tests: flag carry-over per agent (Claude/Codex/Copilot/Amp/OpenCode), interpreter-wrapped argv, env-assignment anchoring, stale-flag stripping, positional-prompt rejection, shell-unsafe fallback, serde round-trip of the new fields, old-session decode defaults.
- Existing daemon state-machine tests extended for the argv-rides-along probe (`live_pty_child_argv_detects_the_agent`).
- Verified against the real CLIs on this machine: `claude` accepts `--dangerously-skip-permissions` with `--resume`; `codex resume [OPTIONS] [SESSION_ID]` accepts mode flags after the positional id (including the hidden `--yolo` alias); `amp threads continue` accepts global options and hard-errors on unknown ones; `opencode -s/--session` confirmed. Copilot syntax from GitHub docs (`copilot --resume <sessionId>`, `-r` shorthand).
- Full suite: 797 passed, 0 failed; `cargo fmt --check` clean.
