### PR TITLE
fix(window): quit when the last window is closed from the home page

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -698,11 +698,20 @@ impl Tty7App {
                 return true;
             }
             // From the home page (zero tabs) there are no running sessions to
-            // reassure about — prompting would be pure friction. Close directly.
+            // reassure about — prompting would be pure friction. Close directly,
+            // but still quit with the window: closing our only window without
+            // quitting leaves a windowless process sitting in the Dock that no
+            // longer responds to being clicked (#147). Deferred onto the next
+            // tick so the close itself completes first, same as the confirmed
+            // path below.
             if weak_app
                 .upgrade()
                 .is_some_and(|app| app.read(cx).tabs.is_empty())
             {
+                cx.spawn(async move |cx| {
+                    let _ = cx.update(|cx| cx.quit());
+                })
+                .detach();
                 return true;
             }
             let answer = window.prompt(


### PR DESCRIPTION
Quit the app when its only window is closed from the home page, instead of leaving a windowless process alive in the Dock.

Fixes #147.

| | Before | After |
|---|---|---|
| Close window with tabs open → "Close" | Prompt, then app quits | unchanged |
| Close window from the home page (zero tabs) | Window closes, process stays alive with no window | Window closes and the app quits |
| Clicking the Dock icon after that | Nothing happens — the process is still there but has no window and no reopen handler | N/A, the app has exited; a click launches it normally |

### Why

`on_window_should_close` has a shortcut for the home page: with zero tabs there are no running sessions to reassure the user about, so it returns `true` and closes directly. The confirmed path below it calls `cx.quit()` after the prompt; the shortcut never did. gpui does not quit when the last window closes and the app registers no `on_reopen` handler, so the result was a live process with no window that ignored Dock clicks.

The quit is deferred onto the next tick (`cx.spawn` + `cx.update`) so the close itself completes first — the same shape as the post-prompt quit.

### Testing

- Manual, on an isolated dev instance (`--config-dir` in a scratch dir, separate daemon, so the running installed app was untouched):
  - Built the pre-fix binary: ⌘W to close the last tab → home page → click the red traffic light → GUI process still alive. Repro confirmed.
  - Same steps on the fixed build → process exits cleanly.
