### PR TITLE
chore(deps): resync Cargo.lock with Cargo.toml and lock it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,9 @@ jobs:
       # fails here instead of being silently rewritten. Without it the drift is
       # invisible to CI and lands on contributors instead: every local `cargo`
       # run rewrites the lock, leaving a permanently dirty working tree that has
-      # to be re-discarded before every commit. Deliberately not applied to the
-      # release/nightly workflows — those stamp Cargo.toml's version and rely on
-      # cargo refreshing the lock's own root entry.
+      # to be re-discarded before every commit. The release workflow locks its
+      # build too; only nightly stays unlocked, because it stamps Cargo.toml's
+      # version and relies on cargo refreshing the lock's own root entry.
       - name: Build
         run: cargo build --locked --target ${{ matrix.target }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,15 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      # `--locked` on the build so a Cargo.lock that disagrees with Cargo.toml
+      # fails here instead of being silently rewritten. Without it the drift is
+      # invisible to CI and lands on contributors instead: every local `cargo`
+      # run rewrites the lock, leaving a permanently dirty working tree that has
+      # to be re-discarded before every commit. Deliberately not applied to the
+      # release/nightly workflows — those stamp Cargo.toml's version and rely on
+      # cargo refreshing the lock's own root entry.
       - name: Build
-        run: cargo build --target ${{ matrix.target }}
+        run: cargo build --locked --target ${{ matrix.target }}
 
       - name: Test
-        run: cargo test --target ${{ matrix.target }}
+        run: cargo test --locked --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,13 @@ jobs:
         with:
           workspaces: tty7
 
+      # `--locked` because a release must ship the dependency set the tag
+      # recorded, not whatever cargo would re-resolve at build time. Safe here
+      # (unlike nightly) precisely because nothing rewrites Cargo.toml: this is
+      # a plain checkout of the tagged commit.
       - name: Build
         working-directory: tty7
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --locked --target ${{ matrix.target }}
 
       # ---- Packaging: one step per OS ----------------------------------------
       # macOS gets a signed + notarized drag-to-Applications DMG. Windows gets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,7 +2500,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
 dependencies = [
- "roxmltree 0.20.0",
+ "roxmltree",
 ]
 
 [[package]]
@@ -3151,7 +3151,7 @@ dependencies = [
  "raw-window-handle",
  "refineable",
  "regex",
- "resvg 0.45.1",
+ "resvg",
  "scheduler",
  "schemars",
  "seahash",
@@ -3167,7 +3167,7 @@ dependencies = [
  "thiserror 2.0.18",
  "ttf-parser",
  "url",
- "usvg 0.45.1",
+ "usvg",
  "util_macros",
  "uuid",
  "waker-fn",
@@ -3209,7 +3209,7 @@ dependencies = [
  "paste",
  "raw-window-handle",
  "regex",
- "resvg 0.45.1",
+ "resvg",
  "ropey",
  "rust-i18n",
  "schemars",
@@ -4057,12 +4057,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
-name = "imagesize"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
-
-[[package]]
 name = "imgref"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4491,18 +4485,6 @@ checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
 dependencies = [
  "arrayvec",
  "euclid",
- "smallvec",
-]
-
-[[package]]
-name = "kurbo"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
-dependencies = [
- "arrayvec",
- "euclid",
- "polycool",
  "smallvec",
 ]
 
@@ -6308,15 +6290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "polycool"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "polyval"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7084,24 +7057,10 @@ dependencies = [
  "log",
  "pico-args",
  "rgb",
- "svgtypes 0.15.3",
- "tiny-skia 0.11.4",
- "usvg 0.45.1",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
  "zune-jpeg 0.4.21",
-]
-
-[[package]]
-name = "resvg"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
-dependencies = [
- "log",
- "pico-args",
- "rgb",
- "svgtypes 0.16.1",
- "tiny-skia 0.12.0",
- "usvg 0.47.0",
 ]
 
 [[package]]
@@ -7157,15 +7116,6 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
-
-[[package]]
-name = "roxmltree"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "rsa"
@@ -8512,17 +8462,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
- "kurbo 0.11.3",
- "siphasher",
-]
-
-[[package]]
-name = "svgtypes"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
-dependencies = [
- "kurbo 0.13.1",
+ "kurbo",
  "siphasher",
 ]
 
@@ -8859,22 +8799,7 @@ dependencies = [
  "cfg-if",
  "log",
  "png 0.17.16",
- "tiny-skia-path 0.11.4",
-]
-
-[[package]]
-name = "tiny-skia"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
-dependencies = [
- "arrayref",
- "arrayvec",
- "bytemuck",
- "cfg-if",
- "log",
- "png 0.18.1",
- "tiny-skia-path 0.12.0",
+ "tiny-skia-path",
 ]
 
 [[package]]
@@ -8882,17 +8807,6 @@ name = "tiny-skia-path"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
-dependencies = [
- "arrayref",
- "bytemuck",
- "strict-num",
-]
-
-[[package]]
-name = "tiny-skia-path"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -9292,13 +9206,13 @@ dependencies = [
  "portable-pty",
  "regex",
  "reqwest_client",
- "resvg 0.47.0",
+ "resvg",
  "russh",
  "russh-sftp",
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2 0.11.0",
+ "sha2 0.10.9",
  "smallvec",
  "smol",
  "tokio",
@@ -9465,42 +9379,20 @@ dependencies = [
  "data-url",
  "flate2",
  "fontdb",
- "imagesize 0.13.0",
- "kurbo 0.11.3",
+ "imagesize",
+ "kurbo",
  "log",
  "pico-args",
- "roxmltree 0.20.0",
+ "roxmltree",
  "rustybuzz",
  "simplecss",
  "siphasher",
  "strict-num",
- "svgtypes 0.15.3",
- "tiny-skia-path 0.11.4",
+ "svgtypes",
+ "tiny-skia-path",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",
- "xmlwriter",
-]
-
-[[package]]
-name = "usvg"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
-dependencies = [
- "base64",
- "data-url",
- "flate2",
- "imagesize 0.14.0",
- "kurbo 0.13.1",
- "log",
- "pico-args",
- "roxmltree 0.21.1",
- "simplecss",
- "siphasher",
- "strict-num",
- "svgtypes 0.16.1",
- "tiny-skia-path 0.12.0",
  "xmlwriter",
 ]
 


### PR DESCRIPTION
`Cargo.lock` on `main` contradicts `Cargo.toml` and has since 2026-07-20, so every local `cargo` run rewrites it. This resyncs it and makes CI catch the next one.

## The problem

Two lockfile-only dependabot bumps changed `Cargo.lock` **without touching `Cargo.toml`**:

| Commit | Locked version | What `Cargo.toml` asks for |
|---|---|---|
| `e91e706` (#139) | `resvg` 0.47.0 | `resvg = { version = "0.45", … }` |
| `33bebcc` (#140) | `sha2` 0.11.0 | `sha2 = "0.10"` |

Under cargo's 0.x rules the minor version *is* the major, so `"0.45"` cannot accept 0.47.0 and `"0.10"` cannot accept 0.11.0. On `main` today:

```
$ cargo metadata --locked
error: cannot update the lock file /…/Cargo.lock because --locked was passed to prevent this
```

Nothing failed loudly because CI never passed `--locked`. The cost landed on contributors instead:

| | Before | After |
|---|---|---|
| `cargo build` / `test` locally | Silently rewrites `Cargo.lock` → working tree permanently dirty | No change to the lock |
| `git status` after any build | ` M Cargo.lock`, to be re-discarded before every commit | Clean |
| `cargo metadata --locked` | Fails | Passes |
| A future lockfile/manifest mismatch | Invisible; reaches `main` — and ships in a release | Build job fails in the PR |
| Copies of resvg/usvg/tiny-skia/kurbo compiled | 2 each | 1 each |

That last row is a side benefit: gpui-component already depends on resvg 0.45.1, so once tty7 stops asking for 0.47.0 the duplicate trees collapse — `resvg`, `usvg`, `tiny-skia`, `tiny-skia-path`, `kurbo`, `svgtypes`, `roxmltree`, `imagesize` and `polycool` each drop to a single version.

`sha2 0.11.0` and `png 0.18.1` stay in the lock: the russh chain genuinely depends on them. Only tty7's own entries move.

## Why resync rather than bump the manifest

Raising `Cargo.toml` to `resvg = "0.47"` would keep both copies alive, since the fork's gpui-component stays on 0.45.1. Matching it is the smaller tree and the version this repo has actually been building all along — the 0.47.0 entry never compiled into anything, because cargo replaced it before every build.

## CI

`cargo build` and `cargo test` now pass `--locked`, so the next drift fails in the PR instead of in someone's working tree.

The **release** workflow locks its build too. It is a plain checkout of the tag — nothing there rewrites `Cargo.toml` — and a release is the build you least want silently re-resolving dependencies. One consequence worth knowing: re-running `Release` by hand against an *existing* tag whose lock is drifted (`v26.7.2`) will now fail rather than quietly re-resolve. That is the intended reading of the guard; tags cut after this merge are clean.

**Nightly** stays deliberately unlocked. It stamps `Cargo.toml`'s version before building, which makes the lock's own root entry stale by design, and relies on cargo refreshing it (`nightly.yml` documents this).

## Testing

- `cargo metadata --locked --format-version 1` — fails on `main`'s lockfile, passes on this one.
- `cargo test` — 807 passed, 0 failed.
- The resync is exactly what cargo itself produces: the diff is what got written by ordinary local `cargo build` runs, not hand-edited. It is deletions only — 16 insertions, 124 deletions, and no package is raised to a new version.
