### PR TITLE
Live drag-to-reorder for tabs and repo groups

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -10,7 +10,7 @@ use gpui_component::input::{InputEvent, InputState};
 use gpui_component::select::{SearchableVec, SelectEvent, SelectState};
 use gpui_component::slider::{SliderEvent, SliderState};
 use gpui_component::{ActiveTheme as _, IndexPath, TitleBar, WindowExt as _};
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -360,6 +360,12 @@ pub struct Tty7App {
     /// Scroll handle for the sidebar's row list, so activating a tab scrolls its
     /// row into view.
     pub(crate) sidebar_scroll: gpui::ScrollHandle,
+    /// `Some` while a tab / group is being dragged to a new position, in either
+    /// the strip or the rail: the frozen geometry the live preview reflow is
+    /// computed against (see [`crate::ui::reorder`]). Shared by `Rc` because the
+    /// `on_drag` that opens it only gets `&mut App`, not the entity. Cleared on
+    /// the first frame after gpui ends the drag.
+    pub(crate) reorder: Rc<RefCell<Option<crate::ui::reorder::Reorder>>>,
     /// Filter box in the sidebar's top control bar ("Search tabs…"); its text
     /// narrows the visible rows by fuzzy-ish substring match on the tab label.
     pub(crate) sidebar_search: Entity<InputState>,
@@ -636,6 +642,7 @@ impl Tty7App {
             sidebar_width: Rc::new(Cell::new(sidebar_width)),
             sidebar_dragging: Rc::new(Cell::new(false)),
             sidebar_scroll: gpui::ScrollHandle::new(),
+            reorder: Rc::new(RefCell::new(None)),
             sidebar_search,
             _sidebar_search_sub: sidebar_search_sub,
             settings: None,
@@ -753,7 +760,7 @@ impl Tty7App {
     /// Snapshot the current tabs/active index into a `Session` and persist it.
     /// Called after every structural change; the write is a small synchronous
     /// JSON dump and any error is swallowed inside `Session::save`.
-    fn save_session(&self, cx: &App) {
+    pub(crate) fn save_session(&self, cx: &App) {
         let tabs: Vec<SessionTab> = self
             .tabs
             .iter()
@@ -2770,33 +2777,25 @@ impl Tty7App {
         cx.notify();
     }
 
-    /// Reorder tabs: move the tab at `from` to position `to` (drag-and-drop).
-    /// Keeps the same tab active across the move and re-persists the session.
-    pub(crate) fn move_tab(&mut self, from: usize, to: usize, cx: &mut Context<Self>) {
-        if from == to || from >= self.tabs.len() || to >= self.tabs.len() {
+    /// Rearrange the whole tab vector into `order` (old indices in their new
+    /// order) — the single path by which a drag-reorder lands, used by the
+    /// sidebar where a single visual move can imply a larger permutation
+    /// (relocating a tab inside its group without disturbing the group order,
+    /// or moving an entire group). Keeps the same tab active and re-persists.
+    pub(crate) fn apply_tab_order(&mut self, order: &[usize], cx: &mut Context<Self>) {
+        if order.len() != self.tabs.len() || order.iter().enumerate().all(|(i, &o)| i == o) {
             return;
         }
-        // Reordering shifts indices; a pending rename keyed on a fixed index would
-        // commit onto the wrong tab. Drop it.
+        // Reordering shifts indices: a rename pending on a fixed one would
+        // commit onto the wrong tab.
         self.renaming = None;
         let was_active = self.active;
-        let tab = self.tabs.remove(from);
-        self.tabs.insert(to, tab);
-        // Re-derive the active index so the same logical tab stays selected:
-        // removal shifts indices after `from` left, insertion shifts indices at
-        // or after `to` right.
-        self.active = if was_active == from {
-            to
-        } else {
-            let mut a = was_active;
-            if from < a {
-                a -= 1;
-            }
-            if to <= a {
-                a += 1;
-            }
-            a
-        };
+        let mut slots: Vec<Option<Tab>> = std::mem::take(&mut self.tabs)
+            .into_iter()
+            .map(Some)
+            .collect();
+        self.tabs = order.iter().filter_map(|&i| slots[i].take()).collect();
+        self.active = order.iter().position(|&i| i == was_active).unwrap_or(0);
         self.save_session(cx);
         cx.notify();
     }
@@ -4282,6 +4281,32 @@ impl Tty7App {
 
 impl Render for Tty7App {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        // A live drag-reorder commits when the drag *ends*, which in gpui means
+        // the mouse was released (nothing else clears an active drag): the first
+        // frame without one retires the preview and applies the order it was
+        // last showing. Deliberately not an `on_drop` handler — those only fire
+        // when the pointer is over that particular element at release, so a
+        // release a hair outside the rail or the strip would silently lose the
+        // move. What you were looking at is what you get, wherever you let go.
+        // One place at the root covers every surface that can start a drag.
+        if cx.has_active_drag() {
+            // Still dragging: forget last frame's answer so only what this
+            // frame actually draws can be committed (see `clear_pending`).
+            crate::ui::reorder::clear_pending(&self.reorder);
+        } else if let Some(order) = crate::ui::reorder::take_pending(&self.reorder) {
+            self.apply_tab_order(&order, cx);
+        }
+        // While a tab or group is in hand, the cursor is a closed hand for the
+        // whole window. It has to be set on the *drag* rather than styled on
+        // the element: gpui overrides every hovered element's cursor with the
+        // active drag's for the duration, and that override is `None` — a plain
+        // arrow — unless something fills it in. Set once per drag (it forces a
+        // refresh, so re-setting it every frame would spin).
+        if self.reorder.borrow().is_some()
+            && cx.active_drag_cursor_style() != Some(gpui::CursorStyle::ClosedHand)
+        {
+            cx.set_active_drag_cursor_style(gpui::CursorStyle::ClosedHand, window);
+        }
         // Vertical-tab mode: the sidebar owns the tab list, so the title-bar strip
         // drops its chips (keeping only "+"/"⋯"). Gated on having tabs — the
         // zero-tab home page keeps the full-width horizontal layout, so an empty

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,6 +16,7 @@ pub mod palette;
 pub mod pane;
 pub mod perf;
 pub mod presets;
+pub mod reorder;
 pub mod settings;
 pub mod sftp;
 pub mod ssh_connect;

--- a/src/ui/reorder.rs
+++ b/src/ui/reorder.rs
@@ -1,0 +1,560 @@
+//! Live drag-to-reorder — the "the list gets out of your way while you drag"
+//! behaviour behind the tab strip's chips, the sidebar's rows and the sidebar's
+//! group headers.
+//!
+//! Nothing floats above the window: the item you're dragging stays in the
+//! list, dimmed, and travels by the list rearranging around it. gpui's drag
+//! system is used only for what it's good at here — knowing a drag is live and
+//! redrawing every mouse move — while its floating preview renders nothing.
+//! What it doesn't offer at all is any way to know *where* the cursor is
+//! mid-drag from inside a drop target: only a `drag_over` style and a final
+//! `on_drop`, which is the "one tile swaps with another on release" model this
+//! module replaces. Here the surface reads [`Window::mouse_position`] every
+//! frame, asks [`Reorder`] where the dragged slot belongs *right now*, and
+//! renders the list in that order, so what you see is already the result.
+//!
+//! The shape of it:
+//!
+//! | Step | Who | What |
+//! |---|---|---|
+//! | Measure | every slot, every frame | its own bounds into a per-frame cell |
+//! | Freeze | `on_drag` | that cell becomes [`Reorder::rects`] for the whole drag |
+//! | Preview | the surface, per frame | [`Reorder::target`] → [`Reorder::order`] |
+//! | Track | the held slot | [`Reorder::held_offset`] → follows the cursor |
+//! | Slide | each displaced slot | [`Reorder::flip_offset`] → animate to zero |
+//! | Record | the surface, per frame | [`set_pending`] — the order a release would give |
+//! | Commit | the root, on drag end | [`take_pending`] → `Tty7App::apply_tab_order` |
+//!
+//! **Geometry is frozen at drag start on purpose.** The preview reflow moves
+//! the very slots the hit-testing reads, so measuring live would let the list
+//! feed back into its own input and oscillate under a still cursor. Freezing
+//! also means a mid-drag scroll isn't tracked — a deliberate trade for a rail
+//! whose rows are a few dozen pixels tall.
+
+use gpui::{Axis, Bounds, Pixels, Point, px};
+use std::cell::{Cell, RefCell};
+use std::path::PathBuf;
+use std::rc::Rc;
+
+/// The app-wide slot for the one drag that can be live at a time. Shared by
+/// `Rc` because the `on_drag` that opens it only gets `&mut App`.
+pub(crate) type ReorderState = Rc<RefCell<Option<Reorder>>>;
+
+/// Everything a surface needs to draw one frame of a live reorder.
+pub(crate) struct Preview {
+    /// Slot indices in the order to render them.
+    pub(crate) order: Vec<usize>,
+    /// The slot the held item currently occupies — where a release right now
+    /// would land it.
+    pub(crate) target: usize,
+    /// The slot being dragged. It stays in the list like any other — the drag
+    /// is drawn by the list rearranging, not by a card floating over it — and
+    /// only wears a "picked up" dimming so you can see which one you have.
+    pub(crate) from: usize,
+    /// Bumped whenever the preview order changes; part of each slot's
+    /// animation id so a slide restarts rather than resuming.
+    pub(crate) generation: usize,
+    /// Per slot (indexed by its *frozen* index), the offset to start this
+    /// frame at so it slides into place. Zero for everything the last change
+    /// didn't touch, and unused for [`Self::from`] — the held item doesn't
+    /// slide, it tracks.
+    pub(crate) offsets: Vec<Pixels>,
+    /// Where to draw the held item relative to the slot it's laid out in, so
+    /// it follows the cursor continuously instead of hopping slot to slot.
+    pub(crate) held: Pixels,
+}
+
+/// This frame's preview of `surface`, if that's where the live drag started
+/// and its frozen geometry still describes a list of `len` slots.
+pub(crate) fn preview(
+    state: &ReorderState,
+    surface: &Surface,
+    len: usize,
+    pointer: Point<Pixels>,
+) -> Option<Preview> {
+    let state = state.borrow();
+    let r = state.as_ref().filter(|r| r.covers(surface, len))?;
+    let target = r.target(pointer);
+    let (generation, prev) = r.begin_frame(target);
+    Some(Preview {
+        order: r.order(target),
+        target,
+        from: r.from,
+        generation,
+        offsets: (0..len)
+            .map(|slot| r.flip_offset(slot, prev, target))
+            .collect(),
+        held: r.held_offset(pointer, target),
+    })
+}
+
+/// Record the tab order the current preview implies, so releasing the mouse
+/// applies exactly what the user was looking at.
+///
+/// The surface computes this every frame while it draws the preview, rather
+/// than a drop handler working it out on release, because a drop handler only
+/// fires when the pointer is over *that element* at release — release a hair
+/// above the rail (easy when dragging a row upward) and the move would be
+/// silently lost, the list snapping back. The drag ending is the commit, and
+/// where the cursor happens to be at that moment doesn't enter into it.
+pub(crate) fn set_pending(state: &ReorderState, surface: &Surface, order: Vec<usize>) {
+    if let Some(r) = state.borrow().as_ref().filter(|r| r.surface == *surface) {
+        *r.pending.borrow_mut() = Some(order);
+    }
+}
+
+/// Forget the order recorded by the previous frame, at the start of every
+/// frame a drag is live — the surfaces re-record it as they draw.
+///
+/// Without this the recording is a high-water mark rather than a snapshot: drag
+/// a row down and back to its own slot and the surface stops recording (the
+/// move is a no-op), so a stale "moved" order would survive to be committed by
+/// a release the user made after visibly putting the row back. Same for a frame
+/// where the drag's frozen geometry no longer matches the list ([`Reorder::covers`]
+/// — a tab closed, or a git probe moved one to another group): nothing is drawn
+/// and so nothing may commit.
+pub(crate) fn clear_pending(state: &ReorderState) {
+    if let Some(r) = state.borrow().as_ref() {
+        r.pending.borrow_mut().take();
+    }
+}
+
+/// Take the recorded order out of a finished drag — see [`set_pending`].
+pub(crate) fn take_pending(state: &ReorderState) -> Option<Vec<usize>> {
+    state.borrow_mut().take()?.pending.into_inner()
+}
+
+/// Which of the app's reorderable lists a drag belongs to. The sidebar rail
+/// holds two at once — the rows inside a group, and the group blocks
+/// themselves — so a surface asking "is this drag mine?" needs more than
+/// "am I the sidebar". Rows carry their group's repo root (`None` = Scratch)
+/// because a row drag must never reflow a sibling group: a tab's group comes
+/// from its cwd, not from where it sits in the list.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub(crate) enum Surface {
+    /// The horizontal title-bar strip. Display order is plain tab order.
+    Strip,
+    /// The rows of one sidebar group.
+    SidebarRows(Option<PathBuf>),
+    /// The sidebar's group blocks (header + its rows), dragged by the header.
+    SidebarGroups,
+}
+
+/// One live drag-reorder. Created when gpui starts a drag, read by the surface
+/// on every frame until the drop, then dropped.
+pub(crate) struct Reorder {
+    /// The list this drag belongs to; a surface ignores state that isn't its own.
+    pub(crate) surface: Surface,
+    /// Index of the dragged slot in the frozen order.
+    pub(crate) from: usize,
+    /// Every slot's bounds in display order, as measured on the last frame
+    /// before the drag started (see the module docs on why they're frozen).
+    rects: Vec<Bounds<Pixels>>,
+    /// The axis the list runs along — vertical for the rail, horizontal for the strip.
+    axis: Axis,
+    /// The list's gap between slots, so a displaced slot's shift matches what
+    /// the layout will actually do.
+    gap: Pixels,
+    /// Where inside the dragged slot the pointer grabbed it, so the slot's
+    /// position is derived from the cursor exactly as gpui's floating preview is.
+    grab: Point<Pixels>,
+    /// The target the previous frame drew, and a counter bumped whenever it
+    /// changes. The slide-in animation keys its element id off the counter, so
+    /// a slot that has just been displaced restarts its slide instead of
+    /// resuming a finished one.
+    prev: Cell<usize>,
+    generation: Cell<usize>,
+    /// The tab order releasing right now would produce, refreshed every frame
+    /// by the surface drawing the preview. See [`set_pending`].
+    pending: RefCell<Option<Vec<usize>>>,
+}
+
+impl Reorder {
+    pub(crate) fn new(
+        surface: Surface,
+        from: usize,
+        rects: Vec<Bounds<Pixels>>,
+        axis: Axis,
+        gap: Pixels,
+        grab: Point<Pixels>,
+    ) -> Self {
+        Self {
+            surface,
+            from,
+            rects,
+            axis,
+            gap,
+            grab,
+            prev: Cell::new(from),
+            generation: Cell::new(0),
+            pending: RefCell::new(None),
+        }
+    }
+
+    /// True when this state belongs to `surface` and its frozen geometry still
+    /// describes a list of `len` slots — a tab closing mid-drag, or the git
+    /// probe moving a tab to another group, invalidates it rather than letting
+    /// stale indices reorder the wrong thing.
+    pub(crate) fn covers(&self, surface: &Surface, len: usize) -> bool {
+        self.surface == *surface && self.rects.len() == len && self.from < len
+    }
+
+    /// The scalar component along the list's axis.
+    fn along(&self, p: Point<Pixels>) -> Pixels {
+        match self.axis {
+            Axis::Vertical => p.y,
+            Axis::Horizontal => p.x,
+        }
+    }
+
+    /// A slot's extent along the list's axis.
+    fn extent(&self, b: &Bounds<Pixels>) -> Pixels {
+        match self.axis {
+            Axis::Vertical => b.size.height,
+            Axis::Horizontal => b.size.width,
+        }
+    }
+
+    /// How far a slot moves when the dragged one passes it: the dragged slot's
+    /// extent plus the gap it also takes with it.
+    fn shift(&self) -> Pixels {
+        self.extent(&self.rects[self.from]) + self.gap
+    }
+
+    /// Where the dragged slot belongs for a cursor at `pointer`: how many of
+    /// the other slots would sit before it.
+    ///
+    /// A neighbour yields once the held item covers half of it — its *trailing*
+    /// edge past that neighbour's centre going forward, its *leading* edge past
+    /// it going back. Edges rather than the held item's own centre, because the
+    /// two are only equivalent when everything is the same size: in the rail a
+    /// three-row group block is twice a one-row block, and a centre-to-centre
+    /// test would demand the tall block's middle reach the short one's middle —
+    /// pointer travel that runs off the top of the list, which is exactly the
+    /// "big group won't move up" case. Half-overlap asks the same of both
+    /// directions and of any pair of sizes.
+    ///
+    /// The comparison is against the *frozen* centres, never the reflowed ones,
+    /// so the reflow can't move the number it's being compared to and the
+    /// crossing can't chase itself under a still cursor.
+    pub(crate) fn target(&self, pointer: Point<Pixels>) -> usize {
+        let leading = self.free_origin(pointer);
+        let trailing = leading + self.extent(&self.rects[self.from]);
+        self.rects
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != self.from)
+            .filter(|(i, r)| {
+                let centre = self.along(r.origin) + self.extent(r) / 2.;
+                if *i < self.from {
+                    // Still above the held item: it hasn't reached back this far.
+                    leading >= centre
+                } else {
+                    trailing > centre
+                }
+            })
+            .count()
+    }
+
+    /// Where the dragged slot's leading edge is, following the pointer without
+    /// limit: the cursor less where inside the slot it was grabbed, so the item
+    /// sits under the cursor exactly where you picked it up.
+    fn free_origin(&self, pointer: Point<Pixels>) -> Pixels {
+        self.along(pointer) - self.along(self.grab)
+    }
+
+    /// [`Self::free_origin`] confined to the list's own span, so dragging far
+    /// past either end parks the item against that end instead of sending it
+    /// off across the window. Only the *drawing* is clamped — [`Self::target`]
+    /// reads the free position, so pushing past the last slot still selects it.
+    fn held_origin(&self, pointer: Point<Pixels>) -> Pixels {
+        let first = self.along(self.rects[0].origin);
+        let last = self.rects.last().expect("non-empty");
+        let end = self.along(last.origin) + self.extent(last);
+        self.free_origin(pointer)
+            .clamp(first, end - self.extent(&self.rects[self.from]))
+    }
+
+    /// The offset to draw the dragged slot at so it tracks the pointer: the
+    /// distance from where the list has *laid it out* this frame (its slot
+    /// under `target`) to where the cursor is actually holding it.
+    ///
+    /// This is what makes the drag feel attached rather than stepwise — the
+    /// held item moves pixel-for-pixel with the mouse, and the reflow of the
+    /// others is the only thing that snaps.
+    pub(crate) fn held_offset(&self, pointer: Point<Pixels>, target: usize) -> Pixels {
+        let home = self.along(self.rects[self.from].origin);
+        self.held_origin(pointer) - (home + self.displacement(self.from, target))
+    }
+
+    /// Slot indices in preview order: the dragged one lifted out of `from` and
+    /// dropped back in at `target`.
+    pub(crate) fn order(&self, target: usize) -> Vec<usize> {
+        let mut order: Vec<usize> = (0..self.rects.len()).collect();
+        let dragged = order.remove(self.from);
+        order.insert(target.min(order.len()), dragged);
+        order
+    }
+
+    /// Open a frame previewing `target`: returns the animation generation to
+    /// key slide-ins on, and the target the previous frame drew — which
+    /// [`Self::flip_offset`] measures the slide from. Call once per frame,
+    /// before laying the slots out.
+    pub(crate) fn begin_frame(&self, target: usize) -> (usize, usize) {
+        let prev = self.prev.get();
+        if prev != target {
+            self.generation.set(self.generation.get() + 1);
+            self.prev.set(target);
+        }
+        (self.generation.get(), prev)
+    }
+
+    /// Where the slot frozen at index `slot` sits under a given preview,
+    /// relative to its resting place.
+    ///
+    /// The displaced slots each close up by one dragged-slot pitch, in the
+    /// direction the drag came from. The dragged slot itself moves the other
+    /// way by everything it has jumped over — it stays in the list rather than
+    /// floating above it, so it has a position to be displaced to like anyone
+    /// else, and the two sides always add up to a swap.
+    fn displacement(&self, slot: usize, target: usize) -> Pixels {
+        if slot == self.from {
+            // Sum the pitches of the slots crossed, since rows differ in height.
+            let crossed = if target > self.from {
+                self.from + 1..=target
+            } else {
+                target..=self.from.saturating_sub(1)
+            };
+            let span: Pixels = crossed
+                .filter(|&i| i != self.from && i < self.rects.len())
+                .map(|i| self.extent(&self.rects[i]) + self.gap)
+                .fold(px(0.), |a, b| a + b);
+            if target > self.from { span } else { -span }
+        } else if self.from < slot && slot <= target {
+            -self.shift()
+        } else if target <= slot && slot < self.from {
+            self.shift()
+        } else {
+            px(0.)
+        }
+    }
+
+    /// The offset a slot should *start* this frame at so it slides into its new
+    /// place instead of teleporting: where the last frame drew it, minus where
+    /// this frame puts it. Zero for every slot the new target didn't disturb —
+    /// which is all but one on a typical frame, so the list only animates the
+    /// row you just crossed.
+    pub(crate) fn flip_offset(&self, slot: usize, prev: usize, target: usize) -> Pixels {
+        self.displacement(slot, prev) - self.displacement(slot, target)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{point, size};
+
+    /// A vertical list of `n` slots, each `h` tall with a `gap` between them,
+    /// starting at y = 0 — the sidebar's shape.
+    fn column(n: usize, h: f32, gap: f32, from: usize) -> Reorder {
+        let rects = (0..n)
+            .map(|i| Bounds {
+                origin: point(px(0.), px(i as f32 * (h + gap))),
+                size: size(px(200.), px(h)),
+            })
+            .collect();
+        Reorder::new(
+            Surface::Strip,
+            from,
+            rects,
+            Axis::Vertical,
+            px(gap),
+            // Grabbed dead centre of the slot.
+            point(px(100.), px(h / 2.)),
+        )
+    }
+
+    /// The dragged slot claims a new index the moment its centre reaches where
+    /// the neighbour would sit without it, and holds its own index until then.
+    #[test]
+    fn target_follows_the_pointer_across_neighbours() {
+        // 4 rows of 30px + 2px gaps: centres at 15, 47, 79, 111.
+        let r = column(4, 30., 2., 0);
+        // Dragging row 0, held by its centre. Row 1 yields once row 0's bottom
+        // edge covers half of it — pointer 32, i.e. bottom edge at 47.
+        assert_eq!(r.target(point(px(100.), px(32.))), 0);
+        assert_eq!(r.target(point(px(100.), px(34.))), 1);
+        // Then row 2's centre (79) at pointer 64, row 3's (111) at 96.
+        assert_eq!(r.target(point(px(100.), px(66.))), 2);
+        assert_eq!(r.target(point(px(100.), px(200.))), 3);
+    }
+
+    /// Dragging upward is the mirror image, and the order it previews is the
+    /// dragged slot lifted out and re-inserted.
+    #[test]
+    fn order_lifts_the_dragged_slot_into_the_target() {
+        let r = column(4, 30., 2., 3);
+        assert_eq!(r.target(point(px(100.), px(2.))), 0);
+        assert_eq!(r.order(0), vec![3, 0, 1, 2]);
+        assert_eq!(r.order(1), vec![0, 3, 1, 2]);
+        assert_eq!(r.order(3), vec![0, 1, 2, 3]);
+    }
+
+    /// Only the slot the drag just crossed gets a slide offset, and it's the
+    /// full row pitch (row height + gap) in the direction it came from.
+    #[test]
+    fn flip_offset_animates_only_the_slot_just_crossed() {
+        let r = column(4, 30., 2., 0);
+        // Preview moved from "row 0 stays" to "row 0 sits after row 1":
+        // row 1 closed up by one pitch, so it starts one pitch lower.
+        assert_eq!(r.flip_offset(1, 0, 1), px(32.));
+        // Rows the crossing didn't touch don't move at all.
+        assert_eq!(r.flip_offset(2, 0, 1), px(0.));
+        assert_eq!(r.flip_offset(3, 0, 1), px(0.));
+        // The dragged slot slides too, now that it rides in the list rather
+        // than floating over it: three rows crossed, three pitches to travel.
+        assert_eq!(r.flip_offset(0, 0, 3), px(-96.));
+        assert_eq!(r.flip_offset(0, 3, 0), px(96.));
+        // Backing out again slides row 1 the other way.
+        assert_eq!(r.flip_offset(1, 1, 0), px(-32.));
+    }
+
+    /// A tall block and a short one swap in *both* directions, with the same
+    /// half-overlap threshold. The regression this pins: under a
+    /// centre-to-centre test a three-row group could never move above a
+    /// one-row group, because reaching its centre meant dragging the pointer
+    /// off the top of the list.
+    #[test]
+    fn unequal_sizes_swap_in_both_directions() {
+        // A 60px block at y=0 and a 140px block at y=62 (2px gap).
+        let rects = vec![
+            Bounds {
+                origin: point(px(0.), px(0.)),
+                size: size(px(200.), px(60.)),
+            },
+            Bounds {
+                origin: point(px(0.), px(62.)),
+                size: size(px(200.), px(140.)),
+            },
+        ];
+        let grab = point(px(100.), px(10.));
+        let tall = Reorder::new(
+            Surface::SidebarGroups,
+            1,
+            rects.clone(),
+            Axis::Vertical,
+            px(2.),
+            grab,
+        );
+        // Dragging the tall block up: it takes the top slot once its leading
+        // edge passes the short block's centre (30) — pointer 40, i.e. ~30px
+        // of travel from rest, all of it well inside the list.
+        assert_eq!(tall.target(point(px(100.), px(41.))), 1);
+        assert_eq!(tall.target(point(px(100.), px(39.))), 0);
+        // Held at rest, it keeps its own slot.
+        assert_eq!(tall.target(point(px(100.), px(72.))), 1);
+
+        // And the short block still goes down past the tall one, at the same
+        // half-overlap rule: trailing edge (pointer + 50) past centre 132.
+        let short = Reorder::new(
+            Surface::SidebarGroups,
+            0,
+            rects,
+            Axis::Vertical,
+            px(2.),
+            grab,
+        );
+        assert_eq!(short.target(point(px(100.), px(80.))), 0);
+        assert_eq!(short.target(point(px(100.), px(84.))), 1);
+    }
+
+    /// The held item tracks the pointer pixel for pixel, measured from
+    /// whichever slot the list has currently laid it out in — so it sits under
+    /// the cursor both before and after a crossing re-slots it.
+    #[test]
+    fn held_offset_tracks_the_pointer_across_a_crossing() {
+        // 4 rows of 30px + 2px gaps (pitch 32), grabbed dead centre of row 0.
+        let r = column(4, 30., 2., 0);
+        // Nudged 10px down, still target 0: the row is 10px off its home slot.
+        assert_eq!(r.held_offset(point(px(100.), px(25.)), 0), px(10.));
+        // Just past row 1's centre the target flips to 1, and the row is now
+        // laid out one pitch lower — so the same pointer reads 32px less.
+        assert_eq!(r.held_offset(point(px(100.), px(48.)), 1), px(1.));
+        // Dragging far past the end parks it against the last slot instead of
+        // running off: row 3 starts at 96, so that's the furthest it goes.
+        assert_eq!(r.held_offset(point(px(100.), px(900.)), 3), px(0.));
+    }
+
+    /// Only what the last drawn frame recorded may commit. The regression this
+    /// pins: dragging an item away and then back to its own slot stops the
+    /// surface recording (the move became a no-op), so without the per-frame
+    /// clear the earlier "moved" order would survive and be applied on release,
+    /// moving an item the user had visibly put back.
+    #[test]
+    fn pending_only_survives_the_frame_that_recorded_it() {
+        let state: ReorderState = Rc::new(RefCell::new(Some(column(3, 30., 2., 0))));
+        let mine = Surface::Strip;
+
+        // A frame that previews a move records it.
+        clear_pending(&state);
+        set_pending(&state, &mine, vec![1, 0, 2]);
+        // Another surface's recording is ignored — one drag, one owner.
+        set_pending(&state, &Surface::SidebarGroups, vec![2, 1, 0]);
+
+        // The next frame draws the item back in its own slot and records
+        // nothing; the earlier order must not outlive it.
+        clear_pending(&state);
+        assert_eq!(take_pending(&state), None);
+        // Taking also retires the drag.
+        assert!(state.borrow().is_none());
+
+        // And the ordinary path: recorded, then released.
+        *state.borrow_mut() = Some(column(3, 30., 2., 0));
+        clear_pending(&state);
+        set_pending(&state, &mine, vec![1, 0, 2]);
+        assert_eq!(take_pending(&state), Some(vec![1, 0, 2]));
+    }
+
+    /// The generation only advances when the preview actually changes, so a
+    /// jittering cursor inside one slot doesn't restart the slide every frame.
+    #[test]
+    fn begin_frame_bumps_the_generation_only_on_change() {
+        let r = column(3, 30., 2., 0);
+        assert_eq!(r.begin_frame(0), (0, 0));
+        assert_eq!(r.begin_frame(1), (1, 0));
+        assert_eq!(r.begin_frame(1), (1, 1));
+        assert_eq!(r.begin_frame(2), (2, 1));
+    }
+
+    /// A horizontal list measures along x — the strip's chips, which are wider
+    /// than they are tall and vary in width.
+    #[test]
+    fn horizontal_lists_measure_along_x() {
+        let widths = [100., 160., 120.];
+        let mut x = 0.;
+        let rects = widths
+            .iter()
+            .map(|w| {
+                let b = Bounds {
+                    origin: point(px(x), px(0.)),
+                    size: size(px(*w), px(30.)),
+                };
+                x += w + 6.;
+                b
+            })
+            .collect();
+        let r = Reorder::new(
+            Surface::Strip,
+            0,
+            rects,
+            Axis::Horizontal,
+            px(6.),
+            point(px(50.), px(15.)),
+        );
+        // Chip 1's centre is at x=186; chip 0 takes its slot once its trailing
+        // edge (pointer + 50) covers half of it.
+        assert_eq!(r.target(point(px(135.), px(15.))), 0);
+        assert_eq!(r.target(point(px(137.), px(15.))), 1);
+        assert_eq!(r.order(2), vec![1, 2, 0]);
+    }
+}

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -5,30 +5,32 @@
 //!
 //! Split out of `app.rs` as an `impl Tty7App` block, exactly like `tab_strip`.
 //! It shares the model wholesale: the same `self.tabs`/`self.active` state, the
-//! same `tab_label`, the same `activate`/`close_tab`/`move_tab`/`start_rename`
-//! operations, the same `DragTab` payload, and the same theme tokens the chips
-//! use — so the vertical list stays pixel-consistent with the strip and adds no
-//! new state or business logic, only a new set of click targets in a new shape.
+//! same `tab_label`, the same `activate`/`close_tab`/`start_rename` operations,
+//! the same `DragTab` payload and reorder machinery, and the same theme tokens
+//! the chips use — so the vertical list stays pixel-consistent with the strip
+//! and adds no new state or business logic, only a new set of click targets in
+//! a new shape.
 
 use gpui::{
-    AnyElement, Bounds, Context, FontWeight, MouseButton, MouseDownEvent, MouseMoveEvent,
-    MouseUpEvent, Pixels, SharedString, Window, canvas, div, linear_color_stop, linear_gradient,
-    prelude::*, px,
+    Animation, AnimationExt as _, AnyElement, Axis, Bounds, Context, Div, FontWeight, MouseButton,
+    MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, SharedString, Stateful, Window, canvas,
+    deferred, div, ease_out_quint, linear_color_stop, linear_gradient, prelude::*, px,
 };
 use gpui_component::button::{Button, ButtonVariants as _};
 use gpui_component::input::Input;
-use gpui_component::menu::ContextMenuExt as _;
+use gpui_component::menu::{ContextMenu, ContextMenuExt as _};
 use gpui_component::{ActiveTheme as _, Icon, IconName, Sizable as _, h_flex, v_flex};
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::core::config::{Config, SidebarGrouping};
 use crate::terminal::git_status::GitStatusCache;
 use crate::ui::app::{TITLE_BAR_HEIGHT, Tty7App};
 use crate::ui::hints::tab_badge_label;
-use crate::ui::tab_strip::DragTab;
+use crate::ui::reorder::{self, Reorder, Surface};
+use crate::ui::tab_strip::{DragTab, REORDER_SLIDE_MS};
 
 /// Minimum sidebar width, and the maximum as a fraction of the window width, so
 /// a resize drag can't collapse the rail or let it swallow the terminal.
@@ -39,6 +41,27 @@ const MAX_SIDEBAR_WIDTH_RATIO: f32 = 0.5;
 /// the rail's right border; it holds a 1px hairline that brightens on hover /
 /// drag. Centered (half overhangs the body) so it clears the row close buttons.
 const RESIZE_HANDLE_WIDTH: f32 = 8.;
+
+/// Gap between rows in the rail, and between the group blocks — the distance a
+/// row or block travels on top of its own height when a drag passes it.
+const ROW_GAP: f32 = 2.;
+
+/// Marks a live drag as a *group* drag — the sidebar counterpart to
+/// [`DragTab`], and like it a stateless marker that renders nothing: the block
+/// being dragged never leaves the rail, so there is no card floating over the
+/// window. Its type is what tells the rail's drop handlers "this is a group,
+/// not a tab". Scratch never starts one: it's pinned last by
+/// [`sidebar_sections`], so it has no slot to move to.
+#[derive(Clone)]
+pub(crate) struct DragGroup;
+
+impl Render for DragGroup {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        // gpui always paints *something* at the cursor for an active drag;
+        // an empty, zero-sized element is how this drag paints nothing.
+        div()
+    }
+}
 
 impl Tty7App {
     /// The vertical tab sidebar rendered down the left edge of the body in
@@ -88,24 +111,105 @@ impl Tty7App {
         let keys: Rc<Vec<Option<PathBuf>>> = Rc::new(self.sidebar_group_keys(cx));
         let sections = sidebar_sections(&keys);
 
-        // Each row's position in display order — the digit its ⌘N badge
-        // shows. Advanced for every tab, filtered-out ones included, so the
-        // digits (and what ⌘N targets) don't shift while the search box
-        // narrows the list.
-        let mut visual_pos = 0usize;
-        for (group_name, idxs) in sections {
-            // Rows first: the search filter may empty a group, in which case
-            // its header is skipped too (and the header's count reflects the
-            // *visible* rows while a filter narrows the list).
-            let mut rows: Vec<AnyElement> = Vec::new();
-            for i in idxs {
-                // This row's display-order digit; claimed before the search
-                // filter can skip the row (see `visual_pos` above).
-                let badge_pos = visual_pos;
-                visual_pos += 1;
+        // Each row's position in display order — the digit its ⌘N badge shows.
+        // Claimed for every tab, filtered-out ones included, and read off this
+        // map rather than counted as rows are emitted, so neither the search
+        // box nor a drag's live reflow can renumber the shortcuts under you.
+        let badge_pos: Vec<usize> = {
+            let mut pos = vec![0usize; self.tabs.len()];
+            for (n, i) in sections.iter().flat_map(|s| s.tabs.iter()).enumerate() {
+                pos[*i] = n;
+            }
+            pos
+        };
+
+        // Which tabs each section actually lists, and their labels. Settled
+        // before anything is laid out, because both drag surfaces are keyed to
+        // what is *visible*: a group the search box has emptied isn't rendered,
+        // so it must not claim a slot in the group geometry either — a phantom
+        // zero-sized slot would sit at the origin and swallow every crossing.
+        // (Matching is on the visible label; a row keeps its real tab index, so
+        // activate/close/reorder still hit the right tab when the list is
+        // narrowed.)
+        let visible_by_section: Vec<Vec<(usize, String)>> = sections
+            .iter()
+            .map(|s| {
+                s.tabs
+                    .iter()
+                    .map(|&i| (i, self.tab_label(&self.tabs[i], i, Some(window), cx)))
+                    .filter(|(_, label)| query.is_empty() || label.to_lowercase().contains(&query))
+                    .collect()
+            })
+            .collect();
+
+        // ── Live drag-reorder, part 1: the group blocks ───────────────────────
+        // Repo groups can be dragged by their header to reorder the whole
+        // block; Scratch can't (it's pinned last, so it has neither a slot to
+        // move to nor one to give up), so the draggable slots are exactly the
+        // rendered repo groups. See [`crate::ui::reorder`] for the machinery.
+        let pointer = window.mouse_position();
+        let rendered = |ix: &usize| !visible_by_section[*ix].is_empty();
+        let repo_slots: Vec<usize> = (0..sections.len())
+            .filter(|&ix| sections[ix].key.is_some())
+            .filter(rendered)
+            .collect();
+        let repo_groups = repo_slots.len();
+        let group_slots: Rc<RefCell<Vec<Bounds<Pixels>>>> =
+            Rc::new(RefCell::new(vec![Bounds::default(); repo_groups]));
+        let group_preview =
+            reorder::preview(&self.reorder, &Surface::SidebarGroups, repo_groups, pointer);
+        let repo_roots: Vec<PathBuf> = repo_slots
+            .iter()
+            .filter_map(|&ix| sections[ix].key.clone())
+            .collect();
+        let slot_display: Vec<usize> = match &group_preview {
+            Some(p) => {
+                // Same as the rows below: record what releasing right now would
+                // produce, so the commit doesn't depend on where the cursor is.
+                if let (Some(from), Some(to)) = (repo_roots.get(p.from), repo_roots.get(p.target))
+                    && let Some(order) = regrouped_order(&keys, from, to)
+                {
+                    reorder::set_pending(&self.reorder, &Surface::SidebarGroups, order);
+                }
+                p.order.clone()
+            }
+            None => (0..repo_groups).collect(),
+        };
+        // The blocks to lay out, as `(drag slot, section)`. Repo groups lead in
+        // the previewed slot order; Scratch trails them with no slot of its own.
+        let mut blocks: Vec<(Option<usize>, usize)> = slot_display
+            .into_iter()
+            .map(|slot| (Some(slot), repo_slots[slot]))
+            .collect();
+        blocks.extend(
+            (0..sections.len())
+                .filter(|&ix| sections[ix].key.is_none())
+                .filter(rendered)
+                .map(|ix| (None, ix)),
+        );
+
+        for (group_slot, group_ix) in blocks {
+            let section = &sections[group_ix];
+            let group_key = section.key.clone();
+            // Kept as concrete elements, not `AnyElement`s: a live drag
+            // restyles them (the slide-in offset), which can only be applied
+            // once every row of the group has been built.
+            let mut rows: Vec<ContextMenu<Stateful<Div>>> = Vec::new();
+            let visible = visible_by_section[group_ix].clone();
+            let visible_tabs: Vec<usize> = visible.iter().map(|(i, _)| *i).collect();
+            let row_slots: Rc<RefCell<Vec<Bounds<Pixels>>>> =
+                Rc::new(RefCell::new(vec![Bounds::default(); visible.len()]));
+            // ── Live drag-reorder, part 2: the rows of this group ─────────────
+            let row_preview = reorder::preview(
+                &self.reorder,
+                &Surface::SidebarRows(group_key.clone()),
+                visible.len(),
+                pointer,
+            );
+            for (slot, (i, label)) in visible.into_iter().enumerate() {
+                let badge_pos = badge_pos[i];
                 let tab = &self.tabs[i];
                 let is_active = i == active;
-                let label = self.tab_label(tab, i, Some(window), cx);
                 // No status/cwd text under the title: the avatar's status dot
                 // already carries working/waiting/done, and the group header + the
                 // trailing branch tag carry the location — a "Working…" or cwd
@@ -188,14 +292,6 @@ impl Tty7App {
                     }
                     line
                 });
-                // Filter by the search box; matching is on the visible label. The row
-                // keeps its real index `i`, so activate/close/move still hit the right
-                // tab even when the list is narrowed.
-                if !query.is_empty() && !label.to_lowercase().contains(&query) {
-                    continue;
-                }
-                let drag_label: SharedString = label.clone().into();
-
                 // Inline rename input for this tab, if it's the one being renamed —
                 // the same `self.renaming` branch the strip uses, so a context-menu
                 // rename works identically in either layout.
@@ -234,26 +330,12 @@ impl Tty7App {
                         )
                         // Branch + diff line, when the pane sits in a git repo.
                         .children(git_line)
-                        // Click activates. (Renaming lives in the context menu,
-                        // matching the strip — no double-click rename.)
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(move |this, _: &MouseDownEvent, window, cx| {
-                                cx.stop_propagation();
-                                this.activate(i, window, cx);
-                            }),
-                        )
-                        // Drag the row by its label to reorder it (shared `DragTab`).
-                        .on_drag(
-                            DragTab {
-                                index: i,
-                                label: drag_label.clone(),
-                            },
-                            |drag, _, _, cx| {
-                                cx.stop_propagation();
-                                cx.new(|_| drag.clone())
-                            },
-                        )
+                        // No mouse handler of its own: activation *and* the
+                        // reorder drag both live on the row, and a child that
+                        // swallowed the press would take the label — the
+                        // largest part of the row — out of both. (Only the
+                        // diff counts inside the branch line stop the press,
+                        // deliberately: they're their own click target.)
                         .into_any_element(),
                 };
 
@@ -262,6 +344,38 @@ impl Tty7App {
                     // A per-row group so this row's close affordance reveals on its own
                     // hover without touching siblings (same trick as the chip).
                     .group(SharedString::from(format!("tab-row-{i}")))
+                    // A row is first of all a switch target, so the hover
+                    // cursor says "click me"; picking it up swaps in the
+                    // closed hand (see `Tty7App::render`).
+                    .cursor_pointer()
+                    // Drag anywhere on the row to reorder it (shared `DragTab`).
+                    // On the row, not on its label: the drag's frame of
+                    // reference is where the *row* was grabbed, which is what
+                    // the frozen geometry below measures — hang it off the
+                    // label and the held row rides a few pixels off the cursor,
+                    // skewing every crossing by that much. `slot` is the row's
+                    // position among the *visible* rows of its group; a drag
+                    // never leaves the group, so that's the whole world it
+                    // needs. The builder runs once, when gpui promotes the
+                    // press into a drag, freezing the geometry as of the last
+                    // painted frame.
+                    .on_drag(DragTab, {
+                        let state = self.reorder.clone();
+                        let slots = row_slots.clone();
+                        let group_key = group_key.clone();
+                        move |_drag, grab, _window, cx| {
+                            cx.stop_propagation();
+                            *state.borrow_mut() = Some(Reorder::new(
+                                Surface::SidebarRows(group_key.clone()),
+                                slot,
+                                slots.borrow().clone(),
+                                Axis::Vertical,
+                                px(ROW_GAP),
+                                grab,
+                            ));
+                            cx.new(|_| DragTab)
+                        }
+                    })
                     .w_full()
                     // Size to content with a small, uniform vertical padding: a
                     // one-line shell tab is a short row, a two-line git tab
@@ -288,20 +402,31 @@ impl Tty7App {
                         s.text_color(cx.theme().sidebar_foreground)
                             .hover(|s| s.bg(cx.theme().sidebar_accent.opacity(0.5)))
                     })
-                    // Drop target: dropping a dragged row here moves it to this
-                    // slot — but only within the same group; a cross-group drop is
-                    // a no-op, since a tab's group comes from its cwd's repo, not
-                    // from where it sits in the list. (With grouping off all keys
-                    // are `None`, so the check never blocks anything.)
-                    .drag_over::<DragTab>(|s, _, _, cx| s.bg(cx.theme().drag_border.opacity(0.2)))
-                    .on_drop(cx.listener({
-                        let keys = keys.clone();
-                        move |this, drag: &DragTab, _window, cx| {
-                            if keys.get(drag.index) == keys.get(i) {
-                                this.move_tab(drag.index, i, cx);
-                            }
-                        }
-                    }))
+                    // Held: a light dimming so the row under your cursor reads
+                    // as picked up. Not a lift — it stays in the rail's plane.
+                    .when(row_preview.as_ref().is_some_and(|p| p.from == slot), |s| {
+                        s.opacity(0.75)
+                    })
+                    // Measures this row into its group's slot table — the
+                    // geometry a drag starting on a later frame freezes.
+                    // Absolute and empty, so it costs the layout nothing.
+                    .child(
+                        canvas(
+                            {
+                                let slots = row_slots.clone();
+                                move |bounds, _window, _cx| {
+                                    if let Some(s) = slots.borrow_mut().get_mut(slot) {
+                                        *s = bounds;
+                                    }
+                                }
+                            },
+                            |_, _, _, _| {},
+                        )
+                        // `inset_0`, not `size_full` — see the strip's copy of
+                        // this canvas for why the distinction matters.
+                        .absolute()
+                        .inset_0(),
+                    )
                     // A click anywhere on the row (padding, gaps) activates it; the
                     // label and close children stop propagation for their own actions.
                     .on_mouse_down(
@@ -398,54 +523,203 @@ impl Tty7App {
                 // `below_wording` flips the trailing close to "Close Tabs Below"
                 // to match the vertical layout.
                 let menu_app = cx.entity().downgrade();
-                rows.push(
-                    row.context_menu(move |menu, window, cx| {
-                        Tty7App::tab_context_menu(menu, i, true, &menu_app, window, cx)
-                    })
-                    .into_any_element(),
-                );
+                rows.push(row.context_menu(move |menu, window, cx| {
+                    Tty7App::tab_context_menu(menu, i, true, &menu_app, window, cx)
+                }));
             }
 
             if rows.is_empty() {
                 continue;
             }
+
+            let row_display: Vec<usize> = match &row_preview {
+                Some(p) => {
+                    // Record the tab order releasing right now would produce, so
+                    // letting go applies exactly what's on screen no matter where
+                    // the cursor ended up (see `reorder::set_pending`).
+                    if let Some(order) =
+                        reordered_rows(&keys, &group_key, &visible_tabs, p.from, p.target)
+                    {
+                        reorder::set_pending(
+                            &self.reorder,
+                            &Surface::SidebarRows(group_key.clone()),
+                            order,
+                        );
+                    }
+                    p.order.clone()
+                }
+                None => (0..rows.len()).collect(),
+            };
+            let row_count = rows.len();
+            let mut rows: Vec<Option<ContextMenu<Stateful<Div>>>> =
+                rows.into_iter().map(Some).collect();
+            let rows: Vec<AnyElement> = row_display
+                .into_iter()
+                .map(|slot| match &row_preview {
+                    // The row in hand: drawn wherever the cursor is holding it,
+                    // pixel for pixel, with no animation in the way. `deferred`
+                    // keeps its slot in the layout but paints it after its
+                    // siblings, so it passes *over* the rows it's crossing
+                    // instead of being clipped behind them.
+                    Some(p) if p.from == slot => deferred(
+                        rows[slot]
+                            .take()
+                            .expect("each slot emitted once")
+                            .relative()
+                            .top(p.held),
+                    )
+                    .into_any_element(),
+                    // Slide into place rather than teleporting. `offset` is
+                    // zero for every row the last crossing left alone, so one
+                    // row moves at a time instead of the group re-animating.
+                    Some(p) => {
+                        let offset = p.offsets[slot].as_f32();
+                        rows[slot]
+                            .take()
+                            .expect("each slot emitted once")
+                            .with_animation(
+                                (
+                                    SharedString::from(format!("row-slide-{}", p.generation)),
+                                    slot,
+                                ),
+                                Animation::new(std::time::Duration::from_millis(REORDER_SLIDE_MS))
+                                    .with_easing(ease_out_quint()),
+                                move |el, delta| el.top(px(offset * (1. - delta))),
+                            )
+                            .into_any_element()
+                    }
+                    None => rows[slot]
+                        .take()
+                        .expect("each slot emitted once")
+                        .into_any_element(),
+                })
+                .collect();
             // Group header: the repo's directory name (or "Scratch"), small
             // and muted so it labels without competing with the rows, plus the
-            // visible-row count. Not a click target — rows do the activating.
-            if let Some(name) = group_name {
-                list = list.child(
-                    h_flex()
-                        .w_full()
-                        .items_center()
-                        .gap_1p5()
-                        .pl_2()
-                        .pr_1p5()
-                        .pt_1p5()
-                        .pb_0p5()
-                        .text_size(px(11.))
-                        .text_color(cx.theme().muted_foreground)
-                        // Count sits right next to the name (not pushed to the
-                        // rail's right edge): the name shrinks and truncates if
-                        // long, the count trails it as a quiet tally.
-                        .child(
-                            div()
-                                .flex_shrink(1.)
-                                .min_w_0()
-                                .truncate()
-                                .font_weight(FontWeight::SEMIBOLD)
-                                .child(name.to_uppercase()),
+            // visible-row count. Not a click target — rows do the activating —
+            // but it *is* the whole group's drag handle: drag one project name
+            // and the block moves, tabs and all, with the other groups sliding
+            // around it exactly as rows do inside one. Scratch (`group_key ==
+            // None`) sits out: it's pinned last, so it has nowhere to go.
+            let header = section.name.clone().map(|name| {
+                let label: SharedString = name.to_uppercase().into();
+                h_flex()
+                    .id(("sidebar-group", group_ix))
+                    .w_full()
+                    .items_center()
+                    .gap_1p5()
+                    .pl_2()
+                    .pr_1p5()
+                    .pt_1p5()
+                    .pb_0p5()
+                    .text_size(px(11.))
+                    .text_color(cx.theme().muted_foreground)
+                    .when_some(group_slot, |header, slot| {
+                        // Unlike a row, a header does nothing on click — its
+                        // only affordance is the drag, so the open hand is the
+                        // honest hover cursor (it closes once you pick it up).
+                        header.cursor_grab().on_drag(DragGroup, {
+                            let state = self.reorder.clone();
+                            let slots = group_slots.clone();
+                            move |_drag, grab, _window, cx| {
+                                cx.stop_propagation();
+                                *state.borrow_mut() = Some(Reorder::new(
+                                    Surface::SidebarGroups,
+                                    slot,
+                                    slots.borrow().clone(),
+                                    Axis::Vertical,
+                                    px(ROW_GAP),
+                                    // The header is the handle, but the *block*
+                                    // is what moves. The header leads the block,
+                                    // so the grab point inside the header is
+                                    // also the grab point inside the block —
+                                    // it passes through unchanged.
+                                    grab,
+                                ));
+                                cx.new(|_| DragGroup)
+                            }
+                        })
+                    })
+                    // Count sits right next to the name (not pushed to the
+                    // rail's right edge): the name shrinks and truncates if
+                    // long, the count trails it as a quiet tally.
+                    .child(
+                        div()
+                            .flex_shrink(1.)
+                            .min_w_0()
+                            .truncate()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .child(label),
+                    )
+                    .child(
+                        div()
+                            .flex_shrink_0()
+                            .text_color(cx.theme().muted_foreground.opacity(0.7))
+                            .child(row_count.to_string()),
+                    )
+            });
+
+            // One block per group — header plus its rows — so a header drag can
+            // move the whole thing as a unit and measure it as one slot.
+            let block = v_flex()
+                .w_full()
+                .gap(px(ROW_GAP))
+                // Held: the block you're dragging dims, exactly as a held row
+                // does — nothing lifts off the rail.
+                .when(
+                    group_preview
+                        .as_ref()
+                        .is_some_and(|p| Some(p.from) == group_slot),
+                    |b| b.opacity(0.75),
+                )
+                .children(header)
+                .children(rows)
+                // Measures the block for the group-drag geometry. Only the
+                // rendered repo groups hold a slot — Scratch is pinned last and
+                // never moves, and a group the search box emptied isn't here at
+                // all — so `group_slot` indexes that list, not `sections`.
+                .when_some(group_slot, |block, slot| {
+                    block.child(
+                        canvas(
+                            {
+                                let slots = group_slots.clone();
+                                move |bounds, _window, _cx| {
+                                    if let Some(s) = slots.borrow_mut().get_mut(slot) {
+                                        *s = bounds;
+                                    }
+                                }
+                            },
+                            |_, _, _, _| {},
                         )
-                        .child(
-                            div()
-                                .flex_shrink_0()
-                                .text_color(cx.theme().muted_foreground.opacity(0.7))
-                                .child(rows.len().to_string()),
-                        ),
-                );
-            }
-            for row in rows {
-                list = list.child(row);
-            }
+                        .absolute()
+                        .inset_0(),
+                    )
+                });
+
+            list = list.child(match (&group_preview, group_slot) {
+                // The block in hand tracks the cursor, painted over the ones it
+                // crosses (same treatment a held row gets inside a group).
+                (Some(p), Some(slot)) if p.from == slot => {
+                    deferred(block.relative().top(p.held)).into_any_element()
+                }
+                // Everything else slides; a slotless block (Scratch) never
+                // moves, so it falls through to the plain block below.
+                (Some(p), Some(slot)) => {
+                    let offset = p.offsets[slot].as_f32();
+                    block
+                        .with_animation(
+                            (
+                                SharedString::from(format!("group-slide-{}", p.generation)),
+                                slot,
+                            ),
+                            Animation::new(std::time::Duration::from_millis(REORDER_SLIDE_MS))
+                                .with_easing(ease_out_quint()),
+                            move |el, delta| el.top(px(offset * (1. - delta))),
+                        )
+                        .into_any_element()
+                }
+                _ => block.into_any_element(),
+            });
         }
 
         // Top control bar: a right-aligned "+" new-tab button (the same shell
@@ -648,7 +922,7 @@ impl Tty7App {
         let keys = self.sidebar_group_keys(cx);
         sidebar_sections(&keys)
             .into_iter()
-            .flat_map(|(_, idxs)| idxs)
+            .flat_map(|s| s.tabs)
             .collect()
     }
 
@@ -667,12 +941,25 @@ impl Tty7App {
     }
 }
 
-/// Partition per-tab group keys into the sidebar's sections: `(header,
-/// indices)` with groups in first-appearance order (a new repo appends, the
-/// existing ones never reshuffle) and the Scratch group pinned last. A `None`
-/// header means "render flat, no headers" — used when no tab is in any repo,
-/// where a lone Scratch header over everything would be noise.
-fn sidebar_sections(keys: &[Option<PathBuf>]) -> Vec<(Option<String>, Vec<usize>)> {
+/// One block of the sidebar: a header and the tabs under it.
+#[derive(Debug, PartialEq)]
+struct Section {
+    /// The repo root this group is keyed on, `None` for Scratch. Sections with
+    /// a key are the draggable ones (Scratch is pinned last), and it doubles as
+    /// the group's identity in a drag.
+    key: Option<PathBuf>,
+    /// The header text, or `None` for "render flat, no header".
+    name: Option<String>,
+    /// The group's tabs, in tab order.
+    tabs: Vec<usize>,
+}
+
+/// Partition per-tab group keys into the sidebar's sections: groups in
+/// first-appearance order (a new repo appends, the existing ones never
+/// reshuffle) with the Scratch group pinned last. A nameless single section
+/// means "render flat, no headers" — used when no tab is in any repo, where a
+/// lone Scratch header over everything would be noise.
+fn sidebar_sections(keys: &[Option<PathBuf>]) -> Vec<Section> {
     let mut group_order: Vec<&PathBuf> = Vec::new();
     for k in keys.iter().flatten() {
         if !group_order.iter().any(|g| *g == k) {
@@ -680,24 +967,107 @@ fn sidebar_sections(keys: &[Option<PathBuf>]) -> Vec<(Option<String>, Vec<usize>
         }
     }
     if group_order.is_empty() {
-        return vec![(None, (0..keys.len()).collect())];
+        return vec![Section {
+            key: None,
+            name: None,
+            tabs: (0..keys.len()).collect(),
+        }];
     }
     let names = group_names(&group_order);
-    let mut sections: Vec<(Option<String>, Vec<usize>)> = group_order
+    let mut sections: Vec<Section> = group_order
         .iter()
         .zip(names)
-        .map(|(root, name)| {
-            let idxs = (0..keys.len())
+        .map(|(root, name)| Section {
+            key: Some((*root).clone()),
+            name: Some(name),
+            tabs: (0..keys.len())
                 .filter(|&i| keys[i].as_ref() == Some(*root))
-                .collect();
-            (Some(name), idxs)
+                .collect(),
         })
         .collect();
     let scratch: Vec<usize> = (0..keys.len()).filter(|&i| keys[i].is_none()).collect();
     if !scratch.is_empty() {
-        sections.push((Some("Scratch".into()), scratch));
+        sections.push(Section {
+            key: None,
+            name: Some("Scratch".into()),
+            tabs: scratch,
+        });
     }
     sections
+}
+
+/// The tab permutation for a row dropped at a new place inside its own group:
+/// `visible` are the group's rows as the rail currently lists them (the search
+/// box may be hiding others), and the row at `from` lands where the row at `to`
+/// is now.
+///
+/// Like [`regrouped_order`] this returns a whole-vector permutation rather than
+/// a single move, because "third row in this group" only means something once
+/// the vector is laid out the way the rail draws it: groups in their existing
+/// order, each one contiguous, Scratch last. Rows the filter is hiding keep
+/// their place in the group, and no other group is disturbed.
+fn reordered_rows(
+    keys: &[Option<PathBuf>],
+    group: &Option<PathBuf>,
+    visible: &[usize],
+    from: usize,
+    to: usize,
+) -> Option<Vec<usize>> {
+    let (&moved, &anchor) = (visible.get(from)?, visible.get(to)?);
+    if moved == anchor {
+        return None;
+    }
+    let mut members: Vec<usize> = (0..keys.len()).filter(|&i| keys[i] == *group).collect();
+    members.retain(|&i| i != moved);
+    // Land it on the far side of the row it was dropped onto, so dragging down
+    // ends up below that row and dragging up above it.
+    let at = members.iter().position(|&i| i == anchor)? + usize::from(to > from);
+    members.insert(at, moved);
+
+    let mut out: Vec<usize> = Vec::with_capacity(keys.len());
+    for g in sidebar_sections(keys).iter().map(|s| &s.key) {
+        if g == group {
+            out.extend_from_slice(&members);
+        } else {
+            out.extend((0..keys.len()).filter(|&i| keys[i] == *g));
+        }
+    }
+    Some(out)
+}
+
+/// The tab permutation that moves the group rooted at `from` into `to`'s slot,
+/// as old indices in their new order — or `None` when the move is a no-op (same
+/// group, or either root no longer has any tab).
+///
+/// Groups are ordered by first appearance in the tab vector, so the move is
+/// "reorder the group list, then lay the tabs back out group by group". Each
+/// group therefore comes out *contiguous*, with Scratch last, matching exactly
+/// what the sidebar renders — which also settles the old caveat that a tab drag
+/// inside an interleaved group could shuffle other groups' headers: after any
+/// header drag the vector is compacted and interleaving is gone. Relative order
+/// within a group is preserved.
+fn regrouped_order(keys: &[Option<PathBuf>], from: &Path, to: &Path) -> Option<Vec<usize>> {
+    if from == to {
+        return None;
+    }
+    let mut order: Vec<&PathBuf> = Vec::new();
+    for k in keys.iter().flatten() {
+        if !order.iter().any(|g| *g == k) {
+            order.push(k);
+        }
+    }
+    let fi = order.iter().position(|g| g.as_path() == from)?;
+    let ti = order.iter().position(|g| g.as_path() == to)?;
+    let moved = order.remove(fi);
+    order.insert(ti, moved);
+
+    let mut out: Vec<usize> = Vec::with_capacity(keys.len());
+    for g in &order {
+        out.extend((0..keys.len()).filter(|&i| keys[i].as_ref() == Some(*g)));
+    }
+    // Scratch tabs trail the repo groups, which is where the sidebar draws them.
+    out.extend((0..keys.len()).filter(|&i| keys[i].is_none()));
+    Some(out)
 }
 
 /// Display names for the group roots: each root's directory name, extended
@@ -769,17 +1139,100 @@ mod tests {
             Some(p("/w/beta")),
         ];
         let sections = sidebar_sections(&keys);
+        let shape: Vec<(Option<PathBuf>, Option<String>, Vec<usize>)> = sections
+            .into_iter()
+            .map(|s| (s.key, s.name, s.tabs))
+            .collect();
         assert_eq!(
-            sections,
+            shape,
             vec![
-                (Some("beta".into()), vec![0, 3]),
-                (Some("alpha".into()), vec![2]),
-                (Some("Scratch".into()), vec![1]),
+                (Some(p("/w/beta")), Some("beta".into()), vec![0, 3]),
+                (Some(p("/w/alpha")), Some("alpha".into()), vec![2]),
+                (None, Some("Scratch".into()), vec![1]),
             ]
         );
 
+        // No tab in any repo: one headerless section over everything.
         let flat = sidebar_sections(&[None, None]);
-        assert_eq!(flat, vec![(None, vec![0, 1])]);
+        assert_eq!(flat.len(), 1);
+        assert_eq!(flat[0].name, None);
+        assert_eq!(flat[0].tabs, vec![0, 1]);
+    }
+
+    /// A row dropped inside its group lands on the far side of the row it was
+    /// dropped onto, leaves every other group alone, and comes out with the
+    /// groups laid out contiguously the way the rail draws them.
+    #[test]
+    fn reordered_rows_moves_within_the_group_only() {
+        // alpha owns 0 and 2, interleaved with beta's 1; scratch is 3.
+        let keys = vec![
+            Some(p("/w/alpha")),
+            Some(p("/w/beta")),
+            Some(p("/w/alpha")),
+            None,
+        ];
+        let alpha = Some(p("/w/alpha"));
+        // alpha's first row dragged onto its second: alpha reads [2, 0], and
+        // the vector comes out grouped — alpha, beta, scratch.
+        assert_eq!(
+            reordered_rows(&keys, &alpha, &[0, 2], 0, 1),
+            Some(vec![2, 0, 1, 3])
+        );
+        // Back the other way.
+        assert_eq!(
+            reordered_rows(&keys, &alpha, &[0, 2], 1, 0),
+            Some(vec![2, 0, 1, 3])
+        );
+        // Dropping a row on itself changes nothing.
+        assert_eq!(reordered_rows(&keys, &alpha, &[0, 2], 1, 1), None);
+    }
+
+    /// Rows the search box is hiding aren't dragged along: the visible rows
+    /// reorder among themselves and the hidden one keeps its place in the group.
+    #[test]
+    fn reordered_rows_leaves_filtered_out_rows_alone() {
+        let keys = vec![Some(p("/w/a")), Some(p("/w/a")), Some(p("/w/a"))];
+        let a = Some(p("/w/a"));
+        // Only rows 0 and 2 are listed; dragging 0 past 2 puts it after row 2,
+        // and row 1 stays between… where it was relative to the others.
+        assert_eq!(
+            reordered_rows(&keys, &a, &[0, 2], 0, 1),
+            Some(vec![1, 2, 0])
+        );
+    }
+
+    /// A header drag moves the whole group into the target's slot and lays
+    /// every group out contiguously, Scratch last, keeping intra-group order.
+    #[test]
+    fn regrouped_order_moves_the_group_into_the_target_slot() {
+        // Groups by first appearance: alpha (0, 3), beta (2), gamma (4).
+        let keys = vec![
+            Some(p("/w/alpha")),
+            None,
+            Some(p("/w/beta")),
+            Some(p("/w/alpha")),
+            Some(p("/w/gamma")),
+        ];
+        // gamma dropped on alpha → gamma, alpha, beta, then Scratch.
+        assert_eq!(
+            regrouped_order(&keys, &p("/w/gamma"), &p("/w/alpha")),
+            Some(vec![4, 0, 3, 2, 1])
+        );
+        // alpha dropped on gamma (a move down) → beta, gamma, alpha.
+        assert_eq!(
+            regrouped_order(&keys, &p("/w/alpha"), &p("/w/gamma")),
+            Some(vec![2, 4, 0, 3, 1])
+        );
+    }
+
+    /// Dropping a group on itself, or naming a root no tab lives in, is a
+    /// no-op rather than a re-shuffle.
+    #[test]
+    fn regrouped_order_ignores_self_and_unknown_roots() {
+        let keys = vec![Some(p("/w/alpha")), Some(p("/w/beta"))];
+        assert_eq!(regrouped_order(&keys, &p("/w/alpha"), &p("/w/alpha")), None);
+        assert_eq!(regrouped_order(&keys, &p("/w/gone"), &p("/w/beta")), None);
+        assert_eq!(regrouped_order(&keys, &p("/w/alpha"), &p("/w/gone")), None);
     }
 
     /// Same-named roots grow a parent prefix until distinct; unrelated names

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -5,19 +5,30 @@
 //! orchestration rather than chrome rendering.
 
 use gpui::{
-    App, Axis, Context, FontWeight, MouseButton, MouseDownEvent, SharedString, Window, div,
+    Animation, AnimationExt as _, App, Axis, Bounds, Context, FontWeight, MouseButton,
+    MouseDownEvent, Pixels, SharedString, Window, canvas, deferred, div, ease_out_quint,
     linear_color_stop, linear_gradient, prelude::*, px,
 };
 use gpui_component::button::{Button, ButtonVariants as _};
 use gpui_component::input::Input;
 use gpui_component::menu::{ContextMenuExt as _, DropdownMenu as _, PopupMenu, PopupMenuItem};
 use gpui_component::{ActiveTheme as _, Icon, IconName, Sizable as _, h_flex};
+use std::cell::RefCell;
+use std::rc::Rc;
 
 use crate::core::actions::{OpenSettings, TogglePalette};
 use crate::core::config::Config;
 use crate::daemon::protocol::ShellSpec;
 use crate::ui::app::{Tab, Tty7App};
 use crate::ui::hints::tab_badge_label;
+use crate::ui::reorder::{self, Reorder, Surface};
+
+/// How long a slot takes to slide out of the way of a dragged tab, and the
+/// gap between chips it has to travel. Short and hard-decelerating: long
+/// enough to read as motion, short enough that a fast drag across the strip
+/// never queues up a backlog of sliding tabs.
+pub(crate) const REORDER_SLIDE_MS: u64 = 140;
+const CHIP_GAP: f32 = 6.;
 
 /// How many trailing path components a deep tab label keeps, mirroring
 /// ghostty's zsh integration title `%(4~|…/%3~|%~)`: a path deeper than this
@@ -121,28 +132,21 @@ fn short_title(raw: &str) -> String {
     label
 }
 
-/// Drag payload for reordering tabs. Carries the source index and a label so the
-/// drag preview can show the tab being moved. `pub(crate)` so the vertical
-/// [`tab_sidebar`](crate::ui::tab_sidebar) reuses the same payload (and could one
-/// day support strip ↔ sidebar cross-drops via the shared `move_tab`).
+/// Marks a live drag as a *tab* drag: its type is what the rail's and strip's
+/// drop handlers match on, and its presence is what keeps gpui redrawing while
+/// the pointer moves. It deliberately carries no state and renders nothing —
+/// the tab being dragged never leaves the list, so there is no card floating
+/// over the window; the reorder is drawn entirely by the list itself (see
+/// [`crate::ui::reorder`]). `pub(crate)` so the vertical
+/// [`tab_sidebar`](crate::ui::tab_sidebar) shares the same payload.
 #[derive(Clone)]
-pub(crate) struct DragTab {
-    pub(crate) index: usize,
-    pub(crate) label: SharedString,
-}
+pub(crate) struct DragTab;
 
 impl Render for DragTab {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        // gpui always paints *something* at the cursor for an active drag;
+        // an empty, zero-sized element is how this drag paints nothing.
         div()
-            .px_3()
-            .py_1()
-            .rounded_lg()
-            .bg(cx.theme().secondary)
-            .border_1()
-            .border_color(cx.theme().border)
-            .text_sm()
-            .text_color(cx.theme().foreground)
-            .child(self.label.clone())
     }
 }
 
@@ -562,17 +566,47 @@ impl Tty7App {
         // `min_w`) and truncates their labels rather than pushing the "+" away.
         let mut chips = h_flex()
             .items_center()
-            .gap_1p5()
+            .gap(px(CHIP_GAP))
             .min_w_0()
             .max_w(chips_avail)
             .overflow_hidden();
 
-        for (i, tab) in self.tabs.iter().enumerate() {
+        // ── Live drag-reorder ─────────────────────────────────────────────────
+        // While a chip is being dragged the strip renders in the order a drop
+        // would produce (see [`crate::ui::reorder`]): the dragged chip travels
+        // along the row itself — nothing floats over the window — and every
+        // chip it passes slides over to meet it. `slots` collects this frame's
+        // chip geometry: the reference a drag starting on a later frame freezes.
+        let slots: Rc<RefCell<Vec<Bounds<Pixels>>>> =
+            Rc::new(RefCell::new(vec![Bounds::default(); self.tabs.len()]));
+        let preview = reorder::preview(
+            &self.reorder,
+            &Surface::Strip,
+            self.tabs.len(),
+            window.mouse_position(),
+        );
+        // Display order: plain tab order, or the previewed one mid-drag. In the
+        // strip a slot *is* a tab index, so the previewed order doubles as the
+        // tab permutation a release would commit — recorded every frame so
+        // letting go applies exactly what's on screen (see `reorder`).
+        let display: Vec<usize> = match &preview {
+            Some(p) => {
+                reorder::set_pending(&self.reorder, &Surface::Strip, p.order.clone());
+                p.order.clone()
+            }
+            None => (0..self.tabs.len()).collect(),
+        };
+
+        for i in display {
             // In sidebar mode the vertical rail carries the tab list; the strip
             // keeps only its "+"/"⋯" chrome, so skip the chip row entirely.
             if !show_chips {
                 break;
             }
+            // The chip you're holding: still a chip in the row, just dimmed so
+            // it reads as picked up while it slides between slots.
+            let dragged = preview.as_ref().is_some_and(|p| p.from == i);
+            let tab = &self.tabs[i];
             let is_active = i == active;
             let label = self.tab_label(tab, i, Some(window), cx);
             // SSH status dot (PRD FR-E2): coloured by the pane's connection phase.
@@ -590,9 +624,6 @@ impl Tty7App {
                 .as_ref()
                 .filter(|r| r.index == i)
                 .map(|r| r.input.clone());
-            // Clean label (no pane-count suffix) for the rename prefill / drag preview.
-            let drag_label: SharedString = label.clone().into();
-
             // Either the editable input (while renaming) or the clickable,
             // draggable label.
             let label_region = match rename_input {
@@ -618,42 +649,38 @@ impl Tty7App {
                     // from the type, not from colour alone.
                     .when(is_active, |d| d.font_weight(FontWeight::MEDIUM))
                     .child(label)
-                    // Single click activates; double click zooms the window,
-                    // same as the rest of the titlebar. (Renaming lives in the
-                    // context menu.)
-                    .on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(move |this, ev: &MouseDownEvent, window, cx| {
-                            // Swallow the event — on Windows the chip's `occlude()`
-                            // means it would never reach the TitleBar anyway, so we
-                            // forward the double-click zoom explicitly instead.
-                            // Caveat: gpui only implements `titlebar_double_click`
-                            // on macOS; on Windows/Linux it's a no-op, so the chip
-                            // doesn't zoom there until upstream adds support.
-                            cx.stop_propagation();
-                            if ev.click_count >= 2 {
-                                window.titlebar_double_click();
-                            } else {
-                                this.activate(i, window, cx);
-                            }
-                        }),
-                    )
-                    // Drag the tab by its label to reorder it.
-                    .on_drag(
-                        DragTab {
-                            index: i,
-                            label: drag_label.clone(),
-                        },
-                        |drag, _, _, cx| {
-                            cx.stop_propagation();
-                            cx.new(|_| drag.clone())
-                        },
-                    )
+                    // No mouse handler of its own: click and drag both live on
+                    // the chip, and a child that swallowed the press would take
+                    // the label — most of the chip — out of both.
                     .into_any_element(),
             };
 
             let chip = h_flex()
                 .id(("tab-chip", i))
+                // Drag anywhere on the chip to reorder it. On the chip, not on
+                // its label: the drag's frame of reference is where the *chip*
+                // was grabbed, which is what the frozen geometry below
+                // measures — hang it off the label and the held chip rides
+                // offset from the cursor, skewing every crossing by that much.
+                // The builder runs once, when gpui promotes the press into a
+                // drag, freezing the strip's geometry as of the last painted
+                // frame.
+                .on_drag(DragTab, {
+                    let state = self.reorder.clone();
+                    let slots = slots.clone();
+                    move |_drag, grab, _window, cx| {
+                        cx.stop_propagation();
+                        *state.borrow_mut() = Some(Reorder::new(
+                            Surface::Strip,
+                            i,
+                            slots.borrow().clone(),
+                            Axis::Horizontal,
+                            px(CHIP_GAP),
+                            grab,
+                        ));
+                        cx.new(|_| DragTab)
+                    }
+                })
                 // The strip lives inside gpui-component's `TitleBar`, which marks
                 // its whole area as `WindowControlArea::Drag`. On Windows that maps
                 // to `HTCAPTION`, so unless an element on top registers a
@@ -666,6 +693,10 @@ impl Tty7App {
                 // A group so this chip's close affordance can reveal on hover
                 // (progressive disclosure) without affecting sibling tabs.
                 .group(SharedString::from(format!("tab-chip-{i}")))
+                // Same as the sidebar rows: a chip is a switch target first, so
+                // hover says "click me" and the drag swaps in the closed hand
+                // (see `Tty7App::render`).
+                .cursor_pointer()
                 .items_center()
                 .justify_between()
                 .gap_1p5()
@@ -696,20 +727,53 @@ impl Tty7App {
                     s.text_color(cx.theme().muted_foreground)
                         .hover(|s| s.bg(cx.theme().muted))
                 })
-                // Drop target: dropping a dragged tab here moves it to this slot.
-                .drag_over::<DragTab>(|s, _, _, cx| s.bg(cx.theme().drag_border.opacity(0.2)))
-                .on_drop(cx.listener(move |this, drag: &DragTab, _window, cx| {
-                    this.move_tab(drag.index, i, cx);
-                }))
-                // A click anywhere on the chip activates the tab. Clicks on the
-                // label or close button are handled by those children (which stop
-                // propagation), so this fires for the rest — icon, padding, the
-                // bare chip — making the whole tab a switch target, not just text.
+                // Held: a light dimming so the chip under your cursor reads as
+                // picked up. Not a lift — it stays in the row's own plane.
+                .when(dragged, |s| s.opacity(0.75))
+                // Measures this chip into the frame's slot table. Absolute and
+                // empty, so it costs the layout nothing.
+                .child(
+                    canvas(
+                        {
+                            let slots = slots.clone();
+                            move |bounds, _window, _cx| {
+                                if let Some(slot) = slots.borrow_mut().get_mut(i) {
+                                    *slot = bounds;
+                                }
+                            }
+                        },
+                        |_, _, _, _| {},
+                    )
+                    // `inset_0`, not `size_full`: an absolutely-positioned
+                    // child with no insets is laid out at its parent's
+                    // *content* box, so a measuring canvas inside a padded
+                    // element would report an origin shifted right by the
+                    // left padding — and the held chip would ride that far
+                    // off the cursor. Pinning all four insets to 0 anchors it
+                    // to the padding box, which is the chip itself.
+                    .absolute()
+                    .inset_0(),
+                )
+                // A click anywhere on the chip activates the tab; a double click
+                // zooms the window, as the rest of the title bar does. Both live
+                // here rather than on the label so the whole chip — label, icon,
+                // padding — is one switch target and one drag handle. (The close
+                // button and the rename input stop the press for their own use.)
+                //
+                // The event is swallowed: on Windows the chip's `occlude()` means
+                // it would never reach the TitleBar anyway, so the zoom is
+                // forwarded explicitly. Caveat: gpui only implements
+                // `titlebar_double_click` on macOS; elsewhere it's a no-op until
+                // upstream adds support.
                 .on_mouse_down(
                     MouseButton::Left,
-                    cx.listener(move |this, _: &MouseDownEvent, window, cx| {
+                    cx.listener(move |this, ev: &MouseDownEvent, window, cx| {
                         cx.stop_propagation();
-                        this.activate(i, window, cx);
+                        if ev.click_count >= 2 {
+                            window.titlebar_double_click();
+                        } else {
+                            this.activate(i, window, cx);
+                        }
                     }),
                 )
                 // Leading SSH status dot when this tab hosts an SSH session.
@@ -813,9 +877,35 @@ impl Tty7App {
             // Per-tab right-click menu (rename / worktree / split / copy cwd /
             // close group) — the same builder the sidebar rows use.
             let menu_app = cx.entity().downgrade();
-            chips = chips.child(chip.context_menu(move |menu, window, cx| {
+            let chip = chip.context_menu(move |menu, window, cx| {
                 Self::tab_context_menu(menu, i, false, &menu_app, window, cx)
-            }));
+            });
+            chips = chips.child(match &preview {
+                // The chip in hand: drawn wherever the cursor is holding it,
+                // pixel for pixel, with no animation in the way. `deferred`
+                // keeps its slot in the layout but paints it after its
+                // siblings, so it passes *over* the chips it's crossing
+                // instead of being clipped behind them.
+                Some(p) if p.from == i => deferred(chip.relative().left(p.held)).into_any_element(),
+                // A chip the drag just crossed starts the frame where it used
+                // to be and eases to its new slot. `offset` is zero for every
+                // chip the last crossing left alone, so this is one moving
+                // chip at a time, not the whole row re-animating every frame.
+                Some(p) => {
+                    let offset = p.offsets[i].as_f32();
+                    chip.with_animation(
+                        (
+                            SharedString::from(format!("chip-slide-{}", p.generation)),
+                            i,
+                        ),
+                        Animation::new(std::time::Duration::from_millis(REORDER_SLIDE_MS))
+                            .with_easing(ease_out_quint()),
+                        move |el, delta| el.left(px(offset * (1. - delta))),
+                    )
+                    .into_any_element()
+                }
+                None => chip.into_any_element(),
+            });
         }
 
         // "+" new-tab button — click opens the shell picker. The default shell
@@ -883,6 +973,7 @@ impl Tty7App {
         // Only `chips` is width-capped and `overflow_hidden`, so neither button is
         // pushed off-screen no matter how many tabs are open.
         h_flex()
+            .id("tab-strip")
             .items_center()
             .gap_1p5()
             // Chip mode: viewport-derived width (see `strip_w`) so the right edge —


### PR DESCRIPTION
Tabs now reorder the way Chrome and Warp do — the list rearranges live under the cursor instead of swapping two tiles on release — and repo group blocks in the sidebar become draggable as whole units.

## Before / After

| | Before | After |
|---|---|---|
| Dragging a tab | A card floats over the window; the list stays frozen | The tab stays in the list, dimmed, and tracks the cursor pixel for pixel |
| The tabs it passes | Nothing moves; only a drop-target highlight | Each slides out of the way (140ms, `ease_out_quint`) as it is crossed |
| Where it will land | Guess from the highlight | The list already shows it — what you see is what you get |
| Grab area | Only the icon and padding (the label swallowed the press) | Anywhere on the tab |
| Cursor | Default arrow throughout | Pointer on a tab, open hand on a group header, closed hand while dragging |
| Releasing | `on_drop` on the element under the cursor; a release a hair off the rail silently lost the move | The drag ending is the commit, wherever the cursor is |
| Reordering repo groups | Not possible | Drag the project name; the header and its tabs move as one block |
| Group order after a row drag | Could shuffle other groups' headers when a group's tabs were non-contiguous | Every group is laid out contiguously, Scratch last |

Applies to all three surfaces: the horizontal title-bar strip, the sidebar rows within a group, and the sidebar's group blocks.

## How it works

`src/ui/reorder.rs` (new) owns the geometry; the three surfaces only render what it computes.

```mermaid
flowchart LR
    M["Measure<br/><i>every slot, every frame</i>"] --> F["Freeze<br/><i>on_drag: bounds + grab point</i>"]
    F --> P["Preview<br/><i>pointer → target slot → order</i>"]
    P --> T["Track<br/><i>held item follows cursor</i>"]
    P --> S["Slide<br/><i>displaced slots animate</i>"]
    P --> R["Record<br/><i>the order a release would give</i>"]
    R --> C["Commit<br/><i>on drag end → apply_tab_order</i>"]
    P -.->|next frame| P
```

Three decisions worth calling out:

- **Geometry is frozen at drag start.** The preview reflow moves the very slots the hit-testing reads, so measuring live would let the list feed back into its own input and oscillate under a still cursor.
- **Slot selection is half-overlap**, not centre-to-centre: the held item's trailing edge past a neighbour's centre going forward, its leading edge going back. Centre-to-centre only behaves when everything is the same size — a three-row group block could never move above a one-row block, because reaching its centre meant dragging the pointer off the top of the list.
- **The commit is recorded per frame, not resolved on release.** `on_drop` fires only when the pointer is over that particular element, so releasing slightly outside the rail dropped the move and the list snapped back. The recording is cleared at the start of every frame so only what was actually drawn can land.

`apply_tab_order` (a whole-vector permutation) replaces `move_tab`/`move_group` as the single commit path — a visual move in the grouped sidebar generally implies more than a single swap.

## Testing

- **15 unit tests** across `ui::reorder` and `ui::tab_sidebar`, including: slot selection in both directions and on both axes, unequal-size blocks swapping symmetrically, the held item's offset staying attached across a crossing, only the just-crossed slot animating, the recorded order not outliving the frame that drew it, row moves inside a group leaving other groups and filtered-out rows alone, and whole-group moves.
- **Manual**: verified in an isolated dev instance (`--config-dir`) with 4 repo groups plus Scratch — rows dragged up and down within a group, group blocks reordered by their headers in both directions, releases inside and outside the rail, and the horizontal strip in `tab_bar_position: top`.
- Full suite green (`cargo test --bin tty7`; the one intermittent failure, `daemon::server::tests::conn::spawn_writer_exits_on_write_failure_while_sender_is_alive`, is pre-existing and passes in isolation).
