### PR TITLE
feat(ssh): shell integration for native SSH panes (zsh/bash/fish)

### DIFF
--- a/src/core/ssh_profile.rs
+++ b/src/core/ssh_profile.rs
@@ -74,6 +74,12 @@ pub struct SshProfile {
     pub warn_on_close: Option<bool>,
     /// Suppress the server login banner.
     pub skip_banner: bool,
+    /// Bootstrap tty7's shell integration into the remote shell (prompt marks,
+    /// exit codes, cwd — what the inline line editor runs on). On by default;
+    /// a remote we can't integrate declines itself, so this is the escape hatch
+    /// for one we *can* but shouldn't.
+    #[serde(default = "default_true")]
+    pub shell_integration: bool,
     /// Commands sent automatically right after the shell opens.
     pub login_scripts: Vec<String>,
     /// Request X11 forwarding.
@@ -110,6 +116,7 @@ impl Default for SshProfile {
             connect_timeout_s: None,
             warn_on_close: None,
             skip_banner: false,
+            shell_integration: true,
             login_scripts: Vec::new(),
             x11: false,
             algorithms: Algorithms::default(),
@@ -434,6 +441,22 @@ pub fn expand_tilde(path: &str) -> String {
 mod tests {
     use super::*;
 
+    /// Profiles written before the shell-integration switch existed must load
+    /// with it *on*: a plain `#[serde(default)]` would give `false` and quietly
+    /// opt every existing profile out of the feature it never knew about.
+    #[test]
+    fn profiles_saved_before_the_switch_existed_default_to_integrated() {
+        let profile: SshProfile =
+            serde_json::from_str(r#"{"name":"prod","host":"h","user":"u"}"#).unwrap();
+        assert!(profile.shell_integration);
+        // …and a profile that explicitly opted out stays opted out.
+        let off: SshProfile = serde_json::from_str(
+            r#"{"name":"prod","host":"h","user":"u","shell_integration":false}"#,
+        )
+        .unwrap();
+        assert!(!off.shell_integration);
+    }
+
     #[test]
     fn quick_connect_parses_basic_forms() {
         let q = parse_quick_connect("deploy@10.0.0.5").unwrap();
@@ -678,4 +701,12 @@ fn new_id() -> Uuid {
 /// Serde default for [`SshProfile::port`]: the standard SSH port.
 fn default_port() -> u16 {
     22
+}
+
+/// Serde default for [`SshProfile::shell_integration`]. Named rather than
+/// `#[serde(default)]` because the default is `true`, and because profiles
+/// written before the field existed must deserialize as opted *in* — the
+/// integration is the behavior we want everywhere it works.
+fn default_true() -> bool {
+    true
 }

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -536,6 +536,19 @@ pub struct NativeSshSpec {
     pub verify_host_keys: bool,
     #[serde(default)]
     pub skip_banner: bool,
+    /// Bootstrap tty7's shell integration (OSC 133 prompt marks + cwd
+    /// reporting) into the remote shell — what powers the inline line editor,
+    /// exit-code marks and cwd tracking for this pane. See
+    /// [`crate::daemon::shell_integration::remote`].
+    ///
+    /// On by default, and a remote we can't integrate declines itself (the
+    /// probe answers "unknown shell" and the session starts bare), so this is
+    /// for the case the probe can't detect: a remote where the bootstrap *would*
+    /// work but the user would rather it didn't — a bash host where the
+    /// login-shell → `--rcfile` swap upsets something, or simply a host they
+    /// want left exactly as stock ssh leaves it.
+    #[serde(default = "default_true")]
+    pub shell_integration: bool,
     /// Lines sent verbatim (each + `\n`) to the shell channel after it starts,
     /// sequentially, with no expect-logic.
     #[serde(default)]
@@ -592,6 +605,7 @@ impl std::fmt::Debug for NativeSshSpec {
             .field("term", &self.term)
             .field("verify_host_keys", &self.verify_host_keys)
             .field("skip_banner", &self.skip_banner)
+            .field("shell_integration", &self.shell_integration)
             .field("login_script", &self.login_script)
             .field("display_name", &self.display_name)
             .field("profile_id", &self.profile_id)
@@ -1919,6 +1933,7 @@ mod tests {
                 term: "xterm-256color".into(),
                 verify_host_keys: true,
                 skip_banner: false,
+                shell_integration: true,
                 login_script: vec![],
                 display_name: None,
                 profile_id: None,
@@ -1942,6 +1957,7 @@ mod tests {
             term: "xterm-256color".into(),
             verify_host_keys: true,
             skip_banner: false,
+            shell_integration: true,
             login_script: vec!["tmux attach".into()],
             display_name: Some("prod-web".into()),
             profile_id: Some("uuid-1".into()),
@@ -1965,6 +1981,10 @@ mod tests {
                 .unwrap();
         assert_eq!(spec.term, "xterm-256color"); // defaulted
         assert!(spec.verify_host_keys); // defaulted true
+        // A spec persisted before shell integration existed must come back
+        // opted *in* — `#[serde(default)]` on a bool would silently turn it off
+        // for every reconnect to a pane saved by an older build.
+        assert!(spec.shell_integration);
         assert_eq!(spec.password, None);
         assert!(spec.jump.is_none());
     }

--- a/src/daemon/shell_integration.rs
+++ b/src/daemon/shell_integration.rs
@@ -1615,6 +1615,16 @@ fi
         /// Parse `script` with the real shell, without running it. Returns
         /// `None` when that shell isn't installed here, which is a skip and not
         /// a failure — these tests are a local safety net, not a CI dependency.
+        ///
+        /// Unix-only, and not merely for convenience: on Windows a bare `bash`
+        /// resolves through `PATH` to `C:\Windows\System32\bash.exe` — the WSL
+        /// launcher, not a shell — which on a machine with no distro installed
+        /// exits non-zero with an empty stderr and is indistinguishable from a
+        /// rejected script. (`is_msys_bash` above exists for the same trap on
+        /// the production path.) Nothing is lost by skipping: these scripts are
+        /// destined for a remote POSIX host, so their syntax has nothing to do
+        /// with the platform running the test, and the Unix CI jobs cover them.
+        #[cfg(unix)]
         fn parse_check(
             shell: &str,
             syntax_only_flag: &str,
@@ -1656,6 +1666,7 @@ fi
         ///
         /// Skipped where the shell isn't installed; `-n` / `--no-execute` parse
         /// without running anything, so this never spawns a shell session.
+        #[cfg(unix)]
         #[test]
         fn bootstrap_scripts_parse_under_their_real_shells() {
             let cases = [
@@ -1673,6 +1684,7 @@ fi
 
         /// A quoted heredoc's body is data, so the check above never parses the
         /// rc files it writes — they have to be fed to the shell separately.
+        #[cfg(unix)]
         #[test]
         fn heredoc_bodies_parse_under_their_real_shells() {
             for (name, contents) in zsh_redirectors() {

--- a/src/daemon/shell_integration.rs
+++ b/src/daemon/shell_integration.rs
@@ -53,6 +53,12 @@
 //! Across all of them: **the user's own dotfiles are never modified** — the
 //! mechanisms above only affect shells tty7 itself launches.
 //!
+//! All of the above configure a *local* process spawn. Native-SSH panes have no
+//! spawn to configure — only the command string an `exec` channel request
+//! carries — so they take a different route to the same place: probe the remote
+//! for its login shell, then send a script that recreates these very files on
+//! the remote side and `exec`s through them. See [`remote`].
+//!
 //! **cmd** stays unintegrated by design, not omission. It exposes exactly one
 //! hook, the `PROMPT` env var, which can emit the `A`/`B` marks but not `C` or
 //! `D`: it has no preexec/postexec, and `PROMPT` is expanded when it is *set*,
@@ -1222,6 +1228,469 @@ pub fn setup(program: Option<&str>, args: &[String], has_custom_args: bool) -> O
         .insert("TTY7_SHELL_INTEGRATION".to_string(), String::new());
 
     Some(injection)
+}
+
+/// Reaching a shell on *another machine* — the native-SSH panes (`daemon::ssh`).
+///
+/// Everything above this point injects by arranging a *local* process spawn: we
+/// write files into a throwaway dir and hand the child an env var or an argv
+/// entry pointing at them. None of that is available over SSH, where the only
+/// lever is the one string the `exec` channel request carries — sshd runs it as
+/// `$SHELL -c <string>` and that is the whole interface.
+///
+/// So the remote path inverts the mechanism: instead of *configuring* a spawn,
+/// we send a short script that **materializes the same files on the remote side
+/// and then `exec`s the real shell through them**. The shell that comes out the
+/// other end is configured exactly as a local one — same `ZDOTDIR` redirector
+/// chain, same bash rcfile replaying the login-file chain, same fish `-C` — so
+/// the integration bodies above are reused verbatim rather than forked.
+///
+/// **Why probe first.** The bootstrap script cannot be shell-agnostic: sshd
+/// hands it to the user's *login* shell, so a POSIX script is parsed by fish (a
+/// syntax error) and a fish script by zsh. Warp solves this with a single
+/// expression contorted to parse identically in sh/bash/zsh/fish; we instead
+/// spend one cheap round-trip on [`PROBE_COMMAND`] — deliberately written to be
+/// valid in all of them because it contains no substitution, no assignment and
+/// no grouping — and then emit a script in the dialect we now know we're
+/// talking to. The result reads like ordinary shell code instead of a puzzle,
+/// and it also tells us when to keep our hands off entirely: a remote whose
+/// login shell isn't one of the three (or isn't POSIX at all — a Windows
+/// `cmd.exe`, where the probe echoes a literal `$SHELL`) parses as `None` and
+/// the caller falls back to a plain shell request. That negative answer is the
+/// load-bearing half: it is what keeps a non-Unix remote from being handed a
+/// script it would choke on, and it's why the probe exists rather than us just
+/// sending a bootstrap and hoping.
+///
+/// The probe's cost is paid once per *connection*, not once per pane — the
+/// caller caches it on the connection registry key, so extra tabs to a host
+/// already open cost nothing.
+pub mod remote {
+    use super::{FISH_INTEGRATION, bash_rcfile, zsh_redirectors};
+
+    /// Asks the remote for the login shell it would have started.
+    ///
+    /// Runs under whatever that shell is, so it is restricted to the
+    /// intersection of sh/bash/zsh/fish/csh syntax: two `echo`s and a `;`.
+    /// Notably absent is any command substitution — fish only learned `$(…)` in
+    /// 3.4 and csh never had it — and any assignment, which fish spells
+    /// differently from everyone else.
+    ///
+    /// The marker line is what makes the answer parseable rather than guessed:
+    /// a remote `.zshenv`/`config.fish` that prints something of its own (banner,
+    /// version-manager chatter) is ignored, because we only read the line that
+    /// follows the marker. See [`parse_probe`].
+    pub const PROBE_COMMAND: &str = "echo __tty7_shell; echo $SHELL";
+
+    /// The line [`PROBE_COMMAND`] prints immediately before the shell path.
+    const PROBE_MARKER: &str = "__tty7_shell";
+
+    /// Heredoc delimiter for the rc files the bootstrap writes remotely. Quoted
+    /// at the use site (`<<'…'`) so the bodies are copied *literally* — they are
+    /// full of `$`, backticks and backslashes that must reach the file intact.
+    const HEREDOC: &str = "__TTY7_RC_EOF__";
+
+    /// A remote login shell we know how to integrate.
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    pub enum RemoteShell {
+        Zsh,
+        Bash,
+        Fish,
+    }
+
+    impl RemoteShell {
+        fn from_path(path: &str) -> Option<Self> {
+            match path.rsplit('/').next()? {
+                "zsh" => Some(Self::Zsh),
+                "bash" => Some(Self::Bash),
+                "fish" => Some(Self::Fish),
+                _ => None,
+            }
+        }
+    }
+
+    /// Read [`PROBE_COMMAND`]'s output: the first non-empty line after the
+    /// marker is the remote's `$SHELL`.
+    ///
+    /// Returns `None` — meaning "launch a plain shell, inject nothing" — unless
+    /// that line is an absolute path to a shell we support. The absolute-path
+    /// requirement is what rejects a non-POSIX remote: `cmd.exe` echoes the
+    /// string `$SHELL` back unexpanded, and PowerShell prints an empty line, so
+    /// neither can be mistaken for an answer.
+    pub fn parse_probe(output: &str) -> Option<(RemoteShell, String)> {
+        let mut lines = output
+            .lines()
+            .map(|l| l.trim_end_matches('\r').trim())
+            .skip_while(|l| *l != PROBE_MARKER);
+        lines.next()?; // the marker itself
+        let path = lines.find(|l| !l.is_empty())?;
+        if !path.starts_with('/') {
+            return None;
+        }
+        RemoteShell::from_path(path).map(|shell| (shell, path.to_string()))
+    }
+
+    /// The script to send as the channel's `exec` request: it sets the remote up
+    /// for integration and `exec`s `shell_path` as the session's shell.
+    ///
+    /// Every arm ends in an `exec` of the user's own shell, and every arm
+    /// reaches that `exec` even if its setup failed — a remote with a full or
+    /// read-only `$TMPDIR` loses the integration, never the session.
+    pub fn bootstrap_command(shell: RemoteShell, shell_path: &str) -> String {
+        match shell {
+            RemoteShell::Zsh => zsh_bootstrap(shell_path),
+            RemoteShell::Bash => bash_bootstrap(shell_path),
+            RemoteShell::Fish => fish_bootstrap(shell_path),
+        }
+    }
+
+    /// Quote for a POSIX-family shell (zsh/bash): wrap in single quotes and
+    /// spell an embedded quote the only way single-quoting allows.
+    fn shell_quote(s: &str) -> String {
+        format!("'{}'", s.replace('\'', r"'\''"))
+    }
+
+    /// Quote for fish, whose single quotes — unlike POSIX's fully literal ones —
+    /// honour exactly two escapes, `\\` and `\'`. Both need doubling up, and
+    /// nothing else may be touched: the fish body is dense with `\e`, `\a` and
+    /// `$argv`, all of which must survive verbatim.
+    fn fish_quote(s: &str) -> String {
+        format!("'{}'", s.replace('\\', r"\\").replace('\'', r"\'"))
+    }
+
+    /// `command cat > <dir>/<name> <<'EOF' … EOF`, the remote-side equivalent of
+    /// the local `std::fs::write`.
+    ///
+    /// `command` bypasses any alias or function the remote's own startup files
+    /// have put in the way — sshd's `$SHELL -c` still reads `.zshenv`, so we are
+    /// not running in a pristine environment.
+    fn write_file(out: &mut String, name: &str, body: &str) {
+        out.push_str(&format!(
+            "command cat > \"$__tty7_d/{name}\" <<'{HEREDOC}'\n{}\n{HEREDOC}\n",
+            body.trim_end_matches('\n')
+        ));
+    }
+
+    /// Recreate the local `ZDOTDIR` redirector dir on the remote, point `ZDOTDIR`
+    /// at it, and exec zsh as a login shell — the same shape as [`setup_zsh`],
+    /// with the throwaway dir built by a script instead of by `std::fs`.
+    ///
+    /// `ZDOTDIR` is only exported once every redirector is confirmed written:
+    /// pointing zsh at a half-populated dir would silently cost the user their
+    /// dotfiles, which is far worse than not integrating at all.
+    ///
+    /// [`setup_zsh`]: super::setup_zsh
+    fn zsh_bootstrap(shell_path: &str) -> String {
+        let mut out = String::new();
+        out.push_str("__tty7_d=${TMPDIR:-/tmp}/tty7-zdotdir-$$\n");
+        out.push_str("command mkdir -p \"$__tty7_d\" 2>/dev/null\n");
+
+        let mut guard = String::new();
+        for (name, contents) in zsh_redirectors() {
+            // The cleanup hook rides along in .zshrc, after the integration body
+            // — see ZSH_CLEANUP_HOOK for why it can't be a plain `rm` here.
+            let body = if name == ".zshrc" {
+                format!("{contents}{ZSH_CLEANUP_HOOK}")
+            } else {
+                contents
+            };
+            write_file(&mut out, name, &body);
+            guard.push_str(&format!("[ -s \"$__tty7_d/{name}\" ] && "));
+        }
+        out.push_str(&format!(
+            "{guard}export ZDOTDIR=\"$__tty7_d\" TTY7_RM_DIR=\"$__tty7_d\"\n"
+        ));
+        out.push_str(&format!("exec {} -l\n", shell_quote(shell_path)));
+        out
+    }
+
+    /// Write the rcfile and exec bash *non-login* through it, exactly as
+    /// [`setup_bash`] does locally and for the same reason: `--rcfile` is
+    /// silently ignored for a login shell, so the rcfile replays the login-file
+    /// chain itself.
+    ///
+    /// [`setup_bash`]: super::setup_bash
+    fn bash_bootstrap(shell_path: &str) -> String {
+        let quoted = shell_quote(shell_path);
+        let mut out = String::new();
+        out.push_str("__tty7_d=${TMPDIR:-/tmp}/tty7-bashrc-$$\n");
+        out.push_str("command mkdir -p \"$__tty7_d\" 2>/dev/null\n");
+        write_file(
+            &mut out,
+            "bashrc",
+            &format!("{}{BASH_CLEANUP_HOOK}", bash_rcfile()),
+        );
+        out.push_str("if [ -s \"$__tty7_d/bashrc\" ]; then\n");
+        out.push_str("export TTY7_RM_DIR=\"$__tty7_d\"\n");
+        out.push_str(&format!("exec {quoted} --rcfile \"$__tty7_d/bashrc\" -i\n"));
+        out.push_str("fi\n");
+        out.push_str(&format!("exec {quoted} -l\n"));
+        out
+    }
+
+    /// fish needs nothing on disk at either end: `-C` runs the body after the
+    /// user's own `config.fish`, so the whole bootstrap is one `exec`.
+    fn fish_bootstrap(shell_path: &str) -> String {
+        format!(
+            "exec {} -C {} -l\n",
+            fish_quote(shell_path),
+            fish_quote(FISH_INTEGRATION)
+        )
+    }
+
+    /// Remove the throwaway rc dir once the shell has finished reading it.
+    ///
+    /// Unlike a local pane — where the terminal owns the dir and deletes it on
+    /// drop — nothing on the tty7 side can reach the remote filesystem, so the
+    /// shell has to clean up after itself. The deletion can't happen in the
+    /// bootstrap script (zsh hasn't read the files yet) nor at the end of the
+    /// rc file (zsh still has `.zlogin` to read), so it hangs off the first
+    /// `precmd`: by the time a prompt is drawn every startup file has been read,
+    /// and unlinking them is invisible to the running shell.
+    ///
+    /// The path arrives in an exported `TTY7_RM_DIR` because a quoted heredoc
+    /// copies its body literally — there is no interpolation to splice a Rust
+    /// value into. It's immediately demoted to a plain shell variable so it
+    /// doesn't leak into every child process.
+    ///
+    /// The hook doesn't unregister itself, unlike its neighbours: re-running a
+    /// two-line no-op each prompt is cheaper than the array surgery removing it
+    /// would cost.
+    const ZSH_CLEANUP_HOOK: &str = r#"
+# --- tty7 remote cleanup (zsh) ---
+if [[ -n "$TTY7_RM_DIR" ]]; then
+  typeset -g __tty7_rm_dir=$TTY7_RM_DIR
+  unset TTY7_RM_DIR
+  __tty7_rm_rcdir() {
+    [[ -n "$__tty7_rm_dir" ]] || return 0
+    command rm -rf -- "$__tty7_rm_dir"
+    unset __tty7_rm_dir
+  }
+  autoload -Uz add-zsh-hook
+  add-zsh-hook precmd __tty7_rm_rcdir
+fi
+# --- end tty7 remote cleanup ---
+"#;
+
+    /// The bash counterpart of [`ZSH_CLEANUP_HOOK`], registered through the
+    /// `precmd_functions` array that the integration body's vendored
+    /// bash-preexec drives.
+    ///
+    /// This sits *outside* that body's install guard, so on a remote that
+    /// already has tty7 integration in its own `.bashrc` the guard skips the
+    /// install and no `precmd_functions` ever runs — the dir then outlives the
+    /// session. That is the one case we let leak: a few KB under `/tmp` on a
+    /// host the user has explicitly set up, versus the alternative of an `EXIT`
+    /// trap that would clobber whatever trap their dotfiles installed.
+    const BASH_CLEANUP_HOOK: &str = r#"
+# --- tty7 remote cleanup (bash) ---
+if [[ -n "$TTY7_RM_DIR" ]]; then
+  __tty7_rm_dir=$TTY7_RM_DIR
+  unset TTY7_RM_DIR
+  __tty7_rm_rcdir() {
+    [[ -n "$__tty7_rm_dir" ]] || return 0
+    command rm -rf -- "$__tty7_rm_dir"
+    unset __tty7_rm_dir
+  }
+  precmd_functions+=(__tty7_rm_rcdir)
+fi
+# --- end tty7 remote cleanup ---
+"#;
+
+    #[cfg(test)]
+    mod tests {
+        use super::super::{BASH_INTEGRATION, ZSH_INTEGRATION};
+        use super::*;
+
+        #[test]
+        fn probe_reads_the_line_after_the_marker() {
+            assert_eq!(
+                parse_probe("__tty7_shell\n/bin/zsh\n"),
+                Some((RemoteShell::Zsh, "/bin/zsh".to_string()))
+            );
+            // Startup chatter ahead of the marker is ignored — a remote
+            // `.zshenv` that echoes a banner must not be read as the answer.
+            assert_eq!(
+                parse_probe("Welcome to prod!\n__tty7_shell\n/usr/local/bin/fish\n"),
+                Some((RemoteShell::Fish, "/usr/local/bin/fish".to_string()))
+            );
+            assert_eq!(
+                parse_probe("__tty7_shell\r\n/bin/bash\r\n"),
+                Some((RemoteShell::Bash, "/bin/bash".to_string()))
+            );
+        }
+
+        #[test]
+        fn probe_declines_anything_that_isnt_a_shell_we_know() {
+            // cmd.exe echoes the variable back unexpanded; PowerShell prints
+            // nothing. Neither may be mistaken for a POSIX remote.
+            assert_eq!(parse_probe("__tty7_shell\n$SHELL\n"), None);
+            assert_eq!(parse_probe("__tty7_shell\n\n"), None);
+            // A shell we have no integration body for.
+            assert_eq!(parse_probe("__tty7_shell\n/bin/ksh\n"), None);
+            // No marker at all: the command never ran as intended.
+            assert_eq!(parse_probe("/bin/zsh\n"), None);
+        }
+
+        #[test]
+        fn zsh_bootstrap_gates_zdotdir_on_every_redirector_landing() {
+            let script = bootstrap_command(RemoteShell::Zsh, "/bin/zsh");
+            // Pointing zsh at a partially-written dir would drop the user's
+            // dotfiles, so all four files are checked before ZDOTDIR is set.
+            for name in [".zshenv", ".zprofile", ".zshrc", ".zlogin"] {
+                assert!(
+                    script.contains(&format!("[ -s \"$__tty7_d/{name}\" ] &&")),
+                    "missing landing check for {name}"
+                );
+            }
+            let export = script.find("export ZDOTDIR=").expect("exports ZDOTDIR");
+            let exec = script.find("exec '/bin/zsh' -l").expect("execs zsh");
+            assert!(export < exec);
+            // The integration body must actually reach the remote .zshrc.
+            assert!(script.contains("__tty7_report_cwd"));
+        }
+
+        #[test]
+        fn file_writing_bootstraps_end_in_a_bare_exec_of_the_users_shell() {
+            // The last thing either script does is hand over an unintegrated
+            // shell, so a remote where the setup failed loses the integration
+            // and nothing else. (fish writes no files and so has no failure
+            // path to fall out of — it is a single `exec`, checked below.)
+            for (shell, path) in [
+                (RemoteShell::Zsh, "/bin/zsh"),
+                (RemoteShell::Bash, "/bin/bash"),
+            ] {
+                let script = bootstrap_command(shell, path);
+                let last = script.trim_end().lines().last().unwrap();
+                assert_eq!(
+                    last,
+                    format!("exec '{path}' -l"),
+                    "{shell:?} bootstrap must end by exec'ing {path} bare"
+                );
+            }
+        }
+
+        #[test]
+        fn bash_bootstrap_forces_a_non_login_shell_through_the_rcfile() {
+            let script = bootstrap_command(RemoteShell::Bash, "/bin/bash");
+            // `--rcfile` is ignored for login shells, so the integrated arm must
+            // be `-i`, with the rcfile replaying the login chain itself.
+            assert!(script.contains("exec '/bin/bash' --rcfile \"$__tty7_d/bashrc\" -i"));
+            assert!(script.contains("source /etc/profile"));
+        }
+
+        #[test]
+        fn fish_bootstrap_is_one_exec_carrying_the_escaped_body() {
+            let script = bootstrap_command(RemoteShell::Fish, "/usr/bin/fish");
+            // The whole bootstrap is a single (multi-line) command: fish reads
+            // `-C` after its own config.fish, so there is nothing to write to
+            // disk and no failure path to fall out of.
+            assert!(script.starts_with("exec '/usr/bin/fish' -C '"));
+            assert!(script.trim_end().ends_with("' -l"));
+            assert!(!script.contains("mkdir"));
+
+            // fish single quotes honour exactly \\ and \', so both must be
+            // doubled up on the way in. The body's `printf '\e]%s\a' $argv[1]`
+            // therefore arrives with its quotes escaped *and* its backslashes
+            // doubled — get either wrong and fish sees a terminated string or
+            // an escape sequence instead of the literal text.
+            assert!(script.contains(r"printf \'\\e]%s\\a\' $argv[1]"));
+        }
+
+        #[test]
+        fn quoting_survives_paths_and_bodies_that_fight_back() {
+            assert_eq!(shell_quote("/o'dd/zsh"), r"'/o'\''dd/zsh'");
+            assert_eq!(fish_quote(r"a'b\c"), r"'a\'b\\c'");
+        }
+
+        #[test]
+        fn heredoc_delimiter_cannot_appear_in_a_body_it_delimits() {
+            // A body containing the delimiter on its own line would end the
+            // heredoc early and spill shell code into the script.
+            for body in [ZSH_INTEGRATION, BASH_INTEGRATION, FISH_INTEGRATION] {
+                assert!(!body.contains(HEREDOC));
+            }
+            assert!(!bash_rcfile().contains(HEREDOC));
+        }
+
+        /// Parse `script` with the real shell, without running it. Returns
+        /// `None` when that shell isn't installed here, which is a skip and not
+        /// a failure — these tests are a local safety net, not a CI dependency.
+        fn parse_check(
+            shell: &str,
+            syntax_only_flag: &str,
+            script: &str,
+        ) -> Option<(bool, String)> {
+            use std::io::Write as _;
+            use std::process::{Command, Stdio};
+
+            let mut child = Command::new(shell)
+                .arg(syntax_only_flag)
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .ok()?;
+            child
+                .stdin
+                .take()
+                .expect("piped stdin")
+                .write_all(script.as_bytes())
+                .expect("write script");
+            let out = child.wait_with_output().expect("wait for parse check");
+            Some((
+                out.status.success(),
+                String::from_utf8_lossy(&out.stderr).into_owned(),
+            ))
+        }
+
+        /// The bootstrap scripts, and the rc files they carry, must parse under
+        /// the shells they're written for.
+        ///
+        /// This is worth a real subprocess where the local paths' unit tests
+        /// aren't, because a syntax error costs far more here: a local shell
+        /// with a broken rcfile still opens (bash just complains), but a remote
+        /// one takes the whole `exec` request down with it and the user gets a
+        /// session that dies on connect. Quoting is also doing much more work
+        /// on this path — a heredoc, two escaping dialects, and a body that
+        /// travels as an argv entry — so there is correspondingly more to break.
+        ///
+        /// Skipped where the shell isn't installed; `-n` / `--no-execute` parse
+        /// without running anything, so this never spawns a shell session.
+        #[test]
+        fn bootstrap_scripts_parse_under_their_real_shells() {
+            let cases = [
+                (RemoteShell::Zsh, "zsh", "-n", "/bin/zsh"),
+                (RemoteShell::Bash, "bash", "-n", "/bin/bash"),
+                (RemoteShell::Fish, "fish", "--no-execute", "/usr/bin/fish"),
+            ];
+            for (shell, bin, flag, path) in cases {
+                let script = bootstrap_command(shell, path);
+                if let Some((ok, stderr)) = parse_check(bin, flag, &script) {
+                    assert!(ok, "{bin} rejected its bootstrap script:\n{stderr}");
+                }
+            }
+        }
+
+        /// A quoted heredoc's body is data, so the check above never parses the
+        /// rc files it writes — they have to be fed to the shell separately.
+        #[test]
+        fn heredoc_bodies_parse_under_their_real_shells() {
+            for (name, contents) in zsh_redirectors() {
+                let body = if name == ".zshrc" {
+                    format!("{contents}{ZSH_CLEANUP_HOOK}")
+                } else {
+                    contents
+                };
+                if let Some((ok, stderr)) = parse_check("zsh", "-n", &body) {
+                    assert!(ok, "zsh rejected the remote {name}:\n{stderr}");
+                }
+            }
+            let rcfile = format!("{}{BASH_CLEANUP_HOOK}", bash_rcfile());
+            if let Some((ok, stderr)) = parse_check("bash", "-n", &rcfile) {
+                assert!(ok, "bash rejected the remote rcfile:\n{stderr}");
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/daemon/ssh/mod.rs
+++ b/src/daemon/ssh/mod.rs
@@ -35,12 +35,13 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::Duration;
 
-use russh::Pty;
+use russh::{ChannelMsg, Pty};
 
 use crate::daemon::protocol::{
     LoopbackForward, LoopbackForwardId, LoopbackForwardInfo, ManagedForward, NativeSshSpec,
     SshForwardRule, SshPhase, WinSize,
 };
+use crate::daemon::shell_integration::remote;
 
 use forward::RemoteForwardTable;
 use handler::ClientHandler;
@@ -84,6 +85,11 @@ pub struct SshManager {
     /// The WS4 managed-forward registry (Local/Remote/Dynamic + native loopback),
     /// driven on this manager's runtime.
     forwards: SshForwardRegistry,
+    /// Memoized remote shell-integration probes, keyed like connections. A
+    /// present `None` means "probed, nothing to inject" — cached just as firmly
+    /// as a hit so an unintegrable host isn't re-probed on every new tab. See
+    /// [`SshManager::remote_bootstrap`].
+    probes: Mutex<HashMap<ConnectionKey, Option<(remote::RemoteShell, String)>>>,
 }
 
 impl SshManager {
@@ -101,6 +107,7 @@ impl SshManager {
                 runtime,
                 conns: Mutex::new(HashMap::new()),
                 forwards: SshForwardRegistry::default(),
+                probes: Mutex::new(HashMap::new()),
             }
         })
     }
@@ -316,10 +323,29 @@ impl SshManager {
             let _ = channel.agent_forward(false).await;
         }
 
-        channel
-            .request_shell(true)
-            .await
-            .map_err(|e| format!("shell request failed: {e}"))?;
+        // Shell integration (OSC 133 + cwd reporting) for the remote shell. When
+        // the remote is one we know how to bootstrap, the shell is started by an
+        // `exec` request carrying a setup script that ends in `exec <shell>`,
+        // rather than by a bare `shell` request; see `shell_integration::remote`.
+        // Anything unrecognized — or a probe that couldn't be run — falls through
+        // to the plain shell request, which is exactly what every session did
+        // before this existed.
+        // Opting out short-circuits the probe too, not just the bootstrap: a
+        // profile with the switch off should cost nothing and touch nothing.
+        let bootstrap = match spec.shell_integration {
+            true => self.remote_bootstrap(&conn).await,
+            false => None,
+        };
+        match bootstrap {
+            Some(script) => channel
+                .exec(true, script)
+                .await
+                .map_err(|e| format!("shell request failed: {e}"))?,
+            None => channel
+                .request_shell(true)
+                .await
+                .map_err(|e| format!("shell request failed: {e}"))?,
+        }
 
         // Login script: each line verbatim + newline, in order, no expect-logic.
         for line in &spec.login_script {
@@ -339,6 +365,41 @@ impl SshManager {
     /// by the self-healing reuse path when a reused connection turns out dead.
     fn evict_connection(&self, key: &ConnectionKey) {
         self.conns.lock().unwrap().remove(key);
+    }
+
+    /// The shell-integration bootstrap script for `conn`'s next shell, or `None`
+    /// to start that shell bare.
+    ///
+    /// Deciding costs one `exec` round-trip against the remote (see
+    /// [`probe_remote_shell`]), so the answer is memoized on the connection key —
+    /// the same identity connections are reused under. Opening a second tab to a
+    /// host therefore pays nothing, and a *reconnect* to a host probed earlier
+    /// pays nothing either: which shell a login lands in doesn't change between
+    /// connections, so the cache deliberately outlives them.
+    ///
+    /// Two panes racing to a not-yet-probed host may both probe. That is a
+    /// duplicated round-trip on a cold connection, not a correctness problem —
+    /// the probe has no side effects and both arrive at the same answer — so it
+    /// isn't worth serializing every spawn behind a per-key lock the way
+    /// connection establishment is.
+    async fn remote_bootstrap(&self, conn: &Arc<SshConnection>) -> Option<String> {
+        let key = conn.key().clone();
+        let cached = { self.probes.lock().unwrap().get(&key).cloned() };
+        let probed = match cached {
+            Some(hit) => hit,
+            None => {
+                let probed = probe_remote_shell(conn).await;
+                match &probed {
+                    Some((shell, path)) => {
+                        log::debug!("ssh {key:?}: remote shell {shell:?} at {path}")
+                    }
+                    None => log::debug!("ssh {key:?}: no remote shell integration"),
+                }
+                self.probes.lock().unwrap().insert(key, probed.clone());
+                probed
+            }
+        };
+        probed.map(|(shell, path)| remote::bootstrap_command(shell, &path))
     }
 
     /// Establish (or reuse) the connection for `spec`, recursing through the jump
@@ -443,6 +504,54 @@ impl SshManager {
     }
 }
 
+/// How long to wait for the shell probe before giving up on integrating a
+/// remote. Generous, because the probe runs under the remote's login shell and
+/// therefore behind whatever its `.zshenv` does; short enough that a host which
+/// never answers costs a pause, not a hang. Expiring is not an error — the
+/// session continues with a plain shell.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Cap on probe output, in case the remote's startup files are chatty. Far more
+/// than the two lines we asked for; a remote that exceeds it has already told us
+/// everything [`remote::parse_probe`] could use.
+const PROBE_OUTPUT_LIMIT: usize = 8 * 1024;
+
+/// Ask the remote which login shell it would start, on a throwaway channel.
+///
+/// This is a non-PTY `exec`, so it runs and exits without touching the session
+/// the user is about to get; nothing here can break that session, and every
+/// failure path returns `None`, meaning "start the shell bare".
+///
+/// stderr is folded in with stdout because the marker-based parse tolerates
+/// noise, and a remote whose startup files complain on stderr would otherwise
+/// have its (perfectly good) answer thrown away.
+async fn probe_remote_shell(conn: &SshConnection) -> Option<(remote::RemoteShell, String)> {
+    let mut channel = conn.open_session_channel().await.ok()?;
+    channel.exec(true, remote::PROBE_COMMAND).await.ok()?;
+
+    let mut out: Vec<u8> = Vec::new();
+    let collect = async {
+        while let Some(msg) = channel.wait().await {
+            match msg {
+                ChannelMsg::Data { data } | ChannelMsg::ExtendedData { data, .. } => {
+                    out.extend_from_slice(&data);
+                    if out.len() >= PROBE_OUTPUT_LIMIT {
+                        break;
+                    }
+                }
+                ChannelMsg::Eof | ChannelMsg::Close => break,
+                _ => {}
+            }
+        }
+    };
+    // A timeout doesn't discard what did arrive: the answer is on the second
+    // line, so a remote that printed it and then stalled before closing the
+    // channel is still perfectly readable.
+    let _ = tokio::time::timeout(PROBE_TIMEOUT, collect).await;
+
+    remote::parse_probe(&String::from_utf8_lossy(&out))
+}
+
 /// A conservative set of PTY modes for the shell channel — an interactive TTY
 /// with canonical input, echo, and signal handling on, and standard baud codes.
 /// The remote line discipline uses these as its starting point.
@@ -487,6 +596,7 @@ mod tests {
             term: "xterm-256color".into(),
             verify_host_keys: true,
             skip_banner: false,
+            shell_integration: true,
             login_script: vec![],
             display_name: None,
             profile_id: None,
@@ -523,6 +633,7 @@ mod tests {
             runtime,
             conns: Mutex::new(HashMap::new()),
             forwards: SshForwardRegistry::default(),
+            probes: Mutex::new(HashMap::new()),
         };
         let key = ConnectionKey::from_spec(&base_spec());
         mgr.conns

--- a/src/terminal/completion.rs
+++ b/src/terminal/completion.rs
@@ -169,19 +169,26 @@ pub fn complete(line: &str, cursor: usize, cwd: Option<&Path>) -> Option<Complet
         // back to filesystem paths. A signature slot that declares suggestions
         // or generators owns the position: it returns `Some` (possibly with no
         // sync candidates but pending scripts) rather than ceding to paths.
-        match cwd {
-            // No local cwd — a remote pane. The filesystem here is not the one
-            // the command will run against, so offer nothing rather than this
-            // machine's names, which would be inserted into a remote command
-            // line where they do not exist. Command completion above still
-            // works; real remote-aware path completion would have to source
-            // the listing from the remote and is out of scope.
-            None => (Vec::new(), Vec::new()),
-            Some(cwd) => match complete_signature(&chars, word_start, &word, cwd) {
-                Some(sig) => (sig.cands, sig.pending),
-                None => {
-                    // No signature: generic paths, narrowed to directories when
-                    // the command only takes those (`cd`, `pushd`, …).
+        //
+        // A missing `cwd` means a remote pane, and it disables only the parts
+        // that read *this* machine: paths and generators (see
+        // [`complete_signature`]). The rest of a signature is static text —
+        // `git push`, `--verbose` — and is just as true on the remote, so it is
+        // still offered. Withholding it too would make every Tab in a remote
+        // pane a no-match, and a no-match hands the line to the shell, which
+        // costs the user the inline editor for that prompt.
+        match complete_signature(&chars, word_start, &word, cwd) {
+            Some(sig) => (sig.cands, sig.pending),
+            None => match cwd {
+                // No signature and no local filesystem to fall back on. Offering
+                // this machine's names would insert them into a remote command
+                // line where they do not exist; returning nothing instead lets
+                // the caller hand the Tab to the remote's own completion, which
+                // can actually see that filesystem.
+                None => (Vec::new(), Vec::new()),
+                // No signature: generic paths, narrowed to directories when
+                // the command only takes those (`cd`, `pushd`, …).
+                Some(cwd) => {
                     let dirs_only = current_command(&chars, word_start)
                         .is_some_and(|c| DIR_ONLY_COMMANDS.contains(&c.as_str()));
                     (complete_path(&word, cwd, dirs_only), Vec::new())
@@ -350,11 +357,19 @@ struct SigResult {
 /// value, suggestion, or generator slot (so a bare argument still lists files).
 /// A slot with generators returns `Some` even with zero sync candidates — its
 /// results are still inbound, and falling back to paths there is exactly #51.
+///
+/// `cwd` is `None` for a remote pane, which suppresses the two things that would
+/// answer with *this* machine's state: path completion, and generators. The
+/// generator exclusion matters more than it looks — a generator is a local
+/// `/bin/sh -c` (see [`super::generator`]), so `git checkout <Tab>` against a
+/// remote would offer the branches of whatever repo the *local* cwd happens to
+/// sit in. Wrong filenames are obvious when they fail; wrong branch names look
+/// plausible and land in a real command.
 fn complete_signature(
     chars: &[char],
     word_start: usize,
     word: &str,
-    cwd: &Path,
+    cwd: Option<&Path>,
 ) -> Option<SigResult> {
     // Only the current simple command matters: start after the last shell
     // separator so `foo | git <tab>` completes `git`, not `foo`.
@@ -398,10 +413,15 @@ fn complete_signature(
     if let Some(arg) = pending_value {
         let mut out = Vec::new();
         push_arg_suggestions(&mut out, arg, word);
-        if arg.wants_paths() {
-            out.extend(complete_path(word, cwd, arg.wants_dirs_only()));
+        if let Some(cwd) = cwd {
+            if arg.wants_paths() {
+                out.extend(complete_path(word, cwd, arg.wants_dirs_only()));
+            }
         }
-        let pending = collect_generators(arg);
+        let pending = match cwd {
+            Some(_) => collect_generators(arg),
+            None => Vec::new(),
+        };
         // A slot that declares suggestions or generators owns the position even
         // when nothing matches yet; only a truly featureless value slot cedes to
         // path completion.
@@ -435,10 +455,14 @@ fn complete_signature(
     let mut claims_slot = false;
     if let Some(arg) = node.args().first() {
         push_arg_suggestions(&mut out, arg, word);
-        if arg.wants_paths() {
-            out.extend(complete_path(word, cwd, arg.wants_dirs_only()));
+        if let Some(cwd) = cwd {
+            if arg.wants_paths() {
+                out.extend(complete_path(word, cwd, arg.wants_dirs_only()));
+            }
         }
-        pending = collect_generators(arg);
+        if cwd.is_some() {
+            pending = collect_generators(arg);
+        }
         // Suggestions/generators mean this positional owns the slot: don't cede
         // to paths just because the sync list came back empty.
         claims_slot = !arg.suggestions.is_empty() || !pending.is_empty();
@@ -1081,12 +1105,57 @@ mod tests {
         assert!(complete("cat only", 8, None).is_none());
         // Nor does a bare argument position dump anything.
         assert!(complete("cat ", 4, None).is_none());
-        // A signature-owned slot must not shell out to a local generator either.
-        assert!(complete("git checkout ", 13, None).is_none());
 
         // Command position still works — that source never touches the cwd.
         let c = complete("ech", 3, None).expect("command completion needs no cwd");
         assert!(c.candidates.iter().any(|c| c.text == "echo"));
+    }
+
+    /// The static half of a signature — subcommands, flags — describes the
+    /// *command*, not the machine, so it survives the loss of a local cwd. This
+    /// is what keeps Tab useful in a remote pane: a position with no candidates
+    /// hands the line to the shell (`handoff_tab_to_shell`), which costs the
+    /// user the inline editor until the next prompt, so answering "nothing" for
+    /// every `git <Tab>` was a real regression once remote panes gained an
+    /// editor at all.
+    #[test]
+    fn a_remote_pane_still_gets_a_signatures_static_candidates() {
+        let c = complete("git ", 4, None).expect("subcommands need no filesystem");
+        assert!(c.candidates.iter().any(|c| c.text == "commit"));
+        assert!(c.candidates.iter().any(|c| c.text == "push"));
+
+        // Prefix filtering works the same as it does locally.
+        let c = complete("git ch", 6, None).expect("subcommands need no filesystem");
+        assert!(c.candidates.iter().any(|c| c.text == "checkout"));
+        assert!(!c.candidates.iter().any(|c| c.text == "commit"));
+
+        // Flags too.
+        let c = complete("git commit --", 13, None).expect("flags need no filesystem");
+        assert!(c.candidates.iter().any(|c| c.text == "--message"));
+    }
+
+    /// Generators are local `/bin/sh -c` child processes, so against a remote
+    /// they would answer with this machine's state — `git checkout <Tab>`
+    /// offering the branches of whatever repo tty7's own cwd sits in. Unlike a
+    /// wrong filename, a wrong branch name is plausible enough to be accepted.
+    #[test]
+    fn a_remote_pane_never_runs_a_generator() {
+        // Locally this slot is generator-owned (the branch list).
+        let local = complete("git checkout ", 13, Some(Path::new("/"))).unwrap();
+        assert!(
+            !local.pending.is_empty(),
+            "expected the local branch generator to still be declared"
+        );
+
+        // Remotely the same slot may keep its static candidates, but must not
+        // schedule a single script.
+        if let Some(remote) = complete("git checkout ", 13, None) {
+            assert!(
+                remote.pending.is_empty(),
+                "a remote pane scheduled local generators: {:?}",
+                remote.pending
+            );
+        }
     }
 
     #[test]

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -486,6 +486,7 @@ pub(crate) struct SshProfileForm {
     agent_forward: bool,
     x11: bool,
     skip_banner: bool,
+    shell_integration: bool,
     verify_host_keys: Option<bool>,
     warn_on_close: Option<bool>,
 
@@ -1957,6 +1958,7 @@ impl Tty7App {
             agent_forward: profile.agent_forward,
             x11: profile.x11,
             skip_banner: profile.skip_banner,
+            shell_integration: profile.shell_integration,
             verify_host_keys: profile.verify_host_keys,
             warn_on_close: profile.warn_on_close,
             _subs: subs,
@@ -2010,6 +2012,7 @@ impl Tty7App {
             connect_timeout_s: val(&form.connect_timeout).parse().ok(),
             warn_on_close: form.warn_on_close,
             skip_banner: form.skip_banner,
+            shell_integration: form.shell_integration,
             login_scripts: split_lines(&form.login_scripts.read(cx).value()),
             x11: form.x11,
             algorithms: Algorithms {
@@ -2569,6 +2572,22 @@ impl Tty7App {
                         .on_click(cx.listener(|this, on: &bool, _w, cx| {
                             if let Some(f) = this.ssh_form_mut() {
                                 f.x11 = *on;
+                                cx.notify();
+                            }
+                        }))
+                        .into_any_element(),
+                    cx,
+                ),
+            )
+            .child(
+                self.settings_row(
+                    "Shell integration",
+                    "Let the remote shell report prompts, exit codes and directory.",
+                    Switch::new("ssh-form-shell-integration")
+                        .checked(form.shell_integration)
+                        .on_click(cx.listener(|this, on: &bool, _w, cx| {
+                            if let Some(f) = this.ssh_form_mut() {
+                                f.shell_integration = *on;
                                 cx.notify();
                             }
                         }))

--- a/src/ui/ssh_connect.rs
+++ b/src/ui/ssh_connect.rs
@@ -299,6 +299,7 @@ fn build_spec_inner(
         term: "xterm-256color".to_string(),
         verify_host_keys: profile.verify_host_keys.unwrap_or(global_verify_host_keys),
         skip_banner: profile.skip_banner,
+        shell_integration: profile.shell_integration,
         login_script: profile.login_scripts.clone(),
         display_name: (!profile.name.is_empty()).then(|| profile.name.clone()),
         profile_id: Some(profile.id.to_string()),


### PR DESCRIPTION
Bring tty7's shell integration — OSC 133 prompt marks, exit codes, cwd reporting — to native-SSH panes, for zsh, bash and fish.

## What changes

| | Before | After |
|---|---|---|
| Inline line editor in an SSH pane | Never armed — no OSC 133 ever arrived | Works, same as a local pane |
| Exit-code marks / cwd in an SSH pane | Absent | Reported by the remote shell |
| Remote shell startup | `shell` channel request | `exec` request carrying a bootstrap script that ends in `exec <user's shell>` |
| Unrecognized / non-POSIX remote | — | Probe declines, falls back to the plain `shell` request |
| `git <Tab>` in a remote pane | No candidates → line handed to the shell, inline editor gone for that prompt | Subcommands and flags offered from the Fig signature |
| `git checkout <Tab>` in a remote pane | Would run a **local** `git branch` if signatures were enabled | Generators disabled without a local cwd; Tab goes to the remote's own compsys |
| Per-profile control | — | **Shell integration** switch in the SSH profile form, on by default |

## Why the shape it has

Every existing integration configures a *local* process spawn — `ZDOTDIR` for zsh, `--rcfile` for bash, `-C` for fish. An SSH channel has no spawn to configure, only the string an `exec` request carries. So the remote path recreates those same files on the remote side and execs through them, reusing the integration bodies verbatim instead of forking them.

The bootstrap cannot be shell-agnostic: sshd runs it as `$SHELL -c <string>`, so a POSIX script is parsed by fish and a fish script by zsh. Rather than contort a single expression into parsing identically in all four shells, this spends one probe round-trip and then emits the dialect it knows it is talking to. `PROBE_COMMAND` is `echo __tty7_shell; echo $SHELL` — no command substitution (fish predates `$(…)` before 3.4), no assignment (fish spells it differently), no grouping. The probe is memoized on the connection key, so extra tabs to an already-open host cost nothing.

The probe's **negative** answer is the load-bearing half: it is what keeps a remote we can't integrate — a `cmd.exe`, where `$SHELL` echoes back unexpanded — from being handed a script it would choke on.

```mermaid
sequenceDiagram
    participant P as pane
    participant M as SshManager
    participant R as remote sshd
    P->>M: open shell channel
    M->>M: probe cached for this ConnectionKey?
    alt cache miss
        M->>R: exec "echo __tty7_shell; echo $SHELL"
        R-->>M: /bin/zsh
        M->>M: memoize on ConnectionKey
    end
    alt known shell, switch on
        M->>R: exec <bootstrap: write rc files; exec zsh -l>
        R-->>P: OSC 133 A/B/C/D + OSC 7
    else unknown shell, or switch off
        M->>R: shell request (unchanged)
        R-->>P: no marks, as before
    end
```

## Safety properties

- **Every arm ends by exec'ing the user's own shell**, failure paths included — a remote with a read-only `$TMPDIR` loses the integration, never the session.
- **zsh's `ZDOTDIR` is only exported once all four redirectors are confirmed written.** Pointing zsh at a half-populated dir would silently cost the user their dotfiles, which is worse than not integrating.
- **The throwaway dir removes itself on the first `precmd`** — by then every startup file has been read (including `.zlogin`), and unlinking is invisible to the running shell. Not an `EXIT` trap, which would clobber whatever trap the user's dotfiles installed.
- **The switch defaults to on for profiles saved before it existed** (`#[serde(default = "default_true")]`), so an upgrade doesn't silently opt everyone out.

## The completion fix

Giving remote panes a line editor exposed a latent bug. The argument-position branch answered a missing cwd by returning nothing at all; its comment only justified withholding *filesystem paths*, but the code took `complete_signature` down with them. Since a position with no candidates hands the line to the shell (`handoff_tab_to_shell`, #136) and that clears the inline editor for the rest of the prompt, every `git <Tab>` in a remote pane looked like the editor had crashed.

Measured before the fix — every git position was a handoff:

```
"git "          -> None (HANDOFF)
"git c"         -> None (HANDOFF)
"git checkout " -> None (HANDOFF)
"git status"    -> None (HANDOFF)
```

Generators stay disabled without a cwd, and that exclusion matters more than the path one: a generator is a local `/bin/sh -c`, so `git checkout <Tab>` would have offered the branches of whatever repo tty7's own cwd sat in. A wrong filename fails loudly when it runs; a wrong branch name is plausible enough to be accepted.

## Testing

Unit tests (821 pass):

- Probe parsing: marker-relative so remote startup chatter can't be mistaken for the answer; declines `$SHELL` echoed unexpanded, an empty line, an unknown shell, and a missing marker.
- Bootstrap shape: `ZDOTDIR` gated on all four redirectors landing; bash forced non-login through the rcfile; fish is a single `exec` with nothing written to disk; both file-writing arms end in a bare `exec <shell> -l`.
- Quoting: POSIX `'\''` and fish's `\\`/`\'` escaping, and that the heredoc delimiter can't appear in any body it delimits.
- **Real-shell parse checks**: each bootstrap script, and separately the rc files it carries inside quoted heredocs, are fed to `zsh -n` / `bash -n` / `fish --no-execute` (skipped where the shell isn't installed). Verified these actually run by injecting a syntax error and watching them fail.
- Backward compat: a profile and a spec serialized without the new field both deserialize as opted in.
- Completion: signature statics survive a missing cwd; generators are never scheduled without one.

Manual:

- Drove each bootstrap script through a PTY the way sshd invokes it (`$SHELL -c <script>`) against real zsh, bash and fish: submitted a failing command and confirmed A/B/C/D marks, `D;1` exit code and OSC 7 cwd all come back.
- Verified in an isolated dev instance against a real SSH host: inline editor active in the remote pane, `git <Tab>` offering subcommands without losing the editor, and the profile switch rendering and toggling.

Not covered: the SSH channel itself was not exercised end-to-end by the automated tests — the PTY harness reproduces sshd's invocation shape but not the transport. The manual pass against a real host covers it.
