### PR TITLE
Make the sidebar's top strip drag the window

### DIFF
--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -13,13 +13,16 @@
 
 use gpui::{
     Animation, AnimationExt as _, AnyElement, Axis, Bounds, Context, Div, FontWeight, MouseButton,
-    MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, SharedString, Stateful, Window, canvas,
-    deferred, div, ease_out_quint, linear_color_stop, linear_gradient, prelude::*, px,
+    MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, SharedString, Stateful, Window,
+    WindowControlArea, canvas, deferred, div, ease_out_quint, linear_color_stop, linear_gradient,
+    prelude::*, px,
 };
 use gpui_component::button::{Button, ButtonVariants as _};
 use gpui_component::input::Input;
 use gpui_component::menu::{ContextMenu, ContextMenuExt as _};
-use gpui_component::{ActiveTheme as _, Icon, IconName, Sizable as _, h_flex, v_flex};
+use gpui_component::{
+    ActiveTheme as _, Icon, IconName, InteractiveElementExt as _, Sizable as _, h_flex, v_flex,
+};
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
@@ -871,7 +874,37 @@ impl Tty7App {
                     // sit on the rail's surface here, and it aligns the search box
                     // with the terminal's top (which starts below the title bar),
                     // so the rail reads as one panel from the very top edge.
-                    .child(div().h(px(TITLE_BAR_HEIGHT)).flex_shrink_0())
+                    //
+                    // The real `TitleBar` — which carries the window's drag region
+                    // — only spans the *right* column in this layout, so this strip
+                    // would be dead space you can't grab the window by. Make it act
+                    // like the title bar it sits level with: drag to move,
+                    // double-click to zoom. Driven exactly like `TitleBar` does it
+                    // (and the settings overlay's stand-in strip): a press arms a
+                    // flag and the first *move* starts the window move, so a plain
+                    // click — and a double-click — still lands intact.
+                    .child({
+                        let should_move = Rc::new(Cell::new(false));
+                        div()
+                            .id("sidebar-titlebar-drag")
+                            .h(px(TITLE_BAR_HEIGHT))
+                            .flex_shrink_0()
+                            .window_control_area(WindowControlArea::Drag)
+                            .on_mouse_down(MouseButton::Left, {
+                                let should_move = should_move.clone();
+                                move |_, _, _| should_move.set(true)
+                            })
+                            .on_mouse_up(MouseButton::Left, {
+                                let should_move = should_move.clone();
+                                move |_, _, _| should_move.set(false)
+                            })
+                            .on_mouse_move(move |_, window, _| {
+                                if should_move.replace(false) {
+                                    window.start_window_move();
+                                }
+                            })
+                            .on_double_click(|_, window, _| window.titlebar_double_click())
+                    })
                     .child(top_bar)
                     .child(list),
             )


### PR DESCRIPTION
Make the vertical sidebar's title-bar-height top strip drag the window, like the title bar it sits level with.

| | Before | After |
|---|---|---|
| Drag the rail's top strip (above the search box) | Nothing — dead space | Moves the window |
| Double-click the same strip | Nothing | Zooms the window |
| Single click on the strip | Nothing | Still nothing (the move only arms on an actual drag) |

## Why

In `tab_bar_position: left` mode the sidebar is a full-height *left* column and the real `TitleBar` only spans the *right* column. The rail reserves a `TITLE_BAR_HEIGHT` strip at its top so it lines up with the terminal (and so the macOS traffic lights sit on its surface), but that strip carried no drag region — the leftmost ~200px of the window's top edge simply couldn't be grabbed.

The strip is now driven exactly the way `TitleBar` drives itself, and the way the settings overlay's stand-in strip already does: a press arms a flag, and the first mouse *move* calls `start_window_move()`. Deferring to an actual move is what keeps a plain click — and a double-click — intact. `WindowControlArea::Drag` covers the Windows path.

## Testing

- `cargo check` clean.
- **Not yet verified by hand** — the drag / double-click-to-zoom behaviour still needs a manual pass in a `tab_bar_position: left` window.