### PR TITLE
fix(sidebar): the repo group header showed a plain arrow on Windows

### DIFF
--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -621,7 +621,17 @@ impl Tty7App {
                         // Unlike a row, a header does nothing on click — its
                         // only affordance is the drag, so the open hand is the
                         // honest hover cursor (it closes once you pick it up).
-                        header.cursor_grab().on_drag(DragGroup, {
+                        // Windows has no open-hand system cursor, and gpui's
+                        // Windows backend falls every unmapped `CursorStyle`
+                        // through to `IDC_ARROW` — which reads as "nothing to
+                        // do here". Point there instead: it's the same cursor
+                        // the rows use, and it at least says "interactive".
+                        let header = if cfg!(target_os = "windows") {
+                            header.cursor_pointer()
+                        } else {
+                            header.cursor_grab()
+                        };
+                        header.on_drag(DragGroup, {
                             let state = self.reorder.clone();
                             let slots = group_slots.clone();
                             move |_drag, grab, _window, cx| {


### PR DESCRIPTION
The repo group header in the tab sidebar is drag-only — it does nothing on click — so it hovered under `cursor_grab()`, the open hand that says "pick me up".

gpui's Windows backend has no mapping for `CursorStyle::OpenHand`. `load_cursor` (`gpui_windows/src/util.rs:103`) matches `IBeam`, `Crosshair`, `PointingHand`, the resize family and `OperationNotAllowed`, then falls everything else through to `IDC_ARROW`:

```rust
CursorStyle::PointingHand | CursorStyle::DragLink => (&HAND, IDC_HAND),
...
_ => (&ARROW, IDC_ARROW),   // OpenHand lands here
```

Win32 has no open-hand system cursor to map it to either. So on Windows the header's one affordance read as "nothing to do here", while the rows right beside it — `cursor_pointer()` → `IDC_HAND` — looked interactive. macOS and Linux both implement `OpenHand`, so it only shows up on Windows.

## The change

Point on Windows instead. Not as apt as the open hand, but it is the same cursor the rows use and it does say the header responds. macOS and Linux keep the hand.

```rust
let header = if cfg!(target_os = "windows") {
    header.cursor_pointer()
} else {
    header.cursor_grab()
};
```

## Notes

The other cursor call sites are unaffected — `cursor_pointer` (sftp, settings, diff overlay, sidebar rows) maps to `IDC_HAND` and `cursor_col_resize` (the sidebar's resize handle, the pane divider) maps to `IDC_SIZEWE`. `cursor_grab` was the only style in the tree with no Windows mapping.

A tidier fix belongs upstream: map `OpenHand`/`ClosedHand` to `IDC_SIZEALL` in `gpui_windows`. That needs the pinned zed rev to move, so this stays local for now.