### PR TITLE
fix(settings): the theme panel's close button did nothing on Windows

### DIFF
--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -3557,11 +3557,22 @@ impl Tty7App {
                     .child("Themes"),
             )
             .child(
-                Button::new("theme-panel-close")
-                    .icon(IconName::Close)
-                    .ghost()
-                    .small()
-                    .on_click(cx.listener(|this, _, _w, cx| this.close_theme_panel(cx))),
+                // The panel is docked to the window's top edge, so this `×` sits
+                // inside the settings overlay's stand-in title-bar strip — an
+                // absolute `WindowControlArea::Drag` band across the top 40px
+                // (see `root` below). On Windows that band is `HTCAPTION`, and
+                // unless something on top registers a mouse-blocking hitbox the
+                // OS takes the press as a window-drag and the button's `on_click`
+                // never fires. `occlude()` stops hit-testing here, the same way
+                // the tab-strip chips and the page's own `×` do. No-op elsewhere;
+                // the rest of the header still drags the window.
+                div().occlude().child(
+                    Button::new("theme-panel-close")
+                        .icon(IconName::Close)
+                        .ghost()
+                        .small()
+                        .on_click(cx.listener(|this, _, _w, cx| this.close_theme_panel(cx))),
+                ),
             );
 
         let subtitle = div()


### PR DESCRIPTION
Clicking the `×` in the Themes panel header did nothing on Windows.

The settings overlay covers the real title bar, so it lays down its own stand-in drag band (`settings.rs`): absolute, full width, `TITLE_BAR_HEIGHT` tall, tagged `WindowControlArea::Drag`. The theme panel docks to the window's top edge beside it, and its header's `×` — 16px of `pt_4` plus a small button — lands inside that 40px band.

On Windows that band is `HTCAPTION`. gpui resolves which control area the pointer is in by walking hitboxes top-down and stopping only at a `HitboxBehavior::BlockMouse` (`gpui/src/window.rs:936`):

```rust
for hitbox in self.hitboxes.iter().rev() {
    if bounds.contains(&position) {
        hit_test.ids.push(hitbox.id);
        ...
        if hitbox.behavior == HitboxBehavior::BlockMouse { break; }
    }
}
```

A plain `Button` isn't `BlockMouse`, so the band's hitbox stayed in `mouse_hit_test.ids`, the `on_hit_test_window_control` callback answered `Drag`, `gpui_windows/src/events.rs:904` returned `HTCAPTION`, and the OS took every press on the `×` as a window-drag. The button's `on_click` never fired.

## The change

`occlude()` on the button ends the hitbox walk there. Same fix the tab-strip chips carry — and the same one the settings page's own `×` has had since it was written; the theme panel's just missed it.

Scoped to the button rather than the whole panel, so the rest of the header still drags the window. No-op on macOS and Linux, where title-bar dragging doesn't gate child hit-testing.

## Related, not fixed here

The settings content pane is `overflow_y_scroll()` starting at y=0, so scrolled controls pass under the same 40px band and are unclickable on Windows while they sit there. That one wants a layout change (start the scroll area below the band) rather than an `occlude()`, since occluding the pane would cost the drag band its whole width. Left for a separate PR.