### PR TITLE
style(settings): size the page's close button to the title bar's rhythm

### DIFF
--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -902,11 +902,19 @@ impl Tty7App {
             // and carries its own ✕, so keeping this one would stack two ✕ there.
             .when(!show_theme_panel, |r| {
                 r.child(
-                    div().absolute().top(px(6.)).right(px(10.)).occlude().child(
+                    // Sized like the title bar's "⋯" (30px, 15px glyph,
+                    // `rounded_lg`), because it stands in the same corner: a
+                    // `small` icon button is 24px, which reads undersized next
+                    // to the 34px window-control tiles this spot belongs to.
+                    // `top` centres it in the title bar's band — (40 − 30) / 2.
+                    div().absolute().top(px(5.)).right(px(10.)).occlude().child(
                         Button::new("settings-close")
-                            .icon(IconName::Close)
+                            .icon(Icon::new(IconName::Close).size(px(15.)))
                             .ghost()
-                            .small()
+                            .xsmall()
+                            .w(px(30.))
+                            .h(px(30.))
+                            .rounded_lg()
                             .on_click(
                                 cx.listener(|this, _, window, cx| this.close_settings(window, cx)),
                             ),


### PR DESCRIPTION
The settings page's `×` sits at the window's top-right corner — the spot the native window controls own, whose tiles are 34px. As a `small` icon button gpui-component gives it a fixed 24px square (`button.rs`: icon-only + `Size::Small` → `size_6()`), which reads undersized standing there alone once the overlay has covered the real title bar.

## The change

Give it the shape the title bar's own corner button already uses — 30px square, 15px glyph, `rounded_lg`, the same spec as the `⋯` in `tab_strip.rs`:

```rust
Button::new("settings-close")
    .icon(Icon::new(IconName::Close).size(px(15.)))
    .ghost()
    .xsmall()
    .w(px(30.))
    .h(px(30.))
    .rounded_lg()
```

Matching that beats taking the component's medium default (32px): 30px is the size this app already puts in this corner. `top` drops 6 → 5 so the taller button still centres in the title bar's 40px band.

24px → 30px, no behaviour change.