### PR TITLE
fix(windows): titlebar chrome — ⋯ menu rhythm + clickable sidebar controls

### DIFF
--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -755,36 +755,48 @@ impl Tty7App {
             .gap(px(2.))
             // Glyph, not hit box, on the content edge — see `TILE_PAD`.
             .pr(px(crate::ui::app::CONTENT_INSET - crate::ui::app::TILE_PAD))
+            // Both tiles are wrapped in an `occlude()` div, exactly like the
+            // title-strip chrome. This row is a `WindowControlArea::Drag` (set
+            // below), which on Windows maps to HTCAPTION — the OS claims the click
+            // as a window-drag before gpui ever hit-tests, so a bare button never
+            // fires its `on_click`. `occlude()` gives each a BlockMouse hitbox so
+            // hit-testing stops on the button. (No-op on macOS, where titlebar
+            // dragging doesn't gate child hit-testing — which is why this worked
+            // there and silently did nothing on Windows.)
             .child(
-                self.attach_new_tab_menu(
-                    // `chrome_tile`, not `ghost()`: this "+" sits beside the
-                    // collapse tile and the title bar's own "+", and ghost's
-                    // hover is a heavier, differently-derived grey.
+                div().occlude().flex_shrink_0().child(
+                    self.attach_new_tab_menu(
+                        // `chrome_tile`, not `ghost()`: this "+" sits beside the
+                        // collapse tile and the title bar's own "+", and ghost's
+                        // hover is a heavier, differently-derived grey.
+                        crate::ui::tab_strip::chrome_tile(
+                            Button::new("sidebar-add").icon(Icon::new(IconName::Plus).size(px(18.))),
+                            false,
+                            cx,
+                        )
+                        .xsmall()
+                        .w(px(32.))
+                        .h(px(32.))
+                        .rounded_lg(),
+                        cx,
+                    ),
+                ),
+            )
+            .child(
+                div().occlude().flex_shrink_0().child(
                     crate::ui::tab_strip::chrome_tile(
-                        Button::new("sidebar-add").icon(Icon::new(IconName::Plus).size(px(18.))),
+                        Button::new("sidebar-collapse")
+                            .icon(Icon::empty().path("icons/panel-left.svg").size(px(18.))),
                         false,
                         cx,
                     )
                     .xsmall()
                     .w(px(32.))
                     .h(px(32.))
-                    .rounded_lg(),
-                    cx,
+                    .rounded_lg()
+                    .tooltip("Hide Sidebar")
+                    .on_click(cx.listener(|this, _, _window, cx| this.toggle_left_panel(cx))),
                 ),
-            )
-            .child(
-                crate::ui::tab_strip::chrome_tile(
-                    Button::new("sidebar-collapse")
-                        .icon(Icon::empty().path("icons/panel-left.svg").size(px(18.))),
-                    false,
-                    cx,
-                )
-                .xsmall()
-                .w(px(32.))
-                .h(px(32.))
-                .rounded_lg()
-                .tooltip("Hide Sidebar")
-                .on_click(cx.listener(|this, _, _window, cx| this.toggle_left_panel(cx))),
             );
         // Borderless "Search tabs…" that sits directly on the sunk surface: a
         // leading magnifier + an appearance-less input, no box and no divider

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -770,7 +770,8 @@ impl Tty7App {
                         // collapse tile and the title bar's own "+", and ghost's
                         // hover is a heavier, differently-derived grey.
                         crate::ui::tab_strip::chrome_tile(
-                            Button::new("sidebar-add").icon(Icon::new(IconName::Plus).size(px(18.))),
+                            Button::new("sidebar-add")
+                                .icon(Icon::new(IconName::Plus).size(px(18.))),
                             false,
                             cx,
                         )

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -215,9 +215,14 @@ impl Tty7App {
             // *glyph* there instead of its 30px hit box.
             .pr(px(crate::ui::app::CONTENT_INSET - crate::ui::app::TILE_PAD))
             // On Windows/Linux the window controls (─ ▢ ✕) sit on the right, right
-            // where the "⋯" lands; give it extra breathing room there so it reads
-            // as a menu affordance, not a fourth window control.
-            .when(!cfg!(target_os = "macos"), |this| this.pr_3())
+            // where the "⋯" lands, so its inset has to match *their* rhythm rather
+            // than add breathing room: the 34px control tiles put consecutive glyph
+            // centres 34px apart, and the "⋯" centre sits `16 + pr + 17` from the
+            // minimise glyph. `pr_1` (4px) lands it at ~37px — reading as part of
+            // the same row, with just enough slack to not be mistaken for a fourth
+            // window control. `pr_3` (12px) put it at ~45px, visibly adrift from the
+            // group (this is where the de3896c chrome redesign reset it — see 9b1c7bf).
+            .when(!cfg!(target_os = "macos"), |this| this.pr_1())
             .child(
                 div().occlude().flex_shrink_0().child(
                     chrome_tile(


### PR DESCRIPTION
Two Windows-only titlebar-chrome fixes, both reported and verified in a local dev build.

## 1. `⋯` menu drifted from the window controls

The `de3896c` chrome redesign moved the right-corner chrome into `window_chrome()` and reset its non-macOS right padding to `pr_3` (12px), silently reverting the earlier `pr_1` fix (`9b1c7bf`). The `⋯` glyph ended up ~45px from the minimise glyph — adrift from the native controls, which sit on a 34px rhythm.

Restored `pr_1` (4px) so the `⋯` centre lands ~37px out — on the native rhythm, with just enough slack not to read as a fourth window control. macOS unaffected.

The tuning is measured against Windows' native caption buttons; the `!macos` branch covers Linux too, where decoration sizes vary by DE and this value has not been tuned separately. That was already true of `pr_3` — this change doesn't alter it.

## 2. Sidebar collapse / new-tab buttons did nothing on Windows

The rail's control row is a `WindowControlArea::Drag` (so you can drag the window by it). On Windows that maps to `HTCAPTION`, so the OS claims the click as a window-drag before GPUI hit-tests — the `+` and collapse tiles never fired their `on_click`. Fine on macOS, where titlebar dragging doesn't gate child hit-testing, so it looked correct there.

Wrapped both tiles in an `occlude()` div (a `BlockMouse` hitbox), exactly as the title-strip chrome tiles already do (`tab_strip.rs`, the chips at ~849 and the add tiles at ~1084).

## Testing

- `cargo check` clean (pre-existing dead-code warnings only).
- Ran the dev build (`--config-dir .tty7-dev`) on Windows 11; `⋯` spacing matches the native rhythm and the sidebar collapse/`+` now respond to clicks.
- macOS paths untouched (both fixes are gated on `!macos` / are no-ops there).
