### PR TITLE
fix(settings): keep the stock glyphs on the Settings page

### DIFF
--- a/src/ui/assets.rs
+++ b/src/ui/assets.rs
@@ -16,8 +16,23 @@ use gpui::{AssetSource, Result, SharedString};
 /// tty7's asset source. Registered once in `main` via `with_assets`.
 pub struct Assets;
 
+/// Prefix that opts a single call site *out* of the overrides in [`agent_icon`]
+/// and takes gpui-component's own glyph instead: `stock/icons/search.svg`.
+///
+/// Needed because the overrides are keyed on the asset path, which makes them
+/// app-wide (see [`agent_icon`]). Most of them are wanted everywhere, but the
+/// detail panel's set is drawn for 18px tiles sitting beside solid dock glyphs,
+/// and a few of those shapes are too heavy at the 16px the Settings page uses —
+/// its `⋯` in particular, whose filled `r=2` dots smear into three blobs there.
+/// Rather than fork the whole set under a second name, those call sites ask for
+/// stock by path.
+const STOCK_PREFIX: &str = "stock/";
+
 impl AssetSource for Assets {
     fn load(&self, path: &str) -> Result<Option<Cow<'static, [u8]>>> {
+        if let Some(downstream) = path.strip_prefix(STOCK_PREFIX) {
+            return gpui_component_assets::Assets.load(downstream);
+        }
         if let Some(bytes) = agent_icon(path) {
             return Ok(Some(Cow::Borrowed(bytes)));
         }
@@ -43,7 +58,8 @@ impl AssetSource for Assets {
 /// tty7's and gpui-component's own — resolves through the arm below. Adding a
 /// name that upstream also ships redraws it everywhere; check the call sites
 /// before doing so, and prefer a name upstream *doesn't* use (`circle-info`)
-/// when only one place should change.
+/// when only one place should change. A call site that wants the downstream
+/// glyph despite an override here asks for it by [`STOCK_PREFIX`].
 fn agent_icon(path: &str) -> Option<&'static [u8]> {
     let bytes: &'static [u8] = match path {
         // Flush `>_` prompt glyph for the plain-shell tab avatar (Lucide's
@@ -132,4 +148,40 @@ fn agent_icon(path: &str) -> Option<&'static [u8]> {
         _ => return None,
     };
     Some(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The Settings page reaches for stock glyphs by path; if that stopped
+    /// bypassing the overrides it would silently pick up the detail panel's
+    /// heavier redraws again, which is the regression this prefix exists to undo.
+    #[test]
+    fn stock_prefix_bypasses_the_overrides() {
+        for name in ["search", "ellipsis"] {
+            let overridden = Assets
+                .load(&format!("icons/{name}.svg"))
+                .unwrap()
+                .expect("tty7 override present");
+            let stock = Assets
+                .load(&format!("{STOCK_PREFIX}icons/{name}.svg"))
+                .unwrap()
+                .expect("downstream glyph present");
+            assert_ne!(
+                overridden, stock,
+                "`{name}` should resolve to different art with and without `{STOCK_PREFIX}`"
+            );
+        }
+    }
+
+    /// A `stock/` path for a glyph tty7 never overrode still has to resolve —
+    /// the prefix is a bypass, not a separate asset set.
+    #[test]
+    fn stock_prefix_works_for_unoverridden_glyphs() {
+        assert_eq!(
+            Assets.load("stock/icons/check.svg").unwrap(),
+            Assets.load("icons/check.svg").unwrap(),
+        );
+    }
 }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -796,7 +796,15 @@ impl Tty7App {
                         h_flex()
                             .items_center()
                             .gap_1()
-                            .child(Icon::new(IconName::Search).small().text_color(header_muted))
+                            // Stock magnifier, not tty7's: this page's glyphs run at
+                            // 16px, where the detail panel's redraw reads thin and
+                            // its handle stubby. See `assets::STOCK_PREFIX`.
+                            .child(
+                                Icon::empty()
+                                    .path("stock/icons/search.svg")
+                                    .small()
+                                    .text_color(header_muted),
+                            )
                             .child(
                                 div()
                                     .flex_1()
@@ -1695,7 +1703,11 @@ impl Tty7App {
                             })
                             .child(
                                 Button::new(("ssh-prof-menu", row_idx))
-                                    .icon(IconName::Ellipsis)
+                                    // Stock `⋯`, not tty7's: the redraw's filled
+                                    // `r=2` dots are weighted for the title bar's
+                                    // 18px tiles and smear into three blobs at the
+                                    // 16px `small()` uses. See `assets::STOCK_PREFIX`.
+                                    .icon(Icon::empty().path("stock/icons/ellipsis.svg"))
                                     .ghost()
                                     .small()
                                     .dropdown_menu_with_anchor(
@@ -3618,7 +3630,13 @@ impl Tty7App {
             div().w(px(268.)).child(
                 Input::new(&search)
                     .small()
-                    .prefix(Icon::new(IconName::Search).small().text_color(muted_fg)),
+                    // Stock magnifier — same reason as the page header's.
+                    .prefix(
+                        Icon::empty()
+                            .path("stock/icons/search.svg")
+                            .small()
+                            .text_color(muted_fg),
+                    ),
             ),
         );
 


### PR DESCRIPTION
Reverts the Settings page to gpui-component's stock glyphs. Everything else keeps #161's redraw.

## What went wrong

The overrides in `assets.rs` match on the asset **path**, and `gpui_component_macros::icon_named!` derives `IconName` from those same downstream filenames — `IconName::Search.path()` is literally `"icons/search.svg"`. So #161's redraws took effect **app-wide**, not just in the detail panel, and three Settings glyphs came along for the ride:

| Call site | Glyph | Why it's worse there |
|---|---|---|
| Page header search | magnifier | Thinner ring and a stubbier handle at 16px |
| SSH host search (`.prefix`) | magnifier | Same |
| SSH profile row menu | `⋯` | The redraw's filled `r=2` dots are weighted for the title bar's 18px tiles; scaled to the 16px `small()` uses they smear into three blobs |

The set was drawn for 18px tiles sitting beside solid dock glyphs. That's the wrong brief for a settings form.

## The fix

A `stock/` path prefix that bypasses the override table and delegates straight downstream:

```rust
const STOCK_PREFIX: &str = "stock/";

fn load(&self, path: &str) -> Result<Option<Cow<'static, [u8]>>> {
    if let Some(downstream) = path.strip_prefix(STOCK_PREFIX) {
        return gpui_component_assets::Assets.load(downstream);
    }
    ...
}
```

The three call sites ask for `stock/icons/search.svg` / `stock/icons/ellipsis.svg`.

A prefix rather than a second copy of the art, for two reasons: nothing is duplicated, and the page keeps following upstream if lucide's magnifier or ellipsis ever changes there. It also scales — any future call site that wants stock despite an override says so in one token.

## Not changed

The detail panel's tabs and controls, the title-bar `+` / `⋯`, the sidebar's 11px branch mark, the diff overlay header, the file tree, and the SFTP browser all keep the redraw. The Settings nav's About row already kept its circled `i` via `circle-info.svg` (added in #161).

## Testing

- Two unit tests in `assets.rs`: `stock/` resolves to *different* bytes than the overridden path for both affected names, and a `stock/` path for a glyph tty7 never overrode still resolves identically to the bare path (the prefix is a bypass, not a separate asset set).
- `cargo test --bin tty7 ui::assets` — 2 passed.
- `cargo check --all-targets` clean; `cargo fmt --check` clean.
