### PR TITLE
fix(release): assemble the release as a draft once every platform is green

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,13 +109,65 @@ jobs:
         shell: pwsh
         run: '& ./.github/scripts/bundle-windows.ps1 "${{ matrix.target }}" "${{ matrix.arch }}"'
 
-      - name: Release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+      # Hand the artifacts to the assemble job rather than uploading them to the
+      # release here. Four parallel jobs each publishing their own slice would
+      # make the release "latest" the moment the *first* platform finished — the
+      # in-app update check (src/core/update.rs) reads /releases/latest, so users
+      # would be prompted to download a release that was still missing most of
+      # its assets. Same glob list as before: the bundle scripts leave
+      # intermediates in dist/ (tty7.app, entitlements.plist, the Windows staging
+      # dir) that must not reach the release assets.
+      - uses: actions/upload-artifact@v7
         with:
-          files: |
+          name: release-${{ matrix.os }}-${{ matrix.arch }}
+          path: |
             tty7/dist/*.dmg
             tty7/dist/*.tar.gz
             tty7/dist/*.zip
             tty7/dist/*-setup.exe
             tty7/dist/*.AppImage
+          if-no-files-found: error
+
+  # Single assembly step, after all four platforms succeed. The release object is
+  # created as a **draft** and left that way: a draft is invisible to both
+  # /releases/latest and the releases page, so nothing can prompt a user to
+  # download a version whose asset set is incomplete or whose notes are still
+  # empty. Publishing is the release skill's job — it verifies the six assets and
+  # writes the body first, then flips the draft. See .claude/skills/release/SKILL.md.
+  draft-release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+
+      # Reuse an existing release rather than failing: re-triggering a tag
+      # (force-push after a fixed platform) must top up the same draft. If the
+      # release was already published, --clobber just replaces its assets and it
+      # stays published.
+      #
+      # Existence is probed with `release list`, not `release view`: GitHub's
+      # get-release-by-tag endpoint does not return drafts, so a view-based check
+      # could miss the very draft a previous run left behind and create a second
+      # one (GitHub happily allows duplicate drafts on one tag).
+      - name: Assemble the draft release
+        run: |
+          set -euo pipefail
+          # Captured into a variable, not piped into `grep -q`: -q exits on the
+          # first match, and the resulting SIGPIPE would make `pipefail` report
+          # the pipeline as failed — i.e. "found" would read as "not found".
+          # `release list` includes drafts (cf. its --exclude-drafts flag).
+          EXISTING=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 \
+            --json tagName -q '.[].tagName')
+          if grep -Fxq "$GITHUB_REF_NAME" <<<"$EXISTING"; then
+            echo "release $GITHUB_REF_NAME already exists; reusing it"
+          else
+            gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
+              --draft --title "$GITHUB_REF_NAME" --notes ""
+          fi
+          gh release upload "$GITHUB_REF_NAME" dist/* --clobber --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
Stop advertising a release before all four platforms have finished building it.

## The problem

The `Release` step ran inside the build matrix, so **each of the four platform jobs published its own slice** of the release. `softprops/action-gh-release` defaults to `draft: false` / `make_latest: true`, so the first job to finish created a *published* release carrying only its own assets — and that release immediately became `/releases/latest`.

`src/core/update.rs` polls exactly that endpoint on startup and pops a modal. The result was a window, minutes wide, where users were told to download a release whose assets were still being built. macOS was worst hit: notarization makes it the slowest platform, so macOS users could open the releases page and find no `.dmg` at all. The release body was empty too — the skill writes it by hand afterwards.

With `fail-fast: false`, a permanently failing platform left that gap open indefinitely.

## Before / After

| | Before | After |
|---|---|---|
| Who creates the release | Each of the 4 build jobs | One `draft-release` job, after all 4 pass |
| Release state on creation | Published + Latest | **Draft** |
| Visible to `/releases/latest` | The moment the fastest job finished | Only once published by hand |
| Assets at that moment | One platform's slice | All six |
| Release body at that moment | Empty | Written before publishing |
| One platform fails | Release published anyway, permanently missing assets | No release object created at all |
| Re-triggering a tag | Succeeding platforms re-upload over a live release | Tops up the invisible draft |

## Flow

```mermaid
flowchart LR
  subgraph before["Before — 4 publishers, first one wins"]
    B1[macOS arm64] --> BR[("Release<br/>published + latest")]
    B2[macOS x86_64] --> BR
    B3[Linux] --> BR
    B4[Windows] --> BR
    BR -.->|"/releases/latest<br/>partial assets"| BU[update prompt]
  end
  subgraph after["After — assemble once, publish by hand"]
    A1[macOS arm64] --> AA
    A2[macOS x86_64] --> AA
    A3[Linux] --> AA
    A4[Windows] --> AA
    AA["draft-release<br/>(needs: build)"] --> AD[("Release<br/>draft")]
    AD -.->|invisible| AU[no prompt]
    AD ==>|"manual publish<br/>after verify + notes"| AP[("published + latest")]
  end
```

## Changes

- Build jobs drop `softprops/action-gh-release` and `upload-artifact` their bundles instead (same glob list — the bundle scripts leave intermediates in `dist/` that must not ship).
- New `draft-release` job: `needs: build`, downloads all artifacts with `merge-multiple`, creates the release as a draft and uploads all six assets in one go.
- Publishing moves to the release skill (`gh release edit --draft=false --latest`), after it has verified the assets and written the notes.

This is the shape `nightly.yml` already used — build → `upload-artifact` → a single all-or-nothing publish job. The two workflows now match, which the release skill's "keep both in sync" note asks for.

Two details worth flagging in review:

- Existence is probed with `gh release list`, not `gh release view`. GitHub's get-release-by-tag endpoint doesn't return drafts, so a view-based check could miss the draft a previous run left behind and create a **second** one — GitHub allows duplicate drafts on a single tag.
- The result is captured into a variable rather than piped into `grep -q`. `-q` exits on first match, and the resulting SIGPIPE under `set -o pipefail` would report the pipeline as failed — turning "found" into "not found", which is precisely what triggers the duplicate-draft case above.

## Testing

- `actionlint` (with its bundled shellcheck) clean on `release.yml` and `nightly.yml`.
- The assemble script was extracted and run against a mock `gh` covering three branches: existing tag → reuse without creating; new tag → create draft; and `v26.7.40` present while releasing `v26.7.4` → correctly treated as absent (`grep -Fx` exact-line match).
- Not exercised end-to-end — the real path only runs on a `v*` tag push, so the next release is the first live run. `draft-release` failing is non-destructive: no release object is created and nothing is published.

## Note for whoever cuts the next release

**CI finishing no longer means the release is out.** It leaves a draft; publishing is now an explicit final step. The local release skill has been updated to match (verify assets → write notes → publish), and its description mentions a release "still sitting as a draft" so the case is recoverable if the step is missed.
