### PR TITLE
fix(macos): seed UTF-8 locale for GUI-launched shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **tmux keeps UTF-8 output when tty7 is launched from Finder/Dock** — macOS
+  GUI launches can omit every locale variable, which makes tmux deliberately
+  replace each Unicode display cell with `_`. New shells now receive the
+  macOS `UTF-8` character locale only when no inherited or configured locale
+  exists; explicit locale choices remain untouched.
+
 ## [26.7.3] - 2026-07-25
 
 ### Added

--- a/src/daemon/pane.rs
+++ b/src/daemon/pane.rs
@@ -309,25 +309,20 @@ fn initial_working_directory(cwd: Option<PathBuf>) -> Option<PathBuf> {
         .find(|d| d.is_dir())
 }
 
-/// Whether the effective child environment leaves every locale selector empty.
+/// Whether a GUI-launched child needs tty7 to supply a character locale.
 ///
-/// `extra_env` has the same precedence it gets at spawn: a configured value,
-/// including an explicitly empty one, overrides the daemon's inherited value.
 /// tmux checks these variables in this exact order to decide whether its client
-/// supports UTF-8; when all three are empty it deliberately renders each Unicode
-/// cell as `_`.
+/// supports UTF-8; when all three are absent or empty it deliberately renders
+/// each Unicode cell as `_`. Any configured locale key is authoritative, even
+/// when its value is empty, so the generic `env` override remains capable of
+/// opting out of this fallback.
 #[cfg(any(target_os = "macos", test))]
-fn locale_environment_is_empty(
+fn locale_fallback_is_needed(
     extra_env: &std::collections::HashMap<String, String>,
     mut inherited: impl FnMut(&str) -> Option<String>,
 ) -> bool {
     ["LC_ALL", "LC_CTYPE", "LANG"].iter().all(|key| {
-        extra_env
-            .get(*key)
-            .cloned()
-            .or_else(|| inherited(key))
-            .as_deref()
-            .map_or(true, str::is_empty)
+        !extra_env.contains_key(*key) && inherited(key).as_deref().map_or(true, str::is_empty)
     })
 }
 
@@ -361,10 +356,10 @@ fn apply_common_command_setup(cmd: &mut CommandBuilder, initial_cwd: &Option<Pat
     // environment as a non-UTF-8 terminal and substitutes one `_` per display
     // cell. Seed only LC_CTYPE (the macOS `UTF-8` locale alias) so character
     // handling is correct without changing message/date/number localization.
-    // Respect any non-empty inherited or user-configured locale, including an
-    // explicit `C`; configured empty values are absence, so repair them too.
+    // Respect any inherited non-empty locale and every user-configured locale
+    // key, including `C` or an empty value used to opt out of the fallback.
     #[cfg(target_os = "macos")]
-    if locale_environment_is_empty(&extra_env, |key| std::env::var(key).ok()) {
+    if locale_fallback_is_needed(&extra_env, |key| std::env::var(key).ok()) {
         cmd.env("LC_CTYPE", "UTF-8");
     }
 }
@@ -3573,30 +3568,33 @@ mod tests {
         assert!(dead_rx.try_recv().is_err(), "on_dead must fire only once");
     }
 
-    /// The macOS UTF-8 fallback applies only when the child would otherwise have
-    /// no locale at all. An inherited or config-provided value is authoritative;
-    /// an explicit empty config value masks the inherited one just as it does at
-    /// spawn, allowing the fallback to repair the resulting empty environment.
+    /// The macOS UTF-8 fallback applies only when the inherited environment has
+    /// no locale and the user has not taken control through the generic `env`
+    /// map. Key presence is authoritative there, including an empty value.
     #[test]
-    fn locale_fallback_respects_the_effective_child_environment() {
-        let inherited = |pairs: &[(&str, &str)]| {
+    fn locale_fallback_respects_inherited_and_configured_environments() {
+        let environment = |pairs: &[(&str, &str)]| {
             pairs
                 .iter()
                 .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
                 .collect::<std::collections::HashMap<_, _>>()
         };
-        let is_empty = |extra: &[(&str, &str)], parent: &[(&str, &str)]| {
-            let extra = inherited(extra);
-            let parent = inherited(parent);
-            locale_environment_is_empty(&extra, |key| parent.get(key).cloned())
+        let fallback_is_needed = |extra: &[(&str, &str)], parent: &[(&str, &str)]| {
+            let extra = environment(extra);
+            let parent = environment(parent);
+            locale_fallback_is_needed(&extra, |key| parent.get(key).cloned())
         };
 
-        assert!(is_empty(&[], &[]));
-        assert!(is_empty(&[("LC_CTYPE", "")], &[]));
-        assert!(is_empty(&[("LANG", "")], &[("LANG", "en_US.UTF-8")]));
-        assert!(!is_empty(&[], &[("LANG", "en_US.UTF-8")]));
-        assert!(!is_empty(&[], &[("LC_ALL", "C")]));
-        assert!(!is_empty(&[("LC_CTYPE", "UTF-8")], &[]));
+        assert!(fallback_is_needed(&[], &[]));
+        assert!(fallback_is_needed(&[], &[("LANG", "")]));
+        assert!(!fallback_is_needed(&[], &[("LANG", "en_US.UTF-8")]));
+        assert!(!fallback_is_needed(&[], &[("LC_ALL", "C")]));
+        assert!(!fallback_is_needed(&[("LC_CTYPE", "UTF-8")], &[]));
+        assert!(!fallback_is_needed(&[("LC_CTYPE", "")], &[]));
+        assert!(!fallback_is_needed(
+            &[("LANG", "")],
+            &[("LANG", "en_US.UTF-8")]
+        ));
     }
 
     /// Every spawned shell carries the `TTY7` marker, so the `tty7 agent-hook`

--- a/src/daemon/pane.rs
+++ b/src/daemon/pane.rs
@@ -309,6 +309,28 @@ fn initial_working_directory(cwd: Option<PathBuf>) -> Option<PathBuf> {
         .find(|d| d.is_dir())
 }
 
+/// Whether the effective child environment leaves every locale selector empty.
+///
+/// `extra_env` has the same precedence it gets at spawn: a configured value,
+/// including an explicitly empty one, overrides the daemon's inherited value.
+/// tmux checks these variables in this exact order to decide whether its client
+/// supports UTF-8; when all three are empty it deliberately renders each Unicode
+/// cell as `_`.
+#[cfg(any(target_os = "macos", test))]
+fn locale_environment_is_empty(
+    extra_env: &std::collections::HashMap<String, String>,
+    mut inherited: impl FnMut(&str) -> Option<String>,
+) -> bool {
+    ["LC_ALL", "LC_CTYPE", "LANG"].iter().all(|key| {
+        extra_env
+            .get(*key)
+            .cloned()
+            .or_else(|| inherited(key))
+            .as_deref()
+            .map_or(true, str::is_empty)
+    })
+}
+
 fn apply_common_command_setup(cmd: &mut CommandBuilder, initial_cwd: &Option<PathBuf>) {
     if let Some(dir) = initial_cwd {
         cmd.cwd(dir);
@@ -324,13 +346,26 @@ fn apply_common_command_setup(cmd: &mut CommandBuilder, initial_cwd: &Option<Pat
         crate::core::agent_hooks::TTY7_ENV_MARKER,
         env!("CARGO_PKG_VERSION"),
     );
-    // User-configured environment variables, injected last so they can override
-    // the inherited environment (but not TERM/COLORTERM above, which reflect our
-    // emulator's real capabilities).
-    for (k, v) in crate::core::config::extra_env() {
+
+    // User-configured environment variables override inherited values (but not
+    // TERM/COLORTERM above, which reflect our emulator's real capabilities).
+    let extra_env = crate::core::config::extra_env();
+    for (k, v) in &extra_env {
         if k != "TERM" && k != "COLORTERM" {
             cmd.env(k, v);
         }
+    }
+
+    // LaunchServices commonly starts a macOS app with no locale variables at
+    // all. Direct children can still print UTF-8, but tmux interprets that empty
+    // environment as a non-UTF-8 terminal and substitutes one `_` per display
+    // cell. Seed only LC_CTYPE (the macOS `UTF-8` locale alias) so character
+    // handling is correct without changing message/date/number localization.
+    // Respect any non-empty inherited or user-configured locale, including an
+    // explicit `C`; configured empty values are absence, so repair them too.
+    #[cfg(target_os = "macos")]
+    if locale_environment_is_empty(&extra_env, |key| std::env::var(key).ok()) {
+        cmd.env("LC_CTYPE", "UTF-8");
     }
 }
 
@@ -3536,6 +3571,32 @@ mod tests {
 
         assert!(dead_rx.try_recv().is_ok(), "unattached death → on_dead");
         assert!(dead_rx.try_recv().is_err(), "on_dead must fire only once");
+    }
+
+    /// The macOS UTF-8 fallback applies only when the child would otherwise have
+    /// no locale at all. An inherited or config-provided value is authoritative;
+    /// an explicit empty config value masks the inherited one just as it does at
+    /// spawn, allowing the fallback to repair the resulting empty environment.
+    #[test]
+    fn locale_fallback_respects_the_effective_child_environment() {
+        let inherited = |pairs: &[(&str, &str)]| {
+            pairs
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect::<std::collections::HashMap<_, _>>()
+        };
+        let is_empty = |extra: &[(&str, &str)], parent: &[(&str, &str)]| {
+            let extra = inherited(extra);
+            let parent = inherited(parent);
+            locale_environment_is_empty(&extra, |key| parent.get(key).cloned())
+        };
+
+        assert!(is_empty(&[], &[]));
+        assert!(is_empty(&[("LC_CTYPE", "")], &[]));
+        assert!(is_empty(&[("LANG", "")], &[("LANG", "en_US.UTF-8")]));
+        assert!(!is_empty(&[], &[("LANG", "en_US.UTF-8")]));
+        assert!(!is_empty(&[], &[("LC_ALL", "C")]));
+        assert!(!is_empty(&[("LC_CTYPE", "UTF-8")], &[]));
     }
 
     /// Every spawned shell carries the `TTY7` marker, so the `tty7 agent-hook`


### PR DESCRIPTION
## Summary

- detect whether `LC_ALL` / `LC_CTYPE` / `LANG` are absent from the GUI-launched environment
- on macOS, seed `LC_CTYPE=UTF-8` only when no inherited locale exists and the user has not configured any locale key
- preserve every explicit locale override, including `C` and empty values, and document the fix in the changelog

## Why

LaunchServices can start the tty7 GUI and detached daemon without any locale variables. tmux uses those variables to set its client UTF-8 capability; without it, tmux deliberately replaces every non-ASCII display cell with `_`. tty7 already advertises `TERM=xterm-256color` and truecolor, but did not establish the corresponding character locale for GUI-launched shells.

Using the macOS `UTF-8` alias for `LC_CTYPE` fixes character handling without changing message, date, or number localization. The existing generic `env` config remains authoritative: the fallback does not override a configured locale key, even if its value is intentionally empty.

## Verification

- `cargo fmt --check`
- `cargo +1.97.1 test --locked locale_fallback_respects_inherited_and_configured_environments`
- unit coverage added for missing, inherited, configured, explicitly empty, and explicit `C` locale environments
- live environment evidence: both the tty7 GUI and daemon launched from `/Applications/tty7.app` inherited `HOME` but no `LC_ALL`, `LC_CTYPE`, or `LANG`
