### PR TITLE
fix(chrome): soften idle chrome-tile glyphs to the sidebar's ink weight

### DIFF
--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -165,12 +165,24 @@ impl Render for DragTab {
 /// use. (Overriding just the hover from outside doesn't work: `Button` applies
 /// its own `.hover()` during render, after any the caller set.)
 pub(crate) fn chrome_tile_variant(cx: &gpui::App) -> ButtonCustomVariant {
+    chrome_tile_variant_for(false, cx)
+}
+
+/// The tile's paint, with the glyph weight that matches its state.
+///
+/// At rest the glyphs sit at `sidebar_foreground` — the same step the tab
+/// rail's inactive rows use. Full `foreground` (#111 on white) was a hard,
+/// near-black row of ink against the near-white bar around it: the darkest
+/// treatment in the window sitting on its lightest surface. A lit toggle still
+/// gets full strength, so "on" reads as both a filled capsule *and* darker ink.
+pub(crate) fn chrome_tile_variant_for(selected: bool, cx: &gpui::App) -> ButtonCustomVariant {
     ButtonCustomVariant::new(cx)
         .color(cx.theme().transparent)
-        // Full `foreground`, not the softer `secondary_foreground`: the chrome
-        // glyphs read as deliberate controls rather than faint hints — the
-        // "commercial-app" weight, paired with the filled dock icons below.
-        .foreground(cx.theme().foreground)
+        .foreground(if selected {
+            cx.theme().foreground
+        } else {
+            cx.theme().sidebar_foreground
+        })
         // The sidebar's own selected-row fill (a 12% mix, ≈#E2E2E2 on white) at
         // full strength: every icon tile in the chrome answers the pointer with
         // the exact grey the rows do. It used to be that grey at 55% opacity,
@@ -211,7 +223,7 @@ pub(crate) fn chrome_tile_sized(
     cx: &gpui::App,
 ) -> Button {
     button
-        .custom(chrome_tile_variant(cx))
+        .custom(chrome_tile_variant_for(selected, cx))
         .selected(selected)
         .with_size(px(glyph / BUTTON_ICON_SCALE))
         .w(px(tile))


### PR DESCRIPTION
Idle chrome tiles (title-bar toggles, panel tabs, `+`, sidebar toggle, and their siblings across the app) now paint their glyph at the sidebar's ink weight instead of full `foreground`; a selected tile keeps full strength.

| | Before | After |
|---|---|---|
| Idle chrome-tile glyph | `foreground` — `#111111` on the light theme | `sidebar_foreground` — `#545454` |
| Selected chrome-tile glyph | `foreground` | `foreground` (unchanged) |
| What says a tile is "on" | The filled grey capsule alone — every glyph was the same near-black | The filled capsule **and** a step darker ink |
| Tile fills (rest / hover / selected) | transparent / `sidebar_accent` / `sidebar_accent` | unchanged |

## Why

`foreground` was the darkest ink treatment in the window, and the chrome sits on its lightest surface. That put the title bar a full step darker than the tab rail's inactive rows (`sidebar_foreground`) and two steps darker than every other secondary icon (`muted_foreground`) — a hard black row against the soft greys it neighbours. Dropping idle tiles to the rail's own step puts the chrome in the same language as the rest of the window, and reserving full strength for the selected tile gives the toggle state a second, redundant cue.

Both values are theme tokens derived by `Theme::neutrals`, so the relationship holds on dark themes too.

## Scope

`chrome_tile_variant` is shared, so this moves every chrome tile, not only the title bar: `tab_strip`, `tab_sidebar`, `right_panel`, `diff_overlay`, `sftp`, `forwards`, and the `code_editor` status bar. That is intentional — they are one control language and should not drift apart.

## Testing

- `cargo build` clean (only the two pre-existing `shell_integration` dead-code warnings).
- Manual verification in an isolated dev instance (`--config-dir` scratch, own daemon), light theme:
  - Title-bar row with the right panel open: the INFO tab and the panel toggle read as selected (dark ink + capsule) while list / git-branch / folder recede — previously all five were the same near-black and only the capsule distinguished them.
  - Left `+` and the sidebar toggle soften with them.
  - No change to hover/pressed fills, tile geometry, or glyph size.
