### PR TITLE
fix(linux): stop `theme_follow_system` from panicking every launch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -358,6 +358,10 @@ fn main() {
             set_dock_icon_for_bare_binary();
             // Load user config once and stash it as a global for views to read.
             cx.set_global(Config::load());
+            // Seed the cached OS light/dark appearance before anything resolves a
+            // theme from it. It has to be read here, off the appearance-observer
+            // path — see `ui::theme::SystemAppearance`.
+            crate::ui::theme::refresh_system_appearance(cx);
             // Read `session.json` (migrating a pre-multi-window file) before any
             // window is built: windows claim their workspace from this store
             // rather than each parsing the file themselves. It also dedupes

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -807,6 +807,12 @@ impl Tty7App {
         // to the theme — skip, or the pin would re-trigger a redundant apply.
         let this = cx.weak_entity();
         let appearance_watch = window.observe_window_appearance(move |window, cx| {
+            // This is the only place the OS flip is observed, so cache it here —
+            // from the *window*, never `cx.window_appearance()`, which would
+            // re-enter gpui's already-borrowed Linux client and panic. Before the
+            // early return, so a flip that happens while following is off still
+            // lands. See `ui::theme::SystemAppearance`.
+            crate::ui::theme::note_system_appearance(window, cx);
             if !cx.global::<Config>().theme_follow_system {
                 return;
             }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -248,15 +248,60 @@ pub(crate) fn window_background(bg: &presets::ActiveBackground) -> Background {
     }
 }
 
-/// Whether the OS is currently in dark mode, as gpui reports it. Only
-/// meaningful while the native appearance isn't pinned (see
+/// The OS light/dark appearance, cached as a global rather than asked of the
+/// platform on demand.
+///
+/// gpui's Linux backends dispatch a window's appearance-changed callback while
+/// the platform client's `RefCell` is *already* mutably borrowed: both the
+/// Wayland and X11 XDP handlers hold `client.borrow_mut()` across
+/// `set_appearance`, which invokes the callback synchronously. `window_appearance`
+/// re-borrows that same cell, so calling it from inside an appearance observer
+/// panics with "RefCell already borrowed". The portal source emits one appearance
+/// event during startup, which made `theme_follow_system: true` — the only path
+/// that reads the OS appearance from that observer — panic on *every* launch.
+///
+/// `Window::appearance()` reads the window's own cell instead, and that borrow is
+/// released before the callback runs. So the observer caches what the window
+/// reports and every other caller reads the cache. (Zed keeps a `SystemAppearance`
+/// global for the same reason.)
+#[derive(Clone, Copy)]
+pub(crate) struct SystemAppearance {
+    dark: bool,
+}
+
+impl gpui::Global for SystemAppearance {}
+
+fn is_dark(appearance: gpui::WindowAppearance) -> bool {
+    matches!(
+        appearance,
+        gpui::WindowAppearance::Dark | gpui::WindowAppearance::VibrantDark
+    )
+}
+
+/// Seed [`SystemAppearance`] from the platform. Only safe *off* the
+/// appearance-observer path (see the type's note): at startup, and on macOS right
+/// after the native pin is released.
+pub(crate) fn refresh_system_appearance(cx: &mut App) {
+    let dark = is_dark(cx.window_appearance());
+    cx.set_global(SystemAppearance { dark });
+}
+
+/// Cache the appearance a window just reported. This is the observer-safe update
+/// — the one that runs on an actual OS light/dark flip.
+pub(crate) fn note_system_appearance(window: &Window, cx: &mut App) {
+    let dark = is_dark(window.appearance());
+    cx.set_global(SystemAppearance { dark });
+}
+
+/// Whether the OS is currently in dark mode, per the cached [`SystemAppearance`].
+/// Only meaningful while the native appearance isn't pinned (see
 /// [`sync_native_appearance`]) — a pinned appearance reports the pin, not the
 /// OS setting, which is why callers gate on `Config::theme_follow_system`.
 pub(crate) fn system_dark(cx: &App) -> bool {
-    matches!(
-        cx.window_appearance(),
-        gpui::WindowAppearance::Dark | gpui::WindowAppearance::VibrantDark
-    )
+    // Unset only before startup seeds it, i.e. before any theme resolves; light
+    // is the same default the config ships.
+    cx.try_global::<SystemAppearance>()
+        .is_some_and(|appearance| appearance.dark)
 }
 
 /// The id of the theme that should be on screen right now: the light/dark
@@ -300,6 +345,13 @@ pub(crate) fn apply_theme(mut window: Option<&mut Window>, cx: &mut App) {
     // until the pin is cleared.
     if follow {
         sync_native_appearance(None);
+        // The cache may still hold the pin that call just released (the observer
+        // caches whatever the window reports, pin included), so re-read it from
+        // the platform. macOS-only on both counts: nothing pins the appearance
+        // elsewhere, and this is exactly the platform read that would re-enter
+        // gpui's borrowed Linux client — see [`SystemAppearance`].
+        #[cfg(target_os = "macos")]
+        refresh_system_appearance(cx);
     }
     let theme = presets::by_id(cx, &effective_preset_id(cx));
     let config = cx.global::<Config>();
@@ -516,3 +568,38 @@ fn sync_native_appearance(dark: Option<bool>) {
 
 #[cfg(not(target_os = "macos"))]
 fn sync_native_appearance(_dark: Option<bool>) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::TestAppContext;
+
+    /// The follow-system slot has to come from the cached [`SystemAppearance`],
+    /// not from a fresh `cx.window_appearance()` — that read is what re-enters
+    /// gpui's borrowed Linux client and panics inside the appearance observer.
+    /// The test platform always reports `Light`, so the dark half only passes
+    /// while the cache is what's consulted.
+    #[gpui::test]
+    fn effective_preset_follows_the_cached_system_appearance(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            cx.set_global(Config {
+                theme_follow_system: true,
+                theme_preset_light: "light-slot".into(),
+                theme_preset_dark: "dark-slot".into(),
+                ..Config::default()
+            });
+
+            cx.set_global(SystemAppearance { dark: false });
+            assert!(!system_dark(cx));
+            assert_eq!(effective_preset_id(cx), "light-slot");
+
+            cx.set_global(SystemAppearance { dark: true });
+            assert!(system_dark(cx));
+            assert_eq!(effective_preset_id(cx), "dark-slot");
+
+            // Following off, the manual preset wins whatever the OS is doing.
+            cx.global_mut::<Config>().theme_follow_system = false;
+            assert_eq!(effective_preset_id(cx), Config::default().theme_preset);
+        });
+    }
+}


### PR DESCRIPTION
Fixes #179.

## What happens

On Linux, `"theme_follow_system": true` panics the app on launch — every launch, on both the Wayland and X11 backends:

```
thread 'main' panicked at gpui_linux/src/linux/wayland/client.rs:924:23:
RefCell already borrowed
```

Because the setting is persisted as soon as the user flips "sync with system" on in Settings → Appearance, this bricks the app until `config.json` is hand-edited back — and the panic points at gpui internals, with nothing to connect it to the theme toggle.

## Why

gpui's Linux backends dispatch a window's appearance-changed callback while the platform client's `RefCell` is **already mutably borrowed**. Both XDP handlers hold the borrow across `set_appearance`, which invokes the callback synchronously:

- `wayland/client.rs` — `let mut client = client.borrow_mut(); … window.set_appearance(appearance)`
- `x11/client.rs` — `for window in client.0.borrow_mut().windows.values_mut() { … set_appearance(…) }`

`cx.window_appearance()` re-borrows that same cell (`platform.rs` → `with_common` → `self.0.borrow_mut()`, i.e. the exact `client.rs:924` / `client.rs:1520` in the reports).

Our observer went straight into that read:

`observe_window_appearance` → `apply_theme` → `effective_preset_id` → `system_dark` → `cx.window_appearance()` → 💥

Two things follow, and both match the reporter's bisect exactly:

- **Only while following the system.** With the setting off, the observer returns before ever touching the appearance, so a default install is fine.
- **Every launch, deterministically.** The XDG portal source emits one appearance event during startup, so the re-entrant callback always fires.

macOS/Windows don't route `window_appearance` through a shared `RefCell`, hence Linux-only.

## The fix

Cache the OS appearance in a `SystemAppearance` global instead of asking the platform on demand:

- the observer fills it from `Window::appearance()` — the window's own cell, whose borrow *is* released before the callback runs
- `system_dark` reads the cache, so nothing on the re-entrant path touches the client
- the cache updates before the `theme_follow_system` early return, so a flip that happens while following is off still lands
- macOS re-seeds from the platform right after `apply_theme` releases the native appearance pin — until then the window reports the pin, not the OS setting (the existing `sync_native_appearance` invariant, unchanged)

This is the same shape as Zed's own `SystemAppearance` global, and gpui-component moved to `window.appearance()` over this identical Linux panic (longbridge/gpui-component#104).

## Testing

- `cargo test --locked` — 834 pass (Windows). New test `effective_preset_follows_the_cached_system_appearance` covers the light/dark slot resolution; it fails if `system_dark` goes back to reading the platform (the test platform always reports `Light`), which is the regression that matters.
- `cargo fmt --check` clean.
- **Not verified on a real Linux desktop** — no Linux machine here, so the runtime path is reasoned from the gpui source at the pinned rev plus CI. Worth a manual smoke test on Wayland with `theme_follow_system: true` before merge, including an actual OS light/dark flip.

Separately worth reporting upstream: gpui should drop the client borrow before dispatching `set_appearance` / `set_button_layout` callbacks — any app that reads platform state from those observers hits this.
