### PR TITLE
fix(deps): pin a patched alacritty to survive deep keyboard-mode pushes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "alacritty_terminal"
 version = "0.26.1-dev"
-source = "git+https://github.com/zed-industries/alacritty?rev=fcf32feacb367b75ec84dd40f041e4fd411d3cc1#fcf32feacb367b75ec84dd40f041e4fd411d3cc1"
+source = "git+https://github.com/l0ng-ai/alacritty?rev=22b1d74842732f6ea30d8f4eec768b3ac659d0b6#22b1d74842732f6ea30d8f4eec768b3ac659d0b6"
 dependencies = [
  "base64",
  "bitflags 2.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,10 +65,19 @@ image = "0.25"
 # to gpui's rev so the shared `http_client`/`zed-reqwest` versions stay aligned.
 reqwest_client = { git = "https://github.com/zed-industries/zed", rev = "1d217ee39d381ac101b7cf49d3d22451ac1093fe" }
 
-# Zed's fork of alacritty_terminal — same rev Zed pins. Used by the *client*
+# Our fork of Zed's alacritty_terminal fork. Used by the *client*
 # (`terminal::remote`) for the VT parser + grid (`Term`/`ansi::Processor`) that
 # renders the mirror. The daemon's PTY itself is driven by `portable-pty` below.
-alacritty_terminal = { git = "https://github.com/zed-industries/alacritty", rev = "fcf32feacb367b75ec84dd40f041e4fd411d3cc1" }
+#
+# The `tty7` branch is Zed's `fcf32fe` (the rev Zed pins) plus one commit:
+# `push_keyboard_mode` capped its stack by removing from `title_stack` instead of
+# `keyboard_mode_stack` — a copy-paste slip from `push_title` that compiles because
+# both are `Vec`s. With `kitty_keyboard` on (see `terminal_config_from_user`) every
+# overflowing push silently drops a saved title, and once the title stack is empty
+# `Vec::remove(0)` panics — 4097 unpopped `CSI > 1 u` pushes, about 20KB of output,
+# kill the reader thread and freeze the pane. Still present on alacritty master as
+# of 852e971; drop this fork once it lands upstream.
+alacritty_terminal = { git = "https://github.com/l0ng-ai/alacritty", rev = "22b1d74842732f6ea30d8f4eec768b3ac659d0b6" }
 
 # Desktop notifications driven by OSC 9 / OSC 777 escape sequences. Cross-platform;
 # the macOS backend uses the deprecated NSUserNotification (weak — a completion

--- a/src/terminal/remote.rs
+++ b/src/terminal/remote.rs
@@ -1692,6 +1692,46 @@ mod tests {
         );
     }
 
+    /// Guards the `alacritty_terminal` pin, not our own code. Upstream's
+    /// `push_keyboard_mode` trims its stack by removing from `title_stack` — a
+    /// copy-paste slip from `push_title` — so once the title stack is empty the
+    /// `Vec::remove(0)` panics and takes the reader thread with it. Enabling
+    /// `kitty_keyboard` made that reachable from any foreground program: ~20KB of
+    /// unpopped pushes is enough. Our fork fixes it; a bump back to an unpatched
+    /// rev must fail here rather than in the field.
+    #[test]
+    fn deep_keyboard_mode_pushes_leave_the_reader_alive() {
+        let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
+        let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
+
+        // One past alacritty's KEYBOARD_MODE_STACK_MAX_DEPTH (4096): the push that
+        // overflows is the one that used to panic. The trailing query is the
+        // liveness probe — a dead reader thread simply never answers.
+        let mut payload = b"\x1b[>1u".repeat(4097);
+        payload.extend_from_slice(b"\x1b[?u");
+        DaemonMsg::Output(payload).encode(&mut daemon_side).unwrap();
+        daemon_side.flush().unwrap();
+
+        let mut reply = None;
+        for _ in 0..200 {
+            while let Ok(event) = term.events.try_recv() {
+                if let AlacEvent::PtyWrite(text) = event {
+                    reply = Some(text);
+                }
+            }
+            if reply.is_some() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+
+        assert_eq!(
+            reply.as_deref(),
+            Some("\x1b[?1u"),
+            "the reader thread must survive a deep mode-push run and still answer queries"
+        );
+    }
+
     #[test]
     fn spawn_retry_only_for_daemon_disconnects() {
         let eof: anyhow::Error =


### PR DESCRIPTION
## Background

#184 set `kitty_keyboard: true` so foreground applications can negotiate the Kitty keyboard protocol. That flag also made an upstream `alacritty_terminal` bug reachable for the first time.

`push_keyboard_mode` caps its stack by removing from the **wrong stack**:

```rust
// push_title -- correct
if self.title_stack.len() >= TITLE_STACK_MAX_DEPTH {
    let removed = self.title_stack.remove(0);
}

// push_keyboard_mode -- copied over, variable never changed
if self.keyboard_mode_stack.len() >= KEYBOARD_MODE_STACK_MAX_DEPTH {
    let removed = self.title_stack.remove(0);   // <-- wrong stack
}
```

It compiles because both are `Vec`s and `removed` only feeds a `trace!`.

Before #184 every one of alacritty's kitty handlers returned early on `!config.kitty_keyboard`, so this line was dead. It is now live.

## Impact

| | |
|---|---|
| **Panic** | With an empty title stack, `Vec::remove(0)` panics. 4097 unpopped `CSI > 1 u` pushes -- about 20KB of output -- kill the `tty7-remote-reader` thread and freeze the pane. |
| **Silent corruption** | With a non-empty title stack, each overflowing push drops a saved title instead, so a later XTPOPTITLE restores the wrong one. |
| **Cap does nothing** | `keyboard_mode_stack` is never trimmed, so it grows unbounded either way. |

This does not require hostile output. A TUI that pushes without popping -- per redraw, per keypress -- reaches 4096 on its own in a long session. Untrusted output (`cat` of a crafted file, a remote host over SSH) gets there in one burst.

## Change

- Pin `alacritty_terminal` to `l0ng-ai/alacritty`, branch `tty7` = Zed's `fcf32fe` (the rev we were already on) plus one commit: `title_stack` → `keyboard_mode_stack`.
- Add a regression test that pushes past the 4096 cap and then issues `CSI ? u`, using the reply as a liveness probe.

No `[patch]` section is needed here. Unlike the gpui pin, tty7 is the only crate in the tree that depends on `alacritty_terminal`, so a plain URL/rev swap cannot split it into two incompatible copies.

## Verification

- `cargo fmt -- --check`
- `cargo test -- kitty deep_keyboard` — 14 passed, 0 failed
- **Negative control**: with the pin reverted to the unpatched `fcf32fe`, the new test fails as intended:

  ```
  thread 'tty7-remote-reader' panicked at .../alacritty_terminal/src/term/mod.rs:1296:44:
  removal index (is 0) should be < len (is 0)

  assertion `left == right` failed: the reader thread must survive a deep mode-push run
    left: None
   right: Some("\u{1b}[?1u")
  ```

  The test guards the pin, not our own code: a future bump back to an unpatched rev fails here instead of in the field.

## Upstream

Still present on `alacritty/alacritty` master as of `852e971`, and no existing issue or PR found. We carry the fix in our own fork rather than waiting on upstream. If it ever does land there, drop the fork and go back to Zed's pin.
