### PR TITLE
feat(ui): stamp a status dot on each window's taskbar button (Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Taskbar status dot** (Windows) — each window's taskbar button now carries
+  a status overlay in the same colors as the in-window dots: blue while a
+  command or agent is working, green when work finished in the background
+  (cleared the moment you activate the window), amber when an agent needs
+  your input. Settings → Window grows a "Taskbar status dot" toggle
+  (`taskbar_status_icon`, on by default). (#199)
+
 ## [26.7.4] - 2026-07-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9568,6 +9568,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "plist",
  "portable-pty",
+ "raw-window-handle",
  "regex",
  "reqwest_client",
  "resvg",
@@ -9582,6 +9583,7 @@ dependencies = [
  "tokio",
  "tray-icon",
  "uuid",
+ "windows 0.61.3",
  "windows-sys 0.59.0",
  "winresource",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,24 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_Threading",
 ] }
 
+# Taskbar overlay badge (`ui::taskbar`): stamps a status dot on the window's
+# taskbar button (busy / finished / agent-needs-input). `SetOverlayIcon` lives
+# on the COM interface `ITaskbarList3`, which `windows-sys` deliberately omits
+# — the full `windows` crate carries it. Pinned to the exact version gpui's
+# Windows backend already builds (see gpui_windows), so this pins no new
+# native code. Windows-only, matching the taskbar it paints.
+windows = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Gdi",
+    "Win32_System_Com",
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
+] }
+# Unwraps gpui's `HasWindowHandle` into the raw Win32 HWND that
+# `SetOverlayIcon` targets. Same version gpui_windows pins — already in the
+# tree, no new native code.
+raw-window-handle = "0.6"
+
 # Embeds `assets/favicon.ico` into the `.exe` so Windows shows the tty7 logo in
 # the taskbar / window / Explorer (macOS gets its icon from the `.app` bundle via
 # bundle.sh instead). Only needed at build time on Windows — see build.rs.

--- a/docs/features.md
+++ b/docs/features.md
@@ -37,6 +37,7 @@ it never wraps or replaces the agent.
 - **Session resume** — panes lost to a reboot re-launch their agent conversation on restore, carrying the original launch flags (`claude --dangerously-skip-permissions --resume …`) (`restore_agent_sessions`, on by default)
 - **Context feed** — palette commands send the current selection or the repo's `git diff` to the running agent as a ready-made prompt
 - **Tray icon** — a system tray / menu bar item that flips to an attention state the moment any agent needs your input; its menu lists every agent pane (brand avatar + status dot, click to reveal), switches the notification policy, and offers *Quit and Stop Daemon* alongside the plain session-keeping quit (`show_tray_icon`, on by default)
+- **Taskbar status dot** (Windows) — each window's taskbar button carries a status overlay in the same colors as the in-window dots: blue while a command or agent is working, green when work finished in the background (cleared the moment you activate the window), amber when an agent needs your input (`taskbar_status_icon`, on by default)
 
 ## SSH
 

--- a/docs/features.zh-CN.md
+++ b/docs/features.zh-CN.md
@@ -36,6 +36,7 @@ Aider、Amp、OpenCode 等约 17 个）并在其外围加功能 —— 绝不包
 - **会话恢复** —— 重启后无法重连的 pane 会自动续上 agent 对话，并带上原始启动 flags（`claude --dangerously-skip-permissions --resume …`；`restore_agent_sessions`，默认开启）
 - **上下文回填** —— 面板命令把当前选区或仓库 `git diff` 打包成 prompt 直接喂给正在跑的 agent
 - **托盘图标** —— 系统托盘 / 菜单栏常驻图标，任何 agent 等你输入时立即切换为提醒态；菜单列出所有 agent pane（品牌头像 + 状态点，点击直达）、可切换通知策略，并在保留会话的普通退出之外提供 *Quit and Stop Daemon*（`show_tray_icon`，默认开启）
+- **任务栏状态点**（Windows）—— 每个窗口的任务栏按钮带一个状态角标，配色与窗口内状态点一致：蓝色表示命令或 agent 正在运行，绿色表示有任务在后台完成（激活窗口即清除），琥珀色表示 agent 等你输入（`taskbar_status_icon`，默认开启）
 
 ## SSH
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -177,6 +177,14 @@ pub struct Config {
     /// second, so toggling it (Settings or a `config.json` edit) applies live.
     #[serde(default = "default_true")]
     pub show_tray_icon: bool,
+    /// Windows: stamp a status dot on each window's taskbar button — amber
+    /// when an agent needs input, blue while a command or agent works, green
+    /// when work finished unfocused (cleared on activation). Colors match the
+    /// in-window status dots. On by default; the overlay poll re-reads this
+    /// every second, so the toggle and a `config.json` hot-reload apply live.
+    /// Ignored off Windows (a macOS Dock badge would be its own setting).
+    #[serde(default = "default_true")]
+    pub taskbar_status_icon: bool,
     /// Whether the user has already been told, once, that closing a window puts
     /// its workspace away rather than ending it. ⌘W is muscle memory and the
     /// result is off-screen, so the first time it happens deserves one line
@@ -561,6 +569,7 @@ impl Default for Config {
             notify_threshold_secs: default_notify_threshold_secs(),
             restore_session: true,
             show_tray_icon: true,
+            taskbar_status_icon: true,
             workspace_detach_hint_seen: false,
             // Visual flash preserves the pre-config behavior (the bell always
             // flashed); opting into None/Audible is a deliberate change.

--- a/src/terminal/remote.rs
+++ b/src/terminal/remote.rs
@@ -947,6 +947,19 @@ impl RemoteTerminal {
             .unwrap_or(false)
     }
 
+    /// Whether the shell is off its prompt running a command. Not simply
+    /// `!at_prompt()`: both answers are gated on `active`, so a pane whose
+    /// shell integration never reported (plain cmd.exe, an ssh without
+    /// OSC 133) reads as neither at the prompt *nor* busy, rather than
+    /// permanently busy. Feeds the Windows taskbar overlay.
+    #[cfg_attr(not(windows), allow(dead_code))]
+    pub fn shell_busy(&self) -> bool {
+        self.shell_state
+            .lock()
+            .map(|s| s.active && !s.at_prompt)
+            .unwrap_or(false)
+    }
+
     /// Monotonic count of `Prompt` reports applied so far — see
     /// [`ShellState::seq`]. Comparing values from before and after a submit
     /// tells whether the shell has reported back since.

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -1203,6 +1203,14 @@ impl TerminalView {
         self.terminal.agent_session()
     }
 
+    /// Whether the shell is off its prompt running a command (see
+    /// [`RemoteTerminal::shell_busy`] for why integration-less panes answer
+    /// `false` rather than "busy forever"). Feeds the Windows taskbar overlay.
+    #[cfg_attr(not(windows), allow(dead_code))]
+    pub fn shell_busy(&self) -> bool {
+        self.terminal.shell_busy()
+    }
+
     /// Whether this pane's finished turn (the green `Done` dot) is unread — a
     /// turn ended that the user hasn't looked at since (see
     /// [`agent_result_unread`](Self::agent_result_unread) field). Feeds the

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -941,6 +941,11 @@ impl Tty7App {
         // clock.
         if !cfg!(test) && crate::ui::windows::WindowRegistry::count(cx) == 0 {
             crate::ui::tray::init(cx);
+            // The taskbar overlay poll is app-wide for the same reason the
+            // tray's is: one task snapshots every window (each window gets
+            // its own badge, but nobody wants N poll loops).
+            #[cfg(windows)]
+            crate::ui::taskbar::init(cx);
         }
         // Discover this machine's shells for the "+" dropdown off the UI thread
         // (the WSL probe on Windows spawns a process, and /etc/shells hits the
@@ -1340,6 +1345,31 @@ impl Tty7App {
             }
         }
         agents
+    }
+
+    /// This window's aggregated signals for the taskbar overlay
+    /// (`ui::taskbar`): whether any agent pane is blocked on the user, and
+    /// whether any pane is still working (an agent mid-turn or a shell off
+    /// its prompt). Same walk as [`agent_rows`](Self::agent_rows), minus the
+    /// per-row detail the tray menu needs.
+    #[cfg(windows)]
+    pub(crate) fn taskbar_signals(&self, cx: &App) -> (bool, bool) {
+        use crate::core::cli_agent::AgentStatus;
+        let (mut attention, mut busy) = (false, false);
+        for tab in &self.tabs {
+            for leaf in tab.pane.leaves() {
+                let view = leaf.read(cx);
+                match view.agent_session().map(|s| s.status) {
+                    Some(AgentStatus::Waiting) => attention = true,
+                    Some(AgentStatus::Working) => busy = true,
+                    _ => {}
+                }
+                if view.shell_busy() {
+                    busy = true;
+                }
+            }
+        }
+        (attention, busy)
     }
 
     /// Apply a tray menu click. Runs on the foreground executor with the
@@ -2519,6 +2549,13 @@ impl Tty7App {
     /// every second, so the icon appears/disappears without a restart.
     pub(crate) fn set_show_tray_icon(&mut self, on: bool, cx: &mut Context<Self>) {
         self.update_config(cx, |cfg| cfg.show_tray_icon = on);
+    }
+
+    /// Toggle the Windows taskbar status dot. Same live-apply story as the
+    /// tray: the overlay poll re-reads the flag every second, and turning it
+    /// off clears any badge already stamped.
+    pub(crate) fn set_taskbar_status_icon(&mut self, on: bool, cx: &mut Context<Self>) {
+        self.update_config(cx, |cfg| cfg.taskbar_status_icon = on);
     }
 
     // ── Input / Mouse setters ───────────────────────────────────────────────

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -26,6 +26,10 @@ pub mod ssh_connect;
 pub mod ssh_prompt;
 pub mod tab_sidebar;
 pub mod tab_strip;
+// Taskbar overlay badges are a Windows concept (`ITaskbarList3`); macOS's
+// Dock badge would be this module's sibling, not its port.
+#[cfg(windows)]
+pub mod taskbar;
 pub mod theme;
 pub mod tray;
 pub mod windows;

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -3331,6 +3331,7 @@ impl Tty7App {
         let restore_session = cfg.restore_session;
         let remember_window_size = cfg.remember_window_size;
         let show_tray_icon = cfg.show_tray_icon;
+        let taskbar_status_icon = cfg.taskbar_status_icon;
         let tab_bar_idx = match cfg.tab_bar_position {
             TabBarPosition::Top => 0,
             TabBarPosition::Left => 1,
@@ -3398,6 +3399,10 @@ impl Tty7App {
         let tray_switch = Switch::new("wt-tray-icon")
             .checked(show_tray_icon)
             .on_click(cx.listener(|this, on: &bool, _w, cx| this.set_show_tray_icon(*on, cx)))
+            .into_any_element();
+        let taskbar_switch = Switch::new("wt-taskbar-status")
+            .checked(taskbar_status_icon)
+            .on_click(cx.listener(|this, on: &bool, _w, cx| this.set_taskbar_status_icon(*on, cx)))
             .into_any_element();
         let startup_radio = self.segmented(
             "wt-startup",
@@ -3487,6 +3492,19 @@ impl Tty7App {
                 tray_switch,
                 cx,
             ))
+            // Windows only: `SetOverlayIcon` is a taskbar concept. The row is
+            // simply absent elsewhere rather than shown disabled — a switch
+            // that can never do anything is noise, not a setting.
+            .children(cfg!(windows).then(|| {
+                self.settings_row(
+                    "Taskbar status dot",
+                    "Badge the taskbar icon with each window's status: blue while a \
+                     command or agent is working, green when one finishes in the \
+                     background, amber when an agent needs your input.",
+                    taskbar_switch,
+                    cx,
+                )
+            }))
             .child(self.section_rule(cx))
             .child(self.section_header("Tabs", cx))
             .child(self.settings_row(

--- a/src/ui/taskbar.rs
+++ b/src/ui/taskbar.rs
@@ -1,0 +1,329 @@
+//! Windows taskbar overlay badge: a status dot stamped on each window's
+//! taskbar button, so a glance at the taskbar answers "is anything running /
+//! finished / stuck waiting on me" while tty7 is in the background.
+//!
+//! Three states, sharing the in-window dot palette (`AgentStatus::dot_rgb`)
+//! so a color never means two things:
+//! - **amber** — a coding agent in this window is blocked on the user
+//!   (same signal as the tray's attention badge);
+//! - **blue** — a shell command or agent is still working;
+//! - **green** — work finished while the window was unfocused; cleared the
+//!   moment the window is activated (once you've seen it, it's done its job).
+//!
+//! Data flow copies `ui::tray`: a foreground task polls once a second,
+//! aggregates each window's panes into an [`Overlay`], diffs against what the
+//! taskbar currently shows, and only calls into COM on a change. The config
+//! flag is re-read every tick, so the Settings toggle and a `config.json`
+//! hot-reload both apply within a second (off clears any stamped badge).
+//!
+//! Windows-only by nature — `SetOverlayIcon` is a taskbar concept. macOS has
+//! the Dock badge as a natural follow-up; on Linux there is no portable
+//! equivalent and the tray badge already covers attention there.
+
+use std::collections::HashMap;
+
+use gpui::App;
+
+use crate::core::cli_agent::AgentStatus;
+use crate::core::config::Config;
+
+/// Same cadence as the tray poll: agent status reaches the views on a 300 ms
+/// timer, so 1 s here keeps the taskbar a hair behind the in-window dots at
+/// negligible cost.
+const POLL: std::time::Duration = std::time::Duration::from_millis(1000);
+
+/// What the badge shows, least to most urgent. Attention outranks Busy
+/// outranks Done, matching the tray's `urgency` ordering — when panes
+/// disagree, the one that needs the user wins the single overlay slot.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum Overlay {
+    #[default]
+    None,
+    /// Work finished while the window was unfocused (green).
+    Done,
+    /// A shell command or agent is still working (blue).
+    Busy,
+    /// An agent is blocked on the user (amber).
+    Attention,
+}
+
+impl Overlay {
+    /// Dot color, borrowed from the in-window status dots so the taskbar
+    /// never invents a fourth meaning for a color.
+    fn rgb(self) -> Option<u32> {
+        match self {
+            Overlay::None => None,
+            Overlay::Done => AgentStatus::Done.dot_rgb(),
+            Overlay::Busy => AgentStatus::Working.dot_rgb(),
+            Overlay::Attention => AgentStatus::Waiting.dot_rgb(),
+        }
+    }
+
+    /// Screen-reader text for the overlay (`SetOverlayIcon`'s accessibility
+    /// description).
+    fn description(self) -> &'static str {
+        match self {
+            Overlay::None => "",
+            Overlay::Done => "command finished",
+            Overlay::Busy => "working",
+            Overlay::Attention => "needs your input",
+        }
+    }
+}
+
+/// Pick the overlay for one window from its aggregated signals.
+fn overlay_for(attention: bool, busy: bool, done_pending: bool) -> Overlay {
+    if attention {
+        Overlay::Attention
+    } else if busy {
+        Overlay::Busy
+    } else if done_pending {
+        Overlay::Done
+    } else {
+        Overlay::None
+    }
+}
+
+/// Per-window memory for the "finished while unfocused" state: `Done` is an
+/// *edge* (busy stopped while the user was elsewhere), not a level, so
+/// someone has to remember the edge until the user looks.
+#[derive(Default)]
+struct Track {
+    was_busy: bool,
+    done_pending: bool,
+}
+
+impl Track {
+    /// Advance one poll tick. Activation clears a pending Done (seen = done);
+    /// a busy→idle transition while unfocused sets it. Ordering matters: an
+    /// active window never *accumulates* a Done, even on the same tick the
+    /// command finishes — the user is looking right at the result.
+    fn advance(&mut self, busy: bool, active: bool) {
+        if active {
+            self.done_pending = false;
+        } else if self.was_busy && !busy {
+            self.done_pending = true;
+        }
+        self.was_busy = busy;
+    }
+}
+
+/// Wire the overlay up: one app-wide poll task, same lifetime story as
+/// `tray::init` (called once, for the first window; lives for the app).
+pub(crate) fn init(cx: &mut App) {
+    cx.spawn(async move |cx| {
+        // COM object + what each taskbar button currently shows. Both live
+        // here, on the foreground executor: `ITaskbarList3` is !Send and the
+        // taskbar wants to be called from the UI thread anyway (gpui already
+        // ran `OleInitialize` on it).
+        let mut taskbar = Taskbar::default();
+        let mut tracks: HashMap<isize, Track> = HashMap::new();
+        let mut shown: HashMap<isize, Overlay> = HashMap::new();
+        loop {
+            cx.background_executor().timer(POLL).await;
+            let wanted = cx.update(|cx| snapshot(&mut tracks, cx));
+            for (hwnd, overlay) in &wanted {
+                if shown.get(hwnd).copied().unwrap_or_default() != *overlay {
+                    taskbar.stamp(*hwnd, *overlay);
+                    shown.insert(*hwnd, *overlay);
+                }
+            }
+            // Windows that closed take their taskbar button (and overlay)
+            // with them — just forget them.
+            shown.retain(|hwnd, _| wanted.iter().any(|(h, _)| h == hwnd));
+        }
+    })
+    .detach();
+}
+
+/// One poll tick: every open window's HWND and the overlay it should show.
+/// With the setting off, every window maps to `Overlay::None` — going through
+/// the normal diff is what *clears* badges stamped before the toggle flipped.
+fn snapshot(tracks: &mut HashMap<isize, Track>, cx: &mut App) -> Vec<(isize, Overlay)> {
+    use crate::ui::windows::WindowRegistry;
+
+    let enabled = cx.global::<Config>().taskbar_status_icon;
+    let mut wanted = Vec::new();
+    for (workspace, weak) in WindowRegistry::open_windows(cx) {
+        let Some(app) = weak.upgrade() else { continue };
+        let Some(handle) = WindowRegistry::window_for(cx, workspace) else {
+            continue;
+        };
+        let Ok((hwnd, active)) = handle.update(cx, |_, window, _| {
+            (win32_hwnd(window), window.is_window_active())
+        }) else {
+            continue;
+        };
+        let Some(hwnd) = hwnd else { continue };
+        let (attention, busy) = app.read(cx).taskbar_signals(cx);
+        let track = tracks.entry(hwnd).or_default();
+        track.advance(busy, active);
+        let overlay = if enabled {
+            overlay_for(attention, busy, track.done_pending)
+        } else {
+            Overlay::None
+        };
+        wanted.push((hwnd, overlay));
+    }
+    tracks.retain(|hwnd, _| wanted.iter().any(|(h, _)| h == hwnd));
+    wanted
+}
+
+/// The window's Win32 handle, unwrapped from gpui's `HasWindowHandle`. `None`
+/// never actually happens on the Windows backend, but degrading to "no badge"
+/// beats unwrapping someone else's platform invariant.
+fn win32_hwnd(window: &gpui::Window) -> Option<isize> {
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+    // Fully qualified: gpui's inherent `Window::window_handle` (the
+    // `AnyWindowHandle`) shadows the `HasWindowHandle` trait method.
+    match HasWindowHandle::window_handle(window).ok()?.as_raw() {
+        RawWindowHandle::Win32(h) => Some(h.hwnd.get()),
+        _ => None,
+    }
+}
+
+/// The COM half: owns the lazily-created `ITaskbarList3` and turns an
+/// [`Overlay`] into a `SetOverlayIcon` call.
+#[derive(Default)]
+struct Taskbar {
+    list: Option<windows::Win32::UI::Shell::ITaskbarList3>,
+    /// One warning per process on create failure, not one per second.
+    create_failed: bool,
+}
+
+impl Taskbar {
+    fn stamp(&mut self, hwnd: isize, overlay: Overlay) {
+        use windows::Win32::Foundation::HWND;
+        use windows::Win32::UI::WindowsAndMessaging::{DestroyIcon, HICON};
+        use windows::core::PCWSTR;
+
+        let Some(list) = self.list() else { return };
+        let hwnd = HWND(hwnd as *mut core::ffi::c_void);
+        // Null icon + null description == clear the overlay slot.
+        let icon = overlay.rgb().and_then(dot_icon);
+        // Keep the wide string alive across the call.
+        let desc: Vec<u16> = overlay.description().encode_utf16().chain([0]).collect();
+        let desc = if icon.is_some() {
+            PCWSTR(desc.as_ptr())
+        } else {
+            PCWSTR::null()
+        };
+        // A dead HWND (window closed between snapshot and stamp) just errors;
+        // nothing to do about it and the button is gone anyway.
+        unsafe {
+            let _ = list.SetOverlayIcon(hwnd, icon.unwrap_or_default(), desc);
+            // The taskbar copies the icon during the call, so ours is free to
+            // go immediately (per the SetOverlayIcon contract) — holding it
+            // longer would leak one GDI handle per status change.
+            if let Some(icon) = icon
+                && icon != HICON::default()
+            {
+                let _ = DestroyIcon(icon);
+            }
+        }
+    }
+
+    fn list(&mut self) -> Option<&windows::Win32::UI::Shell::ITaskbarList3> {
+        use windows::Win32::System::Com::{CLSCTX_ALL, CoCreateInstance};
+        use windows::Win32::UI::Shell::{ITaskbarList3, TaskbarList};
+
+        if self.list.is_none() && !self.create_failed {
+            // gpui's Windows platform already ran `OleInitialize` on this
+            // thread, so plain creation is all that's needed.
+            let created: Result<ITaskbarList3, _> =
+                unsafe { CoCreateInstance(&TaskbarList, None, CLSCTX_ALL) };
+            match created.and_then(|list| unsafe { list.HrInit() }.map(|()| list)) {
+                Ok(list) => self.list = Some(list),
+                Err(e) => {
+                    // Explorer not running (custom shells) is the realistic
+                    // cause; the app is fine without a badge.
+                    log::warn!("taskbar overlay unavailable: {e}");
+                    self.create_failed = true;
+                }
+            }
+        }
+        self.list.as_ref()
+    }
+}
+
+/// Render the status dot as a 16×16 `HICON`: a solid antialiased disc on a
+/// transparent field. Drawn by hand — at 16px a circle needs no SVG pipeline,
+/// and the alpha channel of a 32-bit icon carries the antialiasing.
+fn dot_icon(rgb: u32) -> Option<windows::Win32::UI::WindowsAndMessaging::HICON> {
+    use windows::Win32::UI::WindowsAndMessaging::CreateIcon;
+
+    const S: usize = 16;
+    let (r, g, b) = ((rgb >> 16) as u8, (rgb >> 8) as u8, rgb as u8);
+    // BGRA, straight (non-premultiplied) alpha — the layout `CreateIcon`
+    // expects for 32-bit XOR bits.
+    let mut xor = vec![0u8; S * S * 4];
+    for y in 0..S {
+        for x in 0..S {
+            let dx = x as f32 - 7.5;
+            let dy = y as f32 - 7.5;
+            // Disc of radius 6.5 with a 1px antialiased rim: alpha ramps
+            // linearly over the last pixel of distance.
+            let a = (7.0 - (dx * dx + dy * dy).sqrt()).clamp(0.0, 1.0);
+            if a > 0.0 {
+                let i = (y * S + x) * 4;
+                xor[i] = b;
+                xor[i + 1] = g;
+                xor[i + 2] = r;
+                xor[i + 3] = (a * 255.0) as u8;
+            }
+        }
+    }
+    // The AND mask is vestigial for 32-bit icons (alpha wins), but CreateIcon
+    // still demands one bit per pixel.
+    let and = [0u8; S * S / 8];
+    unsafe { CreateIcon(None, S as i32, S as i32, 1, 32, and.as_ptr(), xor.as_ptr()) }.ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overlay_priority_is_attention_busy_done() {
+        assert_eq!(overlay_for(true, true, true), Overlay::Attention);
+        assert_eq!(overlay_for(false, true, true), Overlay::Busy);
+        assert_eq!(overlay_for(false, false, true), Overlay::Done);
+        assert_eq!(overlay_for(false, false, false), Overlay::None);
+    }
+
+    #[test]
+    fn done_arms_only_on_a_busy_edge_while_unfocused() {
+        let mut t = Track::default();
+        // Command runs and finishes with the window focused: never Done.
+        t.advance(true, true);
+        t.advance(false, true);
+        assert!(!t.done_pending);
+        // Runs focused, finishes unfocused: Done.
+        t.advance(true, true);
+        t.advance(true, false);
+        t.advance(false, false);
+        assert!(t.done_pending);
+        // Sticks while unfocused, even as new work starts and stops…
+        t.advance(true, false);
+        assert!(t.done_pending);
+        // …and clears the moment the window is activated.
+        t.advance(false, true);
+        assert!(!t.done_pending);
+    }
+
+    #[test]
+    fn idle_unfocused_window_never_arms_done() {
+        let mut t = Track::default();
+        t.advance(false, false);
+        t.advance(false, false);
+        assert!(!t.done_pending);
+    }
+
+    #[test]
+    fn overlay_colors_track_the_shared_dot_palette() {
+        assert_eq!(Overlay::Busy.rgb(), AgentStatus::Working.dot_rgb());
+        assert_eq!(Overlay::Attention.rgb(), AgentStatus::Waiting.dot_rgb());
+        assert_eq!(Overlay::Done.rgb(), AgentStatus::Done.dot_rgb());
+        assert_eq!(Overlay::None.rgb(), None);
+    }
+}


### PR DESCRIPTION
Closes #199.

Each window's taskbar button now carries a `SetOverlayIcon` status dot, in the same palette as the in-window status dots (`AgentStatus::dot_rgb`) so a color never means two things:

- **blue** — a shell command or agent is working in some pane;
- **green** — work finished while the window was unfocused, cleared the moment the window is activated;
- **amber** — an agent is blocked on your input (same signal as the tray badge).

## How

- `ui::taskbar` mirrors `ui::tray`'s flow exactly: one app-wide foreground task polls once a second, aggregates each window's panes, diffs against what the taskbar shows, and only touches COM on a change. Priority when panes disagree: attention > busy > done, matching the tray's `urgency` ordering.
- Busy comes from agents mid-turn plus a new `RemoteTerminal::shell_busy()` — gated on shell integration being `active` (like `at_prompt`), so an integration-less pane reads as idle rather than busy forever.
- "Finished in background" is an edge, not a level: a per-window tracker arms it on a busy→idle transition while unfocused and clears it on activation (unit-tested).
- The dot is drawn by hand into a 16×16 32-bit `HICON` (no SVG pipeline for a circle) and destroyed right after `SetOverlayIcon` returns, so no GDI handles leak.
- Settings → Window gains a **"Taskbar status dot"** toggle (`taskbar_status_icon`, on by default, re-read every tick so it live-applies; the row only renders on Windows).

## Dependencies

`windows = "0.61"` (the COM interface `windows-sys` deliberately omits) and `raw-window-handle = "0.6"` — both pinned to the exact versions gpui's Windows backend already builds, so no new native code, per the Cargo.toml convention.

## Platform notes

Windows-only by nature (`cfg(windows)` module + stubs; macOS/Linux builds are untouched). A macOS Dock badge would be this module's sibling as a follow-up, and Linux has no portable equivalent — the tray badge already covers attention there.

## Verified

- `cargo test` on Windows: 838 passed (4 new tests for the overlay state machine and palette).
- `cargo check` of this commit on Linux (Ubuntu 24.04): clean, no new warnings.
- Live on Windows 11: ran a command in a pane and watched the blue dot appear on the taskbar button within a poll tick (happy to attach screenshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
