### PR TITLE
feat(settings): let the last-window close confirmation be turned off

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -184,6 +184,17 @@ pub struct Config {
     /// `true` by that hint; there is no UI to reset it (nor a reason to).
     #[serde(default)]
     pub workspace_detach_hint_seen: bool,
+    /// Ask before closing the *last* window (the close that also quits the app).
+    /// On by default, which is the behavior every build so far has had.
+    ///
+    /// The prompt was only ever a teaching device, not a safety net: ⌘Q, the
+    /// tray's Quit and the palette's Quit all leave without asking, and nothing
+    /// is lost either way — the panes keep running in the daemon. So once the
+    /// user has learned that (Settings states it permanently under "How sessions
+    /// work"), being asked on every quit is pure friction. Off makes the last
+    /// window close exactly like any other: detach the workspace, quit.
+    #[serde(default = "default_true")]
+    pub confirm_window_close: bool,
     /// How the terminal bell (BEL / `^G`) is signalled. Defaults to a brief
     /// visual flash (the current behavior).
     #[serde(default, deserialize_with = "de_lenient")]
@@ -619,6 +630,7 @@ impl Default for Config {
             restore_session: true,
             show_tray_icon: true,
             workspace_detach_hint_seen: false,
+            confirm_window_close: true,
             // Visual flash preserves the pre-config behavior (the bell always
             // flashed); opting into None/Audible is a deliberate change.
             bell: BellMode::Visual,
@@ -1035,6 +1047,23 @@ mod tests {
         let back: Config = serde_json::from_str(&json).unwrap();
         assert!(back.ssh_warn_on_close);
         assert_eq!(back.ssh_profile_frecency.get(&id).unwrap().count, 4);
+    }
+
+    /// Opt-*out*, unlike most flags here: a config written before this setting
+    /// existed must keep the prompt, or an update would silently take away the
+    /// one thing telling people their sessions survive a quit.
+    #[test]
+    fn confirm_window_close_defaults_on_and_round_trips() {
+        assert!(Config::default().confirm_window_close);
+
+        let old: Config = serde_json::from_str(r#"{"font_size": 15.0}"#).unwrap();
+        assert!(old.confirm_window_close);
+
+        let off: Config = serde_json::from_str(r#"{"confirm_window_close": false}"#).unwrap();
+        assert!(!off.confirm_window_close);
+        let json = serde_json::to_string(&off).unwrap();
+        let back: Config = serde_json::from_str(&json).unwrap();
+        assert!(!back.confirm_window_close);
     }
 
     #[test]

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1064,6 +1064,14 @@ mod tests {
         let json = serde_json::to_string(&off).unwrap();
         let back: Config = serde_json::from_str(&json).unwrap();
         assert!(!back.confirm_window_close);
+
+        // ...and a key this build has never heard of — a config last written by
+        // a newer tty7, or hand-edited — must be ignored rather than failing the
+        // whole parse, which `Config::load` would swallow into *defaults*: the
+        // opt-out would come back on with nothing said.
+        let newer: Config =
+            serde_json::from_str(r#"{"confirm_window_close": false, "not_a_setting": 7}"#).unwrap();
+        assert!(!newer.confirm_window_close);
     }
 
     #[test]

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -994,10 +994,14 @@ impl Tty7App {
         //
         // The last window is different: closing it also quits the app (a
         // windowless process left in the Dock no longer responds to being
-        // clicked — #147), so that one keeps the reassuring prompt. We veto the
-        // immediate close (return `false`), show it, and quit only if the user
-        // picks "Close"; a one-shot flag lets that post-confirm close through
-        // instead of looping the prompt.
+        // clicked — #147), so that one keeps the reassuring prompt by default.
+        // We veto the immediate close (return `false`), show it, and quit only
+        // if the user picks "Close"; a one-shot flag lets that post-confirm
+        // close through instead of looping the prompt.
+        //
+        // `confirm_window_close` turns the prompt off for users who have learned
+        // the model — it is teaching, not protection (⌘Q never asked), so it has
+        // to be escapable.
         let close_confirmed = std::rc::Rc::new(std::cell::Cell::new(false));
         let weak_app = cx.weak_entity();
         window.on_window_should_close(cx, move |window, cx| {
@@ -1009,9 +1013,11 @@ impl Tty7App {
                 .upgrade()
                 .is_some_and(|app| app.read(cx).tabs.is_empty());
 
-            // Any window but the last, or an empty one with nothing to
-            // reassure about: detach and go. Prompting here would be friction.
-            if !last_window || empty {
+            // Any window but the last, an empty one with nothing to reassure
+            // about, or a user who has turned the prompt off: detach and go.
+            // Prompting here would be friction.
+            let confirm = cx.global::<Config>().confirm_window_close;
+            if !last_window || empty || !confirm {
                 if let Some(app) = weak_app.upgrade() {
                     app.update(cx, |app, cx| app.detach_workspace(cx));
                 }
@@ -2520,6 +2526,13 @@ impl Tty7App {
     /// every second, so the icon appears/disappears without a restart.
     pub(crate) fn set_show_tray_icon(&mut self, on: bool, cx: &mut Context<Self>) {
         self.update_config(cx, |cfg| cfg.show_tray_icon = on);
+    }
+
+    /// Toggle the "Close Window?" prompt on the last window. The close handler
+    /// reads the flag when it fires, so this applies to the very next ⌘W with no
+    /// restart and nothing to push to open windows.
+    pub(crate) fn set_confirm_window_close(&mut self, on: bool, cx: &mut Context<Self>) {
+        self.update_config(cx, |cfg| cfg.confirm_window_close = on);
     }
 
     // ── Input / Mouse setters ───────────────────────────────────────────────

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -347,7 +347,10 @@ fn settings_search_entries() -> &'static [SearchEntry] {
         SearchEntry {
             section: WindowTabs,
             title: "Confirm before closing the last window",
-            keywords: "close quit confirm prompt dialog ask again warn last window cmd-w",
+            // Both spellings of the chord: the prompt this turns off is reached
+            // by ⌘W on macOS and Ctrl-W everywhere else, and the user types
+            // whichever one their own keyboard just used.
+            keywords: "close quit confirm prompt dialog ask again warn last window cmd-w ctrl-w",
         },
         SearchEntry {
             section: WindowTabs,
@@ -4578,7 +4581,13 @@ mod tests {
     fn close_confirmation_toggle_is_findable() {
         // Not a bare "confirm": SSH's own close warning owns that word just as
         // legitimately, and the nav's per-section counts are what disambiguate.
-        for query in ["ask again", "closing the last window", "dialog", "cmd-w"] {
+        for query in [
+            "ask again",
+            "closing the last window",
+            "dialog",
+            "cmd-w",
+            "ctrl-w",
+        ] {
             assert_eq!(
                 best_matching_section(query).map(|s| s.profile_label()),
                 Some(SettingsSection::WindowTabs.profile_label()),

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -348,6 +348,11 @@ fn settings_search_entries() -> &'static [SearchEntry] {
         },
         SearchEntry {
             section: WindowTabs,
+            title: "Confirm before closing the last window",
+            keywords: "close quit confirm prompt dialog ask again warn last window cmd-w",
+        },
+        SearchEntry {
+            section: WindowTabs,
             title: "Show tray icon",
             keywords: "tray menu bar status item agent attention system icon",
         },
@@ -3342,6 +3347,7 @@ impl Tty7App {
         let restore_session = cfg.restore_session;
         let remember_window_size = cfg.remember_window_size;
         let show_tray_icon = cfg.show_tray_icon;
+        let confirm_window_close = cfg.confirm_window_close;
         let tab_bar_idx = match cfg.tab_bar_position {
             TabBarPosition::Top => 0,
             TabBarPosition::Left => 1,
@@ -3405,6 +3411,10 @@ impl Tty7App {
         let remember_window_switch = Switch::new("wt-remember-window")
             .checked(remember_window_size)
             .on_click(cx.listener(|this, on: &bool, _w, cx| this.set_remember_window_size(*on, cx)))
+            .into_any_element();
+        let confirm_close_switch = Switch::new("wt-confirm-window-close")
+            .checked(confirm_window_close)
+            .on_click(cx.listener(|this, on: &bool, _w, cx| this.set_confirm_window_close(*on, cx)))
             .into_any_element();
         let tray_switch = Switch::new("wt-tray-icon")
             .checked(show_tray_icon)
@@ -3489,6 +3499,16 @@ impl Tty7App {
                 "Restore last layout",
                 "Reopen the last window's tabs, splits, and directories on launch. Off starts with a single fresh terminal.",
                 restore_switch,
+                cx,
+            ))
+            // Phrased around what stays true either way: the prompt is there to
+            // teach that closing isn't ending, so the row that turns it off is
+            // the last chance to say so.
+            .child(self.settings_row(
+                "Confirm before closing the last window",
+                "Ask first, since that close also quits tty7. Off closes straight away — \
+                 either way your shells keep running in the background.",
+                confirm_close_switch,
                 cx,
             ))
             .child(self.settings_row(
@@ -4462,6 +4482,22 @@ mod tests {
         }
     }
 
+    /// The close-confirmation toggle is the one people go looking for *after*
+    /// the dialog has annoyed them, so it has to be reachable by what they'd
+    /// type in that moment — not just by its own title.
+    #[test]
+    fn close_confirmation_toggle_is_findable() {
+        // Not a bare "confirm": SSH's own close warning owns that word just as
+        // legitimately, and the nav's per-section counts are what disambiguate.
+        for query in ["ask again", "closing the last window", "dialog", "cmd-w"] {
+            assert_eq!(
+                best_matching_section(query).map(|s| s.profile_label()),
+                Some(SettingsSection::WindowTabs.profile_label()),
+                "query {query:?} should land on Window & Tabs"
+            );
+        }
+    }
+
     /// The index names rows, so a title that no longer matches the rendered row
     /// sends the user to the right page and then leaves them hunting. This
     /// pins the ones that had drifted (the index said "Working directory"; the
@@ -4471,6 +4507,7 @@ mod tests {
         for title in [
             "Start in",
             "Restore last layout",
+            "Confirm before closing the last window",
             "Terminal bell",
             "Report mouse to apps",
             "Open files with",


### PR DESCRIPTION
Closes #198.

Adds a `confirm_window_close` setting so the "Close Window?" prompt on the last window can be turned off, and closing just closes.

| | Before | After |
|---|---|---|
| Closing the last window | Always prompts "Close Window?" | Prompts, unless the new toggle is off |
| Closing it with the toggle off | — | Detaches the workspace and quits immediately — same path as closing any non-last window |
| Settings → Window & Tabs | Startup / Remember size / Restore layout / Show tray icon | Adds **Confirm before closing the last window** (on by default) |
| Settings search | — | Findable by "ask again", "closing the last window", "dialog", "cmd-w" |
| `config.json` | — | `"confirm_window_close": true` (absent in an old config ⇒ `true`, so nothing changes on update) |

## Why

The prompt is a teaching device, not a safety net. ⌘Q, the tray's Quit and the palette's "Quit tty7" all call `cx.quit()` with no confirmation, and nothing is lost on either path — the panes keep running in the daemon. The model it teaches now also has a permanent home in Settings ("How sessions work"), added precisely so the dialogs stop being the only place it's explained. Once a user has learned it, an extra dialog on every quit is friction.

This also brings the window-close prompt in line with the SSH close warning, which has had a config toggle (`ssh_warn_on_close`) all along.

Per-profile-style "Don't ask again" checkbox inside the dialog was considered and left out: `window.prompt` is a native system alert (title / detail / buttons), so a checkbox would mean replacing the whole prompt path with an in-app modal — disproportionate for one checkbox.

## Testing

- `core::config::confirm_window_close_defaults_on_and_round_trips` — new: default is on, a config predating the field stays on, `false` round-trips.
- `ui::settings::close_confirmation_toggle_is_findable` — new: the queries someone types right after the dialog annoys them land on Window & Tabs. Deliberately not a bare "confirm" — SSH's own close warning owns that word too, and the nav's per-section match counts are what disambiguate.
- `ui::settings::index_titles_match_rendered_row_labels` — extended with the new row title.
- Full suite: 909 passed, `cargo fmt --check` clean.
- No GUI verification — an isolated dev instance was launched but exited before the toggle could be exercised on screen; the close path itself is a two-term condition change and is not covered by an end-to-end test.
