### PR TITLE
fix(terminal): render emoji presentation sequences at their real width

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "alacritty_terminal"
 version = "0.26.1-dev"
-source = "git+https://github.com/l0ng-ai/alacritty?rev=22b1d74842732f6ea30d8f4eec768b3ac659d0b6#22b1d74842732f6ea30d8f4eec768b3ac659d0b6"
+source = "git+https://github.com/l0ng-ai/alacritty?rev=b79e70484b13308ce766a763531ac25a8302c012#b79e70484b13308ce766a763531ac25a8302c012"
 dependencies = [
  "base64",
  "bitflags 2.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,15 +69,25 @@ reqwest_client = { git = "https://github.com/zed-industries/zed", rev = "1d217ee
 # (`terminal::remote`) for the VT parser + grid (`Term`/`ansi::Processor`) that
 # renders the mirror. The daemon's PTY itself is driven by `portable-pty` below.
 #
-# The `tty7` branch is Zed's `fcf32fe` (the rev Zed pins) plus one commit:
-# `push_keyboard_mode` capped its stack by removing from `title_stack` instead of
-# `keyboard_mode_stack` — a copy-paste slip from `push_title` that compiles because
-# both are `Vec`s. With `kitty_keyboard` on (see `terminal_config_from_user`) every
-# overflowing push silently drops a saved title, and once the title stack is empty
-# `Vec::remove(0)` panics — 4097 unpopped `CSI > 1 u` pushes, about 20KB of output,
-# kill the reader thread and freeze the pane. Still present on alacritty master as
-# of 852e971; drop this fork once it lands upstream.
-alacritty_terminal = { git = "https://github.com/l0ng-ai/alacritty", rev = "22b1d74842732f6ea30d8f4eec768b3ac659d0b6" }
+# The `tty7` branch is Zed's `fcf32fe` (the rev Zed pins) plus two commits, both
+# still missing from alacritty master as of 852e971:
+#
+# 1. `push_keyboard_mode` capped its stack by removing from `title_stack` instead
+#    of `keyboard_mode_stack` — a copy-paste slip from `push_title` that compiles
+#    because both are `Vec`s. With `kitty_keyboard` on (see
+#    `terminal_config_from_user`) every overflowing push silently drops a saved
+#    title, and once the title stack is empty `Vec::remove(0)` panics — 4097
+#    unpopped `CSI > 1 u` pushes, about 20KB of output, kill the reader thread and
+#    freeze the pane.
+# 2. `input` reserves columns per `char`, so an emoji written as base + U+FE0F
+#    (`❤️`, `🗂️`, `⚠️` — any base whose East Asian Width is Neutral) gets one
+#    column instead of two and shifts the rest of the line left by one. The fork
+#    re-scores the sequence with `UnicodeWidthStr` and widens the cell (issue
+#    #203).
+#
+# Each patch has a guard test in `src/terminal/remote.rs`; drop this fork once
+# both land upstream.
+alacritty_terminal = { git = "https://github.com/l0ng-ai/alacritty", rev = "b79e70484b13308ce766a763531ac25a8302c012" }
 
 # Desktop notifications driven by OSC 9 / OSC 777 escape sequences. Cross-platform;
 # the macOS backend uses the deprecated NSUserNotification (weak — a completion

--- a/src/terminal/element.rs
+++ b/src/terminal/element.rs
@@ -201,7 +201,16 @@ fn snapshot_cell(
 
     let mut rc = RenderCell {
         c: cell.c,
-        marks: cell.zerowidth().map(Box::from),
+        // `Cell::zerowidth` answers out of the same lazily-boxed `extra` that
+        // holds SGR 58 and OSC 8, so a cell carrying only an underline color or
+        // a hyperlink reports `Some(&[])`. Drop the empties: an empty mark list
+        // is still `Some`, which would pull every linked or SGR-58 cell off the
+        // batched run path onto its own `Cluster` — a `shape_line` per cell for
+        // a whole `ls --hyperlink` listing, and no powerline fast path either.
+        marks: cell
+            .zerowidth()
+            .filter(|marks| !marks.is_empty())
+            .map(Box::from),
         fg: to_hsla(fgc),
         bg: to_hsla(bgc),
         draw_bg,
@@ -2444,5 +2453,55 @@ mod tests {
             assert!(!rc.draw_bg, "spacers never paint");
             assert_eq!(rc.underline, UnderlineKind::None);
         }
+    }
+
+    /// SGR 58, OSC 8 and combining marks all live in alacritty's one lazily
+    /// boxed `extra`, so `Cell::zerowidth` says `Some(&[])` for a cell that
+    /// merely carries a color or a link. Only real marks may set `marks`: an
+    /// empty list is still `Some`, and `segment_row` would take every linked
+    /// cell off the batched run path onto a `shape_line` of its own.
+    #[test]
+    fn only_real_combining_marks_set_marks() {
+        let palette = [Rgb { r: 0, g: 0, b: 0 }; 256];
+        let colors = test_colors();
+        let point = AlacPoint::new(AlacLine(0), AlacColumn(0));
+
+        let mut colored = Cell {
+            c: 'e',
+            flags: Flags::UNDERCURL,
+            ..Cell::default()
+        };
+        colored.set_underline_color(Some(AnsiColor::Indexed(5)));
+        assert_eq!(
+            snapshot_cell(&colored, point, &palette, &colors, None).marks,
+            None,
+            "SGR 58 alone is not a combining mark"
+        );
+
+        let mut linked = Cell {
+            c: 'e',
+            ..Cell::default()
+        };
+        linked.set_hyperlink(Some(alacritty_terminal::term::cell::Hyperlink::new(
+            Some("id"),
+            "https://example.com".to_string(),
+        )));
+        assert_eq!(
+            snapshot_cell(&linked, point, &palette, &colors, None).marks,
+            None,
+            "OSC 8 alone is not a combining mark"
+        );
+
+        let mut marked = Cell {
+            c: '\u{2764}',
+            ..Cell::default()
+        };
+        marked.push_zerowidth('\u{FE0F}');
+        assert_eq!(
+            snapshot_cell(&marked, point, &palette, &colors, None)
+                .marks
+                .as_deref(),
+            Some(&['\u{FE0F}'][..]),
+        );
     }
 }

--- a/src/terminal/element.rs
+++ b/src/terminal/element.rs
@@ -42,6 +42,11 @@ enum UnderlineKind {
 #[derive(Clone)]
 struct RenderCell {
     c: char,
+    /// Combining marks the emulator stacked on this cell: accents, variation
+    /// selectors, ZWJ-sequence tails. They carry no column of their own, but
+    /// dropping them changes what the shaper sees — `❤` and `❤\u{FE0F}` pick
+    /// different faces — so they ride along and get shaped with their base.
+    marks: Option<Box<[char]>>,
     fg: Hsla,
     bg: Hsla,
     draw_bg: bool,
@@ -66,6 +71,7 @@ impl Default for RenderCell {
     fn default() -> Self {
         Self {
             c: ' ',
+            marks: None,
             fg: Hsla::default(),
             bg: Hsla::default(),
             draw_bg: false,
@@ -195,6 +201,7 @@ fn snapshot_cell(
 
     let mut rc = RenderCell {
         c: cell.c,
+        marks: cell.zerowidth().map(Box::from),
         fg: to_hsla(fgc),
         bg: to_hsla(bgc),
         draw_bg,
@@ -442,9 +449,11 @@ impl GlyphStyle {
 }
 
 /// A blank cell paints no glyph (and today, no underline either — see
-/// `GlyphStyle::draws_on_blanks`).
+/// `GlyphStyle::draws_on_blanks`). A blank carrying combining marks is not
+/// blank: a mark that opens a line lands on the space the grid starts with, and
+/// it still has to be drawn.
 fn is_blank(cell: &RenderCell) -> bool {
-    cell.c == '\0' || cell.c == ' '
+    (cell.c == '\0' || cell.c == ' ') && cell.marks.is_none()
 }
 
 /// One paintable piece of a row produced by [`segment_row`].
@@ -472,6 +481,16 @@ enum RowSeg {
     /// drawing, accented Latin, …) that may route to a fallback face whose
     /// advance isn't the cell width.
     Solo { col: usize },
+    /// A base plus the combining marks stacked on it, shaped as one string so
+    /// the marks reach the shaper. Never batched with neighbours: the marks add
+    /// characters without adding columns, which is exactly the correspondence
+    /// `force_width` relies on in a [`RowSeg::Run`] or [`RowSeg::Wide`].
+    Cluster {
+        col: usize,
+        /// Columns the base occupies — 2 once the grid marked it wide.
+        cells: usize,
+        text: String,
+    },
 }
 
 /// Split one grid row into paintable segments.
@@ -499,6 +518,21 @@ fn segment_row(row: &[RenderCell]) -> Vec<RowSeg> {
             col += 1;
             continue;
         }
+        // Combining marks come first: they can sit on an ASCII base too, and
+        // either way the whole cluster has to reach the shaper in one string.
+        if let Some(marks) = &cell.marks {
+            let cells = if col + 1 < row.len() && row[col + 1].spacer {
+                2
+            } else {
+                1
+            };
+            let mut text = String::with_capacity(1 + marks.len());
+            text.push(cell.c);
+            text.extend(marks.iter());
+            segs.push(RowSeg::Cluster { col, cells, text });
+            col += cells;
+            continue;
+        }
         if !cell.c.is_ascii_graphic() {
             // Wide (two-column) glyph? The trailing spacer is the grid's own
             // width marker, so no Unicode width guessing is needed.
@@ -513,6 +547,7 @@ fn segment_row(row: &[RenderCell]) -> Vec<RowSeg> {
                 while col + 1 < row.len()
                     && !row[col].spacer
                     && !is_blank(&row[col])
+                    && row[col].marks.is_none()
                     && !row[col].c.is_ascii_graphic()
                     && row[col + 1].spacer
                     && GlyphStyle::of(&row[col]) == style
@@ -552,7 +587,11 @@ fn segment_row(row: &[RenderCell]) -> Vec<RowSeg> {
                 col += 1;
                 continue;
             }
-            if c.spacer || !c.c.is_ascii_graphic() || GlyphStyle::of(c) != style {
+            if c.spacer
+                || c.marks.is_some()
+                || !c.c.is_ascii_graphic()
+                || GlyphStyle::of(c) != style
+            {
                 break;
             }
             for _ in 0..gap {
@@ -797,6 +836,16 @@ fn paint_glyphs(
                     }
                     (col, 1, char_string(cell.c), None, true)
                 }
+                // Same pinning as the batched runs, just for one base: two
+                // columns get `force_width` so a fallback emoji face can't
+                // drift, one column paints at the origin like `Solo`.
+                RowSeg::Cluster { col, cells, text } => (
+                    col,
+                    cells,
+                    SharedString::from(text),
+                    (cells == 2).then(|| geom.cell_width * 2.),
+                    cells == 1,
+                ),
             };
 
             let style = GlyphStyle::of(&buf[row_base + start]);
@@ -2062,6 +2111,66 @@ mod tests {
     fn segment_row_ignores_blank_rows() {
         let row: Vec<_> = "  \0 ".chars().map(cell).collect();
         assert!(segment_row(&row).is_empty());
+    }
+
+    fn cluster(col: usize, cells: usize, text: &str) -> RowSeg {
+        RowSeg::Cluster {
+            col,
+            cells,
+            text: text.to_string(),
+        }
+    }
+
+    /// Combining marks reach the shaper attached to their base, in one string.
+    #[test]
+    fn segment_row_shapes_combining_marks_with_their_base() {
+        // Single column: `e` + U+0301 → é.
+        let mut row = vec![cell('a'), cell('e'), cell('b')];
+        row[1].marks = Some(Box::from(['\u{0301}']));
+        assert_eq!(
+            segment_row(&row),
+            [run(0, 1, "a"), cluster(1, 1, "e\u{0301}"), run(2, 1, "b"),]
+        );
+
+        // Two columns: the emulator widened the base, so the cluster owns the
+        // spacer too (❤ + U+FE0F).
+        let mut row = wide_cells("\u{2764}");
+        row[0].marks = Some(Box::from(['\u{FE0F}']));
+        assert_eq!(segment_row(&row), [cluster(0, 2, "\u{2764}\u{FE0F}")]);
+    }
+
+    /// A marked cell never joins a batch: marks add characters without adding
+    /// columns, which would desync `force_width`'s glyph-per-column pinning.
+    #[test]
+    fn segment_row_never_batches_a_marked_cell() {
+        // ASCII run splits around it.
+        let mut row: Vec<_> = "abc".chars().map(cell).collect();
+        row[1].marks = Some(Box::from(['\u{0301}']));
+        assert_eq!(
+            segment_row(&row),
+            [run(0, 1, "a"), cluster(1, 1, "b\u{0301}"), run(2, 1, "c"),]
+        );
+
+        // Wide run splits around it.
+        let mut row = wide_cells("你好世");
+        row[2].marks = Some(Box::from(['\u{FE0F}']));
+        assert_eq!(
+            segment_row(&row),
+            [
+                wide(0, 2, "你"),
+                cluster(2, 2, "好\u{FE0F}"),
+                wide(4, 2, "世"),
+            ]
+        );
+    }
+
+    /// A mark opening a line lands on the space the grid starts with — that
+    /// cell still has ink, so it must not be skipped as blank.
+    #[test]
+    fn segment_row_keeps_a_blank_that_carries_marks() {
+        let mut row = vec![cell(' '), cell(' ')];
+        row[0].marks = Some(Box::from(['\u{0301}']));
+        assert_eq!(segment_row(&row), [cluster(0, 1, " \u{0301}")]);
     }
 
     #[test]

--- a/src/terminal/remote.rs
+++ b/src/terminal/remote.rs
@@ -1732,6 +1732,50 @@ mod tests {
         );
     }
 
+    /// Guards the `alacritty_terminal` pin, not our own code. Upstream reserves
+    /// columns one `char` at a time, so an emoji written as base + `U+FE0F`
+    /// (`❤️`, `🗂️`, `⚠️` — anything whose base is East Asian Width Neutral) gets
+    /// one column instead of two and shoves the rest of the line left by one.
+    /// Our fork re-scores the sequence and widens the cell; a bump back to an
+    /// unpatched rev must fail here rather than in the field (issue #203).
+    #[test]
+    fn emoji_presentation_sequences_reserve_two_columns() {
+        let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
+        let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
+
+        // `x` marks where the emoji ended: column 2 if ❤️ got its two columns,
+        // column 1 if the selector was counted as free.
+        DaemonMsg::Output("\u{2764}\u{FE0F}x".as_bytes().to_vec())
+            .encode(&mut daemon_side)
+            .unwrap();
+        daemon_side.flush().unwrap();
+
+        let mut row = String::new();
+        for _ in 0..200 {
+            {
+                let t = term.term.lock();
+                let grid = t.grid();
+                row.clear();
+                for col in 0..3usize {
+                    row.push(
+                        grid[alacritty_terminal::index::Line(0)]
+                            [alacritty_terminal::index::Column(col)]
+                        .c,
+                    );
+                }
+            }
+            if row.contains('x') {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+
+        assert_eq!(
+            row, "\u{2764} x",
+            "❤️ must hold two columns (glyph + spacer) before the next glyph"
+        );
+    }
+
     #[test]
     fn spawn_retry_only_for_daemon_disconnects() {
         let eof: anyhow::Error =


### PR DESCRIPTION
Renders an emoji written as base + `U+FE0F` at its real width and in its real presentation, fixing both halves of #203.

## Before / After

| | Before | After |
|---|---|---|
| `🗂️` `❤️` `⚠️` column budget | 1 column — glyph bleeds over the next cell, rest of the line shifts left by one | 2 columns, like every other terminal |
| `baulk brand` emoji row | `🗂️` and `🥝` collide; `🧱` one column off | Evenly spaced, matches Windows Terminal / WezTerm / Rio |
| `❤️` glyph | Black text-presentation heart — identical to bare `❤` | Red emoji heart; bare `❤` still monochrome |
| `⚠️` glyph | Monochrome outline triangle | Yellow emoji warning sign |
| `e` + `U+0301` (é) | Combining mark dropped before shaping | Shaped with its base |
| Selection / click hit-testing over such emoji | Off by one column from the glyph | Matches what's drawn |

## Why

The variation selector is width 0, so it lands as a combining mark **after** the column budget for its base has already been spent — and then nothing revisits either decision.

**Width** lives in the `alacritty_terminal` pin, bumped to the fork's `b79e704`. `Term::input` reserves columns one `char` at a time, so a base whose East Asian Width is Neutral (`U+2764`, `U+1F5C2`, `U+26A0`, …) keeps a single column. `unicode-width` *does* implement UTS #51's "emoji presentation sequences have width 2", but only in `UnicodeWidthStr` — the per-`char` API can't see the pair. The fork re-scores the sequence when a `U+FE0F` lands and widens the cell to match.

This is not tty7-specific: Alacritty and Zed show the identical collision (same grid layer), while Windows Terminal, WezTerm and Rio are correct because they allocate cells per grapheme cluster.

**Presentation** is ours. `snapshot_cell` copied only `cell.c` into `RenderCell`, so `cell.zerowidth()` never reached the shaper — gpui saw the same string for `❤` and `❤\u{FE0F}` and picked the same face. `RenderCell` now carries the marks and a new `RowSeg::Cluster` shapes them with their base. That restores *every* combining mark, not just variation selectors.

A marked cell never joins a batched run: marks add characters without adding columns, which is exactly the correspondence `force_width` relies on to pin one glyph per column in a `Run` or `Wide` segment.

## Scope

Only widening is implemented. The reverse (`U+FE0E` narrowing an already-wide emoji to one column) would have to free a column and reflow the line; WezTerm doesn't do it either. `U+FE0E` and selectors on non-emoji bases score 1 and are left alone.

The fork's patch only widens the cell the cursor just left — the spacer has to go into the next column, and that column has to be the cursor's own. A base sitting in the last column, or a cursor the application moved between the two codepoints, keeps the layout it already has.

## Testing

- **`alacritty_terminal` fork** — 4 new tests (widens its base; `U+FE0E` and non-emoji bases left alone; an already-wide base isn't re-widened; last column stays narrow). Full suite: 142 passed.
- **`src/terminal/element.rs`** — 3 new `segment_row` tests: marks shaped with their base at 1 and 2 columns, marked cells excluded from both ASCII and wide batching, a blank carrying marks not skipped.
- **`src/terminal/remote.rs`** — `emoji_presentation_sequences_reserve_two_columns` guards the pin the way `deep_keyboard_mode_pushes_leave_the_reader_alive` guards the other patch. Verified red against the previous unpatched rev (`❤x` vs `❤ x`).
- Full tty7 suite: 911 passed, `cargo fmt --check` clean.
- **Manual** — isolated dev instance (`--config-dir`) fed the `baulk brand` emoji line plus a column-ruler fixture. Measured the alignment markers pixel-wise: all rows land in one column (previously every `U+FE0F` row was short by exactly one cell width). `❤️` and `⚠️` now render in color while their bare forms stay monochrome.
