### PR TITLE
test(terminal): pin that a base keeps every stacked combining mark

### DIFF
--- a/src/terminal/element.rs
+++ b/src/terminal/element.rs
@@ -2146,6 +2146,15 @@ mod tests {
         let mut row = wide_cells("\u{2764}");
         row[0].marks = Some(Box::from(['\u{FE0F}']));
         assert_eq!(segment_row(&row), [cluster(0, 2, "\u{2764}\u{FE0F}")]);
+
+        // Several marks on one base: an above-base vowel and a tone mark both
+        // sit on the consonant (ที่ = ท U+0E17 + ◌ี U+0E35 + ◌่ U+0E48).
+        let mut row = vec![cell('\u{0E17}'), cell('a')];
+        row[0].marks = Some(Box::from(['\u{0E35}', '\u{0E48}']));
+        assert_eq!(
+            segment_row(&row),
+            [cluster(0, 1, "\u{0E17}\u{0E35}\u{0E48}"), run(1, 1, "a")]
+        );
     }
 
     /// A marked cell never joins a batch: marks add characters without adding


### PR DESCRIPTION
You already fixed combining-mark rendering in f5b4a65 and 0cfbe90 — this only adds a regression case to it, no production changes.

While diagnosing #209 I noticed the combining-mark cases in `segment_row_shapes_combining_marks_with_their_base` carry exactly one mark each: `e` + U+0301, and ❤ + U+FE0F. Thai routinely stacks two on a single consonant — `ที่` is U+0E17 with an above-base vowel (U+0E35) and a tone mark (U+0E48) both sitting on it. Devanagari, Arabic and Hebrew stack the same way.

That axis isn't currently pinned. Truncating the mark iterator to its first element:

```rust
text.extend(marks.iter().take(1));
```

leaves **all thirteen `segment_row` tests green** on current `main`. The cluster still forms, still spans one column, still leaves its neighbour intact — only the trailing codepoint goes missing. In Thai that codepoint is the one carrying the tone, so ไม่ (not) and ไม้ (wood) both collapse to ไม: a change of meaning, not of appearance.

With this case added, that same mutation fails the test.

### The change

Nine lines, added as a third block inside the existing test rather than a new `#[test]`, to match how the neighbouring cases bundle variations. Reuses `cell`, `cluster` and `run`; no new helpers. The codepoints are glossed in a comment since the escapes aren't readable on their own.

### Verification

- Full suite: 938 passed, 0 failed, 1 ignored
- `cargo fmt --check` clean
- Based on `d3064e4`

Happy to drop this if you'd rather keep the case count down, or to reshape it however you prefer — you know this renderer far better than I do.
