### PR TITLE
feat(daemon): tell every pane which terminal it is running in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to tty7 are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Panes are told which terminal they're running in** — every pane now carries
+  `TERM_PROGRAM=tty7` and `TERM_PROGRAM_VERSION`, the de-facto standard pair
+  Apple Terminal introduced and iTerm2, WezTerm, Ghostty, VS Code and tmux all
+  set. `TERM` names terminfo capabilities and can't answer "which program is
+  this", so without the pair, capability probes (`supports-color`,
+  `supports-hyperlinks`, and the CLI ecosystem built on them), editors applying
+  terminal-specific workarounds, and shell prompts all fell back to their most
+  conservative behaviour. tty7's own `TTY7` marker doesn't help them — it exists
+  so globally-installed agent hooks stay silent in other terminals, and nothing
+  third-party knows to look for it. Unlike `TERM` and `COLORTERM`, both new
+  variables can be overridden from `env` in `config.json`: they name an
+  identity, not a capability, and posing as another terminal is a legitimate way
+  to get a tool that only recognises a fixed list to light up. Local panes only
+  — ssh forwards environment variables solely by agreement between client and
+  server, so a remote host still sees whatever it sets for itself. (#212)
+
 ## [26.7.5] - 2026-07-27
 
 ### Added

--- a/src/daemon/pane.rs
+++ b/src/daemon/pane.rs
@@ -422,29 +422,68 @@ fn system_locale_identifier() -> Option<String> {
     }
 }
 
+/// What tty7 answers to in `TERM_PROGRAM`. Terminals name themselves in the
+/// form they brand themselves in — `Apple_Terminal`, `iTerm.app`, `WezTerm`,
+/// `ghostty`, `vscode` — so ours is the lowercase product name.
+const TERM_PROGRAM_NAME: &str = "tty7";
+
+/// Env keys that describe our emulator's real capabilities. A user's `env` map
+/// must not override these: the answer isn't a preference, it's a fact about
+/// what the pane on the other end can decode.
+const CAPABILITY_ENV: [&str; 2] = ["TERM", "COLORTERM"];
+
+/// The environment every pane starts with, in application order — tty7's own
+/// advertisements first, then the user's `env` map, which overrides all but
+/// [`CAPABILITY_ENV`]. Returned as a list rather than applied in place so the
+/// precedence is testable without a `CommandBuilder` or a real `config.json`.
+fn pane_environment(
+    extra_env: &std::collections::HashMap<String, String>,
+) -> Vec<(String, String)> {
+    let version = env!("CARGO_PKG_VERSION");
+    let mut env = vec![
+        // A widely-available terminfo + truecolor.
+        ("TERM".to_string(), "xterm-256color".to_string()),
+        ("COLORTERM".to_string(), "truecolor".to_string()),
+        // Mark the session as tty7's, for tooling that adapts to its host
+        // terminal — most importantly the `tty7 agent-hook` emitter, which
+        // stays silent without it so globally-installed agent hooks can't leak
+        // escape sequences into other terminals (see `core::agent_hooks`).
+        (
+            crate::core::agent_hooks::TTY7_ENV_MARKER.to_string(),
+            version.to_string(),
+        ),
+        // The de-facto standard pair for "which terminal is this": Apple
+        // Terminal introduced it, and iTerm2, WezTerm, Ghostty, VS Code and
+        // tmux all set it. `TERM` describes terminfo capabilities and can't
+        // answer this — but capability probes (`supports-color`,
+        // `supports-hyperlinks` and the JS CLI ecosystem built on them),
+        // editors applying terminal-specific workarounds, and shell prompts all
+        // branch on the program name, falling back to their most conservative
+        // behaviour when it's missing. `TTY7` doesn't help them: it's ours, and
+        // nothing third-party knows to look for it.
+        //
+        // Deliberately overridable below, unlike the capability keys: this
+        // names an identity, and posing as another terminal is a legitimate way
+        // to get a tool that only recognises a fixed list to light up.
+        ("TERM_PROGRAM".to_string(), TERM_PROGRAM_NAME.to_string()),
+        ("TERM_PROGRAM_VERSION".to_string(), version.to_string()),
+    ];
+    env.extend(
+        extra_env
+            .iter()
+            .filter(|(k, _)| !CAPABILITY_ENV.contains(&k.as_str()))
+            .map(|(k, v)| (k.clone(), v.clone())),
+    );
+    env
+}
+
 fn apply_common_command_setup(cmd: &mut CommandBuilder, initial_cwd: &Option<PathBuf>) {
     if let Some(dir) = initial_cwd {
         cmd.cwd(dir);
     }
-    // Advertise a widely-available terminfo + truecolor.
-    cmd.env("TERM", "xterm-256color");
-    cmd.env("COLORTERM", "truecolor");
-    // Mark the session as tty7's, for tooling that adapts to its host terminal
-    // — most importantly the `tty7 agent-hook` emitter, which stays silent
-    // without it so globally-installed agent hooks can't leak escape sequences
-    // into other terminals (see `core::agent_hooks`).
-    cmd.env(
-        crate::core::agent_hooks::TTY7_ENV_MARKER,
-        env!("CARGO_PKG_VERSION"),
-    );
-
-    // User-configured environment variables override inherited values (but not
-    // TERM/COLORTERM above, which reflect our emulator's real capabilities).
     let extra_env = crate::core::config::extra_env();
-    for (k, v) in &extra_env {
-        if k != "TERM" && k != "COLORTERM" {
-            cmd.env(k, v);
-        }
+    for (k, v) in pane_environment(&extra_env) {
+        cmd.env(k, v);
     }
 
     // LaunchServices commonly starts a macOS app with no locale variables at
@@ -4040,6 +4079,74 @@ mod tests {
 
         assert!(dead_rx.try_recv().is_ok(), "unattached death → on_dead");
         assert!(dead_rx.try_recv().is_err(), "on_dead must fire only once");
+    }
+
+    /// Every pane is told which terminal it is running in, under the names the
+    /// rest of the world reads (`TERM_PROGRAM`/`TERM_PROGRAM_VERSION`) as well
+    /// as our own `TTY7` marker. Nothing third-party looks for the marker, so
+    /// dropping the standard pair would leave capability probes guessing.
+    #[test]
+    fn pane_environment_advertises_the_terminal_under_the_standard_names() {
+        let env: std::collections::HashMap<_, _> =
+            pane_environment(&std::collections::HashMap::new())
+                .into_iter()
+                .collect();
+        let version = env!("CARGO_PKG_VERSION");
+
+        assert_eq!(env.get("TERM_PROGRAM").map(String::as_str), Some("tty7"));
+        assert_eq!(
+            env.get("TERM_PROGRAM_VERSION").map(String::as_str),
+            Some(version)
+        );
+        assert_eq!(
+            env.get(crate::core::agent_hooks::TTY7_ENV_MARKER)
+                .map(String::as_str),
+            Some(version)
+        );
+        assert_eq!(
+            env.get("TERM").map(String::as_str),
+            Some("xterm-256color"),
+            "terminfo name is what the pane's decoder actually implements"
+        );
+    }
+
+    /// The user's `env` map may rename the terminal — posing as another program
+    /// is how you get a tool that only recognises a fixed list to light up —
+    /// but it may not contradict what our emulator can decode. Later entries
+    /// win, so the ordering is the precedence.
+    #[test]
+    fn pane_environment_lets_configured_env_override_identity_but_not_capability() {
+        let configured = [
+            ("TERM_PROGRAM", "iTerm.app"),
+            ("TERM_PROGRAM_VERSION", "3.5.0"),
+            ("TERM", "dumb"),
+            ("COLORTERM", ""),
+            ("EDITOR", "hx"),
+        ]
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect();
+
+        let applied: std::collections::HashMap<_, _> =
+            pane_environment(&configured).into_iter().collect();
+
+        assert_eq!(
+            applied.get("TERM_PROGRAM").map(String::as_str),
+            Some("iTerm.app")
+        );
+        assert_eq!(
+            applied.get("TERM_PROGRAM_VERSION").map(String::as_str),
+            Some("3.5.0")
+        );
+        assert_eq!(applied.get("EDITOR").map(String::as_str), Some("hx"));
+        assert_eq!(
+            applied.get("TERM").map(String::as_str),
+            Some("xterm-256color")
+        );
+        assert_eq!(
+            applied.get("COLORTERM").map(String::as_str),
+            Some("truecolor")
+        );
     }
 
     /// The macOS UTF-8 fallback applies only when the inherited environment has

--- a/src/daemon/pane.rs
+++ b/src/daemon/pane.rs
@@ -432,6 +432,22 @@ const TERM_PROGRAM_NAME: &str = "tty7";
 /// what the pane on the other end can decode.
 const CAPABILITY_ENV: [&str; 2] = ["TERM", "COLORTERM"];
 
+/// Whether a configured `env` key names one of [`CAPABILITY_ENV`]. Windows
+/// environment blocks are case-insensitive — `portable-pty` keeps one slot per
+/// lowercased key, so a configured `Term` there would replace `TERM` just as
+/// surely as the exact spelling — so the filter must use the platform's own
+/// notion of "the same variable". On Unix a differently-cased key is a genuinely
+/// distinct variable and stays the user's to set.
+fn names_capability_env(key: &str) -> bool {
+    CAPABILITY_ENV.iter().any(|cap| {
+        if cfg!(windows) {
+            key.eq_ignore_ascii_case(cap)
+        } else {
+            key == *cap
+        }
+    })
+}
+
 /// The environment every pane starts with, in application order — tty7's own
 /// advertisements first, then the user's `env` map, which overrides all but
 /// [`CAPABILITY_ENV`]. Returned as a list rather than applied in place so the
@@ -471,7 +487,7 @@ fn pane_environment(
     env.extend(
         extra_env
             .iter()
-            .filter(|(k, _)| !CAPABILITY_ENV.contains(&k.as_str()))
+            .filter(|(k, _)| !names_capability_env(k))
             .map(|(k, v)| (k.clone(), v.clone())),
     );
     env
@@ -4147,6 +4163,39 @@ mod tests {
             applied.get("COLORTERM").map(String::as_str),
             Some("truecolor")
         );
+    }
+
+    /// Windows environment blocks are case-insensitive — `portable-pty` keeps
+    /// one slot per lowercased key — so a configured `Term` would replace
+    /// `TERM` just as surely as the exact spelling. The capability filter must
+    /// therefore drop any casing of a capability key, not just the canonical
+    /// one. (On Unix a differently-cased key is a distinct variable and passes
+    /// through untouched.)
+    #[cfg(windows)]
+    #[test]
+    fn pane_environment_capability_keys_cannot_be_overridden_by_recasing() {
+        let configured = [("Term", "dumb"), ("ColorTerm", ""), ("term_program", "x")]
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+
+        let applied = pane_environment(&configured);
+
+        assert!(
+            !applied.iter().any(|(k, _)| k == "Term" || k == "ColorTerm"),
+            "a recased capability key must be filtered out, or it would land \
+             in the same case-folded slot and win by coming later"
+        );
+        let get = |key: &str| {
+            applied
+                .iter()
+                .find(|(k, _)| k == key)
+                .map(|(_, v)| v.as_str())
+        };
+        assert_eq!(get("TERM"), Some("xterm-256color"));
+        assert_eq!(get("COLORTERM"), Some("truecolor"));
+        // Identity keys stay overridable in any casing the user spells.
+        assert_eq!(get("term_program"), Some("x"));
     }
 
     /// The macOS UTF-8 fallback applies only when the inherited environment has


### PR DESCRIPTION
Every pane now exports `TERM_PROGRAM=tty7` and `TERM_PROGRAM_VERSION`, the pair the rest of the ecosystem reads to identify its host terminal.

## What changes

| Variable | Before | After |
|---|---|---|
| `TERM_PROGRAM` | unset | `tty7` |
| `TERM_PROGRAM_VERSION` | unset | the running version |
| `TERM` / `COLORTERM` | `xterm-256color` / `truecolor`, not overridable | unchanged |
| `TTY7` | version marker | unchanged |
| `env` in `config.json` overriding the program name | n/a | allowed — a pane can pose as `iTerm.app` |
| `env` overriding `TERM`/`COLORTERM` | ignored | unchanged (still ignored) |

## Why

`TERM` names terminfo capabilities and cannot answer "which program is this". `TERM_PROGRAM`/`TERM_PROGRAM_VERSION` is the de-facto standard that does — Apple Terminal introduced it, and iTerm2, WezTerm, Ghostty, VS Code and tmux all set it.

Plenty of things ask. Capability probes (`supports-color`, `supports-hyperlinks`, and the JS CLI ecosystem built on them) read the program name to decide on truecolor and OSC 8 hyperlinks; editors branch on it for terminal-specific workarounds; shell prompts adapt their glyphs to it. Unset, they all fall back to their most conservative behaviour. The `TTY7` marker is no substitute — it exists so globally-installed agent hooks stay silent in other terminals (see `core::agent_hooks`), and nothing third-party knows to look for it.

**Why the new pair is overridable and `TERM`/`COLORTERM` aren't:** the latter state what the pane's decoder actually implements, which isn't the user's to contradict. The program name is an identity, and posing as another terminal is a legitimate way to get a tool that only recognises a fixed list to light up.

## Scope

Local panes only. ssh forwards environment variables solely by agreement between client and server (`SendEnv`/`AcceptEnv`, `LANG` and `LC_*` by default), so a native-SSH pane still sees whatever the remote host sets for itself — already true of `COLORTERM` and `TTY7`, and unchanged here.

## Implementation note

Building the pane environment is now one function returning the pairs in application order, rather than a sequence of `cmd.env` calls with an inline filter. That makes the precedence testable without a `CommandBuilder` or a real `config.json`; `CommandBuilder::env` inserts into a map, so later entries win.

## Testing

- Two unit tests added in `daemon::pane`: one pinning the advertised names and values, one pinning that configured `env` may rename the terminal but cannot contradict `TERM`/`COLORTERM`.
- Full suite green (948 passed), `cargo fmt --check` and `cargo clippy --all-targets` clean.
- Verified against the pinned `portable-pty` 0.8.1 that a repeated `env` call for the same key replaces rather than appends, which is what the override ordering relies on.

Closes #212
