### PR TITLE
feat(theme): add One Dark Pro built-in theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Native builds for each platform on [**Releases**](https://github.com/l0ng-ai/tty
 | | |
 |---|---|
 | **Input** | ghost suggestions from history · explained tab completion · syntax highlighting · multi-line editing · click places the caret · <kbd>⌃ R</kbd> fuzzy history |
-| **Window** | tabs & splits · <kbd>⌘ P</kbd> palette · <kbd>⌘ F</kbd> scrollback search · eight themes · IME |
+| **Window** | tabs & splits · <kbd>⌘ P</kbd> palette · <kbd>⌘ F</kbd> scrollback search · nine themes · IME |
 | **Coding agents** | per-pane agent detection (~17 CLIs): status dot, notifications, branch + diff, resume after reboot, tray icon that signals "needs your input" |
 | **SSH** | native russh stack: profiles with keychain secrets, SFTP panel, port forwarding, jump hosts |
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -19,7 +19,7 @@
 - **Command palette** <kbd>⌘ P</kbd> · scrollback search <kbd>⌘ F</kbd>
 - **⌘/Ctrl-click links** (⌘ on macOS, Ctrl on Windows/Linux) · desktop notifications · copy on select (opt-in, Settings → Terminal → Clipboard)
 - **Smart double-click selection** — double-click grabs the whole URL, file path, bracket/quote pair, or dictionary-segmented CJK word under the cursor; Shift-click extends a selection (toggle in Settings → Terminal → Mouse; word separators via `word_separators` in `config.json`)
-- **Eight themes, plus your own** — YAML seed themes with solid, gradient, or image backgrounds; iTerm2 `.itermcolors` import; in-app color editor with a background-image picker
+- **Nine themes, plus your own** — YAML seed themes with solid, gradient, or image backgrounds; iTerm2 `.itermcolors` import; in-app color editor with a background-image picker
 - **Sync with system** — Settings → Appearance; pick separate light and dark themes and tty7 follows the OS appearance live (`theme_follow_system`, `theme_preset_light` / `theme_preset_dark` in `config.json`)
 - **Window opacity & blur** — Settings → Appearance → Window; applies to every theme, *Follow theme* returns to the theme's own `opacity` / `blur`
 - **CJK / IME input**

--- a/docs/features.zh-CN.md
+++ b/docs/features.zh-CN.md
@@ -19,7 +19,7 @@
 - **命令面板** <kbd>⌘ P</kbd> · 回滚搜索 <kbd>⌘ F</kbd>
 - **⌘ 点击打开链接** · 桌面通知 · 划选即复制（可选，设置 → 终端 → 剪贴板）
 - **智能双击选中** —— 双击直接选中整条 URL、文件路径、括号/引号对，中文按词典分词出词；Shift 点击扩展选区（设置 → 终端 → 鼠标可开关；分隔符用 `config.json` 的 `word_separators` 配置）
-- **8 套主题，也能自定义** — YAML 种子主题，背景支持纯色、渐变或图片；可导入 iTerm2 `.itermcolors`；应用内颜色编辑器带背景图选择
+- **9 套主题，也能自定义** — YAML 种子主题，背景支持纯色、渐变或图片；可导入 iTerm2 `.itermcolors`；应用内颜色编辑器带背景图选择
 - **跟随系统外观** — 设置 → Appearance；分别选好浅色和深色主题，tty7 随系统深浅模式实时切换（`config.json` 中的 `theme_follow_system`、`theme_preset_light` / `theme_preset_dark`）
 - **窗口透明与模糊** — 设置 → Appearance → Window；对所有主题生效，*Follow theme* 恢复主题自带的 `opacity` / `blur`
 - **CJK / 输入法输入**

--- a/src/ui/presets.rs
+++ b/src/ui/presets.rs
@@ -1109,7 +1109,7 @@ struct BuiltinSpec {
 }
 
 /// A hand-picked set of familiar terminal palettes.
-static BUILTINS: [BuiltinSpec; 8] = [
+static BUILTINS: [BuiltinSpec; 9] = [
     BuiltinSpec {
         id: "light",
         name: "Light",
@@ -1296,6 +1296,35 @@ static BUILTINS: [BuiltinSpec; 8] = [
         ],
     },
     BuiltinSpec {
+        id: "one_dark_pro",
+        name: "One Dark Pro",
+        background: 0x282c34,
+        foreground: 0xabb2bf,
+        // The editor cursor / focus blue, not the syntax blue `#61afef`: the
+        // accent doubles as the switch's checked track, and `#61afef` sits at
+        // the same luminance as the `#abb2bf` knob (1.11:1 — invisible).
+        accent: 0x528bff,
+        caret: None,
+        ansi16: [
+            (0x3f, 0x44, 0x51),
+            (0xe0, 0x6c, 0x75),
+            (0x98, 0xc3, 0x79),
+            (0xe5, 0xc0, 0x7b),
+            (0x61, 0xaf, 0xef),
+            (0xc6, 0x78, 0xdd),
+            (0x56, 0xb6, 0xc2),
+            (0xab, 0xb2, 0xbf),
+            (0x5c, 0x63, 0x70),
+            (0xff, 0x61, 0x6e),
+            (0xa5, 0xe0, 0x75),
+            (0xf0, 0xa4, 0x5d),
+            (0x4d, 0xc4, 0xff),
+            (0xde, 0x73, 0xff),
+            (0x4c, 0xd1, 0xe0),
+            (0xe6, 0xe6, 0xe6),
+        ],
+    },
+    BuiltinSpec {
         id: "rose_pine",
         name: "Rosé Pine",
         background: 0x191724,
@@ -1341,7 +1370,7 @@ mod tests {
     }
 
     /// Brightness is inferred correctly: the four light built-ins classify light,
-    /// the four dark ones dark.
+    /// the five dark ones dark.
     #[test]
     fn dark_is_inferred_from_background() {
         let dark: Vec<_> = builtins()
@@ -1349,7 +1378,10 @@ mod tests {
             .filter(|t| t.dark)
             .map(|t| t.id)
             .collect();
-        assert_eq!(dark, ["dark", "dracula", "harbor", "rose_pine"]);
+        assert_eq!(
+            dark,
+            ["dark", "dracula", "harbor", "one_dark_pro", "rose_pine"]
+        );
     }
 
     /// The selection surface must stay a *tint* — decisively on the background's


### PR DESCRIPTION
## Summary

Adds **One Dark Pro** as a ninth built-in theme, slotted alphabetically among the dark themes (between Harbor and Rosé Pine).

- Background `#282c34`, foreground `#abb2bf`
- Normal ANSI slots use the classic One Dark syntax palette (`#e06c75` / `#98c379` / `#e5c07b` / `#61afef` / `#c678dd` / `#56b6c2`); bright slots use One Dark Pro's bright variants
- README / docs theme count bumped from eight to nine

## Two deliberate departures from the VS Code theme's terminal set

Both were caught by this repo's contrast test suite:

1. **Accent is `#528bff` (the editor cursor/focus blue), not the syntax blue `#61afef`** — the accent doubles as the switch's checked track, and `#61afef` sits at the same luminance as the `#abb2bf` knob (1.11:1, under the 1.25 floor `switch_tracks_and_knob_stay_legible` pins). A code comment on the seed records this.
2. **Normal red is the classic `#e06c75`, not the Pro terminal `#e05561`** — after AA conditioning the latter lands within 37 channel-distance of the orange-yellow `#d18f52`, under the 40 separability floor `semantic_colors_clear_their_floors` requires between danger and warning.

## Testing

- Full suite passes: **946 passed, 0 failed** (includes the ladder/contrast invariants run against every built-in)
- `dark_is_inferred_from_background`'s expected id list updated to include `one_dark_pro`
- Verified visually in the running app (window chrome, prompt colors, theme picker)