### PR TITLE
fix(render): stop italic CJK rendering as unrelated CJK on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to tty7 are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Italic CJK rendered as unrelated CJK on Windows** — every character came out
+  as a different character, one for one, consistently, so it read as a broken
+  locale or a mangled encoding. It was neither. Hack, the bundled default, has no
+  CJK, so those cells are shaped by the font-fallback chain; gpui's Windows
+  backend then threw away the face DirectWrite shaped with and looked a fresh one
+  up by family, weight and style. That round trip mapped DirectWrite's *italic*
+  to *oblique* — the two are numbered the other way around in the API — and a
+  family with no oblique face resolved to its upright one. The glyph indices were
+  right; the outlines they were pointing into belonged to a different face. Fixed
+  in our gpui fork by rasterizing the face DirectWrite actually chose, which also
+  closes a latent use-after-free in the same cache: it keyed fonts by a raw
+  pointer to a face nothing held a reference to.
+
 ## [26.7.5] - 2026-07-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3096,7 +3096,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -3338,7 +3338,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -3385,7 +3385,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3396,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -3409,7 +3409,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "schemars",
  "serde",
@@ -3419,7 +3419,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "anyhow",
  "log",
@@ -3428,7 +3428,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -3452,7 +3452,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3481,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3800,7 +3800,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "http_client_tls"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "rustls",
  "rustls-platform-verifier",
@@ -4946,7 +4946,7 @@ checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -6044,7 +6044,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "collections",
  "serde",
@@ -7021,7 +7021,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "derive_refineable",
 ]
@@ -7064,7 +7064,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 [[package]]
 name = "reqwest_client"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7589,7 +7589,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "async-task",
  "backtrace",
@@ -8396,7 +8396,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "heapless",
  "log",
@@ -9775,7 +9775,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "anyhow",
  "async-fs",
@@ -9814,7 +9814,7 @@ dependencies = [
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "perf",
  "quote",
@@ -11620,7 +11620,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11665,7 +11665,7 @@ dependencies = [
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -11676,7 +11676,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#24ed55f4cf1c6f90c2fb4a1db0f33aca949a7f02"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,12 +319,21 @@ lto = "thin"
 codegen-units = 1
 
 # ---- gpui fork ------------------------------------------------------------
-# Our `tty7` branch (cut from the pinned upstream rev, one commit on top) carries
-# a single patch: `prefers_ime_for_printable_keys` takes the keystroke, so an
-# input handler can answer per key instead of per view. tty7 needs it for
-# Option-as-Meta — macOS routes ⌥-chords to the IME whenever a CJK input source
-# is active, and without the keystroke there is no way to decline just those
-# chords (see `terminal::input::prefers_ime_for_printable_keys`, issue #177).
+# Our `tty7` branch (cut from the pinned upstream rev, two commits on top) carries:
+#
+# 1. `prefers_ime_for_printable_keys` takes the keystroke, so an input handler can
+#    answer per key instead of per view. tty7 needs it for Option-as-Meta — macOS
+#    routes ⌥-chords to the IME whenever a CJK input source is active, and without
+#    the keystroke there is no way to decline just those chords (see
+#    `terminal::input::prefers_ime_for_printable_keys`, issue #177).
+#
+# 2. gpui's Windows backend rasterizes a font-fallback run with the face
+#    DirectWrite actually shaped it with, instead of re-deriving one from the
+#    face's family/weight/style. The round trip mapped DirectWrite's italic to
+#    oblique, so italic CJK — which every pane reaches through the fallback chain,
+#    Hack having no CJK — drew a *different* face's outlines at the shaped glyph
+#    indices. Every character rendered as an unrelated character, one for one,
+#    which reads as mojibake rather than as a font bug.
 #
 # Patching by source rather than editing the `gpui`/`gpui_platform` pins above is
 # deliberate: `gpui-component` declares its own `gpui` from the upstream URL, and


### PR DESCRIPTION
## What was happening

Italic CJK in a pane rendered as *different* CJK — one character for one character, the same substitution every time. It reads as a broken locale or a mangled encoding. It is neither.

| shown | should be | Δ codepoint |
|---|---|---|
| 達 | 这 | +123 |
| 构 | 有 | +123 |
| 俗 | 作 | +123 |
| 尙 | 实 | +123 |
| 报 | 截 | +123 |

A near-constant offset that jumps where a font's coverage has gaps is the signature of a **glyph-index** offset, not a codepoint one — the right indices addressed into the wrong face. Confirmed by reversing the substitution through the installed fonts' cmaps: the pair is *Maple Mono NF CN Italic* shaped, *Maple Mono NF CN Regular* drawn.

## Root cause

In `gpui_windows::direct_write`, `DrawGlyphRun` receives the face DirectWrite shaped a fallback run with — then throws it away and looks a *fresh* face up by family name, weight and style.

`font_style_from_dwrite` made that lossy outright. DirectWrite numbers its style enum `OBLIQUE = 1, ITALIC = 2`; the mapping read `1 => Italic, 2 => Oblique`. So an italic fallback face round-tripped into a request for an *oblique* one, and a family with no oblique face — Maple Mono NF CN, first in our Windows fallback chain — resolved to its **upright** face.

Hack has no CJK, so every CJK cell in every pane goes through this path.

## Fix

In our gpui fork: register the face DirectWrite actually chose instead of re-deriving one. The run's glyph indices are only meaningful in that face, so it is the only correct answer.

That also closes a latent use-after-free in the same cache. `font_info_cache` keys `FontId`s by a font face's COM identity — an address — and nothing held a reference to the object at that address. DirectWrite was free to release the face and let a later allocation reuse the address, silently aliasing the entry onto an unrelated font. Registering the face gives the entry ownership of its own key.

The name round trip has no other callers, so `font_face_to_font` and the two `*_from_dwrite` helpers go with it.

## Tests

Two in `gpui_windows::direct_write`, both written before the fix and both red on the old code (the first fails on the italic case, deterministically, with exactly the +123 glyph-id skew):

- `shaped_run_font_id_denotes_the_face_the_run_was_shaped_with` — every glyph in a shaped run must round-trip through the `FontId` the run reports.
- `every_font_face_cache_key_is_owned_by_the_font_it_maps_to` — every cache key must be the address of a face the text system holds.

`cargo test -p gpui_windows --lib`: 8 passed. Clippy clean.

## Verification

Built and run against an isolated config dir. Italic, upright and bold CJK all render correctly.

## Scope

Fork pin bump only — no tty7 code changes. gpui fork commit: `l0ng-ai/zed@87ce3e2`, on the existing `tty7` branch that `[patch]` already points at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)