### PR TITLE
chore: dedupe the resvg stack with the gpui fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "Dim inactive panes" switch. On by default, so nothing changes for anyone who
   was happy; off renders every pane at full opacity. (#214)
 
+### Changed
+
+- **One fewer duplicate SVG stack in the build** — the resvg 0.47 bump (#227)
+  left the gpui fork on 0.45, so the tree compiled two resvg/usvg/tiny-skia
+  stacks. The fork now pins 0.47 too, re-unifying its stack with the one tty7
+  uses for the tray icon. gpui-component still carries its own 0.45.1 until
+  that fork catches up.
+
 ### Fixed
 
 - **Italic CJK rendered as unrelated CJK on Windows** — every character came out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   left the gpui fork on 0.45, so the tree compiled two resvg/usvg/tiny-skia
   stacks. The fork now pins 0.47 too, re-unifying its stack with the one tty7
   uses for the tray icon. gpui-component still carries its own 0.45.1 until
-  that fork catches up.
+  that fork catches up. (#237)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,7 +817,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1369,7 +1369,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2022,7 +2022,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.8.9",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -3070,7 +3070,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.62.2",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -3096,7 +3096,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -3151,7 +3151,7 @@ dependencies = [
  "raw-window-handle",
  "refineable",
  "regex",
- "resvg 0.45.1",
+ "resvg 0.47.0",
  "scheduler",
  "schemars",
  "seahash",
@@ -3167,7 +3167,7 @@ dependencies = [
  "thiserror 2.0.18",
  "ttf-parser",
  "url",
- "usvg 0.45.1",
+ "usvg 0.47.0",
  "util_macros",
  "uuid",
  "waker-fn",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -3338,7 +3338,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -3385,7 +3385,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3396,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -3409,7 +3409,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "schemars",
  "serde",
@@ -3419,7 +3419,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "anyhow",
  "log",
@@ -3428,7 +3428,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -3452,7 +3452,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3481,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3800,7 +3800,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "http_client_tls"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "rustls",
  "rustls-platform-verifier",
@@ -3918,7 +3918,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -4964,7 +4964,7 @@ checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -6062,7 +6062,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "collections",
  "serde",
@@ -7048,7 +7048,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "derive_refineable",
 ]
@@ -7091,7 +7091,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 [[package]]
 name = "reqwest_client"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7129,12 +7129,15 @@ version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
 dependencies = [
+ "gif 0.14.2",
+ "image-webp",
  "log",
  "pico-args",
  "rgb",
  "svgtypes 0.16.1",
  "tiny-skia 0.12.0",
  "usvg 0.47.0",
+ "zune-jpeg 0.5.15",
 ]
 
 [[package]]
@@ -7639,7 +7642,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "async-task",
  "backtrace",
@@ -8446,7 +8449,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "heapless",
  "log",
@@ -9855,16 +9858,22 @@ dependencies = [
  "base64",
  "data-url",
  "flate2",
+ "fontdb",
  "imagesize 0.14.0",
  "kurbo 0.13.1",
  "log",
  "pico-args",
  "roxmltree 0.21.1",
+ "rustybuzz",
  "simplecss",
  "siphasher",
  "strict-num",
  "svgtypes 0.16.1",
  "tiny-skia-path 0.12.0",
+ "ttf-parser",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
  "xmlwriter",
 ]
 
@@ -9883,7 +9892,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "anyhow",
  "async-fs",
@@ -9922,7 +9931,7 @@ dependencies = [
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "perf",
  "quote",
@@ -11728,7 +11737,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11773,7 +11782,7 @@ dependencies = [
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -11784,7 +11793,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#87ce3e2d5c16d5704a45196a761c8809e4a386c7"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3aac3ef3a1411d539c32610ed29e399ef1d3b0ae"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,10 +152,12 @@ memchr = "2"
 
 # System tray / menu bar status item (`ui::tray`). Rasterizes the bundled SVG
 # logo into the tray bitmap at runtime — gpui's own SVG path only yields a
-# tinted alpha mask, not raw RGBA. NOTE: gpui/gpui-component still pin 0.45.x,
-# so until the fork catches up this compiles a second resvg/usvg/tiny-skia
-# stack (no type conflicts — only `image::RgbaImage` crosses the boundary);
-# default features off drops the text/font machinery our icon SVGs don't use.
+# tinted alpha mask, not raw RGBA. The gpui fork pins the same 0.47, so this
+# shares gpui's resvg/usvg/tiny-skia stack. gpui-component still declares its
+# own `resvg = "0.45.1"` (semver-incompatible with 0.47), so one legacy 0.45
+# stack remains until that fork catches up (no type conflicts — only
+# `image::RgbaImage` crosses the boundary); default features off drops the
+# text/font machinery our icon SVGs don't use.
 resvg = { version = "0.47", default-features = false }
 
 # The tray icon itself, macOS + Windows: tauri's `tray-icon` (NSStatusItem /
@@ -320,7 +322,7 @@ lto = "thin"
 codegen-units = 1
 
 # ---- gpui fork ------------------------------------------------------------
-# Our `tty7` branch (cut from the pinned upstream rev, two commits on top) carries:
+# Our `tty7` branch (cut from the pinned upstream rev, three commits on top) carries:
 #
 # 1. `prefers_ime_for_printable_keys` takes the keystroke, so an input handler can
 #    answer per key instead of per view. tty7 needs it for Option-as-Meta — macOS
@@ -335,6 +337,9 @@ codegen-units = 1
 #    Hack having no CJK — drew a *different* face's outlines at the shaped glyph
 #    indices. Every character rendered as an unrelated character, one for one,
 #    which reads as mojibake rather than as a font bug.
+#
+# 3. resvg/usvg bumped 0.45 → 0.47 so gpui's SVG stack unifies with the resvg
+#    tty7 pins directly above (follow-up to the #227 dependabot bump).
 #
 # Patching by source rather than editing the `gpui`/`gpui_platform` pins above is
 # deliberate: `gpui-component` declares its own `gpui` from the upstream URL, and


### PR DESCRIPTION
## Summary

Follow-up to #227 and #233. The resvg 0.47 bump in #227 landed while the gpui fork (pinned since #233) still declared resvg 0.45, so the dependency tree compiled two full resvg/usvg/tiny-skia stacks. The fork's `tty7` branch now carries resvg/usvg 0.47 (l0ng-ai/zed@3aac3ef3a1411d539c32610ed29e399ef1d3b0ae — a pure dependency bump, no source changes were needed), and this PR moves the lockfile pin to that commit so gpui's SVG renderer and tty7's tray-icon rasterizer share a single 0.47 stack again.

Not fully deduped: gpui-component directly declares `resvg = "0.45.1"`, which is semver-incompatible with 0.47, so one legacy 0.45 stack remains until that fork is bumped too. The manifest comments and CHANGELOG note this.

## Changes

- `Cargo.lock`: gpui/gpui_platform/gpui_macros et al. move 87ce3e2 → 3aac3ef; the resvg 0.47 entries are now shared with gpui
- `Cargo.toml`: fork-pin comment now lists three carried commits; the stale "gpui still pins 0.45.x / second stack" note by the resvg dependency updated to describe the remaining gpui-component-only duplication
- `CHANGELOG.md`: entry under [Unreleased] → Changed

## Testing

- `cargo build --locked` clean
- `cargo clippy --all-targets` — no new warnings (no Rust source touched)
- `cargo test` — 890 passed, 1 ignored
- Fork side: gpui compiles against 0.47 unmodified; `cargo test -p gpui_windows --lib` (8/8) and gpui svg_renderer tests (4/4) pass, clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
