### PR TITLE
fix(file-tree): stop a watcher event repainting a window with nothing to draw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,16 +146,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   under `node_modules` reaches nothing on screen and now costs nothing.
   Real changes still arrive exactly as fast.
 
-  Measured headlessly by counting window draws, before and after: five writes
-  under an unlisted directory cost 5 frames and now cost 0; five rewrites of a
-  file in a displayed directory cost 10 and now cost 0; five `.gitignore` writes
-  under `node_modules` cost 10 and now cost 0.
+- **An idle window stays idle while a file in the Files panel is being written**
+  — the tree watches its roots plus every directory you have expanded, so what
+  it hears about is a change in a directory it is *displaying*, and a file's
+  contents being rewritten reports exactly as loudly as a file appearing. A
+  formatter rewriting in place, an editor saving on every keystroke, a build
+  dropping its log next to the sources: each of those repainted the whole
+  window, twice over, for as long as it went on. A window with nothing new to
+  draw never reached render idle, which is what issue #243 reports in its title.
+  A batch now repaints only when the re-read comes back different from what is
+  already on screen, and that re-read is issued from the watcher callback rather
+  than by asking for a paint in order to get one. A closed Files panel does no
+  work at all: the change is recorded and picked up on reopening. Real changes
+  still arrive exactly as fast.
+
+  Measured headlessly by counting window draws, before and after: five rewrites
+  of a file in a displayed directory cost 10 frames and now cost 0.
+
+  `.gitignore` edits keep their whole-cache refresh, now taken only when the file
+  can actually govern a directory the tree holds. That one is a correctness guard
+  on the most expensive branch here rather than a measurable saving — the watch
+  is non-recursive, so a `.gitignore` has to sit directly in a displayed
+  directory to arrive in the first place.
 
   The other half of that report — the Files panel flickering — was fixed
   independently by "keep file-tree listings on screen while they refresh", which
   landed first and is the mechanism the panel now uses. This is only the frames.
-  Note the redraw behaviour is platform-independent and is what those numbers
-  are about; the reporter's ~15% CPU figure, and whether their flicker also
+  Note the redraw behaviour is platform-independent and is what that number is
+  about; the reporter's ~15% CPU figure, and whether their flicker also
   involved something in the Wayland presentation path, were not reproducible on
   macOS and are not claimed to be confirmed. (#243)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,22 +130,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   survives frames — where gpui-component's own `TitleBar` has always kept it,
   which is why the ordinary caption strip was never affected. (#221)
 
-- **An idle window stays idle when the file tree is watching a busy tree** —
-  the file tree watches its root recursively, so it hears about every write
-  underneath: `.git` internals, build output, everything under `node_modules`.
-  Each of those batches repainted the whole window, several times a second,
-  including the overwhelming majority naming a directory the tree has never
-  listed and does not display. A window with nothing new to draw never reached
-  render idle, which is what issue #243 reports in its title. A batch now
-  repaints only when it reaches a listing the tree actually holds *and* the
-  re-read comes back different — so a file being rewritten in a directory on
-  screen costs nothing, and the re-read is issued from the watcher callback
-  rather than by asking for a paint in order to get one. `.gitignore` edits keep
-  their whole-cache refresh, but only when the file governs a directory the tree
-  is showing or loading: the one an `npm install` unpacks into each package
-  under `node_modules` reaches nothing on screen and now costs nothing.
-  Real changes still arrive exactly as fast.
-
 - **An idle window stays idle while a file in the Files panel is being written**
   — the tree watches its roots plus every directory you have expanded, so what
   it hears about is a change in a directory it is *displaying*, and a file's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,8 +157,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A batch now repaints only when the re-read comes back different from what is
   already on screen, and that re-read is issued from the watcher callback rather
   than by asking for a paint in order to get one. A closed Files panel does no
-  work at all: the change is recorded and picked up on reopening. Real changes
-  still arrive exactly as fast.
+  work at all: the change is recorded and picked up on reopening. A panel showing
+  search hits is the same case — the hits are their own walk, so no listing is on
+  screen to refresh — and the change is picked up when you clear the search box.
+  Real changes still arrive exactly as fast.
 
   Measured headlessly by counting window draws, before and after: five rewrites
   of a file in a displayed directory cost 10 frames and now cost 0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   survives frames — where gpui-component's own `TitleBar` has always kept it,
   which is why the ordinary caption strip was never affected. (#221)
 
+- **An idle window stays idle when the file tree is watching a busy tree** —
+  the file tree watches its root recursively, so it hears about every write
+  underneath: `.git` internals, build output, everything under `node_modules`.
+  Each of those batches repainted the whole window, several times a second,
+  including the overwhelming majority naming a directory the tree has never
+  listed and does not display. A window with nothing new to draw never reached
+  render idle, which is what issue #243 reports in its title. A batch now
+  repaints only when it reaches a listing the tree actually holds *and* the
+  re-read comes back different — so a file being rewritten in a directory on
+  screen costs nothing, and the re-read is issued from the watcher callback
+  rather than by asking for a paint in order to get one. `.gitignore` edits keep
+  their whole-cache refresh, but only when the file governs a directory the tree
+  is showing or loading: the one an `npm install` unpacks into each package
+  under `node_modules` reaches nothing on screen and now costs nothing.
+  Real changes still arrive exactly as fast.
+
+  Measured headlessly by counting window draws, before and after: five writes
+  under an unlisted directory cost 5 frames and now cost 0; five rewrites of a
+  file in a displayed directory cost 10 and now cost 0; five `.gitignore` writes
+  under `node_modules` cost 10 and now cost 0.
+
+  The other half of that report — the Files panel flickering — was fixed
+  independently by "keep file-tree listings on screen while they refresh", which
+  landed first and is the mechanism the panel now uses. This is only the frames.
+  Note the redraw behaviour is platform-independent and is what those numbers
+  are about; the reporter's ~15% CPU figure, and whether their flicker also
+  involved something in the Wayland presentation path, were not reproducible on
+  macOS and are not claimed to be confirmed. (#243)
+
 ## [26.7.6] - 2026-07-28
 
 ### Added

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -1103,7 +1103,8 @@ impl TerminalView {
 
     /// Build the view around an already-connected terminal. Split from [`new`]
     /// so tests can hand in a `RemoteTerminal` backed by a plain socketpair
-    /// and exercise the event plumbing without a live daemon.
+    /// and exercise the event plumbing without a live daemon — see
+    /// [`quiet_test_pane`], which the UI-level tests build their tabs from.
     fn with_terminal(
         terminal: RemoteTerminal,
         pane_id: u64,
@@ -7980,6 +7981,27 @@ mod tests {
         };
         assert_eq!(sibling.target.host_id(), remote);
     }
+}
+
+/// A pane the UI-level gpui tests can put in a tab: a real [`TerminalView`] on a
+/// socketpair with nothing on the far end, so a test window has a pane without a
+/// daemon, a shell, or a byte of output to repaint for. That silence is the
+/// point — the render-idle tests measure what the *window* does when nothing is
+/// happening, so the pane must not be a source of frames.
+///
+/// The caller keeps the returned stream alive: dropping it closes the socket and
+/// the reader retires the pane.
+#[cfg(all(test, unix))]
+pub(crate) fn quiet_test_pane(
+    pane_id: u64,
+    window: &mut Window,
+    cx: &mut gpui::App,
+) -> (gpui::Entity<TerminalView>, std::os::unix::net::UnixStream) {
+    let (client_side, daemon_side) = std::os::unix::net::UnixStream::pair().unwrap();
+    let terminal = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24))
+        .expect("socketpair-backed terminal");
+    let view = cx.new(|cx| TerminalView::with_terminal(terminal, pane_id, window, cx));
+    (view, daemon_side)
 }
 
 /// gpui-harness tests: a real (headless) App + Window around a `TerminalView`

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -6121,6 +6121,65 @@ impl Tty7App {
     }
 }
 
+/// A per-thread count of how many times the window has drawn, for the
+/// render-idle tests (issue #243).
+///
+/// A window that has settled draws once and stops. Anything that notifies from
+/// the paint path turns that into an unbounded loop — the window never reaches
+/// render idle, and on a compositor that presents every frame the panel visibly
+/// flickers. The seam is testable headlessly because gpui's test build redraws
+/// dirty windows inside `flush_effects`: a paint that notifies simply keeps that
+/// loop running, so counting draws across a quiet interval answers the question
+/// without a real window.
+///
+/// The limit of that: `window.request_animation_frame()` does not drive frames
+/// under the test platform. It registers a next-frame callback that only a real
+/// platform window's frame callback drains, so `cx.notify()` is the only thing
+/// this counts. A repaint loop driven by an animation frame would run right past
+/// this probe and needs a different instrument.
+///
+/// Thread-local rather than a global: `#[gpui::test]` cases run in parallel on
+/// their own threads, and gpui drives each one's foreground work on the thread
+/// that owns its `TestAppContext`.
+#[cfg(test)]
+pub(crate) mod render_probe {
+    use std::cell::Cell;
+
+    thread_local! {
+        static DRAWS: Cell<u64> = const { Cell::new(0) };
+        /// When set, the draw that exceeds it panics instead of spinning. A
+        /// repaint loop lives entirely inside one `flush_effects` call, so
+        /// without this a regression hangs the suite rather than failing it.
+        static BUDGET: Cell<Option<u64>> = const { Cell::new(None) };
+    }
+
+    /// One window draw. Called from [`Tty7App::render`].
+    pub(crate) fn record() {
+        let n = DRAWS.get() + 1;
+        DRAWS.set(n);
+        if let Some(budget) = BUDGET.get()
+            && n > budget
+        {
+            BUDGET.set(None);
+            panic!(
+                "the window drew more than {budget} frames without input: it never reached \
+                 render idle (issue #243)"
+            );
+        }
+    }
+
+    /// Start counting from zero, failing the test if `budget` draws pass.
+    pub(crate) fn arm(budget: u64) {
+        DRAWS.set(0);
+        BUDGET.set(Some(budget));
+    }
+
+    /// Draws since [`arm`].
+    pub(crate) fn draws() -> u64 {
+        DRAWS.get()
+    }
+}
+
 impl Tty7App {
     /// Design §10's status strip, on a window that has tabs.
     ///
@@ -6334,6 +6393,15 @@ impl ForwardRoute {
 
 impl Render for Tty7App {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        #[cfg(test)]
+        render_probe::record();
+        // `TTY7_PROFILE`: time the whole window build and, via the aggregated
+        // call rate, expose whether it is rebuilding on real changes or in a
+        // notify loop. A settled window should report no calls at all; anything
+        // above zero on a window nobody is touching is the shape of issue #243,
+        // and this is how a report of it can be checked on the machine that sees
+        // it rather than inferred from the code.
+        let prof = crate::ui::perf::enabled().then(std::time::Instant::now);
         // A live drag-reorder commits when the drag *ends*, which in gpui means
         // the mouse was released (nothing else clears an active drag): the first
         // frame without one retires the preview and applies the order it was
@@ -6654,333 +6722,323 @@ impl Render for Tty7App {
                 .child(self.render_settings(window, cx))
         });
 
-        div()
-            .id("tty7-root")
-            .size_full()
-            .flex()
-            .flex_col()
-            .bg(window_bg)
-            .text_color(cx.theme().foreground)
-            .on_modifiers_changed(cx.listener(Self::on_modifiers_changed))
-            .on_action(cx.listener(|this, _: &NewTab, window, cx| this.new_tab(window, cx)))
-            .on_action(cx.listener(|this, _: &SelectWorkspace1, window, cx| {
-                this.select_workspace_slot(0, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &SelectWorkspace2, window, cx| {
-                this.select_workspace_slot(1, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &SelectWorkspace3, window, cx| {
-                this.select_workspace_slot(2, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &SelectWorkspace4, window, cx| {
-                this.select_workspace_slot(3, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &SelectWorkspace5, window, cx| {
-                this.select_workspace_slot(4, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &SelectWorkspace6, window, cx| {
-                this.select_workspace_slot(5, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &SelectWorkspace7, window, cx| {
-                this.select_workspace_slot(6, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &SelectWorkspace8, window, cx| {
-                this.select_workspace_slot(7, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &SelectWorkspace9, window, cx| {
-                this.select_workspace_slot(8, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &RenameWorkspace, window, cx| {
-                this.start_workspace_rename(window, cx)
-            }))
-            .on_action(
-                cx.listener(|this, _: &ToggleSwitcher, window, cx| {
+        let root =
+            div()
+                .id("tty7-root")
+                .size_full()
+                .flex()
+                .flex_col()
+                .bg(window_bg)
+                .text_color(cx.theme().foreground)
+                .on_modifiers_changed(cx.listener(Self::on_modifiers_changed))
+                .on_action(cx.listener(|this, _: &NewTab, window, cx| this.new_tab(window, cx)))
+                .on_action(cx.listener(|this, _: &SelectWorkspace1, window, cx| {
+                    this.select_workspace_slot(0, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &SelectWorkspace2, window, cx| {
+                    this.select_workspace_slot(1, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &SelectWorkspace3, window, cx| {
+                    this.select_workspace_slot(2, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &SelectWorkspace4, window, cx| {
+                    this.select_workspace_slot(3, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &SelectWorkspace5, window, cx| {
+                    this.select_workspace_slot(4, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &SelectWorkspace6, window, cx| {
+                    this.select_workspace_slot(5, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &SelectWorkspace7, window, cx| {
+                    this.select_workspace_slot(6, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &SelectWorkspace8, window, cx| {
+                    this.select_workspace_slot(7, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &SelectWorkspace9, window, cx| {
+                    this.select_workspace_slot(8, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &RenameWorkspace, window, cx| {
+                    this.start_workspace_rename(window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ToggleSwitcher, window, cx| {
                     this.toggle_switcher(window, cx)
-                }),
-            )
-            .on_action(cx.listener(|this, _: &StopWorkspace, window, cx| {
-                let id = this.workspace;
-                this.stop_workspace(id, window, cx);
-            }))
-            .on_action(cx.listener(|this, _: &DeleteWorkspace, window, cx| {
-                let id = this.workspace;
-                this.delete_workspace(id, window, cx);
-            }))
-            .on_action(cx.listener(|_this, _: &NewWorkspace, _window, cx| {
-                // A fresh workspace, not a copy of this one: the daemon gives
-                // each pane a single subscriber, so a second window onto the
-                // same panes would steal this window's output.
-                crate::ui::windows::open(cx, None);
-            }))
-            .on_action(cx.listener(|this, _: &CloseActiveTab, window, cx| {
-                // With focus in the editor panel, ⌘W closes the active file
-                // tab instead of the terminal pane/tab.
-                if !this.editor_close_active_if_focused(window, cx) {
-                    this.close_pane(window, cx)
-                }
-            }))
-            .on_action(cx.listener(|this, _: &SplitRight, window, cx| {
-                this.split(Axis::Horizontal, window, cx)
-            }))
-            .on_action(
-                cx.listener(|this, _: &SplitDown, window, cx| {
+                }))
+                .on_action(cx.listener(|this, _: &StopWorkspace, window, cx| {
+                    let id = this.workspace;
+                    this.stop_workspace(id, window, cx);
+                }))
+                .on_action(cx.listener(|this, _: &DeleteWorkspace, window, cx| {
+                    let id = this.workspace;
+                    this.delete_workspace(id, window, cx);
+                }))
+                .on_action(cx.listener(|_this, _: &NewWorkspace, _window, cx| {
+                    // A fresh workspace, not a copy of this one: the daemon gives
+                    // each pane a single subscriber, so a second window onto the
+                    // same panes would steal this window's output.
+                    crate::ui::windows::open(cx, None);
+                }))
+                .on_action(cx.listener(|this, _: &CloseActiveTab, window, cx| {
+                    // With focus in the editor panel, ⌘W closes the active file
+                    // tab instead of the terminal pane/tab.
+                    if !this.editor_close_active_if_focused(window, cx) {
+                        this.close_pane(window, cx)
+                    }
+                }))
+                .on_action(cx.listener(|this, _: &SplitRight, window, cx| {
+                    this.split(Axis::Horizontal, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &SplitDown, window, cx| {
                     this.split(Axis::Vertical, window, cx)
-                }),
-            )
-            .on_action(
-                cx.listener(|this, _: &FocusNextPane, window, cx| {
+                }))
+                .on_action(cx.listener(|this, _: &FocusNextPane, window, cx| {
                     this.cycle_pane(true, window, cx)
-                }),
-            )
-            .on_action(
-                cx.listener(|this, _: &FocusPrevPane, window, cx| {
+                }))
+                .on_action(cx.listener(|this, _: &FocusPrevPane, window, cx| {
                     this.cycle_pane(false, window, cx)
-                }),
-            )
-            .on_action(cx.listener(|this, _: &FocusPaneLeft, window, cx| {
-                this.focus_pane_dir(Dir::Left, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &FocusPaneRight, window, cx| {
-                this.focus_pane_dir(Dir::Right, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &FocusPaneUp, window, cx| {
-                this.focus_pane_dir(Dir::Up, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &FocusPaneDown, window, cx| {
-                this.focus_pane_dir(Dir::Down, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &ResizePaneLeft, window, cx| {
-                this.resize_pane(Dir::Left, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &ResizePaneRight, window, cx| {
-                this.resize_pane(Dir::Right, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &ResizePaneUp, window, cx| {
-                this.resize_pane(Dir::Up, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &ResizePaneDown, window, cx| {
-                this.resize_pane(Dir::Down, window, cx)
-            }))
-            .on_action(
-                cx.listener(|this, _: &SwapPaneNext, window, cx| this.swap_pane(true, window, cx)),
-            )
-            .on_action(
-                cx.listener(|this, _: &SwapPanePrev, window, cx| this.swap_pane(false, window, cx)),
-            )
-            .on_action(
-                cx.listener(|this, _: &NextTab, window, cx| this.cycle_tab(true, window, cx)),
-            )
-            .on_action(
-                cx.listener(|this, _: &PrevTab, window, cx| this.cycle_tab(false, window, cx)),
-            )
-            .on_action(
-                cx.listener(|this, _: &ActivateTab1, window, cx| {
-                    this.activate_visual(0, window, cx)
-                }),
-            )
-            .on_action(
-                cx.listener(|this, _: &ActivateTab2, window, cx| {
-                    this.activate_visual(1, window, cx)
-                }),
-            )
-            .on_action(
-                cx.listener(|this, _: &ActivateTab3, window, cx| {
-                    this.activate_visual(2, window, cx)
-                }),
-            )
-            .on_action(
-                cx.listener(|this, _: &ActivateTab4, window, cx| {
-                    this.activate_visual(3, window, cx)
-                }),
-            )
-            .on_action(
-                cx.listener(|this, _: &ActivateTab5, window, cx| {
-                    this.activate_visual(4, window, cx)
-                }),
-            )
-            .on_action(
-                cx.listener(|this, _: &ActivateTab6, window, cx| {
-                    this.activate_visual(5, window, cx)
-                }),
-            )
-            .on_action(
-                cx.listener(|this, _: &ActivateTab7, window, cx| {
-                    this.activate_visual(6, window, cx)
-                }),
-            )
-            .on_action(
-                cx.listener(|this, _: &ActivateTab8, window, cx| {
-                    this.activate_visual(7, window, cx)
-                }),
-            )
-            .on_action(
-                cx.listener(|this, _: &ActivateTab9, window, cx| {
-                    this.activate_visual(8, window, cx)
-                }),
-            )
-            .on_action(cx.listener(|this, _: &IncreaseFontSize, _window, cx| {
-                this.change_font_size(FONT_SIZE_STEP, cx)
-            }))
-            .on_action(cx.listener(|this, _: &DecreaseFontSize, _window, cx| {
-                this.change_font_size(-FONT_SIZE_STEP, cx)
-            }))
-            .on_action(cx.listener(|this, _: &ResetFontSize, _window, cx| this.reset_font_size(cx)))
-            .on_action(
-                cx.listener(|this, _: &TogglePalette, window, cx| this.toggle_palette(window, cx)),
-            )
-            .on_action(cx.listener(|this, _: &ReopenClosedTab, window, cx| {
-                this.reopen_closed_tab(window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &ToggleMaximizePane, window, cx| {
-                this.toggle_maximize(window, cx)
-            }))
-            .on_action(
-                cx.listener(|_, _: &ToggleFullscreen, window, _cx| window.toggle_fullscreen()),
-            )
-            .on_action(
-                cx.listener(|this, _: &ToggleTabSidebar, _window, cx| this.toggle_tab_sidebar(cx)),
-            )
-            .on_action(
-                cx.listener(|this, _: &ToggleLeftPanel, _window, cx| this.toggle_left_panel(cx)),
-            )
-            .on_action(
-                cx.listener(|this, _: &ToggleRightPanel, _window, cx| this.toggle_right_panel(cx)),
-            )
-            .on_action(cx.listener(|this, _: &ShowRightPanelInfo, _window, cx| {
-                this.set_right_panel_tab(crate::core::config::RightPanelTab::Info, cx)
-            }))
-            .on_action(cx.listener(|this, _: &ShowRightPanelOutline, _window, cx| {
-                this.set_right_panel_tab(crate::core::config::RightPanelTab::Outline, cx)
-            }))
-            .on_action(cx.listener(|this, _: &ShowRightPanelChanges, _window, cx| {
-                this.set_right_panel_tab(crate::core::config::RightPanelTab::Changes, cx)
-            }))
-            .on_action(cx.listener(|this, _: &ShowRightPanelFiles, _window, cx| {
-                this.set_right_panel_tab(crate::core::config::RightPanelTab::Files, cx)
-            }))
-            .on_action(
-                cx.listener(|this, _: &OpenSettings, window, cx| this.toggle_settings(window, cx)),
-            )
-            .on_action(
-                cx.listener(|this, _: &RestartDaemon, window, cx| this.restart_daemon(window, cx)),
-            )
-            .on_action(cx.listener(|this, _: &ToggleSftp, window, cx| this.toggle_sftp(window, cx)))
-            .on_action(cx.listener(|this, _: &ShowSshForwards, window, cx| {
-                this.show_ssh_forwards(window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &ToggleCodePanel, window, cx| {
-                this.toggle_code_panel(window, cx)
-            }))
-            .on_action(
-                cx.listener(|this, _: &EditorSave, window, cx| this.editor_save_active(window, cx)),
-            )
-            // Quit lives on the same element-tree action path as every other Cmd
-            // shortcut above, so a focused terminal routes `cmd-q` here rather
-            // than relying solely on the global handler (which the keystroke
-            // doesn't reach while focus is deep in the terminal view).
-            .on_action(cx.listener(|_, _: &Quit, _, cx| cx.quit()))
-            .on_action(cx.listener(|this, _: &OpenSshProfiles, window, cx| {
-                this.open_settings_section(SettingsSection::Ssh, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &RestartSshSession, window, cx| {
-                this.restart_ssh_session(window, cx)
-            }))
-            // Tab operations that used to be reachable only by right-clicking a
-            // chip. Each targets the active tab, so the menu bar / palette /
-            // keyboard all mean "this tab" without a click to say which.
-            .on_action(cx.listener(|this, _: &RenameTab, window, cx| {
-                this.start_rename(this.active, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &NewWorktreeTab, window, cx| {
-                this.new_worktree_tab(this.active, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &CloseOtherTabs, window, cx| {
-                this.close_other_tabs(this.active, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &CloseTabsToTheRight, window, cx| {
-                this.close_tabs_right_of(this.active, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &CopyWorkingDirectory, window, cx| {
-                this.copy_active_cwd(window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &MarkTabUnread, _window, cx| {
-                this.mark_tab_unread(this.active, cx)
-            }))
-            // Fork: the bare action has no pane the user pointed at, so it
-            // opens a new tab; the four directional ones come from the pane
-            // right-click menu, where the ask *was* spatial.
-            .on_action(cx.listener(|this, _: &ForkAgentSession, window, cx| {
-                this.fork_active_pane_session(ForkPlacement::NewTab, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &ForkAgentSessionRight, window, cx| {
-                this.fork_focused_pane_session(Axis::Horizontal, false, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &ForkAgentSessionLeft, window, cx| {
-                this.fork_focused_pane_session(Axis::Horizontal, true, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &ForkAgentSessionDown, window, cx| {
-                this.fork_focused_pane_session(Axis::Vertical, false, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &ForkAgentSessionUp, window, cx| {
-                this.fork_focused_pane_session(Axis::Vertical, true, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &CopyAgentSessionId, window, cx| {
-                this.copy_agent_session_id(this.active, window, cx)
-            }))
-            // Settings destinations that deserve their own way in: Help →
-            // Keyboard Shortcuts and the App menu's About both used to require
-            // opening Settings and then hunting for the section.
-            .on_action(cx.listener(|this, _: &ShowKeyboardShortcuts, window, cx| {
-                this.open_settings_section(SettingsSection::Keybindings, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &About, window, cx| {
-                this.open_settings_section(SettingsSection::About, window, cx)
-            }))
-            .on_action(cx.listener(|this, _: &CheckForUpdates, window, cx| {
-                this.check_for_updates_now(window, cx)
-            }))
-            // Standard macOS App / Window menu items. gpui exposes the platform
-            // calls but ships no actions for them.
-            .on_action(cx.listener(|_, _: &HideApp, _window, cx| cx.hide()))
-            .on_action(cx.listener(|_, _: &HideOthers, _window, cx| cx.hide_other_apps()))
-            .on_action(cx.listener(|_, _: &ShowAll, _window, cx| cx.unhide_other_apps()))
-            .on_action(cx.listener(|_, _: &MinimizeWindow, window, _cx| window.minimize_window()))
-            .on_action(cx.listener(|_, _: &ZoomWindow, window, _cx| window.zoom_window()))
-            // Help destinations. Opened in the default browser; a failure here is
-            // not worth interrupting the user over, so it is logged, not toasted.
-            .on_action(cx.listener(|_, _: &OpenDocumentation, _window, cx| cx.open_url(DOCS_URL)))
-            .on_action(cx.listener(|_, _: &OpenDiscord, _window, cx| cx.open_url(DISCORD_URL)))
-            .on_action(cx.listener(|_, _: &ReportIssue, _window, cx| cx.open_url(ISSUES_URL)))
-            // The theme's background image, composited over the background fill
-            // at its own opacity and under all content. Absolute, so it doesn't
-            // participate in the flex column; the wrapper clips the Cover
-            // overflow (gpui's `img` paints the fitted bounds unclipped).
-            .when_some(bg_image, |this, image| {
-                this.child(
-                    div()
-                        .absolute()
-                        .inset_0()
-                        .overflow_hidden()
-                        .opacity(image.opacity)
-                        .child(
-                            img(image.path)
-                                .size_full()
-                                .object_fit(gpui::ObjectFit::Cover),
-                        ),
+                }))
+                .on_action(cx.listener(|this, _: &FocusPaneLeft, window, cx| {
+                    this.focus_pane_dir(Dir::Left, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &FocusPaneRight, window, cx| {
+                    this.focus_pane_dir(Dir::Right, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &FocusPaneUp, window, cx| {
+                    this.focus_pane_dir(Dir::Up, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &FocusPaneDown, window, cx| {
+                    this.focus_pane_dir(Dir::Down, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ResizePaneLeft, window, cx| {
+                    this.resize_pane(Dir::Left, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ResizePaneRight, window, cx| {
+                    this.resize_pane(Dir::Right, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ResizePaneUp, window, cx| {
+                    this.resize_pane(Dir::Up, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ResizePaneDown, window, cx| {
+                    this.resize_pane(Dir::Down, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &SwapPaneNext, window, cx| {
+                    this.swap_pane(true, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &SwapPanePrev, window, cx| {
+                    this.swap_pane(false, window, cx)
+                }))
+                .on_action(
+                    cx.listener(|this, _: &NextTab, window, cx| this.cycle_tab(true, window, cx)),
                 )
-            })
-            .child(main_layout)
-            // Settings overlay, above the tabs/terminal when open.
-            .when_some(settings_overlay, |this, overlay| this.child(overlay))
-            // The workspace switcher, in the same layer as the palette: they
-            // answer two different questions and are never open at once.
-            .children(self.render_switcher(cx))
-            // Command palette overlay, layered above everything when open.
-            .when_some(self.palette.clone(), |this, palette| this.child(palette))
-            // Toast layer for `window.push_notification` (worktree/SSH errors).
-            // gpui-component's Root only *stores* the list; the root view must
-            // render the layer — without this child every toast was invisible.
-            .children(gpui_component::Root::render_notification_layer(window, cx))
+                .on_action(
+                    cx.listener(|this, _: &PrevTab, window, cx| this.cycle_tab(false, window, cx)),
+                )
+                .on_action(cx.listener(|this, _: &ActivateTab1, window, cx| {
+                    this.activate_visual(0, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ActivateTab2, window, cx| {
+                    this.activate_visual(1, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ActivateTab3, window, cx| {
+                    this.activate_visual(2, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ActivateTab4, window, cx| {
+                    this.activate_visual(3, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ActivateTab5, window, cx| {
+                    this.activate_visual(4, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ActivateTab6, window, cx| {
+                    this.activate_visual(5, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ActivateTab7, window, cx| {
+                    this.activate_visual(6, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ActivateTab8, window, cx| {
+                    this.activate_visual(7, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ActivateTab9, window, cx| {
+                    this.activate_visual(8, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &IncreaseFontSize, _window, cx| {
+                    this.change_font_size(FONT_SIZE_STEP, cx)
+                }))
+                .on_action(cx.listener(|this, _: &DecreaseFontSize, _window, cx| {
+                    this.change_font_size(-FONT_SIZE_STEP, cx)
+                }))
+                .on_action(
+                    cx.listener(|this, _: &ResetFontSize, _window, cx| this.reset_font_size(cx)),
+                )
+                .on_action(cx.listener(|this, _: &TogglePalette, window, cx| {
+                    this.toggle_palette(window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ReopenClosedTab, window, cx| {
+                    this.reopen_closed_tab(window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ToggleMaximizePane, window, cx| {
+                    this.toggle_maximize(window, cx)
+                }))
+                .on_action(
+                    cx.listener(|_, _: &ToggleFullscreen, window, _cx| window.toggle_fullscreen()),
+                )
+                .on_action(cx.listener(|this, _: &ToggleTabSidebar, _window, cx| {
+                    this.toggle_tab_sidebar(cx)
+                }))
+                .on_action(
+                    cx.listener(|this, _: &ToggleLeftPanel, _window, cx| {
+                        this.toggle_left_panel(cx)
+                    }),
+                )
+                .on_action(cx.listener(|this, _: &ToggleRightPanel, _window, cx| {
+                    this.toggle_right_panel(cx)
+                }))
+                .on_action(cx.listener(|this, _: &ShowRightPanelInfo, _window, cx| {
+                    this.set_right_panel_tab(crate::core::config::RightPanelTab::Info, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ShowRightPanelOutline, _window, cx| {
+                    this.set_right_panel_tab(crate::core::config::RightPanelTab::Outline, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ShowRightPanelChanges, _window, cx| {
+                    this.set_right_panel_tab(crate::core::config::RightPanelTab::Changes, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ShowRightPanelFiles, _window, cx| {
+                    this.set_right_panel_tab(crate::core::config::RightPanelTab::Files, cx)
+                }))
+                .on_action(cx.listener(|this, _: &OpenSettings, window, cx| {
+                    this.toggle_settings(window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &RestartDaemon, window, cx| {
+                    this.restart_daemon(window, cx)
+                }))
+                .on_action(
+                    cx.listener(|this, _: &ToggleSftp, window, cx| this.toggle_sftp(window, cx)),
+                )
+                .on_action(cx.listener(|this, _: &ShowSshForwards, window, cx| {
+                    this.show_ssh_forwards(window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ToggleCodePanel, window, cx| {
+                    this.toggle_code_panel(window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &EditorSave, window, cx| {
+                    this.editor_save_active(window, cx)
+                }))
+                // Quit lives on the same element-tree action path as every other Cmd
+                // shortcut above, so a focused terminal routes `cmd-q` here rather
+                // than relying solely on the global handler (which the keystroke
+                // doesn't reach while focus is deep in the terminal view).
+                .on_action(cx.listener(|_, _: &Quit, _, cx| cx.quit()))
+                .on_action(cx.listener(|this, _: &OpenSshProfiles, window, cx| {
+                    this.open_settings_section(SettingsSection::Ssh, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &RestartSshSession, window, cx| {
+                    this.restart_ssh_session(window, cx)
+                }))
+                // Tab operations that used to be reachable only by right-clicking a
+                // chip. Each targets the active tab, so the menu bar / palette /
+                // keyboard all mean "this tab" without a click to say which.
+                .on_action(cx.listener(|this, _: &RenameTab, window, cx| {
+                    this.start_rename(this.active, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &NewWorktreeTab, window, cx| {
+                    this.new_worktree_tab(this.active, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &CloseOtherTabs, window, cx| {
+                    this.close_other_tabs(this.active, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &CloseTabsToTheRight, window, cx| {
+                    this.close_tabs_right_of(this.active, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &CopyWorkingDirectory, window, cx| {
+                    this.copy_active_cwd(window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &MarkTabUnread, _window, cx| {
+                    this.mark_tab_unread(this.active, cx)
+                }))
+                // Fork: the bare action has no pane the user pointed at, so it
+                // opens a new tab; the four directional ones come from the pane
+                // right-click menu, where the ask *was* spatial.
+                .on_action(cx.listener(|this, _: &ForkAgentSession, window, cx| {
+                    this.fork_active_pane_session(ForkPlacement::NewTab, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ForkAgentSessionRight, window, cx| {
+                    this.fork_focused_pane_session(Axis::Horizontal, false, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ForkAgentSessionLeft, window, cx| {
+                    this.fork_focused_pane_session(Axis::Horizontal, true, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ForkAgentSessionDown, window, cx| {
+                    this.fork_focused_pane_session(Axis::Vertical, false, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &ForkAgentSessionUp, window, cx| {
+                    this.fork_focused_pane_session(Axis::Vertical, true, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &CopyAgentSessionId, window, cx| {
+                    this.copy_agent_session_id(this.active, window, cx)
+                }))
+                // Settings destinations that deserve their own way in: Help →
+                // Keyboard Shortcuts and the App menu's About both used to require
+                // opening Settings and then hunting for the section.
+                .on_action(cx.listener(|this, _: &ShowKeyboardShortcuts, window, cx| {
+                    this.open_settings_section(SettingsSection::Keybindings, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &About, window, cx| {
+                    this.open_settings_section(SettingsSection::About, window, cx)
+                }))
+                .on_action(cx.listener(|this, _: &CheckForUpdates, window, cx| {
+                    this.check_for_updates_now(window, cx)
+                }))
+                // Standard macOS App / Window menu items. gpui exposes the platform
+                // calls but ships no actions for them.
+                .on_action(cx.listener(|_, _: &HideApp, _window, cx| cx.hide()))
+                .on_action(cx.listener(|_, _: &HideOthers, _window, cx| cx.hide_other_apps()))
+                .on_action(cx.listener(|_, _: &ShowAll, _window, cx| cx.unhide_other_apps()))
+                .on_action(
+                    cx.listener(|_, _: &MinimizeWindow, window, _cx| window.minimize_window()),
+                )
+                .on_action(cx.listener(|_, _: &ZoomWindow, window, _cx| window.zoom_window()))
+                // Help destinations. Opened in the default browser; a failure here is
+                // not worth interrupting the user over, so it is logged, not toasted.
+                .on_action(
+                    cx.listener(|_, _: &OpenDocumentation, _window, cx| cx.open_url(DOCS_URL)),
+                )
+                .on_action(cx.listener(|_, _: &OpenDiscord, _window, cx| cx.open_url(DISCORD_URL)))
+                .on_action(cx.listener(|_, _: &ReportIssue, _window, cx| cx.open_url(ISSUES_URL)))
+                // The theme's background image, composited over the background fill
+                // at its own opacity and under all content. Absolute, so it doesn't
+                // participate in the flex column; the wrapper clips the Cover
+                // overflow (gpui's `img` paints the fitted bounds unclipped).
+                .when_some(bg_image, |this, image| {
+                    this.child(
+                        div()
+                            .absolute()
+                            .inset_0()
+                            .overflow_hidden()
+                            .opacity(image.opacity)
+                            .child(
+                                img(image.path)
+                                    .size_full()
+                                    .object_fit(gpui::ObjectFit::Cover),
+                            ),
+                    )
+                })
+                .child(main_layout)
+                // Settings overlay, above the tabs/terminal when open.
+                .when_some(settings_overlay, |this, overlay| this.child(overlay))
+                // The workspace switcher, in the same layer as the palette: they
+                // answer two different questions and are never open at once.
+                .children(self.render_switcher(cx))
+                // Command palette overlay, layered above everything when open.
+                .when_some(self.palette.clone(), |this, palette| this.child(palette))
+                // Toast layer for `window.push_notification` (worktree/SSH errors).
+                // gpui-component's Root only *stores* the list; the root view must
+                // render the layer — without this child every toast was invisible.
+                .children(gpui_component::Root::render_notification_layer(window, cx));
+
+        if let Some(start) = prof {
+            crate::ui::perf::record("window", start.elapsed());
+        }
+        root
     }
 }
 
@@ -8066,22 +8124,22 @@ mod tests {
     }
 }
 
+/// The shared headless App + Window the UI-level gpui tests drive.
 #[cfg(test)]
-mod keybinding_gpui_tests {
+pub(crate) mod test_window {
     use crate::core::config::Config;
     use crate::core::session::Session;
     use crate::ui::app::Tty7App;
-    use crate::ui::settings::SettingsSection;
     use gpui::{AppContext, Entity, TestAppContext, VisualTestContext};
 
-    fn harness(cx: &mut TestAppContext) -> (Entity<Tty7App>, VisualTestContext) {
-        // Every keybinding edit below goes through `update_config`, which ends in
-        // `Config::save()` — a *full* overwrite of `config.json` at whatever path
-        // the config dir resolves to. Unpinned, that is the developer's real
-        // `~/.config/tty7/config.json`, so running these tests silently reset the
-        // user's entire config to `Config::default()` plus the shortcut recorded
-        // here. The test-only `Config::save` now panics rather than allow that;
-        // pin a scratch dir so it doesn't have to.
+    pub(crate) fn harness(cx: &mut TestAppContext) -> (Entity<Tty7App>, VisualTestContext) {
+        // Every keybinding edit a caller makes goes through `update_config`,
+        // which ends in `Config::save()` — a *full* overwrite of `config.json`
+        // at whatever path the config dir resolves to. Unpinned, that is the
+        // developer's real `~/.config/tty7/config.json`, so running those tests
+        // silently reset the user's entire config to `Config::default()` plus
+        // the shortcut recorded there. The test-only `Config::save` now panics
+        // rather than allow that; pin a scratch dir so it doesn't have to.
         crate::core::config::pin_test_config_dir();
 
         // The pause-to-commit is a real `smol::Timer` (off the deterministic
@@ -8118,6 +8176,52 @@ mod keybinding_gpui_tests {
         let vcx = VisualTestContext::from_window(window.into(), cx);
         (app, vcx)
     }
+
+    /// [`harness`] plus one open tab, for the tests that need the window to have
+    /// something to show. The pane is a [`quiet_test_pane`], and the returned
+    /// stream must stay alive for as long as it: dropping it closes the socket
+    /// and the pane retires.
+    ///
+    /// Cursor blink is turned off here. It is a real 530ms `cx.notify()` on a
+    /// focused pane and would otherwise be the only thing the render-idle
+    /// measurements ever counted.
+    #[cfg(unix)]
+    pub(crate) fn harness_with_pane(
+        cx: &mut TestAppContext,
+    ) -> (
+        Entity<Tty7App>,
+        VisualTestContext,
+        std::os::unix::net::UnixStream,
+    ) {
+        use crate::terminal::view::quiet_test_pane;
+        use crate::ui::pane::{Pane, PaneSlot};
+
+        let (app, mut vcx) = harness(cx);
+        vcx.update(|_, cx| {
+            let mut cfg = cx.global::<Config>().clone();
+            cfg.cursor_blink = false;
+            cx.set_global(cfg);
+        });
+        let stream = app.update_in(&mut vcx, |app, window, cx| {
+            let (view, stream) = quiet_test_pane(1, window, cx);
+            app.tabs
+                .push(super::Tab::new(Pane::leaf(PaneSlot::Ready(view))));
+            app.active = 0;
+            cx.notify();
+            stream
+        });
+        vcx.background_executor.run_until_parked();
+        (app, vcx, stream)
+    }
+}
+
+#[cfg(test)]
+mod keybinding_gpui_tests {
+    use super::test_window::harness;
+    use crate::core::config::Config;
+    use crate::ui::app::Tty7App;
+    use crate::ui::settings::SettingsSection;
+    use gpui::{Entity, TestAppContext, VisualTestContext};
 
     /// Open Settings → Keybindings and begin capturing `action`.
     fn begin_capture(app: &Entity<Tty7App>, vcx: &mut VisualTestContext, action: &str) {

--- a/src/ui/assets.rs
+++ b/src/ui/assets.rs
@@ -180,7 +180,7 @@ fn agent_icon(path: &str) -> Option<&'static [u8]> {
         "icons/machine-local.svg" => include_bytes!("../../assets/icons/machine-local.svg"),
         "icons/machine-remote.svg" => include_bytes!("../../assets/icons/machine-remote.svg"),
         // The Files tab's remote (SFTP) mode needs a refresh it doesn't need
-        // locally: the local tree runs a recursive filesystem watcher and
+        // locally: the local tree watches the directories it displays and
         // invalidates itself, a remote listing has nothing watching it. Drawn to
         // the circle rule above (r 8.6) so it sits level with the `eye` beside it
         // rather than lucide's r=9 `rotate-cw`, whose arrow head is also a size

--- a/src/ui/code_editor.rs
+++ b/src/ui/code_editor.rs
@@ -1,5 +1,7 @@
-//! The code panel: a full-body overlay of `[file tree | editor]` that covers
-//! the terminal, settings-overlay style.
+//! The code panel: a full-body editor overlay that covers the terminal,
+//! settings-overlay style. It stops short of the right panel rather than
+//! covering it, so the file tree there stays beside the editor — the tree used
+//! to be this overlay's own left column and is not any more.
 //!
 //! A lightweight "look at / touch up code without leaving the terminal"
 //! editor, not a full IDE. The text engine is `gpui_component::input::
@@ -8,8 +10,8 @@
 //! auto-indent, undo/redo and an in-buffer search/replace bar. This module
 //! owns everything around that engine: the open-file set and tab strip, dirty
 //! tracking and save, external-modification reload (via `notify`), the
-//! unsaved-close confirmation, and the overlay chrome itself (the file-tree
-//! column comes from `ui::file_tree`).
+//! unsaved-close confirmation, and the overlay chrome itself. The file tree is
+//! `ui::file_tree`'s, drawn by the right panel's Files tab.
 //!
 //! Deliberately *not* an IDE: there is no language-server integration, and
 //! adding one is not a wanted feature. Opening a `.rs` file silently spawning

--- a/src/ui/file_tree.rs
+++ b/src/ui/file_tree.rs
@@ -1,5 +1,5 @@
-//! Local project file tree (the code overlay's left column — see
-//! `code_editor::render_code_overlay` for the panel that hosts it).
+//! Local project file tree (the right panel's Files tab — see
+//! `right_panel::render_panel_files` for the column that hosts it).
 //!
 //! Modelled on Warp's Project Explorer: lazily-loaded directories, gitignore
 //! awareness (ignored entries render dimmed, not hidden), a filesystem watcher
@@ -13,6 +13,14 @@
 //! same tree work against this machine or a remote one. Listings are cached per
 //! `(host, directory)` and invalidated by watcher events, so a huge repo only
 //! ever pays for the directories actually expanded.
+//!
+//! The watch is scoped the same way: **non-recursive**, over the roots plus the
+//! expanded directories and nothing else — see
+//! [`FileTreeState::sync_watch`]. So `target/`, `node_modules` and the inside of
+//! `.git` produce no events at all unless the user has expanded them, and what
+//! does arrive names a directory the tree is displaying. Anything reasoning
+//! about "what the watcher reports" starts there, not from a recursive walk of
+//! the root.
 //!
 //! **Nothing here touches the filesystem directly.** Every read, every write and
 //! every `git` invocation goes through [`HostOps`], which runs the blocking
@@ -28,6 +36,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use crate::core::config::RightPanelTab;
 use crate::ui::app::Tty7App;
 use crate::ui::host_ops::{ByHost, HostId, HostOps, InFlight, SharedHost, WatchSub};
 use crate::ui::host_registry::HostRegistry;
@@ -686,13 +695,14 @@ impl FileTreeState {
     ///
     /// The listing stays until its replacement lands — see [`FileTreeState::stale`].
     ///
-    /// The return value is what lets the window go idle (issue #243). The
-    /// watcher is recursive over the root, so it reports every write underneath,
-    /// and nearly all of them name a directory the tree has never listed and
-    /// does not show — `.git` internals, build output, `node_modules`. There is
-    /// nothing to re-read and nothing to redraw for those, and saying so is the
-    /// difference between a window that settles and one that repaints every
-    /// [`REFRESH_DEBOUNCE`] for as long as anything is being written.
+    /// The return value is what keeps a batch that reached nothing from
+    /// repainting (issue #243). The subscription is non-recursive over the
+    /// roots plus the expanded directories (see
+    /// [`sync_watch`](FileTreeState::sync_watch)), so nearly everything that
+    /// arrives *does* name a directory the tree holds — but not all of it: a
+    /// watched directory whose listing never landed (a read that failed, a root
+    /// removed underneath) is neither cached nor pending, and relisting for it
+    /// buys a round trip and a frame for rows that are not on screen.
     fn invalidate_dir(&mut self, host: HostId, dir: &Path) -> bool {
         let key: DirKey = (host, dir.to_path_buf());
         let cached = self.children.get(host, dir).is_some();
@@ -708,10 +718,15 @@ impl FileTreeState {
     ///
     /// A `.gitignore` at `D/.gitignore` governs `D` and everything below it and
     /// nowhere else, so it matters only when some directory the tree caches or
-    /// is loading sits under `D`. Without this test an `npm install` writing
-    /// `.gitignore` files all over `node_modules` — or one under any unlisted
-    /// build directory — took the whole-cache branch and repainted the window,
-    /// once per batch, which is the residual of the very symptom #243 is about.
+    /// is loading sits under `D`. A correctness guard on the branch, not a
+    /// throughput one: [`invalidate_all`](FileTreeState::invalidate_all) marks
+    /// *every* cached listing and restarts the search, and taking that for a
+    /// file that cannot govern anything the tree holds is work with no possible
+    /// visible result. A non-recursive watch makes such a batch rare — the
+    /// `.gitignore` has to be a direct child of a watched directory to arrive at
+    /// all — but "rare" is not "never": a watched directory whose own listing
+    /// failed holds nothing, and neither does one still in flight when the
+    /// deeper cache is empty.
     ///
     /// The test is complete as well as safe: any directory whose matchers could
     /// be cached is an ancestor of a directory that was successfully listed, and
@@ -759,9 +774,17 @@ impl FileTreeState {
     /// switch, or on a panel toggle. So this makes the next such derivation
     /// correct rather than relocating a root under a tab that is already open —
     /// which is also what the synchronous version it replaced did.
-    fn invalidate_repo_roots(&mut self) {
+    ///
+    /// Returns whether anything was actually forgotten. Nothing here re-resolves
+    /// what it drops: [`file_tree_refresh_roots`](Tty7App::file_tree_refresh_roots)
+    /// does, and it only runs from a paint. So a caller that has cleared this
+    /// cache still owes the window a frame, whatever else its batch did or did
+    /// not reach (issue #243).
+    fn invalidate_repo_roots(&mut self) -> bool {
+        let had = !self.repo_roots.is_empty() || !self.repo_root_loads.is_empty();
         self.repo_roots.clear();
         self.repo_root_loads.invalidate_all();
+        had
     }
 
     /// Show `op`'s result in `dir`'s cached listing before the host has
@@ -1039,19 +1062,40 @@ impl Tty7App {
         );
     }
 
+    /// Whether the tree column is actually being drawn, for the work that only
+    /// a visible tree can have a result for.
+    ///
+    /// The same pair of conditions [`render_right_panel`](Self::render_right_panel)
+    /// reaches the Files body through, read from the same fields, so the two
+    /// cannot drift into disagreeing about it. Deliberately not
+    /// consulting the tab's `code.visible`: the tree left the code overlay for
+    /// the panel, and the overlay draws the editor only.
+    pub(crate) fn file_tree_on_screen(&self, cx: &App) -> bool {
+        self.right_panel_open(cx) && self.right_panel_tab == RightPanelTab::Files
+    }
+
     /// Watcher callback (debounced): mark the affected listings for a refresh
     /// and re-read them. A `.gitignore` change resets ignore state wholesale —
     /// its patterns can affect any depth below it.
     ///
     /// See [`event_can_change_a_row`] for what is deliberately ignored here.
     ///
-    /// Notably this does **not** repaint (issue #243). The watcher is recursive
-    /// over the root, so on any tree being worked in it fires every
-    /// [`REFRESH_DEBOUNCE`] for writes into `.git`, `target/` or `node_modules`
-    /// that the tree neither caches nor shows, and a `cx.notify()` here was a
-    /// full-window redraw for each of them — the tree asking to be redrawn
-    /// before it knew whether it had anything new to draw. The re-read's own
-    /// landing repaints, and only when the listing came back different.
+    /// Notably this no longer repaints for its own sake (issue #243). The
+    /// subscription is non-recursive over the roots plus the expanded
+    /// directories — see [`sync_watch`](FileTreeState::sync_watch) — so what
+    /// arrives is a change in a directory the tree is *displaying*, and a file's
+    /// contents being rewritten arrives exactly as loudly as an entry appearing
+    /// or disappearing. An editor saving on every keystroke, a build writing its
+    /// log next to the sources, a formatter rewriting the file in place: each of
+    /// those was a full-window redraw every [`REFRESH_DEBOUNCE`], the tree
+    /// asking to be drawn before it knew whether it had anything new to draw.
+    /// The re-read's own landing repaints instead, and only when the listing
+    /// came back different.
+    ///
+    /// Two things still repaint on the event itself: the whole-cache
+    /// `.gitignore` branch, whose re-walk only a paint performs, and a batch
+    /// that moved a repository root. Both are gated on the tree being on screen,
+    /// because both exist to get a paint that would do nothing while it is not.
     pub(crate) fn file_tree_apply_fs_events(
         &mut self,
         host: HostId,
@@ -1068,15 +1112,27 @@ impl Tty7App {
             "fs events on host {host:?}: {:?}",
             paths.iter().take(8).collect::<Vec<_>>()
         );
+        // Whether anything below can act on this batch at all. The tree draws in
+        // one place — the right panel's Files tab — and every effect this
+        // function has is either a paint of that column or a listing read to
+        // fill it. With the panel closed the subscription stays open (it is
+        // derived from every tab's roots and expansion, which outlive the
+        // panel), so without this check a build writing into a watched directory
+        // buys a `read_dir` per marked directory, per batch, for a column nobody
+        // can see — a network round trip each, on a remote workspace. The marks
+        // are what carry the change across: they stay, and the first paint after
+        // the panel comes back re-reads them.
+        let on_screen = self.file_tree_on_screen(cx);
         // A `.git` coming or going moves a repository root, which is the one
         // thing the cached root derivation cannot notice by itself.
+        let mut roots_moved = false;
         if paths.iter().any(|p| {
             p.file_name().is_some_and(|n| n == ".git")
                 || p.parent()
                     .and_then(Path::file_name)
                     .is_some_and(|n| n == ".git")
         }) {
-            self.file_tree.invalidate_repo_roots();
+            roots_moved = self.file_tree.invalidate_repo_roots();
         }
         // The caches are shared across tabs, so invalidate unconditionally —
         // a hidden tab's stale listing would otherwise survive until reopened.
@@ -1088,19 +1144,31 @@ impl Tty7App {
             // its own watcher; what is left for us is the listings that carry
             // the `ignored` flags those matchers produced.
             self.file_tree.invalidate_all();
-            // The one case that repaints on the event itself: `invalidate_all`
-            // restarts the search, and only a paint re-walks it.
-            cx.notify();
+            // Repaints on the event itself: `invalidate_all` restarts the
+            // search, and only a paint re-walks it. `SearchState::restart`
+            // clears `pending`, so a panel that is closed here re-walks on the
+            // paint that reopens it instead.
+            if on_screen {
+                cx.notify();
+            }
         } else {
             let mut touched = false;
             for dir in dirs_to_relist(paths, self.file_tree.show_hidden) {
                 touched |= self.file_tree.invalidate_dir(host, dir);
             }
+            // A batch that moved a repository root owes the window a frame
+            // whatever else it reached: `file_tree_refresh_roots` is what
+            // re-resolves the cache just cleared, and it only runs from a paint.
+            // Nothing else here would ask for one — `.git` is a dot-file, so
+            // under the default `show_hidden: false` it never survives
+            // `dirs_to_relist`, and a batch naming nothing but `.git` leaves
+            // `touched` false and returns just below.
+            if roots_moved && on_screen {
+                cx.notify();
+            }
             if !touched {
                 // Nothing the tree holds was reached, so there is nothing to
-                // re-read and nothing to redraw. This is the overwhelming
-                // majority of what a recursive watch over a working tree
-                // reports.
+                // re-read and nothing more to redraw.
                 return;
             }
             // Deliberately *not* restarting the search here. Its results are
@@ -1109,8 +1177,9 @@ impl Tty7App {
             // the walk outright: this callback fires roughly every
             // `REFRESH_DEBOUNCE`, and a restart bumps the generation that the
             // walk re-checks after waiting `SEARCH_DEBOUNCE`, so under any
-            // sustained churn (a build writing into `target/`, which the
-            // watcher reports because it knows nothing about gitignore) every
+            // sustained churn (a build writing into a directory somebody has
+            // expanded — the watch follows the expansion set and knows nothing
+            // about gitignore) every
             // walk bows out before it ever reads a directory and the list stays
             // empty forever. A snapshot that's a few seconds old until the next
             // keystroke is the better failure.
@@ -1118,8 +1187,11 @@ impl Tty7App {
             // Re-read what was marked, here rather than on the next paint.
             // Waiting for one would mean notifying to *get* one, which is the
             // full-window redraw per event batch this function's doc comment is
-            // about. Only while the tree is still pointed at the machine the
-            // events came from.
+            // about. Only while the tree is on screen, and only while it is
+            // still pointed at the machine the events came from.
+            if !on_screen {
+                return;
+            }
             let Some(shared) = self.active_host(cx) else {
                 return;
             };
@@ -1578,13 +1650,15 @@ enum TreeWrite {
 // ---------------------------------------------------------------------------
 
 impl Tty7App {
-    /// The file-tree column: the code overlay's left side (the overlay
-    /// renders the divider and the editor to its right).
-    /// Just the scrolling rows of the tree — no header, no fixed width, no
-    /// surface of its own — so a host that already has those (the right detail
-    /// panel) can drop the tree into its own column. Shares every bit of state
-    /// with [`render_file_tree_column`]: same roots, same expand set, same
-    /// click-to-open, so the panel and the code overlay are two views of one tree.
+    /// The file-tree column: just the scrolling rows of the tree — no header, no
+    /// fixed width, no surface of its own — because the one thing that draws it
+    /// already has those. That is the right panel's Files tab, and only it: the
+    /// tree left the code overlay, which now draws the editor alone.
+    ///
+    /// The single draw site is why [`file_tree_on_screen`](Self::file_tree_on_screen)
+    /// is one pair of conditions, and why everything this function does per
+    /// paint — re-rooting, moving the watched set, requesting listings — stops
+    /// happening the moment the panel closes.
     pub(crate) fn render_file_tree_rows(
         &mut self,
         window: &mut Window,
@@ -2499,6 +2573,13 @@ mod tests {
 /// [`render_probe`](crate::ui::app::render_probe) counts exactly the frames the
 /// app asked for — the one claim in the issue that is platform-independent, and
 /// answerable without the reporter's Wayland session.
+///
+/// What the live watch can actually deliver bounds what any of this can claim.
+/// The subscription is non-recursive over the roots plus the expanded
+/// directories, so the reachable case is a change *in a directory on screen* —
+/// that is the one measured. Three cases here feed [`fs_event`] a path the live
+/// subscription would drop before batching it; each is labelled a guard on the
+/// predicate it exercises, and none of them is evidence of a symptom.
 #[cfg(all(test, unix))]
 mod render_idle_gpui_tests {
     use super::*;
@@ -2610,7 +2691,12 @@ mod render_idle_gpui_tests {
         })
     }
 
-    /// Hand the app one debounced watcher batch, exactly as the watcher does.
+    /// Hand the app one debounced batch at the seam the watcher delivers to.
+    ///
+    /// The seam, not the watcher: this bypasses `WatchedDirs::translate`, so a
+    /// caller can synthesise a path the live subscription would never deliver.
+    /// The cases that do are labelled as guards on a predicate rather than as
+    /// symptoms, and say so.
     fn fs_event(app: &Entity<Tty7App>, vcx: &mut VisualTestContext, path: &Path) {
         app.update_in(vcx, |app, _, cx| {
             app.file_tree_apply_fs_events(HostId::LOCAL, &HashSet::from([path.to_path_buf()]), cx);
@@ -2716,11 +2802,20 @@ mod render_idle_gpui_tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
-    /// The window never went idle because the watcher is recursive over the
-    /// root: writes into `target/`, `node_modules/` or `.git/` all arrive here,
-    /// and every one of them repainted a window that had nothing new to draw.
+    /// A guard on the `!touched` early return, **not** a symptom.
+    ///
+    /// Read the event below for what it is: `root/target/debug/artifact0.o`,
+    /// whose parent is neither a root nor an expanded directory. The live watch
+    /// cannot deliver it — it is non-recursive over roots ∪ expanded, and
+    /// `WatchedDirs::translate` drops anything whose parent is not in that set
+    /// before it is ever batched. So this measures no bug that can occur today.
+    /// What it holds down is the predicate: `invalidate_dir` answering "nothing
+    /// here" must stay a silent return, because that answer is also what a
+    /// watched directory with no landed listing gives, and because expanding
+    /// the watched set (or restoring a recursive watch) would make this exact
+    /// path live again.
     #[gpui::test]
-    fn a_change_the_tree_does_not_display_costs_no_frames(cx: &mut TestAppContext) {
+    fn an_event_reaching_no_cached_listing_costs_no_frames(cx: &mut TestAppContext) {
         let _serial = serial();
         let root = scratch("unlisted");
         for n in 0..12 {
@@ -2742,9 +2837,15 @@ mod render_idle_gpui_tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
-    /// The same for a directory the tree *is* showing, when what changed is a
-    /// file's contents rather than the entries. A build writing a log into a
-    /// listed directory reports as loudly as one creating a file there.
+    /// The reachable case, and the one issue #243 is actually about on this
+    /// base: a directory the tree *is* showing, where what changed is a file's
+    /// contents rather than the set of entries.
+    ///
+    /// The displayed directories are exactly the watched ones, so this event is
+    /// delivered — a formatter rewriting the file, an editor saving on every
+    /// keystroke, a build dropping its log next to the sources. Each one cost a
+    /// full-window redraw, twice over: once for the `cx.notify()` in the event
+    /// handler and once for the landing of the relist it bought.
     #[gpui::test]
     fn rewriting_a_file_in_a_displayed_directory_costs_no_frames(cx: &mut TestAppContext) {
         let _serial = serial();
@@ -2800,12 +2901,18 @@ mod render_idle_gpui_tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
-    /// `.gitignore` takes the whole-cache branch, so it must be scoped to the
-    /// tree as well: an `npm install` writing them all over `node_modules`
-    /// otherwise repaints the window once per batch, which is the residual of
-    /// the very symptom this fixes.
+    /// A guard on [`FileTreeState::gitignore_reaches_tree`], **not** a symptom.
+    ///
+    /// Same caveat as `an_event_reaching_no_cached_listing_costs_no_frames`:
+    /// `root/node_modules/pkg0/.gitignore` sits under a directory nobody
+    /// expanded, so the live non-recursive watch never delivers it and the
+    /// `npm install` story this test used to tell cannot happen here. It is kept
+    /// because the branch it guards is the expensive one — `invalidate_all`
+    /// marks every cached listing and restarts the search — and the predicate
+    /// deciding when to take it deserves a test that a refactor cannot quietly
+    /// invert.
     #[gpui::test]
-    fn a_gitignore_under_an_unlisted_directory_costs_no_frames(cx: &mut TestAppContext) {
+    fn a_gitignore_that_governs_nothing_cached_costs_no_frames(cx: &mut TestAppContext) {
         let _serial = serial();
         let root = scratch("gitignore-unlisted");
         std::fs::write(root.join("main.rs"), "").unwrap();
@@ -2871,9 +2978,14 @@ mod render_idle_gpui_tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
-    /// The stale marks are keyed by path and the watcher names paths without
-    /// limit — every object a build drops into `target/`. Recording one for
-    /// something the tree does not track would grow that set forever.
+    /// A guard on `stale` staying bounded, **not** a symptom.
+    ///
+    /// The `target/debug/*.o` events below are again ones the live watch cannot
+    /// deliver. What the test defends is that `stale` is keyed by path and the
+    /// handler is fed paths it does not choose: marking one for a directory the
+    /// tree does not hold would let that set grow without limit, and the only
+    /// thing standing between it and that is `invalidate_dir` inserting solely
+    /// where `children` already has an entry.
     #[gpui::test]
     fn untracked_paths_leave_no_bookkeeping_behind(cx: &mut TestAppContext) {
         let _serial = serial();
@@ -2895,6 +3007,139 @@ mod render_idle_gpui_tests {
                 .count()
         });
         assert_eq!(marks, 0, "nothing the tree holds was reached");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The one batch that reaches nothing and must still draw: a `.git`
+    /// appearing or disappearing in a watched directory.
+    ///
+    /// `invalidate_repo_roots` empties the cwd → repository-root cache, and the
+    /// only thing that fills it again is `file_tree_refresh_roots`, which runs
+    /// from a paint. Meanwhile `.git` is a dot-file, so it never survives
+    /// `dirs_to_relist` under the default `show_hidden: false` and the batch
+    /// lands on the "reached nothing" return — which, unguarded, would leave the
+    /// cache cleared with nothing to resolve it and the tree showing the old
+    /// root until an unrelated event bought a frame.
+    #[gpui::test]
+    fn a_moved_repository_root_still_gets_its_frame(cx: &mut TestAppContext) {
+        let _serial = serial();
+        let root = scratch("repo-root");
+        std::fs::write(root.join("main.rs"), "").unwrap();
+        let (app, mut vcx, _pane) = files_panel_on(cx, &root);
+        assert!(
+            app.update_in(&mut vcx, |app, _, _| !app.file_tree.repo_roots.is_empty()),
+            "the panel resolved its pane's root, so there is a cache to clear"
+        );
+
+        // Come to rest first, so the frame counted below is the event's own and
+        // not one still owed from settling — the same reason `draws_while_idle`
+        // measures its second interval rather than its first.
+        vcx.executor()
+            .advance_clock(std::time::Duration::from_secs(3));
+        vcx.background_executor.run_until_parked();
+        render_probe::arm(BUDGET);
+        vcx.executor()
+            .advance_clock(std::time::Duration::from_secs(3));
+        vcx.background_executor.run_until_parked();
+        assert_eq!(render_probe::draws(), 0, "the window is at rest");
+
+        fs_event(&app, &mut vcx, &root.join(".git"));
+        vcx.background_executor.run_until_parked();
+        assert!(
+            render_probe::draws() > 0,
+            "clearing the root cache asked for the paint that re-resolves it"
+        );
+
+        // The paint re-requests the root, and the host answers off the
+        // deterministic executor, so this waits on wall-clock like `settle`
+        // does rather than on a single `run_until_parked`.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            vcx.background_executor.run_until_parked();
+            if app.update_in(&mut vcx, |app, _, _| !app.file_tree.repo_roots.is_empty()) {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the cleared root cache was never re-resolved"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        settle(&app, &mut vcx, &root);
+        assert_eq!(
+            app.update_in(&mut vcx, |app, _, _| app
+                .tab_code()
+                .map(|c| c.roots.clone())
+                .unwrap_or_default()),
+            vec![root.clone()],
+            "the tree is still rooted where it belongs"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A closed panel asks the host for nothing.
+    ///
+    /// The subscription outlives the panel — `file_tree_sync_watch` derives it
+    /// from every tab's roots and expansion, which persist — so events keep
+    /// arriving for a column nobody can see. Re-reading for them is a `read_dir`
+    /// per marked directory per batch, which on a remote workspace is that many
+    /// network round trips. The marks are what carry the change across instead.
+    #[gpui::test]
+    fn a_closed_panel_does_no_filesystem_work(cx: &mut TestAppContext) {
+        let _serial = serial();
+        let root = scratch("closed-panel");
+        for n in 0..12 {
+            std::fs::write(root.join(format!("file{n:02}.rs")), "").unwrap();
+        }
+        let (app, mut vcx, _pane) = files_panel_on(cx, &root);
+
+        app.update_in(&mut vcx, |app, _, cx| {
+            app.right_panel_visible = false;
+            cx.notify();
+        });
+        vcx.background_executor.run_until_parked();
+
+        let path = root.join("file00.rs");
+        std::fs::write(&path, "changed").unwrap();
+        fs_event(&app, &mut vcx, &path);
+        // Long enough for a re-read to have been issued *and* landed. The host
+        // answers off the deterministic executor, so a single `run_until_parked`
+        // would leave "no work was done" and "the work has not come back yet"
+        // indistinguishable; after this, an unwanted re-read shows up as the
+        // mark below having cleared itself.
+        let until = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while std::time::Instant::now() < until {
+            vcx.background_executor.run_until_parked();
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        let (in_flight, marked) = app.update_in(&mut vcx, |app, _, _| {
+            (
+                app.file_tree.loads.len(),
+                app.file_tree
+                    .stale
+                    .iter()
+                    .filter(|(_, dir)| dir.starts_with(&root))
+                    .count(),
+            )
+        });
+        assert_eq!(in_flight, 0, "nothing was asked of the host");
+        assert!(marked > 0, "but the change was recorded");
+
+        // And it is picked up by the first paint after the panel comes back,
+        // which is what a mark is for.
+        app.update_in(&mut vcx, |app, _, cx| {
+            app.right_panel_visible = true;
+            cx.notify();
+        });
+        settle(&app, &mut vcx, &root);
+        let left = app.update_in(&mut vcx, |app, _, _| {
+            app.file_tree
+                .stale
+                .iter()
+                .filter(|(_, dir)| dir.starts_with(&root))
+                .count()
+        });
+        assert_eq!(left, 0, "the marked listing was re-read on reopening");
         let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src/ui/file_tree.rs
+++ b/src/ui/file_tree.rs
@@ -418,10 +418,14 @@ impl FileTreeState {
     }
 
     /// Ask for a listing of every root and expanded directory that isn't cached
-    /// yet. Called from render, so it must stay map lookups: the `read_dir`
-    /// runs on the background executor and the answer arrives with a
-    /// `cx.notify()`, which is why a just-expanded directory fills in on the
-    /// next frame rather than this one.
+    /// yet. Called from render — so it must stay map lookups — and from the
+    /// watcher callback, which re-reads what it just marked instead of asking
+    /// for a paint to do it. Either way the `read_dir` runs on the background
+    /// executor and the answer arrives with a `cx.notify()`, which is why a
+    /// just-expanded directory fills in on the next frame rather than this one.
+    ///
+    /// Both callers first check that the listings are actually being drawn —
+    /// see [`file_tree_listings_on_screen`](Tty7App::file_tree_listings_on_screen).
     fn request_loads(
         &mut self,
         host: &SharedHost,
@@ -1089,6 +1093,39 @@ impl Tty7App {
             && self.sftp_panel.open_pane_id.is_none()
     }
 
+    /// The Files search box's query, trimmed and lowercased. The one place it
+    /// is derived, because what the tree draws turns on it in two places.
+    fn file_tree_query(&self, cx: &App) -> String {
+        self.file_search.read(cx).value().trim().to_lowercase()
+    }
+
+    /// Whether the Files search box has a query in it, which is the tree's
+    /// other mode: [`render_file_tree_rows`](Self::render_file_tree_rows) draws
+    /// [`search_rows`](FileTreeState::search_rows) then — flat hits from their
+    /// own host-side walk — and the cached directory listings are not on screen
+    /// at all.
+    ///
+    /// The test itself rather than each caller's own copy of it, because the
+    /// paint and the watcher have to agree about which mode the tree is in.
+    pub(crate) fn file_tree_searching(&self, cx: &App) -> bool {
+        !self.file_tree_query(cx).is_empty()
+    }
+
+    /// Whether the tree is drawing directory listings, for the work that only a
+    /// drawn listing can have a result for — which is every `read_dir` the tree
+    /// asks for.
+    ///
+    /// Strictly narrower than [`file_tree_on_screen`](Self::file_tree_on_screen):
+    /// a searching tree *is* on screen, and still owes its column paints, but
+    /// none of them read a listing. Relisting for one is the same waste as
+    /// relisting for a closed panel — a round trip per marked directory per
+    /// event batch, on a remote workspace — and the marks carry the change
+    /// across the same way, re-read by the first paint after the box is
+    /// cleared.
+    pub(crate) fn file_tree_listings_on_screen(&self, cx: &App) -> bool {
+        self.file_tree_on_screen(cx) && !self.file_tree_searching(cx)
+    }
+
     /// Watcher callback (debounced): mark the affected listings for a refresh
     /// and re-read them. A `.gitignore` change resets ignore state wholesale —
     /// its patterns can affect any depth below it.
@@ -1109,8 +1146,16 @@ impl Tty7App {
     ///
     /// Two things still repaint on the event itself: the whole-cache
     /// `.gitignore` branch, whose re-walk only a paint performs, and a batch
-    /// that moved a repository root. Both are gated on the tree being on screen,
-    /// because both exist to get a paint that would do nothing while it is not.
+    /// that moved a repository root. Both are gated on
+    /// [`file_tree_on_screen`](Self::file_tree_on_screen), because both exist to
+    /// get a paint that would do nothing while the column is not drawn — and a
+    /// searching tree does want both, its walk being what `invalidate_all`
+    /// restarts.
+    ///
+    /// The re-read is gated on the narrower
+    /// [`file_tree_listings_on_screen`](Self::file_tree_listings_on_screen)
+    /// instead: it is the only effect here that a search box with something in
+    /// it can have no use for.
     pub(crate) fn file_tree_apply_fs_events(
         &mut self,
         host: HostId,
@@ -1138,6 +1183,12 @@ impl Tty7App {
         // are what carry the change across: they stay, and the first paint after
         // the panel comes back re-reads them.
         let on_screen = self.file_tree_on_screen(cx);
+        // The narrower of the two, for the re-read alone: a tree with a query in
+        // its search box is drawn, and owes the paints below, but draws hits
+        // rather than listings — so a `read_dir` issued for it lands in a cache
+        // nothing is reading. Same predicate the paint decides its own mode
+        // with, rather than a second copy of the test.
+        let listings_on_screen = self.file_tree_listings_on_screen(cx);
         // A `.git` coming or going moves a repository root, which is the one
         // thing the cached root derivation cannot notice by itself.
         let mut roots_moved = false;
@@ -1202,9 +1253,10 @@ impl Tty7App {
             // Re-read what was marked, here rather than on the next paint.
             // Waiting for one would mean notifying to *get* one, which is the
             // full-window redraw per event batch this function's doc comment is
-            // about. Only while the tree is on screen, and only while it is
-            // still pointed at the machine the events came from.
-            if !on_screen {
+            // about. Only while the listings are the thing being drawn, and only
+            // while the tree is still pointed at the machine the events came
+            // from.
+            if !listings_on_screen {
                 return;
             }
             let Some(shared) = self.active_host(cx) else {
@@ -1671,9 +1723,16 @@ impl Tty7App {
     /// tree left the code overlay, which now draws the editor alone.
     ///
     /// The single draw site is why [`file_tree_on_screen`](Self::file_tree_on_screen)
-    /// is one pair of conditions, and why everything this function does per
-    /// paint — re-rooting, moving the watched set, requesting listings — stops
-    /// happening the moment the panel closes.
+    /// is three conditions and no more, and why everything this function does
+    /// per paint — re-rooting, moving the watched set, requesting listings —
+    /// stops happening the moment the panel closes.
+    ///
+    /// Requesting listings stops a step earlier than the rest: a query in the
+    /// search box puts the column in its other mode, drawing hits from their own
+    /// walk, and no cached listing is read at all. That test is
+    /// [`file_tree_searching`](Self::file_tree_searching) rather than a local
+    /// one, because the watcher has to reach the same answer — see
+    /// [`file_tree_apply_fs_events`](Self::file_tree_apply_fs_events).
     pub(crate) fn render_file_tree_rows(
         &mut self,
         window: &mut Window,
@@ -1696,7 +1755,7 @@ impl Tty7App {
             Some(code) => (code.roots.clone(), code.expanded.clone()),
             None => (Vec::new(), std::collections::HashSet::new()),
         };
-        let query = self.file_search.read(cx).value().trim().to_lowercase();
+        let query = self.file_tree_query(cx);
         // `None` — the tree's machine has gone away — still renders: the rows
         // come from caches keyed by its id, so the tree stays on screen as it
         // last was instead of blanking. What stops is the work that needs the
@@ -1713,13 +1772,13 @@ impl Tty7App {
         // Both branches only read caches; whatever is missing is queued onto the
         // background executor and shows up on the paint after it lands.
         self.file_tree.sync_search(&query, &roots, cx);
-        let rows = if query.is_empty() {
+        let rows = if self.file_tree_searching(cx) {
+            self.file_tree.search_rows()
+        } else {
             if let Some(host) = &host {
                 self.file_tree.request_loads(host, &roots, &expanded, cx);
             }
             self.file_tree.visible_rows(host_id, &roots, &expanded)
-        } else {
-            self.file_tree.search_rows()
         };
         let column = v_flex()
             .id("right-panel-tree-rows")
@@ -3155,6 +3214,77 @@ mod render_idle_gpui_tests {
                 .count()
         });
         assert_eq!(left, 0, "the marked listing was re-read on reopening");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The same thing one case further in: the panel is open, the tree column is
+    /// drawn, and it is drawing *search hits*. Those come from their own
+    /// host-side walk, so the cached listings are as invisible as they are
+    /// behind a closed panel, and re-reading one for an event batch buys a round
+    /// trip nothing renders.
+    ///
+    /// The query is set on the input rather than typed, which is the same state:
+    /// both the paint and the watcher read `file_search` for the answer.
+    #[gpui::test]
+    fn a_searching_tree_does_no_filesystem_work(cx: &mut TestAppContext) {
+        let _serial = serial();
+        let root = scratch("searching-tree");
+        for n in 0..12 {
+            std::fs::write(root.join(format!("file{n:02}.rs")), "").unwrap();
+        }
+        let (app, mut vcx, _pane) = files_panel_on(cx, &root);
+
+        app.update_in(&mut vcx, |app, window, cx| {
+            app.file_search
+                .update(cx, |st, cx| st.set_value("file0", window, cx));
+            cx.notify();
+        });
+        vcx.background_executor.run_until_parked();
+        assert!(
+            app.update_in(&mut vcx, |app, _, cx| app.file_tree_searching(cx)
+                && !app.file_tree_listings_on_screen(cx)),
+            "the column is drawn, and what it is drawing is not the listings"
+        );
+
+        let path = root.join("file00.rs");
+        std::fs::write(&path, "changed").unwrap();
+        fs_event(&app, &mut vcx, &path);
+        // Long enough for a re-read to have been issued *and* landed, for the
+        // same reason `a_closed_panel_does_no_filesystem_work` waits: an
+        // unwanted one shows up as the mark below having cleared itself.
+        let until = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while std::time::Instant::now() < until {
+            vcx.background_executor.run_until_parked();
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        let (in_flight, marked) = app.update_in(&mut vcx, |app, _, _| {
+            (
+                app.file_tree.loads.len(),
+                app.file_tree
+                    .stale
+                    .iter()
+                    .filter(|(_, dir)| dir.starts_with(&root))
+                    .count(),
+            )
+        });
+        assert_eq!(in_flight, 0, "nothing was asked of the host");
+        assert!(marked > 0, "but the change was recorded");
+
+        // And clearing the box picks it up, exactly as reopening the panel does.
+        app.update_in(&mut vcx, |app, window, cx| {
+            app.file_search
+                .update(cx, |st, cx| st.set_value("", window, cx));
+            cx.notify();
+        });
+        settle(&app, &mut vcx, &root);
+        let left = app.update_in(&mut vcx, |app, _, _| {
+            app.file_tree
+                .stale
+                .iter()
+                .filter(|(_, dir)| dir.starts_with(&root))
+                .count()
+        });
+        assert_eq!(left, 0, "the marked listing was re-read on clearing");
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src/ui/file_tree.rs
+++ b/src/ui/file_tree.rs
@@ -62,13 +62,30 @@ const SEARCH_LIMIT: usize = 200;
 const SEARCH_MAX_DIRS: usize = 2000;
 
 /// One directory entry in a cached listing.
-#[derive(Clone)]
+///
+/// `PartialEq` so a landed relist can tell "this directory changed" from "a file
+/// in it was rewritten": the watcher reports both, and only the first is worth a
+/// repaint (issue #243).
+#[derive(Clone, PartialEq)]
 pub(crate) struct TreeEntry {
     pub name: String,
     pub path: PathBuf,
     pub is_dir: bool,
     /// Matched by the gitignore chain (or is `.git` itself): rendered dimmed.
     pub ignored: bool,
+}
+
+/// What a landed listing means for the caller: whether to go round again, and
+/// whether it is worth a repaint.
+///
+/// Two separate questions. A listing superseded in flight has to be re-read
+/// whatever it contained, and one that came back identical to what is on screen
+/// is not worth a frame however current it is.
+struct Landed {
+    /// The listing was superseded while it flew, so ask again.
+    superseded: bool,
+    /// It differs from what the tree was already showing.
+    changed: bool,
 }
 
 /// A flattened visible row: what the list renders and what keyboard
@@ -473,9 +490,12 @@ impl FileTreeState {
                 }
             },
             move |app, entries, cx| {
-                let again = app.file_tree.land_load(&key, id, dir.clone(), entries);
-                cx.notify();
-                if !again {
+                let landed = app.file_tree.land_load(&key, id, dir.clone(), entries);
+                // Only a listing that came back *different* is worth a frame.
+                if landed.changed {
+                    cx.notify();
+                }
+                if !landed.superseded {
                     return;
                 }
                 // Superseded: the snapshot stays on screen, and we go round
@@ -494,8 +514,7 @@ impl FileTreeState {
         );
     }
 
-    /// Retire a listing and put it in the cache. Returns whether it was
-    /// superseded while in flight, i.e. whether to go round again.
+    /// Retire a listing and put it in the cache.
     ///
     /// The listing lands **either way**. One that was superseded is still a
     /// real snapshot of that directory, and one change out of date beats
@@ -514,8 +533,15 @@ impl FileTreeState {
         id: HostId,
         dir: PathBuf,
         entries: Vec<TreeEntry>,
-    ) -> bool {
-        land_listing(
+    ) -> Landed {
+        // Asked before the insert, because the insert is what destroys the
+        // answer. A relist that read back exactly what is already on screen has
+        // nothing to show, and the watcher reports a file's *contents* changing
+        // as readily as an entry appearing — so a build writing into a
+        // directory the tree is displaying would otherwise repaint the window
+        // once per `REFRESH_DEBOUNCE` to draw the same rows again (#243).
+        let changed = self.children.get(id, &dir) != Some(&entries);
+        let superseded = land_listing(
             &mut self.loads,
             &mut self.children,
             &mut self.stale,
@@ -523,7 +549,11 @@ impl FileTreeState {
             id,
             dir,
             entries,
-        )
+        );
+        Landed {
+            superseded,
+            changed,
+        }
     }
 
     /// Point the search at `query` (empty = not searching), starting a
@@ -652,14 +682,54 @@ impl FileTreeState {
     }
 
     /// Mark the cached listing for `dir` for a refresh after a change under it.
+    /// Returns whether there was anything to mark.
     ///
     /// The listing stays until its replacement lands — see [`FileTreeState::stale`].
-    fn invalidate_dir(&mut self, host: HostId, dir: &Path) {
+    ///
+    /// The return value is what lets the window go idle (issue #243). The
+    /// watcher is recursive over the root, so it reports every write underneath,
+    /// and nearly all of them name a directory the tree has never listed and
+    /// does not show — `.git` internals, build output, `node_modules`. There is
+    /// nothing to re-read and nothing to redraw for those, and saying so is the
+    /// difference between a window that settles and one that repaints every
+    /// [`REFRESH_DEBOUNCE`] for as long as anything is being written.
+    fn invalidate_dir(&mut self, host: HostId, dir: &Path) -> bool {
         let key: DirKey = (host, dir.to_path_buf());
-        if self.children.get(host, dir).is_some() {
+        let cached = self.children.get(host, dir).is_some();
+        if cached {
             self.stale.insert(key.clone());
         }
+        let pending = self.loads.is_pending(&key);
         self.loads.invalidate(&key);
+        cached || pending
+    }
+
+    /// Whether a `.gitignore` in this batch can reach anything the tree holds.
+    ///
+    /// A `.gitignore` at `D/.gitignore` governs `D` and everything below it and
+    /// nowhere else, so it matters only when some directory the tree caches or
+    /// is loading sits under `D`. Without this test an `npm install` writing
+    /// `.gitignore` files all over `node_modules` — or one under any unlisted
+    /// build directory — took the whole-cache branch and repainted the window,
+    /// once per batch, which is the residual of the very symptom #243 is about.
+    ///
+    /// The test is complete as well as safe: any directory whose matchers could
+    /// be cached is an ancestor of a directory that was successfully listed, and
+    /// that one is in `children`.
+    fn gitignore_reaches_tree(&self, host: HostId, paths: &HashSet<PathBuf>) -> bool {
+        paths
+            .iter()
+            .filter(|p| p.file_name().is_some_and(|n| n == ".gitignore"))
+            .filter_map(|p| p.parent())
+            .any(|dir| {
+                self.children
+                    .keys()
+                    .any(|(id, cached)| id == host && cached.starts_with(dir))
+                    || self
+                        .loads
+                        .pending_keys()
+                        .any(|(id, pending)| *id == host && pending.starts_with(dir))
+            })
     }
 
     /// Mark every listing for a refresh — for the changes no smaller invalidation covers: a
@@ -969,11 +1039,19 @@ impl Tty7App {
         );
     }
 
-    /// Watcher callback (debounced): drop affected listing caches so the next
-    /// render relists. A `.gitignore` change resets ignore state wholesale —
+    /// Watcher callback (debounced): mark the affected listings for a refresh
+    /// and re-read them. A `.gitignore` change resets ignore state wholesale —
     /// its patterns can affect any depth below it.
     ///
     /// See [`event_can_change_a_row`] for what is deliberately ignored here.
+    ///
+    /// Notably this does **not** repaint (issue #243). The watcher is recursive
+    /// over the root, so on any tree being worked in it fires every
+    /// [`REFRESH_DEBOUNCE`] for writes into `.git`, `target/` or `node_modules`
+    /// that the tree neither caches nor shows, and a `cx.notify()` here was a
+    /// full-window redraw for each of them — the tree asking to be redrawn
+    /// before it knew whether it had anything new to draw. The re-read's own
+    /// landing repaints, and only when the listing came back different.
     pub(crate) fn file_tree_apply_fs_events(
         &mut self,
         host: HostId,
@@ -1005,14 +1083,25 @@ impl Tty7App {
         let gitignore_touched = paths
             .iter()
             .any(|p| p.file_name().is_some_and(|n| n == ".gitignore"));
-        if gitignore_touched {
+        if gitignore_touched && self.file_tree.gitignore_reaches_tree(host, paths) {
             // The host has already dropped the compiled matchers from inside
             // its own watcher; what is left for us is the listings that carry
             // the `ignored` flags those matchers produced.
             self.file_tree.invalidate_all();
+            // The one case that repaints on the event itself: `invalidate_all`
+            // restarts the search, and only a paint re-walks it.
+            cx.notify();
         } else {
+            let mut touched = false;
             for dir in dirs_to_relist(paths, self.file_tree.show_hidden) {
-                self.file_tree.invalidate_dir(host, dir);
+                touched |= self.file_tree.invalidate_dir(host, dir);
+            }
+            if !touched {
+                // Nothing the tree holds was reached, so there is nothing to
+                // re-read and nothing to redraw. This is the overwhelming
+                // majority of what a recursive watch over a working tree
+                // reports.
+                return;
             }
             // Deliberately *not* restarting the search here. Its results are
             // their own walk rather than a view over the listings just dropped,
@@ -1025,8 +1114,24 @@ impl Tty7App {
             // walk bows out before it ever reads a directory and the list stays
             // empty forever. A snapshot that's a few seconds old until the next
             // keystroke is the better failure.
+
+            // Re-read what was marked, here rather than on the next paint.
+            // Waiting for one would mean notifying to *get* one, which is the
+            // full-window redraw per event batch this function's doc comment is
+            // about. Only while the tree is still pointed at the machine the
+            // events came from.
+            let Some(shared) = self.active_host(cx) else {
+                return;
+            };
+            if shared.id() != host {
+                return;
+            }
+            let (roots, expanded) = match self.tab_code() {
+                Some(code) => (code.roots.clone(), code.expanded.clone()),
+                None => return,
+            };
+            self.file_tree.request_loads(&shared, &roots, &expanded, cx);
         }
-        cx.notify();
     }
 
     fn file_tree_toggle_expand(&mut self, dir: &Path, cx: &mut Context<Self>) {
@@ -1394,7 +1499,9 @@ impl Tty7App {
                     move |h| h.remove(&target, is_dir),
                     move |app, result: std::io::Result<()>, window, cx| {
                         match result {
-                            Ok(()) => app.file_tree.invalidate_dir(id, &parent),
+                            Ok(()) => {
+                                app.file_tree.invalidate_dir(id, &parent);
+                            }
                             Err(e) => {
                                 app.file_tree.rollback(id, &parent, rollback);
                                 HostOps::notify_err(window, cx, "Delete failed", &e);
@@ -2377,5 +2484,417 @@ mod tests {
         assert!(children.get(host, &other).is_none());
         rollback_write(&mut children, host, &other, before);
         assert!(children.get(host, &other).is_none());
+    }
+}
+
+/// Issue #243 at the window: what a watcher event costs in frames.
+///
+/// The other half of that issue — a refreshing directory keeping its rows on
+/// screen — is [`FileTreeState::stale`]'s job and is covered by
+/// `land_listing_keeps_a_superseded_snapshot`. These are about the frames: a
+/// window with nothing new to draw must not be asked to draw.
+///
+/// Measurements, not assertions about internals. gpui's test build redraws every
+/// dirty window from inside `flush_effects`, so a real (headless) window plus
+/// [`render_probe`](crate::ui::app::render_probe) counts exactly the frames the
+/// app asked for — the one claim in the issue that is platform-independent, and
+/// answerable without the reporter's Wayland session.
+#[cfg(all(test, unix))]
+mod render_idle_gpui_tests {
+    use super::*;
+    use crate::daemon::protocol::DaemonMsg;
+    use crate::ui::app::{render_probe, test_window};
+    use gpui::{Entity, TestAppContext, VisualTestContext};
+    use tty7_core::core::config::RightPanelTab;
+
+    /// Draws a settle may legitimately spend before the count reads as a loop.
+    /// A repaint loop blows past this in well under a second, and it fails the
+    /// test rather than hanging it — the loop lives inside one `flush_effects`
+    /// call, which nothing outside it can interrupt.
+    const BUDGET: u64 = 200;
+
+    /// These run one at a time. Every one of them drives a real window through
+    /// `LocalHost::shared()`, which is a process-wide `OnceLock` singleton with
+    /// a shared gitignore cache and its own pool — so concurrent cases contend
+    /// on it and the draw counts, which are the whole point here, stop being
+    /// meaningful. Poisoning is stepped over deliberately: one failing case
+    /// should report its own assertion, not turn every later one into a panic
+    /// about a poisoned lock.
+    fn serial() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn scratch(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("tty7-idle-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // macOS reports watcher paths through `/private/var` while the cache is
+        // keyed by the root as handed in. Canonicalizing keeps these tests about
+        // the frames rather than about that.
+        std::fs::canonicalize(&dir).unwrap()
+    }
+
+    /// A window with the right panel open on the Files tab, rooted at `root` and
+    /// settled: the first listing has landed and everything it woke has run.
+    fn files_panel_on(
+        cx: &mut TestAppContext,
+        root: &Path,
+    ) -> (
+        Entity<Tty7App>,
+        VisualTestContext,
+        std::os::unix::net::UnixStream,
+    ) {
+        let (app, mut vcx, mut pane) = test_window::harness_with_pane(cx);
+        // Tell the pane where it is, rather than writing the roots directly:
+        // render re-derives them from the active tab's panes every frame, so a
+        // root assigned behind that is replaced by the `$HOME` fallback on the
+        // very next paint. The test plays the daemon, and `Cwd` is the message a
+        // shell's OSC 7 turns into.
+        DaemonMsg::Cwd(root.to_path_buf())
+            .encode(&mut pane)
+            .expect("the pane's socket takes the cwd");
+        app.update_in(&mut vcx, |app, _, cx| {
+            app.right_panel_visible = true;
+            app.right_panel_tab = RightPanelTab::Files;
+            cx.notify();
+        });
+        // The pane's reader is a real thread and the cwd has to reach it, then
+        // be resolved to a repository root (a host call, answered off-thread),
+        // before the first listing is even asked for.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+        loop {
+            vcx.background_executor.run_until_parked();
+            let rooted = app.update_in(&mut vcx, |app, window, cx| {
+                app.file_tree_refresh_roots(window, cx);
+                app.tab_code().map(|c| c.roots.clone()).unwrap_or_default()
+                    == vec![root.to_path_buf()]
+            });
+            if rooted {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the pane never reported its cwd"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        // And then until the root's own listing has landed, so a measurement
+        // never starts against a tree that has not drawn its rows yet.
+        loop {
+            app.update_in(&mut vcx, |_, _, cx| cx.notify());
+            vcx.background_executor.run_until_parked();
+            let listed = app.update_in(&mut vcx, |app, _, _| {
+                app.file_tree.children.get(HostId::LOCAL, root).is_some()
+            });
+            if listed {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the root was never listed"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        vcx.background_executor.run_until_parked();
+        (app, vcx, pane)
+    }
+
+    /// What the tree would paint right now.
+    fn rows(app: &Entity<Tty7App>, vcx: &mut VisualTestContext) -> usize {
+        app.update_in(vcx, |app, _, _| {
+            let code = app.tab_code().expect("panel state");
+            app.file_tree
+                .visible_rows(HostId::LOCAL, &code.roots, &code.expanded)
+                .len()
+        })
+    }
+
+    /// Hand the app one debounced watcher batch, exactly as the watcher does.
+    fn fs_event(app: &Entity<Tty7App>, vcx: &mut VisualTestContext, path: &Path) {
+        app.update_in(vcx, |app, _, cx| {
+            app.file_tree_apply_fs_events(HostId::LOCAL, &HashSet::from([path.to_path_buf()]), cx);
+        });
+    }
+
+    /// Run everything the app has queued, including the host's real-thread
+    /// listings, to quiescence. A single `run_until_parked` is not enough: the
+    /// host answers off the deterministic executor, so its reply lands after the
+    /// test thread has already parked.
+    fn settle(app: &Entity<Tty7App>, vcx: &mut VisualTestContext, root: &Path) {
+        // A wall-clock deadline, not an iteration count: the whole suite shares
+        // one `LocalHost` pool, so under a parallel `cargo test` a listing can
+        // take far longer to come back than it does alone.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while std::time::Instant::now() < deadline {
+            vcx.background_executor.run_until_parked();
+            // Loads, plus any mark on the tree *this test is looking at*.
+            // Deliberately not `stale.is_empty()`: the whole-cache branch marks
+            // every cached listing, and the cache outlives the panel's roots —
+            // the `$HOME` listing from before the pane reported its cwd is still
+            // in there, is not a root or an expanded directory, so
+            // `request_loads` never re-asks for it and its mark never clears. A
+            // settle waiting on that waits forever.
+            //
+            // Deliberately does not notify either — a settle that asked for
+            // paints would be counted by the draw probe it exists to serve.
+            let quiet = app.update_in(vcx, |app, _, _| {
+                app.file_tree.loads.is_empty()
+                    && !app
+                        .file_tree
+                        .stale
+                        .iter()
+                        .any(|(_, dir)| dir.starts_with(root))
+            });
+            if quiet {
+                // One more pass so the last landing's own notify is drawn.
+                vcx.background_executor.run_until_parked();
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        panic!("the tree never went quiet");
+    }
+
+    /// Draws over a quiet interval — no input, no filesystem change — *after*
+    /// the window has come to rest. Anything counted here is a frame the window
+    /// asked for with nothing to draw, which is what issue #243 is about.
+    ///
+    /// The rest comes first because settling legitimately costs a last frame or
+    /// two: the final listing lands and asks to be drawn. Render idle is not
+    /// "never draws again", it is "stops drawing" — so the measurement is the
+    /// second interval, once the first has absorbed the tail. A repaint loop
+    /// keeps both intervals busy and trips [`BUDGET`] long before either ends.
+    fn draws_while_idle(vcx: &mut VisualTestContext) -> u64 {
+        render_probe::arm(BUDGET);
+        vcx.background_executor.run_until_parked();
+        vcx.executor()
+            .advance_clock(std::time::Duration::from_secs(3));
+        vcx.background_executor.run_until_parked();
+        // Now it is at rest. Count from here.
+        render_probe::arm(BUDGET);
+        vcx.executor()
+            .advance_clock(std::time::Duration::from_secs(9));
+        vcx.background_executor.run_until_parked();
+        render_probe::draws()
+    }
+
+    /// The reporter's failing case and their two negative cases, measured the
+    /// same way: a settled window draws once and stops, whatever is in the tree.
+    #[gpui::test]
+    fn a_settled_files_panel_reaches_render_idle(cx: &mut TestAppContext) {
+        let _serial = serial();
+        let root = scratch("settled");
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        for n in 0..12 {
+            std::fs::write(root.join(format!("file{n:02}.rs")), "").unwrap();
+        }
+        let (app, mut vcx, _pane) = files_panel_on(cx, &root);
+        assert!(rows(&app, &mut vcx) > 1, "the tree listed nothing");
+        assert_eq!(draws_while_idle(&mut vcx), 0);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[gpui::test]
+    fn a_settled_files_panel_on_an_empty_directory_reaches_render_idle(cx: &mut TestAppContext) {
+        let _serial = serial();
+        let root = scratch("empty");
+        let (app, mut vcx, _pane) = files_panel_on(cx, &root);
+        assert_eq!(rows(&app, &mut vcx), 1, "the root row and nothing else");
+        assert_eq!(draws_while_idle(&mut vcx), 0);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[gpui::test]
+    fn a_settled_files_panel_on_hidden_only_content_reaches_render_idle(cx: &mut TestAppContext) {
+        let _serial = serial();
+        let root = scratch("hidden");
+        std::fs::write(root.join(".hidden"), "").unwrap();
+        let (app, mut vcx, _pane) = files_panel_on(cx, &root);
+        assert_eq!(rows(&app, &mut vcx), 1, "the dotfile is filtered out");
+        assert_eq!(draws_while_idle(&mut vcx), 0);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The window never went idle because the watcher is recursive over the
+    /// root: writes into `target/`, `node_modules/` or `.git/` all arrive here,
+    /// and every one of them repainted a window that had nothing new to draw.
+    #[gpui::test]
+    fn a_change_the_tree_does_not_display_costs_no_frames(cx: &mut TestAppContext) {
+        let _serial = serial();
+        let root = scratch("unlisted");
+        for n in 0..12 {
+            std::fs::write(root.join(format!("file{n:02}.rs")), "").unwrap();
+        }
+        std::fs::create_dir_all(root.join("target/debug")).unwrap();
+        let (app, mut vcx, _pane) = files_panel_on(cx, &root);
+        let before = rows(&app, &mut vcx);
+
+        render_probe::arm(BUDGET);
+        for n in 0..5 {
+            let path = root.join(format!("target/debug/artifact{n}.o"));
+            std::fs::write(&path, "").unwrap();
+            fs_event(&app, &mut vcx, &path);
+            settle(&app, &mut vcx, &root);
+        }
+        assert_eq!(render_probe::draws(), 0, "nothing on screen changed");
+        assert_eq!(rows(&app, &mut vcx), before);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The same for a directory the tree *is* showing, when what changed is a
+    /// file's contents rather than the entries. A build writing a log into a
+    /// listed directory reports as loudly as one creating a file there.
+    #[gpui::test]
+    fn rewriting_a_file_in_a_displayed_directory_costs_no_frames(cx: &mut TestAppContext) {
+        let _serial = serial();
+        let root = scratch("rewrite");
+        for n in 0..12 {
+            std::fs::write(root.join(format!("file{n:02}.rs")), "").unwrap();
+        }
+        let (app, mut vcx, _pane) = files_panel_on(cx, &root);
+        let before = rows(&app, &mut vcx);
+
+        render_probe::arm(BUDGET);
+        for n in 0..5 {
+            let path = root.join("file00.rs");
+            std::fs::write(&path, format!("line {n}")).unwrap();
+            fs_event(&app, &mut vcx, &path);
+            settle(&app, &mut vcx, &root);
+        }
+        assert_eq!(render_probe::draws(), 0, "the listing came back identical");
+        assert_eq!(rows(&app, &mut vcx), before);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Not repainting for an event is only correct if a real change still
+    /// arrives — the re-read now happens in the event handler rather than on a
+    /// paint that a `cx.notify()` had to buy.
+    #[gpui::test]
+    fn a_real_change_still_reaches_the_panel(cx: &mut TestAppContext) {
+        let _serial = serial();
+        let root = scratch("realchange");
+        for n in 0..12 {
+            std::fs::write(root.join(format!("file{n:02}.rs")), "").unwrap();
+        }
+        let (app, mut vcx, _pane) = files_panel_on(cx, &root);
+        let before = rows(&app, &mut vcx);
+
+        let added = root.join("new.rs");
+        std::fs::write(&added, "").unwrap();
+        fs_event(&app, &mut vcx, &added);
+        assert_eq!(
+            rows(&app, &mut vcx),
+            before,
+            "the rows survive the refresh they triggered"
+        );
+        settle(&app, &mut vcx, &root);
+        assert_eq!(rows(&app, &mut vcx), before + 1, "the new file shows up");
+
+        // Deletions too, and then the window settles again.
+        std::fs::remove_file(&added).unwrap();
+        fs_event(&app, &mut vcx, &added);
+        settle(&app, &mut vcx, &root);
+        assert_eq!(rows(&app, &mut vcx), before);
+        assert_eq!(draws_while_idle(&mut vcx), 0);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// `.gitignore` takes the whole-cache branch, so it must be scoped to the
+    /// tree as well: an `npm install` writing them all over `node_modules`
+    /// otherwise repaints the window once per batch, which is the residual of
+    /// the very symptom this fixes.
+    #[gpui::test]
+    fn a_gitignore_under_an_unlisted_directory_costs_no_frames(cx: &mut TestAppContext) {
+        let _serial = serial();
+        let root = scratch("gitignore-unlisted");
+        std::fs::write(root.join("main.rs"), "").unwrap();
+        std::fs::create_dir_all(root.join("node_modules/pkg")).unwrap();
+        let (app, mut vcx, _pane) = files_panel_on(cx, &root);
+
+        render_probe::arm(BUDGET);
+        for n in 0..5 {
+            let path = root.join(format!("node_modules/pkg{n}/.gitignore"));
+            fs_event(&app, &mut vcx, &path);
+            settle(&app, &mut vcx, &root);
+        }
+        assert_eq!(render_probe::draws(), 0, "it cannot reach a cached listing");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The other side of that scoping: a `.gitignore` that *can* reach the tree
+    /// still refreshes it, and the panel does not empty while it does.
+    #[gpui::test]
+    fn a_gitignore_in_the_displayed_tree_still_refreshes(cx: &mut TestAppContext) {
+        let _serial = serial();
+        let root = scratch("gitignore-displayed");
+        for n in 0..12 {
+            std::fs::write(root.join(format!("file{n:02}.rs")), "").unwrap();
+        }
+        std::fs::write(root.join(".gitignore"), "").unwrap();
+        let (app, mut vcx, _pane) = files_panel_on(cx, &root);
+        let before = rows(&app, &mut vcx);
+
+        let ignore = root.join(".gitignore");
+        std::fs::write(&ignore, "file00.rs\n").unwrap();
+        fs_event(&app, &mut vcx, &ignore);
+        // Every cached listing is marked, which is what the whole-cache branch
+        // is for — and the rows are still on screen while it re-reads.
+        let marked = app.update_in(&mut vcx, |app, _, _| {
+            app.file_tree
+                .stale
+                .iter()
+                .filter(|(_, dir)| dir.starts_with(&root))
+                .count()
+        });
+        assert!(marked > 0, "the batch reached the tree");
+        assert_eq!(rows(&app, &mut vcx), before, "rows stay while it re-reads");
+
+        settle(&app, &mut vcx, &root);
+        // Nothing appears or disappears — an ignored entry renders dimmed, not
+        // hidden — and the re-read has cleared every mark.
+        assert_eq!(rows(&app, &mut vcx), before);
+        let left = app.update_in(&mut vcx, |app, _, _| {
+            app.file_tree
+                .stale
+                .iter()
+                .filter(|(_, dir)| dir.starts_with(&root))
+                .count()
+        });
+        assert_eq!(left, 0, "every marked listing under the root was re-read");
+        // Deliberately not asserting the `ignored` flags here. The compiled
+        // matchers live in the host and are dropped from inside *its* watcher,
+        // which driving `file_tree_apply_fs_events` directly bypasses — so what
+        // this seam owns is the marking and the re-read, not what the host
+        // recomputes. `loader_tags_ignored_entries_down_the_gitignore_chain`
+        // covers the matchers themselves.
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The stale marks are keyed by path and the watcher names paths without
+    /// limit — every object a build drops into `target/`. Recording one for
+    /// something the tree does not track would grow that set forever.
+    #[gpui::test]
+    fn untracked_paths_leave_no_bookkeeping_behind(cx: &mut TestAppContext) {
+        let _serial = serial();
+        let root = scratch("bookkeeping");
+        std::fs::write(root.join("main.rs"), "").unwrap();
+        std::fs::create_dir_all(root.join("target/debug")).unwrap();
+        let (app, mut vcx, _pane) = files_panel_on(cx, &root);
+
+        for n in 0..50 {
+            let path = root.join(format!("target/debug/obj{n}.o"));
+            fs_event(&app, &mut vcx, &path);
+        }
+        settle(&app, &mut vcx, &root);
+        let marks = app.update_in(&mut vcx, |app, _, _| {
+            app.file_tree
+                .stale
+                .iter()
+                .filter(|(_, dir)| dir.starts_with(&root))
+                .count()
+        });
+        assert_eq!(marks, 0, "nothing the tree holds was reached");
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src/ui/file_tree.rs
+++ b/src/ui/file_tree.rs
@@ -1065,13 +1065,28 @@ impl Tty7App {
     /// Whether the tree column is actually being drawn, for the work that only
     /// a visible tree can have a result for.
     ///
-    /// The same pair of conditions [`render_right_panel`](Self::render_right_panel)
-    /// reaches the Files body through, read from the same fields, so the two
-    /// cannot drift into disagreeing about it. Deliberately not
-    /// consulting the tab's `code.visible`: the tree left the code overlay for
-    /// the panel, and the overlay draws the editor only.
+    /// Three conditions, because the Files tab does not always draw the local
+    /// tree. An open panel on that tab reaches
+    /// [`render_panel_files`](Self::render_panel_files), which hands the column
+    /// to the SFTP browser instead whenever the tab's detail pane is a connected
+    /// native-SSH one — the local tree is not drawn at all then, and re-reading
+    /// its listings is the same waste as re-reading them for a closed panel.
+    /// `open_pane_id` is the fact that branch leaves behind, so reading it here
+    /// is reading the decision itself rather than re-deriving it (which would
+    /// need a `Window` this callback has not got).
+    ///
+    /// It lags by one paint: the batch arriving between switching to such a pane
+    /// and the paint that opens the browser still counts as on screen. That
+    /// direction is the safe one — a single extra re-read, versus a tree that
+    /// stops refreshing while somebody is looking at it.
+    ///
+    /// Deliberately not consulting the tab's `code.visible`: the tree left the
+    /// code overlay for the panel, and the overlay draws the editor only (see
+    /// `render_code_overlay`).
     pub(crate) fn file_tree_on_screen(&self, cx: &App) -> bool {
-        self.right_panel_open(cx) && self.right_panel_tab == RightPanelTab::Files
+        self.right_panel_open(cx)
+            && self.right_panel_tab == RightPanelTab::Files
+            && self.sftp_panel.open_pane_id.is_none()
     }
 
     /// Watcher callback (debounced): mark the affected listings for a refresh
@@ -3140,6 +3155,63 @@ mod render_idle_gpui_tests {
                 .count()
         });
         assert_eq!(left, 0, "the marked listing was re-read on reopening");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The Files tab is open and the local tree is still not drawn: the SFTP
+    /// browser has the column, because the tab's detail pane is a connected
+    /// native-SSH one.
+    ///
+    /// Driven through `sftp_panel.open_pane_id` rather than through a real SSH
+    /// pane, which this harness cannot stand up — that field *is* what
+    /// `render_panel_files` branches on, set by `sftp_sync_pane` on the paint
+    /// that opens the browser, so it is the state the predicate has to read.
+    /// Everything happens inside one `update` because a paint would run
+    /// `sftp_sync_pane` against this window's local pane and close the browser
+    /// again, which is correct behaviour and would undo the setup.
+    #[gpui::test]
+    fn the_sftp_browser_holding_the_column_counts_as_not_drawn(cx: &mut TestAppContext) {
+        let _serial = serial();
+        let root = scratch("sftp-column");
+        for n in 0..12 {
+            std::fs::write(root.join(format!("file{n:02}.rs")), "").unwrap();
+        }
+        let (app, mut vcx, _pane) = files_panel_on(cx, &root);
+        let path = root.join("file00.rs");
+        std::fs::write(&path, "changed").unwrap();
+
+        let (on_screen, in_flight, marked) = app.update_in(&mut vcx, |app, _, cx| {
+            app.sftp_panel.open_pane_id = Some(7);
+            let on_screen = app.file_tree_on_screen(cx);
+            app.file_tree_apply_fs_events(HostId::LOCAL, &HashSet::from([path.clone()]), cx);
+            (
+                on_screen,
+                app.file_tree.loads.len(),
+                app.file_tree
+                    .stale
+                    .iter()
+                    .filter(|(_, dir)| dir.starts_with(&root))
+                    .count(),
+            )
+        });
+        assert!(!on_screen, "the SFTP browser has the column, not the tree");
+        assert_eq!(in_flight, 0, "so nothing was asked of the host");
+        assert!(marked > 0, "but the change was recorded");
+
+        // The mark is picked up once the tree has the column back.
+        app.update_in(&mut vcx, |app, _, cx| {
+            app.sftp_panel.open_pane_id = None;
+            cx.notify();
+        });
+        settle(&app, &mut vcx, &root);
+        let left = app.update_in(&mut vcx, |app, _, _| {
+            app.file_tree
+                .stale
+                .iter()
+                .filter(|(_, dir)| dir.starts_with(&root))
+                .count()
+        });
+        assert_eq!(left, 0, "the marked listing was re-read once it came back");
         let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src/ui/host_ops.rs
+++ b/src/ui/host_ops.rs
@@ -393,6 +393,12 @@ impl<K: Eq + Hash + Clone> InFlight<K> {
         self.in_flight.contains(key)
     }
 
+    /// The keys with a request outstanding, for callers that have to reason
+    /// about the set rather than about one key.
+    pub fn pending_keys(&self) -> impl Iterator<Item = &K> {
+        self.in_flight.iter()
+    }
+
     /// How many requests are outstanding.
     pub fn len(&self) -> usize {
         self.in_flight.len()


### PR DESCRIPTION
## What this fixes

Issue #243 reported two things. **This PR is only the second of them**, and the first is worth stating up front because it is not this PR's work:

- **The Files panel flickering** was fixed independently on `main` by `4814d94` *"keep file-tree listings on screen while they refresh"*, which reached the same mechanism separately and went further on two axes. This branch originally carried its own version of that fix and it was dropped in favour of main's.
- **The window not reaching render idle** — the issue's title — is what remains, and is what this PR addresses.

## The claim, and a correction

An earlier revision of this branch justified the change on the file tree watching its root *recursively*, and so hearing about every write underneath: `.git` internals, build output, everything under `node_modules`. **That was wrong on this base**, and the review caught it. `sync_watch`'s own doc says the subscription is non-recursive; it covers roots plus expanded directories, and `WatchedDirs::translate` enforces it per backend. The recursive watcher belonged to the older single-host design and the premise was carried across the port to the host-keyed tree without being re-checked. The commit history on this branch carries that correction explicitly.

What is actually true, and all that is claimed here: the tree hears about changes in directories **it is displaying**, and a file's contents being rewritten reports exactly as loudly as a file appearing. A formatter rewriting in place, an editor saving on every keystroke, a build dropping its log beside the sources — each of those repainted the whole window, twice per batch, for as long as it went on.

## What changed

- **Repaint only on a real difference** (`src/ui/file_tree.rs`) — the landed re-read is compared against what is already on screen, and the window is only asked to redraw when it differs. That re-read is issued from the watcher callback rather than by notifying in order to buy the paint that would have done it.
- **A moved repository root still re-roots the tree** — an early return added by the first version of this change meant a `.git` create or delete cleared the repo-root cache with nothing left to re-resolve it. Regression introduced and closed here, with a test.
- **A tree that is not drawn does no filesystem work** — the watcher-driven re-read is gated on the tree actually being on screen. That gate accounts for the Files panel being closed, for the SFTP browser substituting for the local tree on a connected native-SSH pane, and for a search query being active (where the panel draws search results and no listings at all). Each has a test.
- **`.gitignore` refresh is scoped** — the whole-cache refresh is taken only when the changed file can actually govern a directory the tree holds. This is a correctness guard on the most expensive branch here, **not** a measurable saving: the watch is non-recursive, so a `.gitignore` has to sit in a displayed directory to arrive at all.

## Measurement

`Tty7App::render` feeds a per-thread draw counter under `cfg(test)` (`ui::app::render_probe`), and gpui's test build redraws dirty windows from inside `flush_effects` — so a headless window plus that counter answers "does this reach render idle?" with no compositor. Supporting seams: `test_window::harness`/`harness_with_pane` and `terminal::view::quiet_test_pane`. `render_probe::arm` takes a draw budget so a repaint-loop regression fails the test rather than hanging the suite.

Render idle is measured as *stops drawing*, not *never draws again*: settling legitimately costs a last frame as the final listing lands, so the count is taken over a second interval once the first has absorbed that tail. Confirmed rather than assumed — the count is 1 at 3s and still 1 at 12s.

**Measured against the reachable case only, by reverting the comparison and re-running: five rewrites of a file in a displayed directory cost 10 frames and now cost 0.**

Figures quoted by earlier revisions — writes under an unlisted directory (5 → 0) and `.gitignore` writes under `node_modules` (10 → 0) — are **withdrawn**. The tests behind them synthesised watcher events this non-recursive subscription cannot deliver, so they described scenarios the system cannot produce. Those tests are removed or explicitly reframed as guards on the predicate they exercise, and the test module says so where it stops.

## Two limits, stated plainly

All of this was measured on **macOS**; the reporter is on **Linux/Wayland/niri with Intel+NVIDIA hybrid graphics**.

- The redraw behaviour these numbers describe is platform-independent, so the *"does not enter render-idle"* claim is the one addressed here.
- The **~15% CPU figure was not verified**, and whether the reporter's flicker also involved something in the **Wayland presentation path cannot be answered from macOS**. Neither is claimed as confirmed.

## Notes for reviewers

- Separately discovered and deliberately left alone: on macOS the watcher reports paths through `/private/var` while the cache is keyed by the root as handed in, so a root reached via a symlink never matches. Pre-existing, unrelated to #243, invisible on Linux; the tests canonicalize around it and say so.
- The **Test step was skipped deliberately** — it gathers screenshot and recording evidence, which requires building and launching the GUI, and this work was constrained to stay headless. The workspace suite was run locally, `cargo fmt` is clean, and the clippy warning count is unchanged from `origin/main`'s baseline. CI runs `cargo test --locked` and `cargo fmt --check` on this PR. Visual acceptance is the maintainer's.
- `src/ui/right_panel.rs` and `src/ui/diff_overlay.rs` are untouched — a sibling branch owns them for #239.

Refs #243
