### PR TITLE
fix(ui): keep the window-drag arm alive across a repaint, and make every header draggable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   minimum, so it collapsed to exactly 0px once the tab chips saturated the row —
   around 7-8 tabs on a 1440px window — leaving nothing to grab but three 6px
   gaps and a hairline above and below the chips. The chip row's fixed-chrome
-  reserve is corrected to match, from a stale 100px (sized when the corner held a
-  30px "+" and a 30px "⋯") to the ~137px the corner actually occupies, so chips
-  reach their minimum width and truncate a tab or two sooner. (#221)
+  reserve is corrected to match: it was a flat 100px, sized when the corner held
+  a 30px "+" and a 30px "⋯", and was never raised when the workspace chip
+  absorbed the "⋯" menu in #169/#188 — so the row's width budget was ~20px of a
+  lie. It now measures the group it is reserving for, ~121px of fixed chrome plus
+  the 80px grab handle, so chips reach their minimum width and truncate a tab or
+  two sooner. (#221)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- **Dragging the window by a title bar worked only rarely with a trackpad** —
-  five rows that stand in for the caption (the tab rail's top zone, the settings
-  page's top strip, the detail panel's top zone, and the code and diff overlays'
-  headers) armed their window-drag with a flag that was rebuilt on every render.
-  Any repaint between the press and the first drag event threw the arm away, and
-  the press *itself* schedules one — these rows carry a double-click, which makes
-  gpui refresh the window on mouse-down — so the drag only survived if the first
-  move beat the next vsync: 16ms at 60Hz, 8ms on ProMotion. A mouse press nudges
-  the pointer and often won that race; a trackpad press is a finger pushing down
-  without translating, and almost never did. The terminal's cursor blink disarmed
-  it on its own even without a press. The arm now lives in element state, which
-  survives frames — where gpui-component's own `TitleBar` has always kept it,
-  which is why the ordinary caption strip was never affected. (#221)
+- **Pi is a first-class agent, not a fallback one** — Pi panes drew the generic
+  robot glyph every unbranded agent shares, so a Pi tab was indistinguishable
+  from an Aider or Qwen one in the sidebar, the tab chip and the tray menu. They
+  now carry their own avatar on the existing sky accent, status dot unchanged.
+  The mark is Pi's own, from pi.dev, rescaled to tty7's 24x24 icon grid — its
+  `prefers-color-scheme` stylesheet dropped, since these avatars are tinted by
+  the app. Restoring a Pi pane also resumes its conversation now: the tty7
+  extension reports Pi's session id, and the resume command is
+  `pi --session <id>` (Pi's `--resume` is a boolean that only opens the
+  interactive picker), with `--session` / `--session-id` / `--fork` /
+  `--resume` / `-r` / `--continue` / `-c` stripped off the replayed launch
+  flags so the restored id wins. A pane launched with `--no-session` is not
+  resumed at all — that pane never wrote a session to disk, and reopening one
+  would override the choice to keep it ephemeral. (#225)
 
 ### Changed
 
@@ -41,22 +42,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the 80px grab handle, so chips reach their minimum width and truncate a tab or
   two sooner. (#221)
 
-### Added
+### Fixed
 
-- **Pi is a first-class agent, not a fallback one** — Pi panes drew the generic
-  robot glyph every unbranded agent shares, so a Pi tab was indistinguishable
-  from an Aider or Qwen one in the sidebar, the tab chip and the tray menu. They
-  now carry their own avatar on the existing sky accent, status dot unchanged.
-  The mark is Pi's own, from pi.dev, rescaled to tty7's 24x24 icon grid — its
-  `prefers-color-scheme` stylesheet dropped, since these avatars are tinted by
-  the app. Restoring a Pi pane also resumes its conversation now: the tty7
-  extension reports Pi's session id, and the resume command is
-  `pi --session <id>` (Pi's `--resume` is a boolean that only opens the
-  interactive picker), with `--session` / `--session-id` / `--fork` /
-  `--resume` / `-r` / `--continue` / `-c` stripped off the replayed launch
-  flags so the restored id wins. A pane launched with `--no-session` is not
-  resumed at all — that pane never wrote a session to disk, and reopening one
-  would override the choice to keep it ephemeral. (#225)
+- **Dragging the window by a title bar worked only rarely with a trackpad** —
+  five rows that stand in for the caption (the tab rail's top zone, the settings
+  page's top strip, the detail panel's top zone, and the code and diff overlays'
+  headers) armed their window-drag with a flag that was rebuilt on every render.
+  Any repaint between the press and the first drag event threw the arm away, and
+  the press *itself* schedules one — these rows carry a double-click, which makes
+  gpui refresh the window on mouse-down — so the drag only survived if the first
+  move beat the next vsync: 16ms at 60Hz, 8ms on ProMotion. A mouse press nudges
+  the pointer and often won that race; a trackpad press is a finger pushing down
+  without translating, and almost never did. The terminal's cursor blink disarmed
+  it on its own even without a press. The arm now lives in element state, which
+  survives frames — where gpui-component's own `TitleBar` has always kept it,
+  which is why the ordinary caption strip was never affected. (#221)
 
 - **Fork an agent session** — branch a live agent conversation into a second,
   independent one, so a risky direction can be tried without losing the thread

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Every header in the window moves it now** — grabbing the window by a header
   is a property of the whole app rather than a per-surface feature, so you never
   have to learn which rows happen to be draggable. The detail panel's section
-  title (Info / Outline / Changes / Files, and the remote Files header) joins the
-  caption rows that already were. In horizontal-tab mode the strip also keeps a
+  title joins the caption rows that already were, wherever the panel draws one —
+  every tab off macOS, where that row is also the panel's tab switcher, and the
+  remote Files header on macOS. In horizontal-tab mode the strip also keeps a
   bare 80px slice of caption for grabbing: its spacer was a flexible one with no
   minimum, so it collapsed to exactly 0px once the tab chips saturated the row —
   around 7-8 tabs on a 1440px window — leaving nothing to grab but three 6px

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dragging the window by a title bar worked only rarely with a trackpad** —
+  five rows that stand in for the caption (the tab rail's top zone, the settings
+  page's top strip, the detail panel's top zone, and the code and diff overlays'
+  headers) armed their window-drag with a flag that was rebuilt on every render.
+  Any repaint between the press and the first drag event threw the arm away, and
+  the press *itself* schedules one — these rows carry a double-click, which makes
+  gpui refresh the window on mouse-down — so the drag only survived if the first
+  move beat the next vsync: 16ms at 60Hz, 8ms on ProMotion. A mouse press nudges
+  the pointer and often won that race; a trackpad press is a finger pushing down
+  without translating, and almost never did. The terminal's cursor blink disarmed
+  it on its own even without a press. The arm now lives in element state, which
+  survives frames — where gpui-component's own `TitleBar` has always kept it,
+  which is why the ordinary caption strip was never affected. (#221)
+
+### Changed
+
+- **Every header in the window moves it now** — grabbing the window by a header
+  is a property of the whole app rather than a per-surface feature, so you never
+  have to learn which rows happen to be draggable. The detail panel's section
+  title (Info / Outline / Changes / Files, and the remote Files header) joins the
+  caption rows that already were. In horizontal-tab mode the strip also keeps a
+  bare 80px slice of caption for grabbing: its spacer was a flexible one with no
+  minimum, so it collapsed to exactly 0px once the tab chips saturated the row —
+  around 7-8 tabs on a 1440px window — leaving nothing to grab but three 6px
+  gaps and a hairline above and below the chips. The chip row's fixed-chrome
+  reserve is corrected to match, from a stale 100px (sized when the corner held a
+  30px "+" and a 30px "⋯") to the ~137px the corner actually occupies, so chips
+  reach their minimum width and truncate a tab or two sooner. (#221)
+
 ### Added
 
 - **Pi is a first-class agent, not a fallback one** — Pi panes drew the generic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,41 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resumed at all — that pane never wrote a session to disk, and reopening one
   would override the choice to keep it ephemeral. (#225)
 
-### Changed
-
-- **Every header in the window moves it now** — grabbing the window by a header
-  is a property of the whole app rather than a per-surface feature, so you never
-  have to learn which rows happen to be draggable. The detail panel's section
-  title joins the caption rows that already were, wherever the panel draws one —
-  every tab off macOS, where that row is also the panel's tab switcher, and the
-  remote Files header on macOS. In horizontal-tab mode the strip also keeps a
-  bare 80px slice of caption for grabbing: its spacer was a flexible one with no
-  minimum, so it collapsed to exactly 0px once the tab chips saturated the row —
-  around 7-8 tabs on a 1440px window — leaving nothing to grab but three 6px
-  gaps and a hairline above and below the chips. The chip row's fixed-chrome
-  reserve is corrected to match: it was a flat 100px, sized when the corner held
-  a 30px "+" and a 30px "⋯", and was never raised when the workspace chip
-  absorbed the "⋯" menu in #169/#188 — so the row's width budget was ~20px of a
-  lie. It now measures the group it is reserving for, ~121px of fixed chrome plus
-  the 80px grab handle, so chips reach their minimum width and truncate a tab or
-  two sooner. (#221)
-
-### Fixed
-
-- **Dragging the window by a title bar worked only rarely with a trackpad** —
-  five rows that stand in for the caption (the tab rail's top zone, the settings
-  page's top strip, the detail panel's top zone, and the code and diff overlays'
-  headers) armed their window-drag with a flag that was rebuilt on every render.
-  Any repaint between the press and the first drag event threw the arm away, and
-  the press *itself* schedules one — these rows carry a double-click, which makes
-  gpui refresh the window on mouse-down — so the drag only survived if the first
-  move beat the next vsync: 16ms at 60Hz, 8ms on ProMotion. A mouse press nudges
-  the pointer and often won that race; a trackpad press is a finger pushing down
-  without translating, and almost never did. The terminal's cursor blink disarmed
-  it on its own even without a press. The arm now lives in element state, which
-  survives frames — where gpui-component's own `TitleBar` has always kept it,
-  which is why the ordinary caption strip was never affected. (#221)
-
 - **Fork an agent session** — branch a live agent conversation into a second,
   independent one, so a risky direction can be tried without losing the thread
   that got you there. tty7 shells the agent's *own* fork command rather than
@@ -115,6 +80,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keybindings match modifiers exactly, and no terminal treats that three-key
   chord as a newline. (#182)
 
+- **Every header in the window moves it now** — grabbing the window by a header
+  is a property of the whole app rather than a per-surface feature, so you never
+  have to learn which rows happen to be draggable. The detail panel's section
+  title joins the caption rows that already were, wherever the panel draws one —
+  every tab off macOS, where that row is also the panel's tab switcher, and the
+  remote Files header on macOS. In horizontal-tab mode the strip also keeps a
+  bare 80px slice of caption for grabbing: its spacer was a flexible one with no
+  minimum, so it collapsed to exactly 0px once the tab chips saturated the row —
+  around 7-8 tabs on a 1440px window — leaving nothing to grab but three 6px
+  gaps and a hairline above and below the chips. The chip row's fixed-chrome
+  reserve is corrected to match: it was a flat 100px, sized when the corner held
+  a 30px "+" and a 30px "⋯", and was never raised when the workspace chip
+  absorbed the "⋯" menu in #169/#188 — so the row's width budget was ~20px of a
+  lie. It now measures the group it is reserving for, ~121px of fixed chrome plus
+  the 80px grab handle, so chips reach their minimum width and truncate a tab or
+  two sooner. (#221)
+
 ### Fixed
 
 - **Rounded UI controls no longer square off their corners**
@@ -133,6 +115,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hover fills, the theme picker's flush previews, and the diff overlay's card
   headers and closing rows. Most visible at a device pixel ratio of 1, where the
   hard clip edge is a whole physical pixel wide.
+
+- **Dragging the window by a title bar worked only rarely with a trackpad** —
+  five rows that stand in for the caption (the tab rail's top zone, the settings
+  page's top strip, the detail panel's top zone, and the code and diff overlays'
+  headers) armed their window-drag with a flag that was rebuilt on every render.
+  Any repaint between the press and the first drag event threw the arm away, and
+  the press *itself* schedules one — these rows carry a double-click, which makes
+  gpui refresh the window on mouse-down — so the drag only survived if the first
+  move beat the next vsync: 16ms at 60Hz, 8ms on ProMotion. A mouse press nudges
+  the pointer and often won that race; a trackpad press is a finger pushing down
+  without translating, and almost never did. The terminal's cursor blink disarmed
+  it on its own even without a press. The arm now lives in element state, which
+  survives frames — where gpui-component's own `TitleBar` has always kept it,
+  which is why the ordinary caption strip was never affected. (#221)
 
 ## [26.7.6] - 2026-07-28
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -283,6 +283,14 @@ pub(crate) struct WindowMoveArm {
 //    `flex-basis: 0` means it collapses to nothing the moment the row fills up.
 //    See `tab_strip::GRAB_HANDLE_W`.
 //
+// What the rule does *not* reach is a row that only reads like a header. Where
+// the press already means something else, it keeps that meaning, so these being
+// undraggable is a decision rather than a backlog: tab chips (a drag reorders
+// them), the SFTP breadcrumb (a navigation control), settings section and
+// disclosure headings (typography, and click-to-expand rows inside a scrolling
+// form), diff file-card headers (click-to-collapse rows inside a scroll list),
+// and the command palette (a transient modal over a dismiss-on-press scrim).
+//
 // One region satisfies the rule by adjacency rather than on its own, and that is
 // deliberate — not an oversight to tidy up later. The detail panel's macOS top
 // zone is every-child-occluded (four tab tiles plus the corner chrome) and that

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -226,37 +226,145 @@ pub(crate) const WINDOW_MARK_SIZE: f32 = 20.;
 /// double-click, still land intact. Note that on Windows the drag area maps to
 /// HTCAPTION and the OS claims the press before gpui hit-tests, so every button
 /// inside one of these rows needs an `occlude()` wrapper to get its clicks back.
-pub(crate) fn title_bar_drag(row: gpui::Stateful<gpui::Div>) -> gpui::Stateful<gpui::Div> {
-    let should_move = Rc::new(Cell::new(false));
+///
+/// `key` must be unique among the stand-in rows that can be on screen together
+/// — see [`window_move_gesture`], which owns the arming and explains why.
+pub(crate) fn title_bar_drag(
+    row: gpui::Stateful<gpui::Div>,
+    key: &'static str,
+    window: &mut gpui::Window,
+    cx: &mut gpui::App,
+) -> gpui::Stateful<gpui::Div> {
+    window_move_gesture(row, key, window, cx).on_double_click(|_, window, _| {
+        // gpui only implements `titlebar_double_click` on macOS — the trait
+        // method is an empty default everywhere else, so on Linux this row
+        // swallowed the double-click and nothing zoomed. `zoom_window` is the
+        // maximise toggle there (x11 `_NET_WM_STATE_MAXIMIZED_*`, wayland
+        // `set_maximized`), and what gpui-component's own `TitleBar` calls on
+        // Linux for exactly this reason. Windows needs neither: the row is a
+        // drag area, which maps to HTCAPTION, and the OS has already restored
+        // or maximised the window before this could run.
+        if cfg!(target_os = "linux") {
+            window.zoom_window();
+        } else {
+            window.titlebar_double_click();
+        }
+    })
+}
+
+/// The armed flag behind [`window_move_gesture`]. A single bool, but *where* it
+/// lives is the whole point — see there.
+pub(crate) struct WindowMoveArm {
+    should_move: bool,
+}
+
+// ── Every header in tty7 is draggable ────────────────────────────────────────
+//
+// A standing rule, not a per-surface feature: a user should never have to learn
+// which of this window's headers happen to move it. Any row that reads as a
+// header, caption or title — the caption strip, the rail's and the detail
+// panel's top zones, an overlay's header, the panel's section title — moves the
+// window when you drag it. New headers are expected to arrive that way.
+//
+// Three things that takes, in the order they bite:
+//
+// 1. **Arm it with [`window_move_gesture`]**, never a fresh `Rc<Cell>` per
+//    render. That function's doc explains why (#221).
+// 2. **Non-controls take no hit box.** Anything drawn inside a header that is not
+//    an interactive control — a label, a count, a brand mark, an icon — gets no
+//    `.id()` and no `occlude()`, so the drag falls straight through it and the
+//    row stays grabbable however long its text runs. This is the rule #202
+//    established for the "duo" mark. Its converse binds too: anything that *is* a
+//    control needs an `occlude()` wrapper, or Windows' HTCAPTION claims the press
+//    before gpui hit-tests and the button never fires.
+// 3. **A flexible spacer needs a minimum.** Where a header's contents *do* take
+//    hit boxes by design — the tab strip, whose chips are draggable for reorder —
+//    the bare spacer beside them is the only grab region there is, and
+//    `flex-basis: 0` means it collapses to nothing the moment the row fills up.
+//    See `tab_strip::GRAB_HANDLE_W`.
+//
+// One region satisfies the rule by adjacency rather than on its own, and that is
+// deliberate — not an oversight to tidy up later. The detail panel's macOS top
+// zone is every-child-occluded (four tab tiles plus the corner chrome) and that
+// fixed footprint comes to 214px against a `right_panel::MIN_WIDTH` of 216, so
+// at the panel's floor its spacer is a couple of pixels — a handle only on
+// paper. It keeps a real one anyway: the panel's section title
+// (`right_panel::panel_title`) is draggable and sits immediately below it.
+// Raising `MIN_WIDTH` far enough to seat a grabbable spacer would trade a real
+// capability — narrowing the panel — for a handle the user already has a few
+// pixels lower, so the floor stays where it is and the row keeps all its
+// controls.
+
+/// Arm-on-press / move-on-first-move window dragging for a row that stands in
+/// for the title bar. [`title_bar_drag`] is this plus the double-click-to-zoom
+/// half; the settings page and the detail panel's top zone take this alone
+/// because their double-click differs.
+///
+/// **The arm has to outlive the frame it was set in (#221).** This used to hold
+/// `should_move` in an `Rc<Cell<bool>>` built inside the render function, which
+/// meant every repaint handed the *next* frame's listeners a fresh, zeroed cell
+/// while the press had written to the old one. Any redraw between the press and
+/// the first drag event silently disarmed the hold — and the press itself
+/// schedules one, because `on_double_click` makes gpui call `window.refresh()`
+/// on mouse-down. So a drag only survived if the first move beat the next vsync:
+/// ≤16ms at 60Hz, ≤8ms on ProMotion. A mouse press nudges the pointer and often
+/// wins that race; a trackpad press is a finger pushing down without translating
+/// and almost never does, which is exactly the "success rate is very low, and
+/// only with the trackpad" the issue reported. The terminal's cursor blink
+/// (`cx.notify()` every 530ms) disarms it on its own even without a press.
+///
+/// `window.use_keyed_state` puts the flag in gpui element state instead, which
+/// survives across frames — the same place gpui-component's own `TitleBar` keeps
+/// it, which is why the ordinary caption strip never had this bug. Keyed rather
+/// than `use_state` because one builder serves several call sites: `use_state`
+/// derives its id from the *caller's* `CodeLocation`, so two of these rows on
+/// screen at once (the rail's top zone plus the code overlay's header is a real
+/// combination) would share one arm. `key` must therefore be unique among the
+/// rows that can coexist.
+///
+/// Releasing outside the row disarms too. With a per-frame cell that never
+/// mattered — the flag died with the frame regardless — but a flag that persists
+/// would otherwise stay armed after a press that wandered off the row, and then
+/// start a window move on a later *hover* over it.
+pub(crate) fn window_move_gesture(
+    row: gpui::Stateful<gpui::Div>,
+    key: &'static str,
+    window: &mut gpui::Window,
+    cx: &mut gpui::App,
+) -> gpui::Stateful<gpui::Div> {
+    let arm = window.use_keyed_state(key, cx, |_, _| WindowMoveArm { should_move: false });
     row.window_control_area(gpui::WindowControlArea::Drag)
-        .on_mouse_down(gpui::MouseButton::Left, {
-            let should_move = should_move.clone();
-            move |_, _, _| should_move.set(true)
-        })
-        .on_mouse_up(gpui::MouseButton::Left, {
-            let should_move = should_move.clone();
-            move |_, _, _| should_move.set(false)
-        })
-        .on_mouse_move(move |_, window, _| {
-            if should_move.replace(false) {
-                window.start_window_move();
-            }
-        })
-        .on_double_click(|_, window, _| {
-            // gpui only implements `titlebar_double_click` on macOS — the trait
-            // method is an empty default everywhere else, so on Linux this row
-            // swallowed the double-click and nothing zoomed. `zoom_window` is the
-            // maximise toggle there (x11 `_NET_WM_STATE_MAXIMIZED_*`, wayland
-            // `set_maximized`), and what gpui-component's own `TitleBar` calls on
-            // Linux for exactly this reason. Windows needs neither: the row is a
-            // drag area, which maps to HTCAPTION, and the OS has already restored
-            // or maximised the window before this could run.
-            if cfg!(target_os = "linux") {
-                window.zoom_window();
-            } else {
-                window.titlebar_double_click();
-            }
-        })
+        .on_mouse_down(
+            gpui::MouseButton::Left,
+            window.listener_for(&arm, |arm, _: &gpui::MouseDownEvent, _, _| {
+                arm.should_move = true;
+            }),
+        )
+        .on_mouse_down_out(
+            window.listener_for(&arm, |arm, _: &gpui::MouseDownEvent, _, _| {
+                arm.should_move = false;
+            }),
+        )
+        .on_mouse_up(
+            gpui::MouseButton::Left,
+            window.listener_for(&arm, |arm, _: &gpui::MouseUpEvent, _, _| {
+                arm.should_move = false;
+            }),
+        )
+        .on_mouse_up_out(
+            gpui::MouseButton::Left,
+            window.listener_for(&arm, |arm, _: &gpui::MouseUpEvent, _, _| {
+                arm.should_move = false;
+            }),
+        )
+        .on_mouse_move(
+            window.listener_for(&arm, |arm, _: &gpui::MouseMoveEvent, window, _| {
+                if arm.should_move {
+                    arm.should_move = false;
+                    window.start_window_move();
+                }
+            }),
+        )
 }
 
 pub(crate) fn window_mark() -> Option<impl IntoElement> {
@@ -6340,7 +6448,7 @@ impl Render for Tty7App {
         // the rail and the right panel (both are siblings), which is the point:
         // the sidebar's git lines stay clickable to switch repo, and the
         // Changes list stays put so you can walk down it file by file.
-        let diff_overlay = self.render_diff_overlay(cx);
+        let diff_overlay = self.render_diff_overlay(window, cx);
 
         // Code panel: an immersive overlay ([file tree | editor], IDE-style)
         // covering the title strip *and* the terminal — the whole column right
@@ -6527,7 +6635,7 @@ impl Render for Tty7App {
                 // the root's paint — deliberate: the overlay must occlude the
                 // terminal behind it to stay readable.
                 .bg(window_bg)
-                .child(self.render_settings(cx))
+                .child(self.render_settings(window, cx))
         });
 
         div()
@@ -7546,6 +7654,217 @@ fn apply_ssh_o_option(
         _ => {}
     }
     Ok(())
+}
+
+/// The window-drag gesture behind every stand-in title bar, exercised against
+/// the real [`title_bar_drag`] rather than a replica of it.
+///
+/// `PlatformWindow::start_window_move` is `unimplemented!()` on gpui's test
+/// platform, which makes a panic a reliable "the window would have started
+/// moving" detector — hence the `#[should_panic]` on the tests that assert a
+/// drag *does* start. The tests that assert one does *not* start simply return.
+#[cfg(test)]
+mod window_drag_tests {
+    use gpui::{
+        Context, InteractiveElement as _, IntoElement, Modifiers, MouseButton, MouseDownEvent,
+        MouseMoveEvent, MouseUpEvent, ParentElement as _, Pixels, PlatformInput, Point, Render,
+        Styled as _, TestAppContext, VisualTestContext, Window, div, point, px,
+    };
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    /// A minimal window whose whole surface is one real `title_bar_drag` row, so
+    /// nothing else in the tree can explain a result.
+    struct Host;
+    impl Render for Host {
+        fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            div().size_full().child(super::title_bar_drag(
+                div().id("stand-in-title-bar").w_full().h(px(40.)),
+                "stand-in-title-bar",
+                window,
+                cx,
+            ))
+        }
+    }
+
+    /// The pattern `title_bar_drag` used to carry: a `should_move` cell built
+    /// inside `render`, so every frame hands the next one a fresh, zeroed cell.
+    /// Kept as a control — it is what makes the assertions above it meaningful,
+    /// by showing the harness detects the bug when the bug is present.
+    struct PerFrameCellHost;
+    impl Render for PerFrameCellHost {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            let should_move = Rc::new(Cell::new(false));
+            div().size_full().child(
+                div()
+                    .id("per-frame-cell")
+                    .w_full()
+                    .h(px(40.))
+                    .on_mouse_down(MouseButton::Left, {
+                        let should_move = should_move.clone();
+                        move |_, _, _| should_move.set(true)
+                    })
+                    .on_mouse_move(move |_, window, _| {
+                        if should_move.replace(false) {
+                            window.start_window_move();
+                        }
+                    }),
+            )
+        }
+    }
+
+    fn down(at: Point<Pixels>) -> PlatformInput {
+        PlatformInput::MouseDown(MouseDownEvent {
+            button: MouseButton::Left,
+            position: at,
+            modifiers: Modifiers::none(),
+            click_count: 1,
+            first_mouse: false,
+        })
+    }
+
+    fn up(at: Point<Pixels>) -> PlatformInput {
+        PlatformInput::MouseUp(MouseUpEvent {
+            button: MouseButton::Left,
+            position: at,
+            modifiers: Modifiers::none(),
+            click_count: 1,
+        })
+    }
+
+    fn moved(at: Point<Pixels>, held: bool) -> PlatformInput {
+        PlatformInput::MouseMove(MouseMoveEvent {
+            position: at,
+            pressed_button: held.then_some(MouseButton::Left),
+            modifiers: Modifiers::none(),
+        })
+    }
+
+    const ON_ROW: Point<Pixels> = Point {
+        x: px(300.),
+        y: px(20.),
+    };
+
+    fn drifted(at: Point<Pixels>) -> Point<Pixels> {
+        point(at.x + px(12.), at.y + px(3.))
+    }
+
+    /// Press, let the window redraw — in production the next vsync — then move.
+    fn press_repaint_move(vcx: &mut VisualTestContext, at: Point<Pixels>) {
+        vcx.update(|window, cx| {
+            window.dispatch_event(moved(at, false), cx);
+            window.dispatch_event(down(at), cx);
+        });
+        vcx.update(|window, _| window.refresh());
+        vcx.run_until_parked();
+        vcx.update(|window, cx| {
+            window.dispatch_event(moved(drifted(at), true), cx);
+        });
+        vcx.run_until_parked();
+    }
+
+    /// **The regression this file exists for (#221).** A repaint between the
+    /// press and the first drag event must not disarm the hold. It used to: the
+    /// arm lived in an `Rc<Cell<bool>>` rebuilt by every `render`, and the press
+    /// itself schedules a repaint (the row's `on_double_click` makes gpui call
+    /// `window.refresh()` on mouse-down), so a trackpad press — which starts
+    /// sliding tens of milliseconds later, well past the next vsync — almost
+    /// never survived to reach `start_window_move`.
+    #[gpui::test]
+    #[should_panic(expected = "not implemented")]
+    fn the_arm_survives_a_repaint_between_press_and_move(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_, _| Host);
+        let mut vcx = VisualTestContext::from_window(window.into(), cx);
+        press_repaint_move(&mut vcx, ON_ROW);
+    }
+
+    /// The control for the test above: with the old per-frame cell, the identical
+    /// event sequence loses the arm and never reaches `start_window_move`. If this
+    /// one ever starts panicking, the harness has stopped being able to tell the
+    /// bug from the fix and the test above proves nothing.
+    #[gpui::test]
+    fn a_per_frame_cell_loses_the_arm_to_the_same_repaint(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_, _| PerFrameCellHost);
+        let mut vcx = VisualTestContext::from_window(window.into(), cx);
+        press_repaint_move(&mut vcx, ON_ROW);
+    }
+
+    /// The gesture still defers to an actual move, which is what keeps a plain
+    /// click — and the double-click that zooms the window — intact.
+    #[gpui::test]
+    fn a_press_alone_does_not_move_the_window(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_, _| Host);
+        let mut vcx = VisualTestContext::from_window(window.into(), cx);
+        vcx.update(|window, cx| {
+            window.dispatch_event(moved(ON_ROW, false), cx);
+            window.dispatch_event(down(ON_ROW), cx);
+            window.dispatch_event(up(ON_ROW), cx);
+        });
+        vcx.run_until_parked();
+    }
+
+    /// The other half of giving the arm a longer life: it now has to be *cleared*
+    /// explicitly. A press that is released and then followed by a plain hover
+    /// must not start a window move — with the old per-frame cell the frame
+    /// boundary did this for free.
+    #[gpui::test]
+    fn a_release_disarms_so_a_later_hover_does_not_drag(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_, _| Host);
+        let mut vcx = VisualTestContext::from_window(window.into(), cx);
+        vcx.update(|window, cx| {
+            window.dispatch_event(moved(ON_ROW, false), cx);
+            window.dispatch_event(down(ON_ROW), cx);
+            window.dispatch_event(up(ON_ROW), cx);
+        });
+        vcx.update(|window, _| window.refresh());
+        vcx.run_until_parked();
+        vcx.update(|window, cx| {
+            window.dispatch_event(moved(drifted(ON_ROW), false), cx);
+        });
+        vcx.run_until_parked();
+    }
+
+    /// Two stand-in rows on screen at once — the rail's top zone plus an overlay
+    /// header is a real combination — must not share one arm. This is why the
+    /// builder takes an explicit `key` instead of `window.use_state`, whose id
+    /// comes from the *caller's* `CodeLocation` and would be identical for both.
+    #[gpui::test]
+    fn two_rows_on_screen_keep_separate_arms(cx: &mut TestAppContext) {
+        struct TwoRows;
+        impl Render for TwoRows {
+            fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+                div()
+                    .size_full()
+                    .child(super::title_bar_drag(
+                        div().id("row-a").w_full().h(px(40.)),
+                        "row-a",
+                        window,
+                        cx,
+                    ))
+                    .child(super::title_bar_drag(
+                        div().id("row-b").w_full().h(px(40.)),
+                        "row-b",
+                        window,
+                        cx,
+                    ))
+            }
+        }
+
+        let window = cx.add_window(|_, _| TwoRows);
+        let mut vcx = VisualTestContext::from_window(window.into(), cx);
+        // Arm the upper row, then hover the lower one without a button held.
+        // A shared arm would fire here; separate arms leave the lower row cold.
+        vcx.update(|window, cx| {
+            window.dispatch_event(moved(point(px(300.), px(20.)), false), cx);
+            window.dispatch_event(down(point(px(300.), px(20.))), cx);
+        });
+        vcx.update(|window, _| window.refresh());
+        vcx.run_until_parked();
+        vcx.update(|window, cx| {
+            window.dispatch_event(moved(point(px(312.), px(60.)), false), cx);
+        });
+        vcx.run_until_parked();
+    }
 }
 
 #[cfg(test)]

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -291,17 +291,25 @@ pub(crate) struct WindowMoveArm {
 // form), diff file-card headers (click-to-collapse rows inside a scroll list),
 // and the command palette (a transient modal over a dismiss-on-press scrim).
 //
-// One region satisfies the rule by adjacency rather than on its own, and that is
-// deliberate — not an oversight to tidy up later. The detail panel's macOS top
-// zone is every-child-occluded (four tab tiles plus the corner chrome) and that
-// fixed footprint comes to 214px against a `right_panel::MIN_WIDTH` of 216, so
-// at the panel's floor its spacer is a couple of pixels — a handle only on
-// paper. It keeps a real one anyway: the panel's section title
-// (`right_panel::panel_title`) is draggable and sits immediately below it.
-// Raising `MIN_WIDTH` far enough to seat a grabbable spacer would trade a real
-// capability — narrowing the panel — for a handle the user already has a few
-// pixels lower, so the floor stays where it is and the row keeps all its
-// controls.
+// One region stops satisfying the rule near one edge of its size range, and
+// that is an accepted limitation rather than an oversight to tidy up later. The
+// detail panel's macOS top zone is every-child-occluded (four tab tiles plus the
+// corner chrome), and that fixed footprint lands within a couple of pixels of
+// `right_panel::MIN_WIDTH` — so the spacer between them is a real handle at any
+// comfortable panel width and effectively nothing at the panel's floor.
+//
+// The row below only partly covers that. The panel's section title
+// (`right_panel::panel_title`) is draggable and sits immediately under the top
+// zone, but on macOS it draws nothing for a tab that passes no `trailing`, which
+// is every tab except the remote SFTP browser. So the adjacent handle is there
+// off macOS (where that row is the panel's tab switcher and always drawn) and on
+// macOS for SFTP; for Info, Outline, Changes and Files on macOS, a panel dragged
+// to its floor has no header of its own to grab.
+//
+// Left that way by explicit decision: `MIN_WIDTH` stays where it is rather than
+// trading a real capability — narrowing the panel — for a grab handle, and no
+// control moves off that row either. The window still moves from the caption
+// strip and the rail's top zone at every panel width.
 
 /// Arm-on-press / move-on-first-move window dragging for a row that stands in
 /// for the title bar. [`title_bar_drag`] is this plus the double-click-to-zoom

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -7687,6 +7687,46 @@ mod window_drag_tests {
         }
     }
 
+    /// A resize handle's geometry over a stand-in title bar. The two real
+    /// handles (`tab_sidebar`, `right_panel`) are absolute, 8px wide, `h_full`
+    /// and centred on a panel edge, so their top band lies over a
+    /// `WindowControlArea::Drag` row; standing either of them up needs a whole
+    /// `Tty7App` window, so this reproduces the geometry instead. `occluded`
+    /// mirrors the real handles; `false` is the control that shows the harness
+    /// detects the hijack when the blocking hitbox is missing.
+    struct HandleOverRow {
+        occluded: bool,
+    }
+    impl Render for HandleOverRow {
+        fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            let handle = div()
+                .absolute()
+                .top_0()
+                .left(px(296.))
+                .w(px(8.))
+                .h_full()
+                .cursor_col_resize()
+                // What each real handle does on press: arm its own drag and ask
+                // for a repaint.
+                .on_mouse_down(MouseButton::Left, |_, window, _| window.refresh());
+            let handle = if self.occluded {
+                handle.occlude()
+            } else {
+                handle
+            };
+            div()
+                .relative()
+                .size_full()
+                .child(super::title_bar_drag(
+                    div().id("stand-in-title-bar").w_full().h(px(40.)),
+                    "stand-in-title-bar",
+                    window,
+                    cx,
+                ))
+                .child(handle)
+        }
+    }
+
     /// The pattern `title_bar_drag` used to carry: a `should_move` cell built
     /// inside `render`, so every frame hands the next one a fresh, zeroed cell.
     /// Kept as a control — it is what makes the assertions above it meaningful,
@@ -7822,6 +7862,32 @@ mod window_drag_tests {
             window.dispatch_event(moved(drifted(ON_ROW), false), cx);
         });
         vcx.run_until_parked();
+    }
+
+    /// A panel resize handle must keep its drag. Its hit area runs the panel's
+    /// full height, so the top 40px sit on a stand-in caption row — and gpui's
+    /// hit test walks *past* a non-blocking hitbox, so without `occlude()` the
+    /// press arms the row's window move as well as the resize, and the first
+    /// drag event moves the window instead of resizing the panel. A durable arm
+    /// makes that reliable rather than a race: the handle's own `window.refresh()`
+    /// used to destroy the per-frame cell before the move could land.
+    #[gpui::test]
+    fn a_press_on_a_resize_handle_does_not_move_the_window(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_, _| HandleOverRow { occluded: true });
+        let mut vcx = VisualTestContext::from_window(window.into(), cx);
+        press_repaint_move(&mut vcx, ON_ROW);
+    }
+
+    /// The control for the test above: the same geometry with a plain hitbox
+    /// hands the press to both the handle and the caption row underneath, and
+    /// the window moves. If this stops panicking, the test above is passing for
+    /// some reason other than the `occlude()` it exists to pin.
+    #[gpui::test]
+    #[should_panic(expected = "not implemented")]
+    fn a_handle_without_a_blocking_hitbox_hands_the_press_to_the_row(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_, _| HandleOverRow { occluded: false });
+        let mut vcx = VisualTestContext::from_window(window.into(), cx);
+        press_repaint_move(&mut vcx, ON_ROW);
     }
 
     /// Two stand-in rows on screen at once — the rail's top zone plus an overlay

--- a/src/ui/code_editor.rs
+++ b/src/ui/code_editor.rs
@@ -1207,7 +1207,7 @@ impl Tty7App {
             .flex_1()
             .min_w_0()
             .h_full()
-            .child(self.render_editor_header(cx))
+            .child(self.render_editor_header(window, cx))
             .when_some(conflict_banner, |this, b| this.child(b))
             .child(div().flex_1().min_h_0().child(body));
 
@@ -1250,7 +1250,11 @@ impl Tty7App {
     /// every buffer that was ever opened. Sits on the title bar's line and matches
     /// its height, so the editor's top edge lines up with the panel's tab row and
     /// the rail's controls across the window.
-    fn render_editor_header(&self, cx: &mut Context<Self>) -> gpui::Stateful<gpui::Div> {
+    fn render_editor_header(
+        &self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> gpui::Stateful<gpui::Div> {
         let active = self.tab_code().and_then(|c| c.active_file());
         let name = active.map(|f| f.label());
         let dirty = active.is_some_and(|f| f.dirty);
@@ -1268,7 +1272,7 @@ impl Tty7App {
         // The overlay covers the real title bar, so this row inherits its drag and
         // zoom gestures — otherwise opening a file turns the top of the window into
         // a strip that looks like the caption and can't move it.
-        crate::ui::app::title_bar_drag(h_flex().id("editor-header"))
+        crate::ui::app::title_bar_drag(h_flex().id("editor-header"), "editor-header", window, cx)
             .flex_none()
             .h(px(crate::ui::app::TITLE_BAR_HEIGHT))
             .items_center()

--- a/src/ui/diff_overlay.rs
+++ b/src/ui/diff_overlay.rs
@@ -288,7 +288,11 @@ impl Tty7App {
     /// The overlay element, or `None` when closed. Mounted as the topmost
     /// absolute child of the body area — it covers the terminal but not the
     /// sidebar or title strip.
-    pub(crate) fn render_diff_overlay(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
+    pub(crate) fn render_diff_overlay(
+        &self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<AnyElement> {
         let overlay = self.tabs.get(self.active)?.diff_overlay.as_ref()?;
 
         let content = match &overlay.load {
@@ -302,7 +306,7 @@ impl Tty7App {
             }
         };
 
-        let header = self.diff_header(overlay, cx);
+        let header = self.diff_header(overlay, window, cx);
 
         Some(
             v_flex()
@@ -338,6 +342,7 @@ impl Tty7App {
     fn diff_header(
         &self,
         overlay: &DiffOverlayState,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> impl IntoElement + use<> {
         let (branch, files, untracked, added, removed) = match &overlay.load {
@@ -359,8 +364,13 @@ impl Tty7App {
         // Standing in for the title bar means carrying its gestures too: the
         // overlay covers the real bar, so without this the whole top of the window
         // stops moving it while a diff is up.
-        crate::ui::app::title_bar_drag(h_flex().id("diff-overlay-header"))
-            .flex_shrink_0()
+        let row = crate::ui::app::title_bar_drag(
+            h_flex().id("diff-overlay-header"),
+            "diff-overlay-header",
+            window,
+            cx,
+        );
+        row.flex_shrink_0()
             .h(px(crate::ui::app::TITLE_BAR_HEIGHT))
             .pl(px(lead))
             // Trailing tile aligns on its glyph's ink, like every corner control.

--- a/src/ui/right_panel.rs
+++ b/src/ui/right_panel.rs
@@ -15,15 +15,13 @@
 //! sidebar row does, Changes probes the same `git_diff` the diff overlay does, and
 //! Files renders the same rows as the code panel's tree.
 
-use gpui::{AnyElement, Context, MouseButton, Window, WindowControlArea, div, prelude::*, px};
+use gpui::{AnyElement, Context, Window, div, prelude::*, px};
 use gpui_component::button::Button;
 use gpui_component::input::Input;
 use gpui_component::{
     ActiveTheme as _, Icon, IconName, InteractiveElementExt as _, Sizable as _, h_flex, v_flex,
 };
-use std::cell::Cell;
 use std::path::PathBuf;
-use std::rc::Rc;
 
 use crate::core::config::{Config, RightPanelTab};
 use crate::daemon::protocol::PaneProcs;
@@ -219,8 +217,7 @@ impl Tty7App {
                 // move into the section header instead (`panel_title`), which is a
                 // row the panel was drawing anyway.
                 .children(cfg!(target_os = "macos").then(|| {
-                    let should_move = Rc::new(Cell::new(false));
-                    h_flex()
+                    let row = h_flex()
                         .id("right-panel-titlebar-drag")
                         .flex_none()
                         .h(px(crate::ui::app::TITLE_BAR_HEIGHT))
@@ -232,42 +229,36 @@ impl Tty7App {
                         // its centre line identical; without it the glyphs jump
                         // down a physical pixel the moment the panel opens.
                         .border_b_1()
-                        .border_color(cx.theme().transparent)
-                        // The top zone sits level with the real `TitleBar`, but the
-                        // bar only spans the terminal column — so, exactly like the
-                        // rail's top strip (`tab_sidebar`), make this one act like
-                        // the title bar it aligns with: drag to move, double-click
-                        // to zoom. A press arms a flag and the first *move* starts
-                        // the window move, so a plain click on a tab — and a
-                        // double-click — still lands intact; the tabs and corner
-                        // chrome take their own.
-                        .window_control_area(WindowControlArea::Drag)
-                        .on_mouse_down(MouseButton::Left, {
-                            let should_move = should_move.clone();
-                            move |_, _, _| should_move.set(true)
-                        })
-                        .on_mouse_up(MouseButton::Left, {
-                            let should_move = should_move.clone();
-                            move |_, _, _| should_move.set(false)
-                        })
-                        .on_mouse_move(move |_, window, _| {
-                            if should_move.replace(false) {
-                                window.start_window_move();
-                            }
-                        })
-                        .on_double_click(|_, window, _| window.titlebar_double_click())
-                        .items_center()
-                        .gap(px(2.))
-                        // Chrome scale, like the corner controls this row ends
-                        // with (`right_panel_tabs`): the leading inset lines the
-                        // *glyph* up on `CONTENT_INSET`, so it subtracts the
-                        // 32px tile's own padding rather than a 24px one's.
-                        .pl(px(tile_trailing_inset()))
-                        .children(self.right_panel_tabs(cx))
-                        .child(div().flex_1())
-                        // The panel is what reaches the window's right edge while
-                        // it's open, so it carries the corner chrome.
-                        .child(self.window_chrome(window, cx))
+                        .border_color(cx.theme().transparent);
+                    // The top zone sits level with the real `TitleBar`, but the
+                    // bar only spans the terminal column — so, exactly like the
+                    // rail's top strip (`tab_sidebar`), make this one act like
+                    // the title bar it aligns with: drag to move, double-click
+                    // to zoom. A press arms a flag and the first *move* starts
+                    // the window move, so a plain click on a tab — and a
+                    // double-click — still lands intact; the tabs and corner
+                    // chrome take their own. `window_move_gesture` holds that
+                    // flag in element state, so a repaint between the press and
+                    // the first move can't disarm it (#221).
+                    crate::ui::app::window_move_gesture(
+                        row,
+                        "right-panel-titlebar-drag",
+                        window,
+                        cx,
+                    )
+                    .on_double_click(|_, window, _| window.titlebar_double_click())
+                    .items_center()
+                    .gap(px(2.))
+                    // Chrome scale, like the corner controls this row ends with
+                    // (`right_panel_tabs`): the leading inset lines the *glyph*
+                    // up on `CONTENT_INSET`, so it subtracts the 32px tile's own
+                    // padding rather than a 24px one's.
+                    .pl(px(tile_trailing_inset()))
+                    .children(self.right_panel_tabs(cx))
+                    .child(div().flex_1())
+                    // The panel is what reaches the window's right edge while
+                    // it's open, so it carries the corner chrome.
+                    .child(self.window_chrome(window, cx))
                 }))
                 .child(body)
                 // The transfers footer is a sibling of the body, not part of any
@@ -398,11 +389,22 @@ impl Tty7App {
     /// line of content. The counts it used to carry move into the tab tooltips.
     /// A tab that has its own control still gets the row, because that control
     /// has nowhere else to go.
+    ///
+    /// When it *does* draw, it is grabbable, like every header in the window (see
+    /// [`crate::ui::app::window_move_gesture`]): it sits above the panel's scroll
+    /// container, not inside it, so a drag here has nothing else to mean. The
+    /// label and its count take no hit box, so the row stays grabbable straight
+    /// through them however long the text gets — the same rule the "duo" mark
+    /// established in #202. Anything in `trailing` is a control and must carry
+    /// its own `occlude()`, or Windows' HTCAPTION eats its clicks. The gesture is
+    /// armed *after* the empty-row early return, so the macOS zero-height case
+    /// never becomes an invisible drag area.
     pub(crate) fn panel_title(
         &self,
         text: &str,
         count: Option<String>,
         trailing: Option<AnyElement>,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let tabs = (!cfg!(target_os = "macos")).then(|| self.right_panel_tabs(cx));
@@ -410,8 +412,13 @@ impl Tty7App {
         if tabs.is_none() && !has_trailing {
             return div().flex_none().into_any_element();
         }
-        h_flex()
-            .flex_none()
+        let row = crate::ui::app::window_move_gesture(
+            h_flex().id("panel-title"),
+            "panel-title-drag",
+            window,
+            cx,
+        );
+        row.flex_none()
             // Tall enough to seat the chrome-scale tiles when it carries them;
             // otherwise the compact label line it has always been.
             .h(px(if tabs.is_some() {
@@ -558,7 +565,7 @@ impl Tty7App {
     /// row comes from an accessor the sidebar already uses, so the panel can
     /// never disagree with the row that spawned it.
     fn render_panel_info(&mut self, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
-        let title = self.panel_title("Info", None, None, cx);
+        let title = self.panel_title("Info", None, None, window, cx);
         let mut rows: Vec<(&'static str, String)> = Vec::new();
         // Held aside from `rows` because they're not key/value lines: the actions
         // hang off the cwd, and the two lists get their own sub-headers below.
@@ -1015,7 +1022,7 @@ impl Tty7App {
             .get(self.active)
             .and_then(|t| t.detail_pane(window, cx))
         else {
-            let title = self.panel_title("Outline", None, None, cx);
+            let title = self.panel_title("Outline", None, None, window, cx);
             return self.panel_scroll(
                 self.panel_empty(
                     "No active session.",
@@ -1032,7 +1039,7 @@ impl Tty7App {
             // Two very different causes, one honest sentence: nothing has run
             // yet, or this shell never reported OSC 133 (no integration, a bare
             // `sh`, a nested PTY that eats the marks).
-            let title = self.panel_title("Outline", None, None, cx);
+            let title = self.panel_title("Outline", None, None, window, cx);
             return self.panel_scroll(
                 self.panel_empty(
                     "No commands recorded for this pane.",
@@ -1042,7 +1049,7 @@ impl Tty7App {
                 title,
             );
         }
-        let title = self.panel_title("Outline", Some(count.to_string()), None, cx);
+        let title = self.panel_title("Outline", Some(count.to_string()), None, window, cx);
 
         let mono = cx.theme().mono_font_family.clone();
         let mut list = v_flex().px(px(CONTENT_INSET - 4.)).py(px(2.)).gap(px(1.));
@@ -1140,7 +1147,7 @@ impl Tty7App {
             });
 
         let Some((host, cwd)) = target else {
-            let title = self.panel_title("Changes", None, None, cx);
+            let title = self.panel_title("Changes", None, None, window, cx);
             return self.panel_scroll(
                 self.panel_empty(
                     "No working directory.",
@@ -1176,7 +1183,7 @@ impl Tty7App {
             }
             _ => None,
         };
-        let title = self.panel_title("Changes", count, None, cx);
+        let title = self.panel_title("Changes", count, None, window, cx);
         let mono = cx.theme().mono_font_family.clone();
 
         let inner = match &self.right_panel.diff {
@@ -1393,7 +1400,7 @@ impl Tty7App {
         // No header control: the tree's one view option (dotfiles) is a
         // right-click away in the tree itself (`file_tree::dotfiles_menu_item`),
         // which is where you are when you want it.
-        let title = self.panel_title("Files", None, None, cx);
+        let title = self.panel_title("Files", None, None, window, cx);
         let search = self.panel_search(&self.file_search.clone(), cx);
         let rows = self.render_file_tree_rows(window, cx);
         v_flex()

--- a/src/ui/right_panel.rs
+++ b/src/ui/right_panel.rs
@@ -334,9 +334,15 @@ impl Tty7App {
         .size_full()
         .into_any_element();
 
+        // `occlude()` for the same reason as the rail's handle (`tab_sidebar`):
+        // it spans the panel's full height, so its top band lies over a
+        // `WindowControlArea::Drag` row — the macOS top zone, and `panel_title`
+        // below it — and a non-blocking hitbox lets a press arm that row's window
+        // move alongside the resize.
         let active = self.right_panel_dragging.get();
         let handle = div()
             .group("right-panel-resize")
+            .occlude()
             .absolute()
             .top_0()
             .left(px(-(RESIZE_HANDLE_WIDTH / 2.)))

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -7,8 +7,8 @@
 
 use gpui::{
     AnyElement, App, Context, Div, Entity, FontWeight, Image, ImageFormat, KeyDownEvent,
-    MouseButton, SharedString, Stateful, Subscription, Window, WindowControlArea, div, img,
-    prelude::*, px, relative, rgb,
+    MouseButton, SharedString, Stateful, Subscription, Window, div, img, prelude::*, px, relative,
+    rgb,
 };
 use gpui_component::InteractiveElementExt as _;
 use gpui_component::button::{Button, ButtonVariants as _};
@@ -23,8 +23,6 @@ use gpui_component::{
     ActiveTheme as _, Disableable as _, Icon, IconName, Sizable as _, WindowExt as _, h_flex,
     v_flex,
 };
-use std::cell::Cell;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use uuid::Uuid;
@@ -914,7 +912,11 @@ fn seed_input(
 impl Tty7App {
     /// Build the settings tab body: a fixed left sidebar (section nav) beside a
     /// scrollable content area for the selected section. Esc closes the tab.
-    pub(crate) fn render_settings(&self, cx: &mut Context<Self>) -> impl IntoElement + use<> {
+    pub(crate) fn render_settings(
+        &self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement + use<> {
         // Copy the palette out (Hsla is Copy) so this borrow doesn't outlive into
         // `render_settings_search_results` below, which needs `cx` mutably.
         let theme = cx.theme();
@@ -1166,31 +1168,25 @@ impl Tty7App {
             // `should_move` flag and the first move calls `start_window_move`
             // (deferring to an actual move keeps a plain click, and double-click,
             // intact); the `WindowControlArea::Drag` tag covers the Windows path.
-            .child({
-                let should_move = Rc::new(Cell::new(false));
-                div()
-                    .id("settings-titlebar-drag")
-                    .absolute()
-                    .top_0()
-                    .left_0()
-                    .right_0()
-                    .h(px(crate::ui::app::TITLE_BAR_HEIGHT))
-                    .window_control_area(WindowControlArea::Drag)
-                    .on_mouse_down(MouseButton::Left, {
-                        let should_move = should_move.clone();
-                        move |_, _, _| should_move.set(true)
-                    })
-                    .on_mouse_up(MouseButton::Left, {
-                        let should_move = should_move.clone();
-                        move |_, _, _| should_move.set(false)
-                    })
-                    .on_mouse_move(move |_, window, _| {
-                        if should_move.replace(false) {
-                            window.start_window_move();
-                        }
-                    })
-                    .on_double_click(|_, window, _| window.titlebar_double_click())
-            })
+            // `window_move_gesture` owns that arming, and keeps the flag in
+            // element state so a repaint between the press and the first move
+            // can't throw it away (#221) — the failure was worst here, because
+            // this strip *is* the whole top band with no immune caption beside it.
+            .child(
+                crate::ui::app::window_move_gesture(
+                    div()
+                        .id("settings-titlebar-drag")
+                        .absolute()
+                        .top_0()
+                        .left_0()
+                        .right_0()
+                        .h(px(crate::ui::app::TITLE_BAR_HEIGHT)),
+                    "settings-titlebar-drag",
+                    window,
+                    cx,
+                )
+                .on_double_click(|_, window, _| window.titlebar_double_click()),
+            )
             .when(show_theme_panel, |r| r.child(self.render_theme_panel(cx)))
             // Close affordance at the page's top-right corner (Esc and Cmd+, also
             // close) — the intuitive "close this page" spot, and clear of the

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -1164,14 +1164,9 @@ impl Tty7App {
             // region is buried. Restore it: a transparent strip across the top
             // band (the height the title bar reserved) that moves the window on
             // drag and zooms it on double-click, exactly like the title bar it
-            // stands in for. Driven the same way `TitleBar` does — a press arms a
-            // `should_move` flag and the first move calls `start_window_move`
-            // (deferring to an actual move keeps a plain click, and double-click,
-            // intact); the `WindowControlArea::Drag` tag covers the Windows path.
-            // `window_move_gesture` owns that arming, and keeps the flag in
-            // element state so a repaint between the press and the first move
-            // can't throw it away (#221) — the failure was worst here, because
-            // this strip *is* the whole top band with no immune caption beside it.
+            // stands in for. `window_move_gesture` owns the gesture and the
+            // reasoning behind it; the #221 failure was worst here, because this
+            // strip *is* the whole top band with no immune caption beside it.
             .child(
                 crate::ui::app::window_move_gesture(
                     div()

--- a/src/ui/sftp.rs
+++ b/src/ui/sftp.rs
@@ -1066,11 +1066,11 @@ impl Tty7App {
     pub(crate) fn render_panel_sftp(
         &mut self,
         host: String,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let controls = self.sftp_controls(cx);
-        let title = self.panel_title("Files", Some(host), Some(controls), cx);
+        let title = self.panel_title("Files", Some(host), Some(controls), window, cx);
         let breadcrumb = self.render_sftp_breadcrumb(cx);
         // The shared panel search box, plus the one behaviour the old SFTP header
         // had that the local tree's doesn't: Esc clears the filter rather than
@@ -1125,14 +1125,20 @@ impl Tty7App {
             .items_center()
             .gap(px(2.))
             .child(
-                tile(
-                    Button::new("panel-sftp-refresh")
-                        .icon(Icon::empty().path("icons/refresh.svg").size(px(13.))),
-                    false,
-                    cx,
-                )
-                .tooltip("Refresh")
-                .on_click(cx.listener(|this, _, _w, cx| this.sftp_refresh(cx))),
+                // `occlude()` like the `⋯` beside it: `panel_title` is a
+                // `WindowControlArea::Drag` now (every header in the window is),
+                // which on Windows maps to HTCAPTION — the OS claims the press
+                // before gpui hit-tests, so a bare button never fires its click.
+                div().occlude().child(
+                    tile(
+                        Button::new("panel-sftp-refresh")
+                            .icon(Icon::empty().path("icons/refresh.svg").size(px(13.))),
+                        false,
+                        cx,
+                    )
+                    .tooltip("Refresh")
+                    .on_click(cx.listener(|this, _, _w, cx| this.sftp_refresh(cx))),
+                ),
             )
             .child(
                 div().occlude().child(

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -950,9 +950,17 @@ impl Tty7App {
         // The draggable handle at the right edge: a comfortable invisible hit-area
         // centered over the border, holding a 1px line that brightens on hover /
         // drag (the border stays visible underneath when idle).
+        //
+        // `occlude()` because it runs the rail's full height, which means its top
+        // 40px lie over the rail's title-bar stand-in — a `WindowControlArea::Drag`
+        // row. Without it gpui's hit test still reports that row hovered under the
+        // handle, so a press there arms the window move *as well as* the resize and
+        // the first drag moves the window instead (and on Windows HTCAPTION claims
+        // the press outright). See [`crate::ui::app::window_move_gesture`].
         let handle_active = self.sidebar_dragging.get();
         let handle = div()
             .group("sidebar-resize")
+            .occlude()
             .absolute()
             .top_0()
             .right(px(-(RESIZE_HANDLE_WIDTH / 2.)))

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -789,12 +789,13 @@ impl Tty7App {
                         .pl(px(crate::ui::app::CONTENT_INSET))
                         .child(mark),
                 )
-                // The row's grab handle, and `min_w` so it stays one: a bare
-                // `flex_1` takes only leftover space, which is nothing once the
-                // rail is dragged narrow enough. Every header in the window has to
-                // stay grabbable — see `app::window_move_gesture`. (On macOS there
-                // is no mark and so no spacer: `justify_end` leaves the row's whole
-                // left half bare, which is the handle.)
+                // The row's grab handle, and `min_w` (`GRAB_HANDLE_W`) so it
+                // stays one whatever the row later gains: a bare `flex_1` takes
+                // only leftover space, and leftover space is what a wider child
+                // eats first. Every header in the window has to stay grabbable —
+                // see `app::window_move_gesture`. (On macOS there is no mark and
+                // so no spacer: `justify_end` leaves the row's whole left half
+                // bare, which is the handle.)
                 .child(div().flex_1().min_w(px(GRAB_HANDLE_W)))
             })
             // Both tiles are wrapped in an `occlude()` div, exactly like the

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -35,6 +35,13 @@ use crate::ui::tab_strip::{DragTab, REORDER_SLIDE_MS};
 /// Minimum sidebar width, and the maximum as a fraction of the window width, so
 /// a resize drag can't collapse the rail or let it swallow the terminal.
 const MIN_SIDEBAR_WIDTH: f32 = 180.;
+
+/// The bare slice of the rail's top zone kept clear for grabbing the window by,
+/// the same guarantee [`crate::ui::tab_strip::GRAB_HANDLE_W`] makes for the
+/// horizontal strip. Smaller than that one because this row is never crowded:
+/// it holds the brand mark and two tiles, and the rail's own floor
+/// ([`MIN_SIDEBAR_WIDTH`]) leaves ~70px of slack even at its narrowest.
+const GRAB_HANDLE_W: f32 = 48.;
 const MAX_SIDEBAR_WIDTH_RATIO: f32 = 0.5;
 
 /// Width (px) of the draggable resize handle's invisible hit-area, centered on
@@ -70,7 +77,7 @@ impl Tty7App {
     /// there's no empty state to render.
     pub(crate) fn tab_sidebar(
         &self,
-        window: &Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> impl IntoElement + use<> {
         let active = self.active;
@@ -782,7 +789,13 @@ impl Tty7App {
                         .pl(px(crate::ui::app::CONTENT_INSET))
                         .child(mark),
                 )
-                .child(div().flex_1())
+                // The row's grab handle, and `min_w` so it stays one: a bare
+                // `flex_1` takes only leftover space, which is nothing once the
+                // rail is dragged narrow enough. Every header in the window has to
+                // stay grabbable — see `app::window_move_gesture`. (On macOS there
+                // is no mark and so no spacer: `justify_end` leaves the row's whole
+                // left half bare, which is the handle.)
+                .child(div().flex_1().min_w(px(GRAB_HANDLE_W)))
             })
             // Both tiles are wrapped in an `occlude()` div, exactly like the
             // title-strip chrome. This row is a `WindowControlArea::Drag` (set
@@ -996,6 +1009,9 @@ impl Tty7App {
                     // right keep taking their own clicks (they're `occlude()`d).
                     .child(crate::ui::app::title_bar_drag(
                         controls.id("sidebar-titlebar-drag"),
+                        "sidebar-titlebar-drag",
+                        window,
+                        cx,
                     ))
                     .child(workspace_head)
                     .child(top_bar)

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -392,10 +392,11 @@ impl Tty7App {
     /// It used to be a monogram in the window's top-right corner. Two things
     /// were wrong with that. Physically: the corner it sat in is the *panel's*
     /// top zone while the panel is open, so a control that has nothing to do
-    /// with the panel was eating width the panel's own tabs needed — at the
-    /// 200px minimum the row wanted 268px. Semantically: a window's workspace is
-    /// exactly what the rail below enumerates (this workspace's tabs), so the
-    /// name belonged at the head of that column, not across the window from it.
+    /// with the panel was eating width the panel's own tabs needed — at
+    /// `right_panel::MIN_WIDTH` the row wanted 268px. Semantically: a window's
+    /// workspace is exactly what the rail below enumerates (this workspace's
+    /// tabs), so the name belonged at the head of that column, not across the
+    /// window from it.
     ///
     /// Here it can afford the full name — the rail is a column with a width of
     /// its own, and it truncates rather than pushing anything off an edge. The

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -34,6 +34,25 @@ use crate::ui::reorder::{self, Reorder, Surface};
 pub(crate) const REORDER_SLIDE_MS: u64 = 140;
 const CHIP_GAP: f32 = 6.;
 
+/// The bare slice of caption the horizontal strip always keeps for grabbing the
+/// window by.
+///
+/// Every header in tty7 has to stay draggable however much content it holds (see
+/// [`crate::ui::app::window_move_gesture`]). Most of them satisfy that for free:
+/// their contents are labels, which take no hit box, so the drag falls straight
+/// through them. This strip is the one that cannot — a tab chip is `occlude()`d
+/// on purpose, because dragging one reorders it — so the spacer between the last
+/// chip and the corner chrome *is* the whole grab region, and a bare `flex_1`
+/// with no floor collapses to exactly 0px once the chip row saturates the line
+/// (around 7-8 tabs on a 1440px window). At that point the only draggable caption
+/// left is three 6px gaps and a ~3.5px band above and below the chips, which is
+/// what "the region that works seems very small" in #221 was describing.
+///
+/// 80px, and the chip row's budget pays for it: chips reach their `min_w` and
+/// start truncating labels a tab or two sooner, and the window is always
+/// grabbable. Chrome and Safari make the same trade for the same reason.
+pub(crate) const GRAB_HANDLE_W: f32 = 80.;
+
 /// How many trailing path components a deep tab label keeps, mirroring
 /// ghostty's zsh integration title `%(4~|…/%3~|%~)`: a path deeper than this
 /// collapses to `…/` plus its last three components; a shallower one shows in
@@ -1183,12 +1202,28 @@ impl Tty7App {
         let chrome_band_w = (!cfg!(target_os = "macos") && self.right_panel_open(cx)).then(|| {
             (self.right_panel_px(window, cx) - crate::ui::app::WINDOW_CONTROLS_W - 1.).max(0.)
         });
-        // The "+" and the right-edge overflow "⋯" (30px each), their surrounding
-        // gaps, and the strip's own left/right padding all live *outside* the
-        // clipped chip row — reserve that whole footprint here so the fixed chrome
-        // never overflows the strip box (which would eat the "⋯"'s right inset and
-        // shove it into the window corner) and cap the chip row at the remainder.
-        let chips_avail = (strip_w - px(100.) - px(chrome_band_w.unwrap_or(0.))).max(px(80.));
+        // Everything the strip lays out *beside* the clipped chip row lives
+        // outside that row's budget — reserve the whole footprint here so the
+        // fixed chrome never overflows the strip box (which would eat the corner
+        // chrome's right inset and shove it into the window corner) and cap the
+        // chip row at the remainder.
+        //
+        // The corner is either the free-standing chrome group (trailing inset +
+        // the panel tile + its 2px gap + the app-menu tile, ~71px) or, off macOS
+        // with the panel open, the wider band the chrome is laid out inside; three
+        // `CHIP_GAP`s and the "+" tile sit between it and the chips.
+        //
+        // This used to be a flat 100px, a leftover from when the corner held a
+        // 30px "+" and a 30px "⋯", and it was never revisited as the group's
+        // contents changed under it — so the reserve and the real footprint had
+        // simply drifted apart, and the flexible spacer, which is the strip's only
+        // grab handle (see `GRAB_HANDLE_W`), was the first thing to pay for it.
+        // Measure the group instead of quoting a number at it.
+        let corner_w = chrome_band_w.unwrap_or_else(|| {
+            tile_trailing_inset() + crate::ui::app::TILE_SIZE + 2. + crate::ui::app::TILE_SIZE
+        });
+        let fixed_w = 3. * CHIP_GAP + crate::ui::app::TILE_SIZE + corner_w;
+        let chips_avail = (strip_w - px(fixed_w + GRAB_HANDLE_W)).max(px(80.));
         // Only the chip row clips; a crowded row shrinks its chips (down to their
         // `min_w`) and truncates their labels rather than pushing the "+" away.
         let mut chips = h_flex()
@@ -1664,7 +1699,12 @@ impl Tty7App {
             // so the title bar drops its "+" to avoid a redundant second one —
             // leaving just the "⋯" overflow menu on a thin strip.
             .when(show_chips, move |this| this.child(add_button))
-            .child(div().flex_1())
+            // The strip's grab handle. `min_w` is the whole point: `flex_1` alone
+            // has `flex-basis: 0` and only ever takes leftover space, so it went to
+            // 0px the moment the chips saturated the line and left nowhere to grab
+            // the window by (#221). A flex item never shrinks below its `min_w`, so
+            // the clipping chip row beside it absorbs the pressure instead.
+            .child(div().flex_1().min_w(px(GRAB_HANDLE_W)))
             .when_some(right_chrome, |this, chrome| match chrome_band_w {
                 // Over the panel: left-aligned on the panel's content edge, and
                 // wide enough that its own right edge lands where the window

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -595,8 +595,9 @@ impl Tty7App {
             // The workspace chip used to lead this group; it moved to the rail's
             // head (`tab_sidebar`), where the list it names actually lives. What
             // forced the move is that this group's other host is the *panel's* top
-            // zone, and a panel the user can drag down to 200px cannot seat the
-            // panel's four tabs plus three window controls — the row wanted 268px.
+            // zone, and a panel the user can drag down to `right_panel::MIN_WIDTH`
+            // cannot seat the panel's four tabs plus three window controls — the
+            // row wanted 268px.
             // Nothing that has no business being scoped to the panel gets to
             // compete for that width.
             //

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -1208,10 +1208,16 @@ impl Tty7App {
         // chrome's right inset and shove it into the window corner) and cap the
         // chip row at the remainder.
         //
-        // The corner is either the free-standing chrome group (trailing inset +
-        // the panel tile + its 2px gap + the app-menu tile, ~71px) or, off macOS
-        // with the panel open, the wider band the chrome is laid out inside; three
-        // `CHIP_GAP`s and the "+" tile sit between it and the chips.
+        // The corner is either the free-standing chrome group (trailing pad + the
+        // panel tile + its 2px gap + the app-menu tile: 71px on macOS, 70px
+        // elsewhere) or, off macOS with the panel open, the wider band the chrome
+        // is laid out inside; three `CHIP_GAP`s and the "+" tile sit between it and
+        // the chips — 121px / 120px of fixed chrome all told.
+        //
+        // The trailing pad is not `tile_trailing_inset()` on every platform:
+        // `window_chrome` follows it with `pr_1` off macOS, and gpui's padding
+        // setters *assign* rather than accumulate, so the later 4px replaces the
+        // 5px rather than adding to it.
         //
         // This used to be a flat 100px, a leftover from when the corner held a
         // 30px "+" and a 30px "⋯", and it was never revisited as the group's
@@ -1220,7 +1226,12 @@ impl Tty7App {
         // grab handle (see `GRAB_HANDLE_W`), was the first thing to pay for it.
         // Measure the group instead of quoting a number at it.
         let corner_w = chrome_band_w.unwrap_or_else(|| {
-            tile_trailing_inset() + crate::ui::app::TILE_SIZE + 2. + crate::ui::app::TILE_SIZE
+            let trailing_pad = if cfg!(target_os = "macos") {
+                tile_trailing_inset()
+            } else {
+                4.
+            };
+            trailing_pad + crate::ui::app::TILE_SIZE + 2. + crate::ui::app::TILE_SIZE
         });
         let fixed_w = 3. * CHIP_GAP + crate::ui::app::TILE_SIZE + corner_w;
         let chips_avail = (strip_w - px(fixed_w + GRAB_HANDLE_W)).max(px(80.));


### PR DESCRIPTION
## Intent

Fix tty7 issue #221: dragging the window by certain title-bar rows works only rarely with a trackpad. A completed prior investigation, confirmed by hand by the project owner, found the cause: five rows that stand in for the title bar (the tab rail's top zone, the settings page's top strip, the detail panel's top zone, and the code and diff overlay headers) armed their window-drag with an Rc<Cell<bool>> allocated fresh inside the render function, so any repaint between the mouse-down and the first drag event threw the armed flag away. The press itself schedules that repaint because these rows carry on_double_click and gpui calls window.refresh() on mouse-down for any element with a click listener, so the drag only survived if the first move beat the next vsync (16ms at 60Hz, 8ms on ProMotion) - a mouse press nudges the pointer and often wins, a trackpad press almost never does.

Deliberate decisions a reviewer reading only the diff would not know:

1. The arm now lives in window.use_keyed_state rather than window.use_state, even though gpui-component's own TitleBar uses use_state. This is intentional: one shared builder (app::window_move_gesture) serves several call sites, and use_state derives its element id from the CALLER's CodeLocation, so two of these rows on screen at once (the rail's top zone plus the code overlay header is a real combination) would collide on one shared arm. Hence the explicit &'static str key parameter threaded through every call site.

2. on_double_click was deliberately NOT removed even though it is what schedules the repaint that triggered the bug. Double-click-to-zoom is required behaviour on these rows; the fix is to make the arm survive the repaint, not to remove the repaint.

3. on_mouse_up_out and on_mouse_down_out were added. These are new, not present in the old code. A flag that dies with its frame needs no explicit clearing, but a flag that survives frames does: without them a press that wandered off the row would stay armed and start a spurious window move on a later plain hover.

4. Threading &mut Window through render_settings, render_diff_overlay, diff_header, render_editor_header, tab_sidebar and panel_title is required plumbing for use_keyed_state, not gratuitous signature churn. tab_sidebar's window parameter changed from &Window to &mut Window for the same reason.

Mid-task the project owner widened the scope with an explicit decision (recorded in a decision record): every header region in the app must support click-and-drag to move the window, not just the caption rows - 'grab the window by its header' is a property of the whole application, and a user should never have to learn which headers happen to be draggable. This superseded the investigation's narrower options and made the horizontal tab strip's grab handle in scope. So this PR also:

5. Makes right_panel::panel_title draggable - the detail panel's shared section header, used by Info, Outline, Changes, Files and the remote SFTP Files browser. It sits above the panel's scroll container, so a drag there has no competing meaning. SFTP's refresh tile gained an occlude() wrapper it was missing; every control inside a WindowControlArea::Drag row needs one or Windows' HTCAPTION claims the press before gpui hit-tests and the button never fires.

6. Gives the horizontal tab strip's flexible spacer an 80px minimum width. It was a bare flex_1 with flex-basis 0, so it collapsed to exactly 0px once the tab chips saturated the row (~7-8 tabs on a 1440px window), leaving only three 6px gaps and a ~3.5px band above and below the chips to grab. Tab chips are occlude()d on purpose because dragging one reorders it, so that spacer is the strip's ONLY grab region - which is why this one header needs a reserved handle when others do not.

7. Corrects the chip row's fixed-chrome reserve from a stale flat px(100.) to the real footprint (~137px) plus the handle. The 100px dated from when the corner held a 30px + and a 30px ellipsis; the workspace chip absorbed the ellipsis menu in #169/#188 and the reserve was never raised, so the chip row's width budget was ~37px of a lie. Accepted tradeoff: chips reach their min_w and truncate labels one or two tabs sooner. This matches what Chrome and Safari do.

8. An inventory of all 21 header/caption/title regions was done; regions deliberately left non-draggable include tab chips (drag reorders), the SFTP breadcrumb (a navigation control), settings section headings and disclosure headers (typographic headings and click-to-expand controls inside a scrolling form), diff file-card headers (click-to-collapse rows inside a scroll list), and the command palette (a transient modal over a dismiss-on-press scrim). These exclusions are intentional, not oversights.

9. The detail panel's macOS top zone has every child occlude()d (four tab tiles plus corner chrome, ~230px fixed) against right_panel::MIN_WIDTH of 200, so its spacer is 0px below ~230px. This was escalated to the project owner, who explicitly decided to leave MIN_WIDTH alone and rely on panel_title directly below it, which this PR made draggable: raising MIN_WIDTH would trade a real capability (narrowing the panel) for a handle that already has an adjacent equivalent. Moving a control off the row was explicitly rejected too. This is a recorded deliberate decision, documented in the source doc beside window_move_gesture so nobody later reads the 0px spacer as an oversight. Do not propose raising MIN_WIDTH or relocating those controls.

10. The regression test module ui::app::window_drag_tests deliberately keeps a control test (a_per_frame_cell_loses_the_arm_to_the_same_repaint) that reproduces the OLD broken Rc<Cell> pattern and asserts it still loses the drag. That duplicated-looking code is intentional: without it the invariant test could pass for the wrong reason. The tests use #[should_panic(expected = "not implemented")] because PlatformWindow::start_window_move is unimplemented!() on gpui's test platform, which makes a panic a reliable 'the window would have started moving' detector.

Constraints the owner set: the GUI must NOT be launched or driven - no screenshots, no window automation, no screen capture; visual acceptance is the owner's own. The test step is skipped per a standing rule (982 tests were run locally and pass). No AGENTS.md or CLAUDE.md may be created or edited in this repo - the owner ruled that tty7 keeps agent-memory files out of the repo, and durable project knowledge goes into the relevant source module's own docs instead, which is where the standing 'every header is draggable' rule was written.

## What Changed

- The five caption-stand-in rows (tab rail top zone, settings top strip, detail panel top zone, code and diff overlay headers) armed their window-drag with an `Rc<Cell<bool>>` allocated fresh inside `render`, so any repaint between the press and the first move discarded it — and the rows' own `on_double_click` makes gpui refresh on mouse-down. The arm now lives in `window.use_keyed_state` via the shared `app::window_move_gesture` builder (keyed, not `use_state`, so two such rows on screen can't collide on one caller-derived id), with `on_mouse_up_out`/`on_mouse_down_out` added to disarm a press that wandered off. `&mut Window` is threaded through `render_settings`, `render_diff_overlay`, `diff_header`, `render_editor_header`, `tab_sidebar` and `panel_title` as the plumbing that requires.
- Extends dragging to the rest of the app's headers per the owner's standing rule: `right_panel::panel_title` (Info, Outline, Changes, Files and remote SFTP) is now a drag row, SFTP's refresh tile gained the `occlude()` wrapper every control inside a drag row needs, and the horizontal tab strip's flexible spacer gets an 80px minimum so it stops collapsing to 0px once chips saturate the row. The chip row's fixed-chrome reserve moves off a stale flat `px(100.)` to the measured group plus the handle, so chips truncate a tab or two sooner.
- Adds the `ui::app::window_drag_tests` module — including a control test that reproduces the old per-frame `Rc<Cell>` pattern and asserts it still loses the drag — plus a CHANGELOG entry and source docs recording the deliberate non-draggable regions and the decision to leave `right_panel::MIN_WIDTH` alone. Review flagged that the durable arm let the sidebar and detail-panel resize handles start a window move; both handles were given `occlude()` in the same branch.

## Risk Assessment

✅ Low: The round-1 regression is fixed at the right boundary with the codebase's established `occlude()` pattern and pinned by a self-validating test pair, the reserve arithmetic now matches gpui's actual padding semantics, and the only remaining note is an acknowledged tradeoff needing no action.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/ui/right_panel.rs` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `src/ui/app.rs:337` - The now-durable arm makes the sidebar and detail-panel resize handles start a window move instead of a resize. Both handles (src/ui/tab_sidebar.rs:972, src/ui/right_panel.rs:356) are absolute, h_full, 8px wide and centred on the panel edge, so their inner 4px overlap a WindowControlArea::Drag row for the row&#39;s full 40px band: the rail&#39;s `sidebar-titlebar-drag` strip, the macOS right-panel top zone, and (newly) `panel_title`. Neither handle carries `occlude()`, so its hitbox is non-opaque and gpui&#39;s hit test still reports the row underneath as hovered — the row&#39;s `on_mouse_down` arms alongside the handle&#39;s `dragging.set(true)`. Previously the handle&#39;s own `window.refresh()` on mouse-down destroyed the per-frame `Rc&lt;Cell&gt;` arm, so the move never started; with the arm in element state it survives, and the first move event hits `window_move_gesture`&#39;s `on_mouse_move` (src/ui/app.rs:360) and calls `start_window_move()`. Concrete sequence: rail open → press the rail&#39;s resize handle at y≈20 → drag → the window moves and the rail is not resized. Fix at the handles, which are the controls sitting inside a drag row: `cx.stop_propagation()` in each handle&#39;s `on_mouse_down` (the handle is painted last, so it runs first in the bubble phase and suppresses the row&#39;s listener), or `occlude()` if losing hover pass-through for the content behind the handle is acceptable.
- ℹ️ `src/ui/tab_strip.rs:1167` - The corrected reserve and the prose describing it disagree. `fixed_w` computes 3*6 + 32 + (5 + 32 + 2 + 32) = 121px, but CHANGELOG.md:38 states the reserve was corrected &#34;to the ~137px the corner actually occupies&#34; — a reader reconciling the two can&#39;t. Separately, `corner_w`&#39;s free-standing branch omits the 4px `pr_1` that `window_chrome` adds off macOS (src/ui/tab_strip.rs:615), so the &#34;measure the group instead of quoting a number at it&#34; branch still under-measures by 4px in the non-macOS panel-closed case. Neither has practical effect (the 80px handle absorbs it), but the numbers are the kind of drift this hunk exists to remove.

🔧 Fix: occlude resize handles; correct chip-reserve arithmetic
1 info still open:
- ℹ️ `src/ui/tab_sidebar.rs:963` - Worth knowing, not worth changing: `occlude()` blocks the hit-test walk for the handle&#39;s whole 8px column, not just its top band. On the rail that column straddles the right edge, and `ui::scrollbar`&#39;s own doc records that the overlay bar &#34;claims mouse-downs in the 16px strip along the container&#39;s right edge&#34; — so the rail&#39;s scrollbar strip is now effectively 12px, and the outer 4px of both handles (the half that hangs over the terminal) no longer reaches the terminal for selection. Both were previously double-handled: a press there already set `dragging = true` and started a resize while the element underneath also got the press, so a single unambiguous owner is the better of the two behaviours. Recording it only so the narrowed strip reads as a consequence of the fix rather than a later mystery.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed (2) ✅</summary>

- ℹ️ `src/ui/tab_strip.rs:597` - `window_chrome`&#39;s doc comment justifies moving the workspace chip out of the corner with &#34;a panel the user can drag down to 200px&#34;, but `right_panel::MIN_WIDTH` has been 216 since 8239b29 (pre-dates this change). This change&#39;s new standing-rule block in `app.rs` now states 216 as part of the same detail-panel width argument, so a reader following the grab-handle reasoning hits two different floors a few hundred lines apart. Left unedited on purpose: the sentence is historical narrative about why the chip moved, and its conclusion holds under either number (the row wanted 268px), so rewriting it risks corrupting the record rather than correcting it. Worth an owner decision on whether to date-stamp it (&#34;the 200px floor of the time&#34;) or drop the figure.

🔧 Fix: make panel grab-handle docs version-neutral and platform-accurate
2 issues (1 warning, 1 info) still open:
- ⚠️ `CHANGELOG.md:27` - Item (3) of this round&#39;s instructions — rebase onto origin/main at 64403cf, resolve the CHANGELOG Unreleased conflicts keeping all entries in Added -&gt; Changed -&gt; Fixed order, then re-verify GRAB_HANDLE_W / spacer min_w / corner_w / the resize-handle occlude() calls and run `cargo test --bin tty7 window_drag_tests` — was NOT performed. This is the document+lint phase; the rebase step and the test step are owned by the outer executor, and this phase is explicitly barred from running tests or other validation phases. The branch is still based on 9246340. Consequence if nobody picks it up: the branch pushes stale, and the three upstream commits (64403cf, 1f09a62, 9ca3319) conflict at push time instead of under supervision. Note for whoever does it: 1f09a62 touches the diff FILE-CARD header inside the scrolling list, which this branch deliberately keeps non-draggable — not the diff overlay title-bar header this branch made draggable. Also note that both documentation edits made this round are deliberately version-neutral (they name `right_panel::MIN_WIDTH` rather than quoting 216/214), so they stay correct even if an upstream commit moves those numbers; only the `corner_w` / `GRAB_HANDLE_W` code invariants still need the post-rebase re-check.
- ℹ️ `src/ui/tab_strip.rs:396` - `workspace_head`&#39;s doc carries the same stale figure the owner just ruled on for `window_chrome`: &#34;a control that has nothing to do with the panel was eating width the panel&#39;s own tabs needed — at the 200px minimum the row wanted 268px&#34;. It is the identical argument (why the workspace chip left the corner), the identical pair of numbers, and `right_panel::MIN_WIDTH` is 216. Round 1 only surfaced the `window_chrome` copy, so the owner&#39;s version-neutral ruling was scoped to that one and I applied it there only; I left this one alone rather than widen the scope of an explicit instruction. The same one-clause substitution (&#39;at the `right_panel::MIN_WIDTH` floor the row wanted 268px&#39;) would settle it consistently. Not urgent — the 268px conclusion holds under either floor, and it now reads as history rather than contradicting a live claim, since the app.rs block no longer quotes a competing number. A third mention at tab_strip.rs:648 (&#39;after the row overflowed a 200px panel&#39;) is genuine past-event narrative and is accurate as written; it should stay.

🔧 Fix: make workspace_head panel-width doc version-neutral
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
