### PR TITLE
feat(remote): open a workspace on a WSL distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Ports need no forwarding (WSL shares `localhost`, so ⌘-clicking a dev server's
   URL just works), and files move over the same `Host` calls every remote
-  workspace uses, or through `\\wsl$` directly.
+  workspace uses, or through `\\wsl$` directly. (#253)
 
 - **Copy Session ID** — the agent's native session id on the clipboard, beside
   *Copy Working Directory* in the tab / sidebar context menu, the palette and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,9 +72,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Two things had to be fixed for this to work at all, both invisible until
   something could actually select a distribution. WSL kills what an interop
   session started the moment its `wsl.exe` exits, and `setsid` does not make the
-  new daemon safe instantly — so the launch now holds its invocation open for a
-  beat, instead of reporting "started but nothing was answering on the control
-  socket" over a correctly installed binary. And a pane's connection now asks
+  new daemon safe instantly — so the launch now holds its invocation open until
+  the daemon answers, instead of reporting "started but nothing was answering on
+  the control socket" over a correctly installed binary. And a pane's connection now asks
   for the remote's *pane* socket: the flag that says so was added by the SSH
   path and by the local `--stdio` one, but never by WSL, so the workspace would
   connect and the window would open with a pane that could not reach the machine.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   transcript, so the turn you're watching won't be in the copy. The parent is
   never modified either way. (#211)
 
+- **Your WSL distributions are machines you can open a workspace on** — the
+  transport for them has been there since remote workspaces landed
+  (`wsl.exe -d <distro> -- tty7-server --stdio`: no SSH, no address, no
+  credential, no host key), but nothing offered one, so nothing could reach it.
+  Every installed distribution now appears in the workspace switcher beside your
+  saved SSH hosts, and opening one is the whole setup — there is nothing to
+  configure, because there is nothing that *could* be configured. The row is
+  named exactly what `wsl -d` calls the distro, since that string is also how
+  the machine is keyed (`wsl:<distro>`), and searching the switcher for `wsl`
+  finds all of them.
+
+  A distribution is served the Linux `tty7-server` this client shipped with
+  rather than one downloaded from a release, so the first connect writes it into
+  `~/.local/share/tty7/bin` inside the distro — with the same one-time
+  confirmation any other machine gets, and no `sudo` anywhere. A build with no
+  bundled server (any `cargo build`, and any platform that isn't Windows) says
+  so and names the directories it looked in.
+
+  Two things had to be fixed for this to work at all, both invisible until
+  something could actually select a distribution. WSL kills what an interop
+  session started the moment its `wsl.exe` exits, and `setsid` does not make the
+  new daemon safe instantly — so the launch now holds its invocation open for a
+  beat, instead of reporting "started but nothing was answering on the control
+  socket" over a correctly installed binary. And a pane's connection now asks
+  for the remote's *pane* socket: the flag that says so was added by the SSH
+  path and by the local `--stdio` one, but never by WSL, so the workspace would
+  connect and the window would open with a pane that could not reach the machine.
+
+  Ports need no forwarding (WSL shares `localhost`, so ⌘-clicking a dev server's
+  URL just works), and files move over the same `Host` calls every remote
+  workspace uses, or through `\\wsl$` directly.
+
 - **Copy Session ID** — the agent's native session id on the clipboard, beside
   *Copy Working Directory* in the tab / sidebar context menu, the palette and
   the File menu. Codex has no copy-or-duplicate subcommand — forking *is* how

--- a/crates/tty7-core/src/core/session.rs
+++ b/crates/tty7-core/src/core/session.rs
@@ -187,7 +187,7 @@ impl std::str::FromStr for WorkspaceId {
 /// | [`Profile`](RemoteTarget::Profile) | A saved [`SshProfile`](crate::core::ssh_profile::SshProfile), by its stable uuid | `ssh-profile:<uuid>` |
 /// | [`Alias`](RemoteTarget::Alias) | A `Host` stanza in `~/.ssh/config` | `ssh-alias:<alias>` |
 /// | [`Direct`](RemoteTarget::Direct) | A typed `user@host:port` (QuickConnect) | `ssh-direct:<user>@<host>:<port>` |
-/// | [`Wsl`](RemoteTarget::Wsl) | A WSL distro — **M8**, defined only so the key table has no hole | `wsl:<distro>` |
+/// | [`Wsl`](RemoteTarget::Wsl) | A distribution installed on this computer, as `wsl.exe -l -q` names it | `wsl:<distro>` |
 ///
 /// Persisted, unlike [`HostId`](crate::host::HostId): this is what survives a
 /// restart, and the id is derived from it at connect time.
@@ -212,9 +212,13 @@ pub enum RemoteTarget {
         #[serde(default = "default_ssh_port")]
         port: u16,
     },
-    /// A WSL distribution. **M8 owns the behaviour**; the variant exists now so
-    /// that [`connection_key`](RemoteTarget::connection_key) is a total function
-    /// over the table rather than one that grows a case later.
+    /// A WSL distribution, named exactly as `wsl -d` takes it.
+    ///
+    /// **The one machine that is configured zero times**: it is reached by
+    /// spawning `wsl.exe`, so there is no address, no credential and no host
+    /// key to spell out anywhere. The picker
+    /// (`ui::remote_connect::available_hosts`) therefore offers every
+    /// distribution installed on this computer rather than reading a store.
     Wsl { distro: String },
     /// A `tty7-server --stdio` child process on *this* machine — the workspace
     /// mirror of [`RouteTarget::LocalStdio`](crate::daemon::router::RouteTarget::LocalStdio),

--- a/crates/tty7-core/src/core/shells.rs
+++ b/crates/tty7-core/src/core/shells.rs
@@ -345,12 +345,26 @@ pub fn git_bash_path() -> Option<PathBuf> {
     find_git_bash()
 }
 
-/// Installed WSL distributions. Exposed only to tests, for the same reason as
-/// [`git_bash_path`]: the live-PTY check needs a real distro to launch into,
-/// and skips itself when there is none.
-#[cfg(all(windows, test))]
+/// Installed WSL distribution names, empty when WSL is absent — and always
+/// empty off Windows, so callers need no `cfg` of their own.
+///
+/// Two callers want the same list for different reasons. [`detect_shells`]
+/// offers a distro as a **shell** to launch in a pane; the workspace switcher
+/// offers it as a **machine** that can host a remote workspace
+/// (`ui::remote_connect::available_hosts`). Same enumeration, so the two lists
+/// can never disagree about which distros exist.
+///
+/// Spawns `wsl.exe` on Windows — the same rule as [`detect_shells`]: call it
+/// off the UI thread.
 pub fn wsl_distros() -> Vec<String> {
-    list_wsl_distros()
+    #[cfg(windows)]
+    {
+        list_wsl_distros()
+    }
+    #[cfg(not(windows))]
+    {
+        Vec::new()
+    }
 }
 
 /// Git Bash from the usual Git-for-Windows install roots (machine-wide x64,

--- a/crates/tty7-core/src/core/shells.rs
+++ b/crates/tty7-core/src/core/shells.rs
@@ -324,7 +324,7 @@ fn detect_windows() -> Vec<DetectedShell> {
         });
     }
 
-    for distro in list_wsl_distros() {
+    for distro in list_wsl_distros().unwrap_or_default() {
         out.push(DetectedShell {
             label: format!("WSL · {distro}"),
             program: "wsl.exe".into(),
@@ -357,13 +357,26 @@ pub fn git_bash_path() -> Option<PathBuf> {
 /// Spawns `wsl.exe` on Windows — the same rule as [`detect_shells`]: call it
 /// off the UI thread.
 pub fn wsl_distros() -> Vec<String> {
+    wsl_distros_probed().unwrap_or_default()
+}
+
+/// [`wsl_distros`], keeping the difference between *nothing is installed* and
+/// *the probe could not answer*.
+///
+/// `Some(vec![])` is an answer — WSL is present and has no distributions, or this
+/// is not Windows at all, where there can never be one. `None` means the probe
+/// itself failed, and a caller holding a previous list should keep it rather than
+/// report that the user's distributions have gone away: `wsl.exe` refuses while a
+/// `wsl --shutdown` is in flight, which is a routine thing to run and a terrible
+/// reason to empty the machine picker.
+pub fn wsl_distros_probed() -> Option<Vec<String>> {
     #[cfg(windows)]
     {
         list_wsl_distros()
     }
     #[cfg(not(windows))]
     {
-        Vec::new()
+        Some(Vec::new())
     }
 }
 
@@ -389,20 +402,23 @@ fn find_git_bash() -> Option<PathBuf> {
     pick_first_existing(candidates)
 }
 
-/// Installed WSL distribution names via `wsl.exe -l -q`, or empty when WSL is
-/// absent. [`hide_console`](crate::core::proc::hide_console) keeps the probe
-/// from flashing a console window (we're a GUI process).
+/// Installed WSL distribution names via `wsl.exe -l -q`.
+///
+/// **`None` is "the probe could not answer", not "there are none"** — no
+/// `wsl.exe`, or one that failed, which is what a distribution mid-`wsl
+/// --shutdown` or a broken WSL install looks like. `Some(vec![])` is the
+/// authoritative empty answer: WSL is there and nothing is registered.
+/// [`hide_console`](crate::core::proc::hide_console) keeps the probe from
+/// flashing a console window (we're a GUI process).
 #[cfg(windows)]
-fn list_wsl_distros() -> Vec<String> {
+fn list_wsl_distros() -> Option<Vec<String>> {
     let mut cmd = std::process::Command::new("wsl.exe");
     cmd.args(["-l", "-q"]);
-    let Ok(output) = crate::core::proc::hide_console(&mut cmd).output() else {
-        return Vec::new();
-    };
+    let output = crate::core::proc::hide_console(&mut cmd).output().ok()?;
     if !output.status.success() {
-        return Vec::new();
+        return None;
     }
-    parse_wsl_list(&output.stdout)
+    Some(parse_wsl_list(&output.stdout))
 }
 
 /// Decode `wsl.exe -l -q` output — UTF-16LE, one distro per line — skipping

--- a/crates/tty7-core/src/daemon/install/mod.rs
+++ b/crates/tty7-core/src/daemon/install/mod.rs
@@ -143,6 +143,16 @@ pub trait RemoteOps: Send + Sync {
     /// for it to exit. Used only for the daemon launch, which by design never
     /// exits.
     fn spawn_detached(&self, cmd: &str) -> Result<(), String>;
+    /// A wait to run in the *same* invocation as the daemon launch, right after
+    /// the launch line, for a transport that cannot let the invocation return
+    /// while the daemon is still fragile. `binary` is the server just launched.
+    ///
+    /// Defaulted to nothing, because SSH needs nothing: closing an exec channel
+    /// is unhurried and a backgrounded daemon survives it. WSL is the one
+    /// transport that does — see [`wsl::launch_settle`](super::install::wsl).
+    fn launch_settle(&self, _binary: &str) -> Option<String> {
+        None
+    }
     /// `stat` following symlinks. `Ok(None)` means "not there", which is a normal
     /// answer, not an error.
     fn stat(&self, path: &str) -> Result<Option<RemoteStat>, String>;
@@ -1293,8 +1303,9 @@ impl<'a> Installer<'a> {
     }
 
     fn launch_daemon(&self, paths: &RemotePaths) -> Result<(), InstallError> {
+        let settle = self.ops.launch_settle(&paths.binary);
         self.ops
-            .spawn_detached(&launch_command(&paths.binary))
+            .spawn_detached(&launch_script(&paths.binary, settle))
             .map_err(|reason| InstallError::Launch { reason })
     }
 
@@ -1417,6 +1428,21 @@ fn launch_command(binary: &str) -> String {
            nohup {bin} --daemon < /dev/null > /dev/null 2>&1 & \
          fi"
     )
+}
+
+/// The launch line, plus whatever wait the transport asked for in
+/// [`RemoteOps::launch_settle`].
+///
+/// A free function so the one thing that must never happen — the wait replacing
+/// the launch instead of following it — is testable without a machine of any
+/// kind. A daemon that was never launched fails exactly like one that was
+/// reaped, so this is cheap to get wrong and expensive to notice.
+fn launch_script(binary: &str, settle: Option<String>) -> String {
+    let launch = launch_command(binary);
+    match settle {
+        Some(settle) => format!("{launch}\n{settle}"),
+        None => launch,
+    }
 }
 
 /// POSIX single-quote escaping. Home directories with spaces, apostrophes or

--- a/crates/tty7-core/src/daemon/install/tests.rs
+++ b/crates/tty7-core/src/daemon/install/tests.rs
@@ -986,6 +986,29 @@ fn the_launch_command_detaches_and_closes_every_stream() {
     );
 }
 
+/// A transport's settle **follows** the launch; it never replaces it. Cheap to
+/// get wrong in a `format!` and expensive to notice, because a daemon that was
+/// never launched fails exactly like one that died right after being launched.
+///
+/// And a transport that asks for nothing — every one but WSL — gets the launch
+/// line by itself, with no trailing newline to change what the shell reads.
+#[test]
+fn a_launch_settle_follows_the_launch_and_never_replaces_it() {
+    let plain = launch_script(BINARY, None);
+    assert_eq!(plain, launch_command(BINARY), "no settle, no wrapping");
+
+    let settled = launch_script(BINARY, Some("sleep 1\n".to_string()));
+    assert!(
+        settled.starts_with(&plain),
+        "the launch survives: {settled}"
+    );
+    assert!(settled.contains("--daemon"), "{settled}");
+    assert!(
+        settled.ends_with("sleep 1\n"),
+        "the settle is last: {settled}"
+    );
+}
+
 /// Every command interpolates a remote path, and home directories with spaces
 /// or apostrophes exist. Unquoted, `/home/o'brien/...` would end the string
 /// mid-path and run whatever followed.

--- a/crates/tty7-core/src/daemon/install/wsl.rs
+++ b/crates/tty7-core/src/daemon/install/wsl.rs
@@ -71,7 +71,8 @@ const MARKER: &str = "__tty7_wsl__";
 /// Budget for one probe. Generous, because the *first* command against a
 /// stopped distribution pays for booting its VM and init.
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(60);
-/// Budget for the fire-and-forget daemon launch, which backgrounds and returns.
+/// Budget for the daemon launch. It backgrounds and returns, but not
+/// immediately — see [`DETACH_SETTLE`], which holds the invocation open.
 const LAUNCH_TIMEOUT: Duration = Duration::from_secs(30);
 /// Budget for writing the server binary — a few megabytes over a pipe, plus
 /// whatever the distribution's disk is doing.
@@ -283,6 +284,53 @@ const HOME_SCRIPT: &str = "printf '__tty7_wsl__ home=%s\\n' \"$HOME\"\n";
 /// life — and its life is "until the machine reboots". `|| cd /` covers a
 /// distribution whose default user has no home directory.
 const CD_HOME: &str = "cd \"$HOME\" 2>/dev/null || cd /\n";
+
+/// Appended after the daemon launch line so `wsl.exe` does not exit while the
+/// daemon is still detaching.
+///
+/// **WSL reaps what an interop session started when that session's `wsl.exe`
+/// exits**, and `setsid` does not make the child safe the instant it runs.
+/// [`launch_command`](super::launch_command) backgrounds the daemon and returns
+/// in milliseconds, so without this the sequence is: `sh` exits, `wsl.exe`
+/// exits, WSL tears the session down, and the daemon dies before it can bind.
+/// What the user sees is [`ensure_daemon`](super::Installer::ensure_daemon)'s
+/// "started but nothing was answering on the control socket", with a correctly
+/// installed binary and nothing else to go on.
+///
+/// Reproduced by hand against `Ubuntu-24.04`, running the launch line by
+/// itself: with nothing after it the daemon is gone; with as little as
+/// `sleep 0.3` after it the daemon lives and serves. Nothing about the launch
+/// line itself is wrong — `nohup`, `setsid --fork` and a double-forked subshell
+/// all die the same way — so the wait is the fix, not a different spelling of
+/// the detach.
+///
+/// The SSH path needs none of this (an exec channel's close is unhurried), which
+/// is why the shared [`launch_command`](super::launch_command) stays as it is
+/// and this lives here.
+///
+/// # Why a flat wait and not a wait *for the socket*
+///
+/// Polling `<config dir>/daemon.sock` until it appears looks like the obvious
+/// improvement, and it is wrong. [`ensure_daemon`](super::Installer::ensure_daemon)
+/// only reaches the launch when the socket did **not** answer, and the ordinary
+/// reason for that is a socket file a dead daemon left behind — `wsl --shutdown`
+/// is a routine thing to run. A `-S` test would pass on that stale file
+/// immediately, skip the wait, and restore the bug in exactly the state that
+/// produced it.
+///
+/// One second, because 0.3 was enough in the reproduction and this is paid only
+/// on a launch — which happens when no daemon is already serving the
+/// distribution, not on every connect.
+const DETACH_SETTLE: &str = "sleep 1\n";
+
+/// The daemon launch line plus its [`DETACH_SETTLE`] wait.
+///
+/// Split out from [`WslRemoteOps::spawn_detached`] so the composition is
+/// testable without a distribution: the one thing that must never happen is the
+/// wait replacing the launch rather than following it.
+fn launch_script(cmd: &str) -> String {
+    format!("{cmd}\n{DETACH_SETTLE}")
+}
 
 /// `HOME_SCRIPT` has to spell the marker out, because a `const` cannot
 /// `format!`. This is the guard that a rename of [`MARKER`] cannot slip past:
@@ -590,7 +638,7 @@ impl RemoteOps for WslRemoteOps {
         // The status is ignored for the same reason it is over SSH: the script
         // reports on the backgrounding, never on the daemon. Whether the daemon
         // came up is settled by probing its socket.
-        self.sh(cmd, LAUNCH_TIMEOUT).map(|_| ())
+        self.sh(&launch_script(cmd), LAUNCH_TIMEOUT).map(|_| ())
     }
 
     fn stat(&self, path: &str) -> Result<Option<RemoteStat>, String> {
@@ -1114,6 +1162,44 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    /// The wait follows the launch; it never replaces it. Cheap to get wrong in
+    /// a `format!` and expensive to notice — a daemon that is never launched
+    /// fails exactly like one that was reaped.
+    #[test]
+    fn the_launch_script_keeps_the_launch_and_appends_the_wait() {
+        let script = launch_script("setsid 'tty7-server' --daemon &");
+        let (launch, wait) = script.split_once('\n').expect("two parts");
+        assert_eq!(launch, "setsid 'tty7-server' --daemon &");
+        assert_eq!(wait.trim(), "sleep 1");
+    }
+
+    /// **The settle wait, executed**: the launch still runs, the invocation is
+    /// really held afterwards, and it is held for a beat rather than for the
+    /// whole budget its caller allows.
+    ///
+    /// The middle assertion is the one with teeth. A wait that silently became a
+    /// no-op — a `sleep` a distro rejects, a line lost in a `format!` — reads as
+    /// a passing test everywhere except against a real distribution, which is
+    /// where it already cost an afternoon.
+    #[cfg(unix)]
+    #[test]
+    fn the_settle_wait_really_holds_the_invocation_open() {
+        let started = std::time::Instant::now();
+        let (out, ok) = real_sh(&launch_script("echo launched"));
+        let elapsed = started.elapsed();
+
+        assert!(ok, "{out}");
+        assert!(out.contains("launched"), "the launch still ran: {out:?}");
+        assert!(
+            elapsed >= Duration::from_millis(900),
+            "the wait did not happen: {elapsed:?}"
+        );
+        assert!(
+            elapsed < LAUNCH_TIMEOUT,
+            "the wait outlived the budget its caller gives the whole launch"
+        );
     }
 
     /// **The stat probe, executed.** Against a real directory, a real

--- a/crates/tty7-core/src/daemon/install/wsl.rs
+++ b/crates/tty7-core/src/daemon/install/wsl.rs
@@ -72,7 +72,8 @@ const MARKER: &str = "__tty7_wsl__";
 /// stopped distribution pays for booting its VM and init.
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(60);
 /// Budget for the daemon launch. It backgrounds and returns, but not
-/// immediately — see [`DETACH_SETTLE`], which holds the invocation open.
+/// immediately — see [`launch_settle`], which holds the invocation open until the
+/// daemon answers.
 const LAUNCH_TIMEOUT: Duration = Duration::from_secs(30);
 /// Budget for writing the server binary — a few megabytes over a pipe, plus
 /// whatever the distribution's disk is doing.
@@ -285,8 +286,17 @@ const HOME_SCRIPT: &str = "printf '__tty7_wsl__ home=%s\\n' \"$HOME\"\n";
 /// distribution whose default user has no home directory.
 const CD_HOME: &str = "cd \"$HOME\" 2>/dev/null || cd /\n";
 
-/// Appended after the daemon launch line so `wsl.exe` does not exit while the
-/// daemon is still detaching.
+/// How many times the settle asks the daemon whether it is serving, and how long
+/// it waits between asks — a little over five seconds in all, generous for a
+/// distribution that is booting its VM, and far inside [`LAUNCH_TIMEOUT`].
+const SETTLE_TRIES: u32 = 25;
+const SETTLE_STEP: &str = "0.2";
+/// How long to hold the invocation open *after* the daemon answers. See
+/// [`launch_settle`].
+const SETTLE_GRACE: &str = "0.3";
+
+/// The wait that runs after the daemon launch, in the same `wsl.exe`
+/// invocation, so `wsl.exe` does not exit while the daemon is still detaching.
 ///
 /// **WSL reaps what an interop session started when that session's `wsl.exe`
 /// exits**, and `setsid` does not make the child safe the instant it runs.
@@ -306,30 +316,52 @@ const CD_HOME: &str = "cd \"$HOME\" 2>/dev/null || cd /\n";
 ///
 /// The SSH path needs none of this (an exec channel's close is unhurried), which
 /// is why the shared [`launch_command`](super::launch_command) stays as it is
-/// and this lives here.
+/// and this is a [`RemoteOps::launch_settle`](super::RemoteOps::launch_settle)
+/// instead.
 ///
-/// # Why a flat wait and not a wait *for the socket*
+/// # It waits for an answer, not for a fixed number of seconds
 ///
-/// Polling `<config dir>/daemon.sock` until it appears looks like the obvious
-/// improvement, and it is wrong. [`ensure_daemon`](super::Installer::ensure_daemon)
-/// only reaches the launch when the socket did **not** answer, and the ordinary
-/// reason for that is a socket file a dead daemon left behind — `wsl --shutdown`
-/// is a routine thing to run. A `-S` test would pass on that stale file
-/// immediately, skip the wait, and restore the bug in exactly the state that
-/// produced it.
+/// A flat `sleep` is a bet on how long a distribution takes to detach, and the
+/// one that loses that bet is the cold or loaded distribution — the same
+/// condition the failure needed in the first place. So the wait asks the daemon
+/// the only question that settles it, `--stdio --bridge`, exactly as
+/// [`ensure_daemon`](super::Installer::ensure_daemon) asks it from this side, and
+/// stops as soon as it is answered. The normal case is therefore *shorter* than
+/// the flat second it replaces, and the cold case is allowed the seconds it
+/// actually needs instead of failing with nothing to go on.
 ///
-/// One second, because 0.3 was enough in the reproduction and this is paid only
-/// on a launch — which happens when no daemon is already serving the
-/// distribution, not on every connect.
-const DETACH_SETTLE: &str = "sleep 1\n";
+/// **Waiting on `<config dir>/daemon.sock` would be wrong**, which is why this
+/// waits on the answer and not on the file.
+/// [`ensure_daemon`](super::Installer::ensure_daemon) only reaches the launch
+/// when the socket did *not* answer, and the ordinary reason for that is a socket
+/// file a dead daemon left behind — `wsl --shutdown` is a routine thing to run.
+/// A `-S` test would pass on that stale file immediately, skip the wait, and
+/// restore the bug in exactly the state that produced it. A daemon that answers
+/// cannot be a leftover file.
+///
+/// [`SETTLE_GRACE`] follows the answer because what makes the daemon safe is not
+/// observable from here — 0.3s of *any* wait was enough in the reproduction, so
+/// the answer is followed by that much regardless.
+pub(super) fn launch_settle(binary: &str) -> String {
+    settle_script(binary, SETTLE_TRIES, SETTLE_STEP, SETTLE_GRACE)
+}
 
-/// The daemon launch line plus its [`DETACH_SETTLE`] wait.
-///
-/// Split out from [`WslRemoteOps::spawn_detached`] so the composition is
-/// testable without a distribution: the one thing that must never happen is the
-/// wait replacing the launch rather than following it.
-fn launch_script(cmd: &str) -> String {
-    format!("{cmd}\n{DETACH_SETTLE}")
+/// [`launch_settle`] with its budget spelled out, so a test can run the real
+/// script against a real `sh` without waiting out the real budget.
+fn settle_script(binary: &str, tries: u32, step: &str, grace: &str) -> String {
+    let bin = shell_quote(binary);
+    // `< /dev/null` on the probe matters twice over: it is what makes `--bridge`
+    // answer and exit rather than proxy, and this script itself arrives on the
+    // shell's stdin, so a probe left reading stdin would eat the rest of it.
+    format!(
+        "__tty7_settle=0\n\
+         while [ \"$__tty7_settle\" -lt {tries} ]; do\n\
+         if {bin} --stdio --bridge < /dev/null > /dev/null 2>&1; then break; fi\n\
+         __tty7_settle=$((__tty7_settle + 1))\n\
+         sleep {step}\n\
+         done\n\
+         sleep {grace}\n"
+    )
 }
 
 /// `HOME_SCRIPT` has to spell the marker out, because a `const` cannot
@@ -638,7 +670,12 @@ impl RemoteOps for WslRemoteOps {
         // The status is ignored for the same reason it is over SSH: the script
         // reports on the backgrounding, never on the daemon. Whether the daemon
         // came up is settled by probing its socket.
-        self.sh(&launch_script(cmd), LAUNCH_TIMEOUT).map(|_| ())
+        self.sh(cmd, LAUNCH_TIMEOUT).map(|_| ())
+    }
+
+    /// WSL is the transport that needs one. See [`launch_settle`].
+    fn launch_settle(&self, binary: &str) -> Option<String> {
+        Some(launch_settle(binary))
     }
 
     fn stat(&self, path: &str) -> Result<Option<RemoteStat>, String> {
@@ -1164,41 +1201,100 @@ mod tests {
         dir
     }
 
-    /// The wait follows the launch; it never replaces it. Cheap to get wrong in
-    /// a `format!` and expensive to notice — a daemon that is never launched
-    /// fails exactly like one that was reaped.
-    #[test]
-    fn the_launch_script_keeps_the_launch_and_appends_the_wait() {
-        let script = launch_script("setsid 'tty7-server' --daemon &");
-        let (launch, wait) = script.split_once('\n').expect("two parts");
-        assert_eq!(launch, "setsid 'tty7-server' --daemon &");
-        assert_eq!(wait.trim(), "sleep 1");
+    /// A stand-in for the remote `tty7-server`: a script that answers the
+    /// settle's probe (`code` 0) or never answers it (anything else).
+    #[cfg(unix)]
+    fn fake_server(dir: &std::path::Path, name: &str, code: u8) -> String {
+        use std::os::unix::fs::PermissionsExt as _;
+        let path = dir.join(name);
+        std::fs::write(&path, format!("#!/bin/sh\nexit {code}\n")).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path.to_str().unwrap().to_string()
     }
 
-    /// **The settle wait, executed**: the launch still runs, the invocation is
-    /// really held afterwards, and it is held for a beat rather than for the
-    /// whole budget its caller allows.
+    /// The settle asks the daemon with *the daemon's own binary*, quoted, in the
+    /// control dialect — the same question
+    /// [`Installer::ensure_daemon`] asks from this side. Not `--pane` (that is
+    /// the other socket and would answer for the wrong thing) and not a test on
+    /// the socket file, which a stale one passes.
+    #[test]
+    fn the_settle_asks_the_control_dialect_with_the_quoted_binary() {
+        let script = settle_script("/home/a b/tty7-server-26.7.6", 4, "0.2", "0.3");
+        assert!(
+            script.contains("'/home/a b/tty7-server-26.7.6' --stdio --bridge < /dev/null"),
+            "{script}"
+        );
+        assert!(!script.contains("--pane"), "{script}");
+        assert!(!script.contains("-S "), "no file test: {script}");
+        assert!(script.contains("-lt 4"), "{script}");
+    }
+
+    /// **The settle, executed against a daemon that answers.** It stops on the
+    /// first answer and still holds the invocation for [`SETTLE_GRACE`] — so the
+    /// normal launch is *shorter* than the flat second this replaced, and the
+    /// wait is still really there.
     ///
-    /// The middle assertion is the one with teeth. A wait that silently became a
-    /// no-op — a `sleep` a distro rejects, a line lost in a `format!` — reads as
-    /// a passing test everywhere except against a real distribution, which is
+    /// This is the assertion with teeth. A settle that silently became a no-op —
+    /// a `sleep` a distro rejects, a line lost in a `format!` — reads as a
+    /// passing test everywhere except against a real distribution, which is
     /// where it already cost an afternoon.
     #[cfg(unix)]
     #[test]
-    fn the_settle_wait_really_holds_the_invocation_open() {
+    fn the_settle_stops_as_soon_as_the_daemon_answers() {
+        let dir = sh_scratch("settle-answers");
+        let serving = fake_server(&dir, "tty7-server-answers", 0);
+
         let started = std::time::Instant::now();
-        let (out, ok) = real_sh(&launch_script("echo launched"));
+        let (out, ok) = real_sh(&settle_script(&serving, SETTLE_TRIES, SETTLE_STEP, "0.3"));
         let elapsed = started.elapsed();
 
         assert!(ok, "{out}");
-        assert!(out.contains("launched"), "the launch still ran: {out:?}");
         assert!(
-            elapsed >= Duration::from_millis(900),
-            "the wait did not happen: {elapsed:?}"
+            elapsed >= Duration::from_millis(250),
+            "the grace after the answer did not happen: {elapsed:?}"
         );
         assert!(
-            elapsed < LAUNCH_TIMEOUT,
-            "the wait outlived the budget its caller gives the whole launch"
+            elapsed < Duration::from_millis(1500),
+            "it kept waiting after the daemon had answered: {elapsed:?}"
+        );
+    }
+
+    /// **The settle, executed against a daemon that never answers.** It spends
+    /// its whole budget and then returns — a launch that failed has to become
+    /// `ensure_daemon`'s verdict, not a hung invocation.
+    #[cfg(unix)]
+    #[test]
+    fn the_settle_gives_up_rather_than_hanging() {
+        let dir = sh_scratch("settle-silent");
+        let silent = fake_server(&dir, "tty7-server-silent", 1);
+
+        let started = std::time::Instant::now();
+        let (out, ok) = real_sh(&settle_script(&silent, 3, "0.1", "0.1"));
+        let elapsed = started.elapsed();
+
+        assert!(ok, "{out}");
+        assert!(
+            elapsed >= Duration::from_millis(350),
+            "it did not ask three times: {elapsed:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "it never gave up: {elapsed:?}"
+        );
+    }
+
+    /// The real budget stays well inside the one its caller allows the *whole*
+    /// launch, or a slow daemon turns into a killed invocation instead of a
+    /// launched one. Also the guard that both steps are still numbers a `sleep`
+    /// accepts.
+    #[test]
+    fn the_settle_budget_fits_inside_the_launch_timeout() {
+        let step: f64 = SETTLE_STEP.parse().expect("a number for `sleep`");
+        let grace: f64 = SETTLE_GRACE.parse().expect("a number for `sleep`");
+        let worst = f64::from(SETTLE_TRIES) * step + grace;
+        assert!(
+            worst < LAUNCH_TIMEOUT.as_secs_f64() / 2.0,
+            "{worst}s of settle inside a {LAUNCH_TIMEOUT:?} launch budget"
         );
     }
 

--- a/crates/tty7-core/src/daemon/remote_link.rs
+++ b/crates/tty7-core/src/daemon/remote_link.rs
@@ -55,6 +55,7 @@ use russh::Channel;
 use russh::client::Msg;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
+use super::router::RouteChannel;
 use super::ssh::ProcessStream;
 
 /// One logical stream between the local daemon and a remote `tty7-server`.
@@ -115,9 +116,21 @@ impl RemoteLink {
     /// No shell is involved, so `server` needs no quoting; the distro name is
     /// validated because it is an *option's* argument and a leading `-` would be
     /// read as another option.
-    pub fn wsl(distro: &str, server: &str) -> io::Result<RemoteLink> {
+    ///
+    /// # `channel`
+    ///
+    /// **A pane bridge and a control bridge are different commands**, and this
+    /// is the only place that can tell them apart for WSL. The remote listens
+    /// twice and the dialects are not interchangeable — a pane landing on the
+    /// control socket writes its `Spawn` and is answered with nothing, which is
+    /// what "the workspace connects but the pane says it can't reach the
+    /// machine" was. The SSH path makes the same choice in
+    /// [`ssh::open_remote_link`](crate::daemon::ssh), and `LocalStdio` makes it
+    /// in the client's `PaneWorkspace::route_header` because its argv is run
+    /// verbatim; WSL builds its argv here, so here is where it belongs.
+    pub fn wsl(distro: &str, server: &str, channel: RouteChannel) -> io::Result<RemoteLink> {
         super::install::wsl::validate_distro(distro)?;
-        let args = super::install::wsl::wsl_args(distro, &[server, "--stdio"]);
+        let args = super::install::wsl::wsl_args(distro, &wsl_link_argv(server, channel));
         Ok(RemoteLink::Wsl(spawn_stdio_owned(
             super::install::wsl::WSL_EXE,
             &args,
@@ -131,9 +144,15 @@ impl RemoteLink {
     ///
     /// The escape hatch for a distribution where the normal install path cannot
     /// be used; the resolved-path form above is what ships.
-    pub fn wsl_shell(distro: &str, command: &str) -> io::Result<RemoteLink> {
+    ///
+    /// `channel` reaches the command through
+    /// [`RouteChannel::bridge_command`], which is the same rewrite the SSH path
+    /// applies to *its* shell command — an override must not silently lose the
+    /// pane dialect that [`RemoteLink::wsl`] gets right.
+    pub fn wsl_shell(distro: &str, command: &str, channel: RouteChannel) -> io::Result<RemoteLink> {
         super::install::wsl::validate_distro(distro)?;
-        let args = super::install::wsl::wsl_args(distro, &["sh", "-c", command]);
+        let command = channel.bridge_command(command);
+        let args = super::install::wsl::wsl_args(distro, &["sh", "-c", &command]);
         Ok(RemoteLink::Wsl(spawn_stdio_owned(
             super::install::wsl::WSL_EXE,
             &args,
@@ -173,6 +192,19 @@ impl RemoteLink {
             RemoteLink::StreamLocal(_) | RemoteLink::SessionExec(_)
         )
     }
+}
+
+/// The command `wsl.exe` runs for a link on `channel`, as an argv.
+///
+/// Pure, because the difference between the two is one flag that decides which
+/// of the remote's two sockets the stream lands on, and it cannot be checked
+/// anywhere a distribution is required. See [`RemoteLink::wsl`].
+fn wsl_link_argv<'a>(server: &'a str, channel: RouteChannel) -> Vec<&'a str> {
+    let mut argv = vec![server, "--stdio"];
+    if channel == RouteChannel::Pane {
+        argv.push("--pane");
+    }
+    argv
 }
 
 fn spawn_stdio(program: &str, args: &[&str]) -> io::Result<ProcessStream> {
@@ -467,6 +499,26 @@ impl std::fmt::Debug for RemoteLink {
 mod tests {
     use super::*;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// **A WSL pane asks for the pane socket.** The remote listens twice and
+    /// answers only the dialect it was asked for, so a pane that reaches the
+    /// control socket writes its `Spawn` and is answered with nothing at all —
+    /// the workspace connects, the window opens, and the pane inside it says it
+    /// cannot reach the machine. Nothing in the transport reports an error,
+    /// which is why this is pinned here rather than left to the one integration
+    /// path that would catch it.
+    #[test]
+    fn only_a_pane_link_asks_for_the_pane_socket() {
+        let server = "/home/me/.local/share/tty7/bin/tty7-server-26.7.6";
+        assert_eq!(
+            wsl_link_argv(server, RouteChannel::Control),
+            vec![server, "--stdio"]
+        );
+        assert_eq!(
+            wsl_link_argv(server, RouteChannel::Pane),
+            vec![server, "--stdio", "--pane"]
+        );
+    }
 
     /// A child process's stdio really is a duplex stream: bytes written reach
     /// the child's stdin and its stdout comes back, through the same

--- a/crates/tty7-core/src/daemon/router.rs
+++ b/crates/tty7-core/src/daemon/router.rs
@@ -1185,9 +1185,12 @@ async fn open_link(
                     )
                 }
             };
+            // `setup.channel`, not `Control`: which of the remote's two sockets
+            // this stream is for is carried by the header, and WSL is the one
+            // transport that builds its own argv — see [`RemoteLink::wsl`].
             let link = match (header.server_command.as_deref(), resolved.as_deref()) {
-                (Some(command), _) => RemoteLink::wsl_shell(distro, command)?,
-                (None, Some(binary)) => RemoteLink::wsl(distro, binary)?,
+                (Some(command), _) => RemoteLink::wsl_shell(distro, command, setup.channel)?,
+                (None, Some(binary)) => RemoteLink::wsl(distro, binary, setup.channel)?,
                 (None, None) => unreachable!("resolved is Some whenever there is no override"),
             };
             Ok((link, None))

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -573,8 +573,7 @@ pub(super) enum LoopbackPlan {
     Direct,
     /// A remote whose `localhost` *is* the client's — WSL shares the network
     /// namespace with its Windows host (the exception). No forward is
-    /// built; the original URL already resolves. Wired now so M8 only has to
-    /// start constructing `RemoteTarget::Wsl`.
+    /// built; the original URL already resolves.
     NoForwardNeeded,
     /// A native-SSH pane ("连一下"): forward on the pane's own connection, owned
     /// by the pane, torn down with it.
@@ -7161,7 +7160,7 @@ mod tests {
 
     /// **The WSL exception.** WSL shares `localhost` with its
     /// Windows host, so the URL already resolves — building a forward would be
-    /// pure overhead. Wired now; M8 supplies the target.
+    /// pure overhead.
     #[test]
     fn wsl_workspace_needs_no_forward() {
         let w = ws(

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1003,6 +1003,10 @@ impl Tty7App {
         // at a different build, and the consent handler that the install path
         // asks before writing a binary onto someone else's machine.
         crate::ui::remote_connect::register(cx);
+        // Enumerate this computer's WSL distributions once at startup so the
+        // first switcher open already lists them, rather than filling them in a
+        // beat later. Backgrounded; a no-op off Windows.
+        crate::ui::remote_connect::sweep_wsl(cx);
         Self::prompt_remote_daemon_mismatch(window, cx);
         // A window that came back on a remote workspace has its last-pulled
         // layout but no connection yet. Reconnecting is M6's; this is the seam

--- a/src/ui/remote_connect.rs
+++ b/src/ui/remote_connect.rs
@@ -240,7 +240,9 @@ fn wsl_choices(names: &[String]) -> Vec<HostChoice> {
 /// The same shape `terminal::pane_liveness` uses for the machine answers drawn
 /// two rows above these.
 #[derive(Default)]
-pub struct WslDistros {
+struct WslDistros {
+    /// The last list a probe actually produced. A probe that could not answer
+    /// leaves it alone — see [`sweep_wsl`].
     names: Vec<String>,
     /// When the last probe landed; `None` while none ever has, which is what
     /// makes the first [`sweep_wsl`] run instead of waiting out the TTL.
@@ -264,6 +266,13 @@ const WSL_TTL: Duration = Duration::from_secs(30);
 /// Safe to call from `render` or from an action: it reads the global, may start
 /// background work, and never blocks. Off Windows there are no distributions
 /// and nothing is spawned.
+///
+/// **A probe that could not answer keeps the last list.** `wsl.exe` refuses while
+/// a `wsl --shutdown` is in flight, and overwriting with its empty answer would
+/// make every distribution vanish from the switcher for a TTL — over something
+/// the user runs routinely and that changed nothing. An *authoritative* empty
+/// answer still clears the rows, which is what unregistering the last
+/// distribution has to look like.
 pub fn sweep_wsl(cx: &mut App) {
     if !cfg!(windows) {
         return;
@@ -276,15 +285,11 @@ pub fn sweep_wsl(cx: &mut App) {
     }
     cx.update_global::<WslDistros, _>(|state, _| state.in_flight = true);
     cx.spawn(async move |cx| {
-        let names = cx
-            .background_spawn(async { crate::core::shells::wsl_distros() })
+        let probed = cx
+            .background_spawn(async { crate::core::shells::wsl_distros_probed() })
             .await;
         let _ = cx.update(|cx| {
-            cx.update_global::<WslDistros, _>(|state, _| {
-                state.names = names;
-                state.probed_at = Some(Instant::now());
-                state.in_flight = false;
-            });
+            cx.update_global::<WslDistros, _>(|state, _| adopt_probe(state, probed));
             // The frame that asked for this list is long gone — the answer lands
             // on a background task, and an idle switcher has nothing else that
             // would redraw it.
@@ -292,6 +297,20 @@ pub fn sweep_wsl(cx: &mut App) {
         });
     })
     .detach();
+}
+
+/// Fold a probe result into the state: an answer replaces the list, a probe that
+/// could not answer leaves it standing, and either way the stamp advances so the
+/// TTL governs the next attempt.
+///
+/// Pure, because this is the whole judgement in [`sweep_wsl`] and the rest of it
+/// is a background task on a platform CI cannot run.
+fn adopt_probe(state: &mut WslDistros, probed: Option<Vec<String>>) {
+    if let Some(names) = probed {
+        state.names = names;
+    }
+    state.probed_at = Some(Instant::now());
+    state.in_flight = false;
 }
 
 /// `user@host` — with the port only when it isn't the default, which is the
@@ -1464,5 +1483,38 @@ mod tests {
         let by_kind = filter_hosts(&hosts, "wsl");
         assert_eq!(by_kind.len(), 1);
         assert_eq!(by_kind[0].label, "Ubuntu");
+    }
+
+    /// **A probe that could not answer is not an empty machine list.** `wsl.exe`
+    /// refuses while a `wsl --shutdown` is in flight; adopting that as "you have
+    /// no distributions" would empty the switcher for a TTL over a command that
+    /// changed nothing.
+    #[test]
+    fn a_failed_probe_keeps_the_distros_it_already_had() {
+        let mut state = WslDistros {
+            names: vec!["Ubuntu-24.04".to_string()],
+            ..Default::default()
+        };
+        adopt_probe(&mut state, None);
+
+        assert_eq!(state.names, vec!["Ubuntu-24.04".to_string()]);
+        assert!(state.probed_at.is_some(), "the TTL still restarts");
+        assert!(!state.in_flight, "the next sweep is allowed to run");
+    }
+
+    /// An answer is adopted whole, *including* an empty one — unregistering the
+    /// last distribution has to take its row away, or the picker offers a machine
+    /// that cannot be reached.
+    #[test]
+    fn an_answered_probe_replaces_the_list_even_when_it_is_empty() {
+        let mut state = WslDistros {
+            names: vec!["Ubuntu-24.04".to_string()],
+            ..Default::default()
+        };
+        adopt_probe(&mut state, Some(Vec::new()));
+        assert!(state.names.is_empty());
+
+        adopt_probe(&mut state, Some(vec!["Arch".to_string()]));
+        assert_eq!(state.names, vec!["Arch".to_string()]);
     }
 }

--- a/src/ui/remote_connect.rs
+++ b/src/ui/remote_connect.rs
@@ -27,6 +27,15 @@
 //! entry points use. A machine reachable as an SSH pane is reachable as a
 //! workspace, with nothing to configure twice and nothing to keep in step.
 //!
+//! ## …except WSL, which is configured zero times
+//!
+//! A WSL distribution is the one machine with nothing to
+//! configure: it is reached by spawning `wsl.exe -d <distro> -- tty7-server
+//! --stdio`, so there is no address, no credential and no host key — nothing
+//! that could be set up, and nothing that could be set up wrongly. So it is not
+//! read from a store like the other rows but *discovered*, by [`sweep_wsl`],
+//! and every distro the user has installed is offered.
+//!
 //! ## The connection is routed, not direct
 //!
 //! Design D3: the GUI never speaks SSH. It opens the same local daemon socket it
@@ -39,9 +48,9 @@ use std::collections::HashMap;
 use std::io;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use gpui::{App, Global};
+use gpui::{App, AppContext as _, BorrowAppContext as _, Global};
 
 use crate::core::config::Config;
 use crate::core::session::{RemoteTarget, WorkspaceId};
@@ -70,14 +79,18 @@ pub struct HostChoice {
     pub detail: String,
 }
 
-/// Every machine tty7 already knows how to reach, saved profiles first and
-/// `~/.ssh/config` aliases after.
+/// Every machine tty7 already knows how to reach: saved profiles first, then
+/// this computer's WSL distributions, then `~/.ssh/config` aliases.
 ///
 /// Profiles come first because they are the ones the user built deliberately;
 /// the config aliases are a long tail that is often machine-generated. An alias
 /// whose name matches a profile is dropped rather than listed twice — the
 /// profile carries strictly more (credentials, forwards), so it is the better
 /// of the two rows and the duplicate would only make the list longer.
+///
+/// Distributions sit between the two: installing one is as deliberate as
+/// writing a profile, but the list is *discovered* rather than written, so it
+/// does not outrank the machines the user named by hand.
 pub fn available_hosts(cx: &App) -> Vec<HostChoice> {
     let mut out: Vec<HostChoice> = Vec::new();
     let mut seen: Vec<String> = Vec::new();
@@ -97,6 +110,8 @@ pub fn available_hosts(cx: &App) -> Vec<HostChoice> {
             target,
         });
     }
+
+    out.extend(wsl_hosts(cx));
 
     for imported in crate::core::ssh_config::import_profiles() {
         let alias = imported.profile.name.clone();
@@ -182,6 +197,103 @@ fn local_stdio_host() -> Option<HostChoice> {
     })
 }
 
+/// What the endpoint column says for a distribution. It has no address to
+/// print, so it says what kind of machine it is and where it is instead — and
+/// it doubles as the thing a user typing `wsl` into the search box matches,
+/// since [`host_score`] falls back to this line.
+const WSL_DETAIL: &str = "WSL · this computer";
+
+/// This computer's WSL distributions, as machines a workspace can live on.
+///
+/// Reads [`WslDistros`] and never probes: this runs inside the switcher's
+/// render, and enumerating distros spawns a process. [`sweep_wsl`] is what
+/// fills it.
+fn wsl_hosts(cx: &App) -> Vec<HostChoice> {
+    let names = cx
+        .try_global::<WslDistros>()
+        .map(|state| state.names.as_slice())
+        .unwrap_or_default();
+    wsl_choices(names)
+}
+
+/// The pure half of [`wsl_hosts`]: distro names in, rows out.
+fn wsl_choices(names: &[String]) -> Vec<HostChoice> {
+    names
+        .iter()
+        .map(|distro| HostChoice {
+            target: RemoteTarget::Wsl {
+                distro: distro.clone(),
+            },
+            // The distro name *is* what the user calls it — `wsl -d` takes this
+            // exact string — so there is no friendlier name to look up.
+            label: distro.clone(),
+            detail: WSL_DETAIL.to_string(),
+        })
+        .collect()
+}
+
+/// This computer's WSL distributions, as of the last probe.
+///
+/// A global filled in the background rather than a call, because
+/// [`available_hosts`] runs inside the switcher's render and `wsl.exe -l -q` is
+/// a process spawn — a beat on a warm distribution, much worse on a cold one.
+/// The same shape `terminal::pane_liveness` uses for the machine answers drawn
+/// two rows above these.
+#[derive(Default)]
+pub struct WslDistros {
+    names: Vec<String>,
+    /// When the last probe landed; `None` while none ever has, which is what
+    /// makes the first [`sweep_wsl`] run instead of waiting out the TTL.
+    probed_at: Option<Instant>,
+    /// One probe at a time: the switcher can render many frames inside the
+    /// couple of hundred milliseconds `wsl.exe` takes to answer.
+    in_flight: bool,
+}
+
+impl Global for WslDistros {}
+
+/// How long a distribution list is trusted. Installing or unregistering one is
+/// rare and deliberate, so this is not a poll — it is short enough that someone
+/// who just ran `wsl --install` finds their distro by reopening the switcher
+/// rather than by restarting tty7.
+const WSL_TTL: Duration = Duration::from_secs(30);
+
+/// Re-enumerate this computer's WSL distributions if the list is missing or
+/// stale.
+///
+/// Safe to call from `render` or from an action: it reads the global, may start
+/// background work, and never blocks. Off Windows there are no distributions
+/// and nothing is spawned.
+pub fn sweep_wsl(cx: &mut App) {
+    if !cfg!(windows) {
+        return;
+    }
+    {
+        let state = cx.default_global::<WslDistros>();
+        if state.in_flight || state.probed_at.is_some_and(|at| at.elapsed() < WSL_TTL) {
+            return;
+        }
+    }
+    cx.update_global::<WslDistros, _>(|state, _| state.in_flight = true);
+    cx.spawn(async move |cx| {
+        let names = cx
+            .background_spawn(async { crate::core::shells::wsl_distros() })
+            .await;
+        let _ = cx.update(|cx| {
+            cx.update_global::<WslDistros, _>(|state, _| {
+                state.names = names;
+                state.probed_at = Some(Instant::now());
+                state.in_flight = false;
+            });
+            // The frame that asked for this list is long gone — the answer lands
+            // on a background task, and an idle switcher has nothing else that
+            // would redraw it.
+            cx.refresh_windows();
+        });
+    })
+    .detach();
+}
+
 /// `user@host` — with the port only when it isn't the default, which is the
 /// convention every other endpoint line in the app follows.
 fn endpoint_label(user: &str, host: &str, port: u16) -> String {
@@ -247,15 +359,12 @@ pub fn spec_for(target: &RemoteTarget, cx: &App) -> Result<NativeSshSpec, String
                 cfg.verify_host_keys,
             ))
         }
-        // M8. Named here so the match is total and the message is honest rather
-        // than a silent connect that never arrives.
-        RemoteTarget::Wsl { .. } => {
-            Err("WSL workspaces aren't available in this build yet".to_string())
-        }
         // Both of these address their machine directly; there is no SSH
         // connection to describe, which is exactly what `Err` means to
-        // [`crate::terminal::PaneWorkspace::route_header`] — it reads the target
-        // instead.
+        // [`control_route`] and
+        // [`crate::terminal::PaneWorkspace::route_header`] — they read the
+        // target instead and build a `wsl:` / `stdio:` header from it.
+        RemoteTarget::Wsl { .. } => Err("a WSL workspace has no SSH connection".to_string()),
         RemoteTarget::LocalStdio { .. } => {
             Err("a local --stdio workspace has no SSH connection".to_string())
         }
@@ -1312,5 +1421,48 @@ mod tests {
     fn a_query_nothing_matches_returns_nothing() {
         let hosts = vec![host("gate2jup", "root@18.143.92.244")];
         assert!(filter_hosts(&hosts, "zzz").is_empty());
+    }
+
+    /// A distro row carries the exact string `wsl -d` takes, because that is
+    /// what [`RouteHeader::wsl`](crate::daemon::router::RouteHeader::wsl) will
+    /// be handed and what `wsl:<distro>` keys the machine by. A row whose label
+    /// were prettied up ("Ubuntu 22.04") would connect to nothing.
+    #[test]
+    fn a_wsl_row_names_the_distro_verbatim() {
+        let rows = wsl_choices(&["Ubuntu-22.04".to_string(), "Arch".to_string()]);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].label, "Ubuntu-22.04");
+        assert_eq!(
+            rows[0].target,
+            RemoteTarget::Wsl {
+                distro: "Ubuntu-22.04".to_string()
+            }
+        );
+        assert_eq!(rows[0].target.connection_key(), "wsl:Ubuntu-22.04");
+        assert_eq!(rows[1].label, "Arch");
+    }
+
+    /// Nothing installed is not an empty *section* — it is no section at all,
+    /// which is what keeps the band off a Mac and off a Windows box with no WSL.
+    #[test]
+    fn no_distros_is_no_rows() {
+        assert!(wsl_choices(&[]).is_empty());
+    }
+
+    /// Both ways a user looks for a distro: by its name, and by the kind of
+    /// thing it is. The second only works because the endpoint column says
+    /// `WSL`, and [`host_score`] searches it.
+    #[test]
+    fn a_distro_is_found_by_name_or_by_wsl() {
+        let mut hosts = vec![host("gate2jup", "root@18.143.92.244")];
+        hosts.extend(wsl_choices(&["Ubuntu".to_string()]));
+
+        let by_name = filter_hosts(&hosts, "ubun");
+        assert_eq!(by_name.len(), 1);
+        assert_eq!(by_name[0].label, "Ubuntu");
+
+        let by_kind = filter_hosts(&hosts, "wsl");
+        assert_eq!(by_kind.len(), 1);
+        assert_eq!(by_kind[0].label, "Ubuntu");
     }
 }

--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -260,6 +260,10 @@ impl Tty7App {
         // connect. Idempotent and last-call-wins, exactly as `begin_connect`
         // registered it.
         remote_connect::register(cx);
+        // Re-enumerate this computer's WSL distributions, which are rows in the
+        // band below. TTL'd and backgrounded, so opening the panel twice in a
+        // row costs nothing and opening it once never waits on `wsl.exe`.
+        remote_connect::sweep_wsl(cx);
         // Named, because the field is the panel's only affordance that does not
         // say what it does: a bare magnifier over a list of machines reads as
         // "filter these rows", and it also finds machines that have no row yet.
@@ -503,6 +507,10 @@ impl Tty7App {
     /// friends), which can never host a workspace. Rather than guess which is
     /// which (guess wrong and the user cannot reach their own box), the panel
     /// sorts by *whether it has been used* and folds the rest away.
+    ///
+    /// The WSL distributions installed on this computer land here too, for the
+    /// same reason and with the same handling: until one has hosted a
+    /// workspace, it is a machine the user *could* use, not one they do.
     fn other_hosts(&self, groups: &[Group], cx: &App) -> Vec<HostChoice> {
         let known: HashSet<&str> = groups.iter().map(|g| g.key.as_str()).collect();
         remote_connect::available_hosts(cx)
@@ -1380,7 +1388,9 @@ impl Tty7App {
                     GUTTER,
                     Icon::new(IconName::Globe).size(px(ICON)).text_color(dim),
                 ))
-                .child(div().text_sm().text_color(muted).child("Other SSH Hosts"))
+                // Not "Other SSH Hosts": a WSL distribution is in this band and
+                // is reached by spawning `wsl.exe`, with no SSH anywhere.
+                .child(div().text_sm().text_color(muted).child("Other Machines"))
                 .child(div().flex_1())
                 .child(
                     div()


### PR DESCRIPTION
Wires this computer's WSL distributions into the machine picker, and fixes the two things that stopped one from working once you could select it.

The WSL half of remote workspaces (design §7.3, §12 — transport, installer, router target, `RemoteKind::Wsl`) has been in the tree since #235, but nothing outside tests ever constructed a `RemoteTarget::Wsl`, so none of it was reachable. Exercising it turned up two bugs that could not have been found any other way.

## The picker

`available_hosts` now returns every installed distribution, between the saved SSH profiles and the `~/.ssh/config` aliases — installing one is as deliberate as writing a profile, but the list is *discovered* rather than written, so it does not outrank the machines named by hand.

- The row is labelled exactly what `wsl -d` takes, since that string is also the connection key (`wsl:<distro>`); the endpoint column reads `WSL · this computer`, which is what makes searching for `wsl` find them all.
- `core::shells::wsl_distros` comes out of `cfg(test)` and answers empty off Windows, so the new-tab dropdown and the switcher enumerate through one function and cannot disagree.
- It spawns `wsl.exe`, and `available_hosts` runs inside the switcher's render, so the list is a global filled by a backgrounded, TTL'd `sweep_wsl` — the shape `terminal::pane_liveness` already uses for the machine answers drawn two rows above these. Swept at startup and on every open, so `wsl --install` shows up on reopening the panel rather than on a restart.
- `spec_for`'s WSL arm no longer says "not available in this build yet"; it says there is no SSH connection to describe, which is what that `Err` has always meant to the routed paths. The band is now "Other Machines", since a distribution reached by spawning `wsl.exe` is sitting in it.

## `fix(wsl): hold the launch open until the daemon has detached`

WSL reaps what an interop session started the moment its `wsl.exe` exits, and `setsid` does not make the child safe instantly. The launch line backgrounds the daemon and returns in milliseconds, so it died before binding — surfacing as `ensure_daemon`'s *"started but nothing was answering on the control socket after 15s"* over a correctly installed binary.

Reproduced by running the launch line alone against Ubuntu-24.04: nothing after it, daemon gone; `sleep 0.3` after it, daemon lives. `nohup`, `setsid --fork` and a double-forked subshell all die identically, so the wait is the fix, not a different detach. Deliberately **not** a wait for the socket — `ensure_daemon` only launches when the socket did not answer, and the usual reason is a stale socket file, which a `-S` test would pass on. SSH is untouched.

## `fix(wsl): send a pane to the remote's pane socket`

The remote listens twice and the dialects are not interchangeable; `--pane` decides which socket a stream lands on. SSH adds it via `RouteChannel::bridge_command`, `LocalStdio` adds it in `PaneWorkspace::route_header` (its argv is verbatim) — `RemoteLink::wsl` dropped `setup.channel` and always built `[binary, "--stdio"]`.

A WSL pane therefore reached the *control* socket, wrote its `Spawn` and got nothing back — `routed connection closed after 56 up / 0 down bytes`. The workspace connected, the window opened, and the pane inside said it could not reach the machine. `PaneWorkspace::route_header` already documents this exact failure shape; WSL was never wired to it. Fixed where WSL builds its argv, with `wsl_shell` routing its override through `bridge_command` so an escape hatch cannot lose the dialect.

## Test plan

- `cargo test --bin tty7` — 665 passed
- `cargo test -p tty7-core --lib`, run inside Ubuntu-24.04 (this crate's test target needs NASM on Windows) — 668 passed, 1 ignored
- `cargo fmt --check`, `.github/scripts/check-host-boundary.sh` — clean
- New tests: the pane/control argv split (`only_a_pane_link_asks_for_the_pane_socket`), the settle wait against a real `sh` (`the_settle_wait_really_holds_the_invocation_open`, `the_launch_script_keeps_the_launch_and_appends_the_wait`), and the picker rows (verbatim distro name + connection key, empty list, found by name or by `wsl`)
- **End to end on Ubuntu-24.04**: picked from the switcher, consented to the install, workspace connected, pane spawned. `ps` inside the distro shows `tty7-server --stdio --pane` and a `bash -i` under the daemon; the routed connection logs `5 up / 69 down bytes` and the workspace record carries `cwd: /home/thomas, pane_id: 1`.

## Not covered

Only Windows release builds bundle the Linux `tty7-server` (`bundle-windows.ps1` stages it at `server/`), so a `cargo build` cannot serve a distribution — it fails at connect time naming the directories it searched, which is what §12 asks for. For local testing, point `TTY7_BUNDLED_SERVER_DIR` at a `tty7-server` built for Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)