### PR TITLE
fix(ui): safe delete prompt default, platform-aware reveal labels, and searchable agent settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   involved something in the Wayland presentation path, were not reproducible on
   macOS and are not claimed to be confirmed. (#243)
 
+- **Return no longer confirms the file tree's delete prompt** — it was the only
+  destructive prompt in tty7 with the destructive action first, and on macOS
+  (NSAlert) and Windows (TaskDialog) the first button is the Return-key
+  default, so pressing Return deleted — recursive folder deletion included. The
+  buttons now put the safe option first, matching every other destructive
+  prompt, with Escape still cancelling. Linux uses gpui's click-only fallback
+  dialog, so the swap only reorders the buttons there.
+
+- **"Finder" is no longer named on Linux and Windows** — the file-tree context
+  menu and the SFTP job list's reveal tooltip hardcoded Finder-flavoured
+  labels on every platform; only the Info row's button was conditional. All
+  three sites now share that one conditional, so the action reads "Reveal in
+  Finder" on macOS and "Open Folder" everywhere else. On macOS the SFTP
+  tooltip's "Show in Finder" becomes "Reveal in Finder" too, retiring a third
+  name for the same action.
+
+- **Grok Build turns up in settings search** — the agent renders a Settings →
+  Agents row but had no search-index entry, so searching could never surface
+  it. The other five agent entries had drifted from what their rows actually
+  say ("Claude Code hooks" for a row titled "Claude Code"), as had "Option
+  acts as Meta" from the rendered "Option (⌥) acts as Meta"; the index titles
+  now match the rows, the mechanism words (hooks / plugin / extension) stay
+  behind as search keywords, and a test derives the Agents index from the
+  agent list so a future agent can't ship unsearchable.
+
 ## [26.7.6] - 2026-07-28
 
 ### Added

--- a/src/ui/file_tree.rs
+++ b/src/ui/file_tree.rs
@@ -2058,7 +2058,7 @@ impl Tty7App {
                     cx.write_to_clipboard(gpui::ClipboardItem::new_string(p.display().to_string()));
                 }
             }))
-            .item(PopupMenuItem::new("Reveal in Finder").on_click({
+            .item(PopupMenuItem::new(crate::ui::right_panel::reveal_label()).on_click({
                 let p = p.clone();
                 move |_, _window, cx| {
                     cx.reveal_path(&p);

--- a/src/ui/file_tree.rs
+++ b/src/ui/file_tree.rs
@@ -1602,11 +1602,14 @@ impl Tty7App {
             PromptLevel::Warning,
             &format!("Delete \"{name}\"?"),
             Some(detail),
-            &["Delete", "Cancel"],
+            // Safe option first: the leading button is the Return-key default on
+            // macOS (NSAlert) and Windows (TaskDialog); "Cancel" is what gpui maps
+            // to the Escape key.
+            &["Cancel", "Delete"],
             cx,
         );
         cx.spawn_in(window, async move |app, cx| {
-            let Ok(0) = answer.await else { return };
+            let Ok(1) = answer.await else { return };
             let _ = app.update_in(cx, |app, window, cx| {
                 let Some(host) = app.active_host(cx) else {
                     return;

--- a/src/ui/file_tree.rs
+++ b/src/ui/file_tree.rs
@@ -2058,12 +2058,14 @@ impl Tty7App {
                     cx.write_to_clipboard(gpui::ClipboardItem::new_string(p.display().to_string()));
                 }
             }))
-            .item(PopupMenuItem::new(crate::ui::right_panel::reveal_label()).on_click({
-                let p = p.clone();
-                move |_, _window, cx| {
-                    cx.reveal_path(&p);
-                }
-            }));
+            .item(
+                PopupMenuItem::new(crate::ui::right_panel::reveal_label()).on_click({
+                    let p = p.clone();
+                    move |_, _window, cx| {
+                        cx.reveal_path(&p);
+                    }
+                }),
+            );
 
         menu = menu.separator().item(dotfiles_menu_item(show_hidden, app));
 

--- a/src/ui/right_panel.rs
+++ b/src/ui/right_panel.rs
@@ -706,11 +706,7 @@ impl Tty7App {
     /// clipboard. An "open in $EDITOR" button would need a picker, a stored
     /// choice and a settings page to change it; that's a feature, not a row.
     fn cwd_actions(&self, cwd: PathBuf, cx: &mut Context<Self>) -> AnyElement {
-        let reveal_label = if cfg!(target_os = "macos") {
-            "Reveal in Finder"
-        } else {
-            "Open Folder"
-        };
+        let reveal_label = reveal_label();
         h_flex()
             .gap(px(2.))
             .px(px(tile_trailing_inset_sm()))
@@ -1475,6 +1471,18 @@ pub(crate) fn info_chip(
         .text_color(fg)
         .child(text.to_string())
         .into_any_element()
+}
+
+/// The label for revealing a path in the OS file manager: only macOS has a
+/// "Finder", so everywhere else it's the generic "Open Folder". Shared by the
+/// Info row, the file-tree context menu and the SFTP job list so the action
+/// carries one name per platform.
+pub fn reveal_label() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "Reveal in Finder"
+    } else {
+        "Open Folder"
+    }
 }
 
 /// The one-word status the Info row shows next to the agent's name.

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -5652,10 +5652,9 @@ mod tests {
     fn agent_rows_are_in_the_search_index() {
         for agent in crate::core::agent_hooks::HookAgent::ALL {
             assert!(
-                settings_search_entries()
-                    .iter()
-                    .any(|e| e.section == SettingsSection::Agents
-                        && e.title == agent.display_name()),
+                settings_search_entries().iter().any(
+                    |e| e.section == SettingsSection::Agents && e.title == agent.display_name()
+                ),
                 "no Agents index entry titled {:?}",
                 agent.display_name()
             );

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -271,7 +271,7 @@ fn settings_search_entries() -> &'static [SearchEntry] {
         SearchEntry {
             section: Input,
             title: "Option (⌥) acts as Meta",
-            keywords: "alt keyboard modifier escape macos option meta",
+            keywords: "alt keyboard modifier escape macos option meta option acts as meta",
         },
         SearchEntry {
             section: Input,

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -270,7 +270,7 @@ fn settings_search_entries() -> &'static [SearchEntry] {
         },
         SearchEntry {
             section: Input,
-            title: "Option acts as Meta",
+            title: "Option (⌥) acts as Meta",
             keywords: "alt keyboard modifier escape macos option meta",
         },
         SearchEntry {
@@ -311,30 +311,38 @@ fn settings_search_entries() -> &'static [SearchEntry] {
             keywords: "ssh tunnel local remote dynamic socks forward rule",
         },
         // ── Agents ──────────────────────────────────────────────────────────
+        // Titles mirror `HookAgent::display_name()`, which is what each row is
+        // rendered with; the mechanism word (hooks/plugin/extension) lives in
+        // `keywords`. Pinned by `agent_rows_are_in_the_search_index`.
         SearchEntry {
             section: Agents,
-            title: "Claude Code hooks",
-            keywords: "agent integration install uninstall status rich session working waiting tab bar sidebar badge claude",
+            title: "Claude Code",
+            keywords: "agent integration hooks install uninstall status rich session working waiting tab bar sidebar badge claude",
         },
         SearchEntry {
             section: Agents,
-            title: "Codex hooks",
-            keywords: "agent integration install openai codex",
+            title: "Codex",
+            keywords: "agent integration hooks install openai codex",
         },
         SearchEntry {
             section: Agents,
-            title: "Copilot CLI hooks",
-            keywords: "agent integration install github copilot",
+            title: "Copilot CLI",
+            keywords: "agent integration hooks install github copilot",
         },
         SearchEntry {
             section: Agents,
-            title: "OpenCode plugin",
-            keywords: "agent integration install opencode",
+            title: "OpenCode",
+            keywords: "agent integration plugin install opencode",
         },
         SearchEntry {
             section: Agents,
-            title: "Pi extension",
-            keywords: "agent integration install pi",
+            title: "Pi",
+            keywords: "agent integration extension install pi",
+        },
+        SearchEntry {
+            section: Agents,
+            title: "Grok Build",
+            keywords: "agent integration hooks install xai grok build",
         },
         // ── Window & Tabs ───────────────────────────────────────────────────
         SearchEntry {
@@ -5625,10 +5633,31 @@ mod tests {
             "Tab completion",
             "History search",
             "Dim inactive panes",
+            "Option (⌥) acts as Meta",
         ] {
             assert!(
                 settings_search_entries().iter().any(|e| e.title == title),
                 "no index entry titled {title:?}"
+            );
+        }
+    }
+
+    /// The Agents rows are titled by [`HookAgent::display_name`], so the index
+    /// is derived rather than pinned: every hook-capable agent must have an
+    /// Agents-section entry under exactly that name. Adding an agent to
+    /// `HookAgent::ALL` without indexing it — how Grok Build became
+    /// unsearchable — fails here, as does renaming an agent without moving its
+    /// index entry.
+    #[test]
+    fn agent_rows_are_in_the_search_index() {
+        for agent in crate::core::agent_hooks::HookAgent::ALL {
+            assert!(
+                settings_search_entries()
+                    .iter()
+                    .any(|e| e.section == SettingsSection::Agents
+                        && e.title == agent.display_name()),
+                "no Agents index entry titled {:?}",
+                agent.display_name()
             );
         }
     }

--- a/src/ui/sftp.rs
+++ b/src/ui/sftp.rs
@@ -1816,7 +1816,7 @@ impl Tty7App {
                                 .icon(IconName::FolderOpen)
                                 .xsmall()
                                 .ghost()
-                                .tooltip("Show in Finder")
+                                .tooltip(crate::ui::right_panel::reveal_label())
                                 .on_click(cx.listener(move |this, _, _w, cx| {
                                     this.sftp_reveal_download(local.clone(), cx)
                                 })),


### PR DESCRIPTION
## Intent

Three small, independent fixes from the tty7 copy audit, scoped deliberately to just these three (the audit's larger copy rewrite is NOT authorised and none of it is included). (1) Safety: the file-tree delete confirmation (src/ui/file_tree.rs) was the only destructive prompt in tty7 with the destructive action first — on macOS (NSAlert) and Windows (TaskDialog) the first button is the Return-key default, so Return deleted, including recursive folder deletion. Swapped to &["Cancel", "Delete"] and Ok(1); the literal string Cancel is deliberate because gpui maps only "cancel" to PromptButton::Cancel, which carries the Escape key. Linux was verified: both X11 and Wayland return None from prompt() and fall back to gpui's click-only renderer, so the swap only reorders buttons there. (2) The file-tree context menu and the SFTP job tooltip hardcoded Finder-flavoured labels shown on Linux/Windows too; the existing platform-conditional in right_panel.rs was extracted into pub fn reveal_label() and reused at all three sites rather than writing a second conditional. Deliberate side effect: the SFTP tooltip's 'Show in Finder' becomes 'Reveal in Finder' on macOS — that convergence is exactly what sharing the helper produces and was sanctioned by the task. No other action renames were made (the audit's wider naming convergence is out of scope). (3) The Grok Build agent renders a settings row but had no search-index entry, so it was unreachable by settings search. Added the entry; aligned the five other agent index titles to HookAgent::display_name() (the mechanism words hooks/plugin/extension moved into keywords, which is how the index disambiguates everything else) and 'Option acts as Meta' to the rendered 'Option (⌥) acts as Meta'. Extended the tests as the task required: the pinned-title test gains the Option row, and a new test derives the Agents index entries from HookAgent::ALL so a future agent added without an index entry, or renamed without moving its entry, fails the suite. All 766 tty7 unit tests pass and clippy is clean. Note: --skip=test is mandatory on this machine because the pipeline's test step builds and launches the GUI for screenshot evidence, which would steal the owner's focus; unit tests were run manually instead. Visual acceptance is the owner's.

## What Changed

- The file-tree delete confirmation now lists `Cancel` before `Delete`, so on macOS and Windows the Return-key default cancels instead of deleting; `Cancel` also keeps the Escape-key binding via gpui's `PromptButton::Cancel` mapping. On Linux the native prompt falls back to gpui's click-only renderer, so only the button order changes.
- The platform-conditional reveal label in `right_panel.rs` was extracted into `pub fn reveal_label()` and reused by the file-tree context menu and the SFTP job tooltip, which previously hardcoded Finder-flavoured labels on Linux and Windows. As a side effect of sharing the helper, the SFTP tooltip on macOS now reads "Reveal in Finder" instead of "Show in Finder".
- The Grok Build agent's settings row, which had no search-index entry and was unreachable via settings search, is now indexed. The five other agent index titles were re-aligned to `HookAgent::display_name()` (with the hooks/plugin/extension mechanism words moved into keywords), the "Option acts as Meta" entry was aligned to the rendered "Option (⌥) acts as Meta" with plain-text keywords added so typing the label without the glyph still matches (a review-pass fix), and tests were extended: the pinned-title test covers the Option row, and a new test derives the Agents entries from `HookAgent::ALL` so a future agent without an index entry fails the suite. The changelog documents all three fixes.

## Risk Assessment

✅ Low: The only delta since round 1 is the requested one-line keywords addition, which verifiably restores the glyph-skipping phrase queries under entry_matches's lowercase substring matching while keeping the intent-required title unchanged.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/ui/settings.rs:273` - Settings search uses whole-query substring matching (entry_matches at src/ui/settings.rs:422-424: query must be a contiguous substring of title or keywords). Retitling the index entry from &#34;Option acts as Meta&#34; to &#34;Option (⌥) acts as Meta&#34; inserts &#34;(⌥)&#34; mid-phrase, so a user who types the visible row label while skipping the glyph — &#34;option acts as meta&#34; or &#34;option acts&#34; — now gets zero matches where the old title matched. The keywords string (&#34;alt keyboard modifier escape macos option meta&#34;) does not contain the phrase either. Fix: add &#34;option acts as meta&#34; to that entry&#39;s keywords (keywords are an invisible synonym bag, so this preserves the intent-required title alignment). The agent-entry renames do not have this problem in practice because the old index titles (&#34;Claude Code hooks&#34; etc.) were never rendered, so users have no reason to type them.

🔧 Fix: add plain search keywords for Option-acts-as-Meta entry
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
