### PR TITLE
fix(transport): bound the Windows test hang — no unbounded loopback accept, and CI timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,23 @@ on:
   pull_request:
   workflow_dispatch:
 
+# A superseded PR run is dead weight the moment the next push lands, and a run
+# left going is not free: the account's concurrent-job budget is shared, and
+# macOS slots are the scarce ones. A zombie Windows job (see the `Test` step's
+# timeout below) once held a slot for the full six-hour job limit while an
+# unrelated PR's macOS job queued behind it for two and a half hours.
+#
+# Pushes to main are exempt: each commit's own run is the record of whether that
+# commit was green, and cancelling one to start the next would erase it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   fmt:
     name: rustfmt
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -36,6 +49,7 @@ jobs:
   host-boundary:
     name: host boundary
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - run: bash .github/scripts/check-host-boundary.sh
@@ -53,6 +67,10 @@ jobs:
           - runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
     runs-on: ${{ matrix.runner }}
+    # Backstop under the per-step timeouts below. Without any timeout at all a
+    # hung test runs to GitHub's six-hour job limit, which is how a 90-second
+    # step turned into a six-hour one three times in a day.
+    timeout-minutes: 60
     steps:
       - name: Checkout tty7
         uses: actions/checkout@v4
@@ -88,10 +106,44 @@ jobs:
       # build too; only nightly stays unlocked, because it stamps Cargo.toml's
       # version and relies on cargo refreshing the lock's own root entry.
       - name: Build
+        # Cold-cache builds have been observed at ~10 min; warm ones at ~90s.
+        timeout-minutes: 30
         run: cargo build --locked --target ${{ matrix.target }}
 
+      # `cargo test` has no timeout of its own, so one hung test is
+      # indistinguishable from a slow suite until the job hits GitHub's six-hour
+      # limit. The Windows suite intermittently hangs here — roughly one run in
+      # ten, on any branch, while the same commit passes on a re-run — and every
+      # time it did, the job held a runner slot for hours and reported nothing.
+      #
+      # The step's honest budget is small: ~75s warm and ~3.5 min when this step
+      # also has to compile the test targets, on every platform. 20 minutes is
+      # pure headroom, so a trip means a hang, not a slow runner.
       - name: Test
+        timeout-minutes: 20
         run: cargo test --locked --target ${{ matrix.target }}
+
+      # What the hang has never left behind: any indication of *which* test was
+      # stuck. libtest prints a test's name when it finishes, so a hung one is
+      # the one name missing from a truncated list. The process table has the
+      # answer instead — the surviving test binary names its crate and test
+      # target — so grab it while the runner is still up.
+      #
+      # Windows-only because that is the only platform this has happened on, and
+      # `failure()` rather than `always()` so a green run stays quiet.
+      - name: Which test was still running (Windows post-mortem)
+        if: failure() && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Write-Host '--- processes under the build/test tree ---'
+          Get-CimInstance Win32_Process |
+            Where-Object { $_.CommandLine -match 'target\\|tty7|cargo' } |
+            Select-Object ProcessId, ParentProcessId, Name, CommandLine |
+            Format-List
+          Write-Host '--- top 15 by working set ---'
+          Get-Process | Sort-Object -Descending WorkingSet64 |
+            Select-Object -First 15 Id, Name, @{n='WS_MB';e={[int]($_.WorkingSet64/1MB)}} |
+            Format-Table -AutoSize
 
   # Static musl builds of the headless server binary that remote workspaces push
   # onto the far machine (decision D10).
@@ -107,6 +159,7 @@ jobs:
   server-musl:
     name: tty7-server musl (${{ matrix.target }})
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/crates/tty7-core/src/daemon/transport.rs
+++ b/crates/tty7-core/src/daemon/transport.rs
@@ -638,6 +638,62 @@ mod imp_windows {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use std::time::{Duration, Instant};
+
+        /// How long a loopback client gets to show up. Generous on purpose — the
+        /// client is a thread in this same process dialling 127.0.0.1 — so a trip
+        /// means the client is never coming, not that the runner is slow.
+        const CLIENT_WITHIN: Duration = Duration::from_secs(10);
+
+        /// `accept()` with a deadline, and a read timeout on what it returns.
+        ///
+        /// Both halves matter, and neither is available on the blocking calls
+        /// these tests would otherwise make. Every client below is a thread that
+        /// `unwrap()`s its `connect`: when one of those panics — a transient
+        /// loopback refusal on a loaded runner is enough — a plain
+        /// `listener.accept()` has nothing left to wake it, and the handshake read
+        /// after it has nothing left to feed it. The test does not fail. The whole
+        /// test binary stops, `cargo test` never returns, and CI bills six hours
+        /// for a step that takes seventy-five seconds.
+        ///
+        /// That is not hypothetical: it happened three times in one day, and
+        /// because libtest only names a test once it *finishes*, no log ever said
+        /// which one. These tests are `cfg(windows)`, so a developer's macOS
+        /// `cargo test` never runs them and CI is the only place they execute.
+        fn accept_within(listener: &TcpListener) -> TcpStream {
+            listener
+                .set_nonblocking(true)
+                .expect("put the listener in polling mode");
+            let deadline = Instant::now() + CLIENT_WITHIN;
+            let accepted = loop {
+                match listener.accept() {
+                    Ok((stream, _)) => break stream,
+                    Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                        assert!(
+                            Instant::now() < deadline,
+                            "no client connected within {CLIENT_WITHIN:?}; the \
+                             client thread most likely panicked, and without this \
+                             deadline this test would hang until CI's job limit"
+                        );
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(e) => panic!("accept failed: {e}"),
+                }
+            };
+            listener
+                .set_nonblocking(false)
+                .expect("restore the listener to blocking");
+            // Winsock gives an accepted socket the listening socket's blocking
+            // mode, so this is a real change rather than a no-op: the handshake
+            // read must block, but only for a bounded time.
+            accepted
+                .set_nonblocking(false)
+                .expect("the accepted socket must block");
+            accepted
+                .set_read_timeout(Some(CLIENT_WITHIN))
+                .expect("bound the handshake read too");
+            accepted
+        }
 
         /// A token round-trips through hex encode → decode unchanged.
         #[test]
@@ -722,7 +778,7 @@ mod imp_windows {
                 s.write_all(&token).unwrap();
                 s
             });
-            let (mut server_side, _) = listener.accept().unwrap();
+            let mut server_side = accept_within(&listener);
             assert!(authenticate_with(&mut server_side, &token).is_ok());
             let _keep = good.join().unwrap();
 
@@ -733,7 +789,7 @@ mod imp_windows {
                 let mut s = TcpStream::connect(loopback(port)).unwrap();
                 let _ = s.write_all(&bad_token);
             });
-            let (mut server_side2, _) = listener.accept().unwrap();
+            let mut server_side2 = accept_within(&listener);
             assert!(authenticate_with(&mut server_side2, &token).is_err());
             bad.join().unwrap();
         }
@@ -769,7 +825,7 @@ mod imp_windows {
             // proof of same-user, which is what filesystem permissions give the
             // Unix socket for free.
             let good = std::thread::spawn(move || connect_endpoint(CONTROL).unwrap());
-            let (mut server_side, _) = listener.accept().unwrap();
+            let mut server_side = accept_within(&listener);
             assert!(check_endpoint_token(&mut server_side, &token).is_ok());
             let _keep = good.join().unwrap();
 
@@ -781,7 +837,7 @@ mod imp_windows {
                 let mut s = TcpStream::connect(loopback(port)).unwrap();
                 let _ = s.write_all(&foreign);
             });
-            let (mut server_side, _) = listener.accept().unwrap();
+            let mut server_side = accept_within(&listener);
             assert_eq!(
                 check_endpoint_token(&mut server_side, &token)
                     .unwrap_err()
@@ -822,7 +878,7 @@ mod imp_windows {
                 s.write_all(&token).unwrap();
                 s
             });
-            let (mut server_side, _) = listener.accept().unwrap();
+            let mut server_side = accept_within(&listener);
             assert!(authenticate(&mut server_side).is_ok());
             let _keep = good.join().unwrap();
 


### PR DESCRIPTION
The Windows `Test` step intermittently hangs and, because `cargo test` has no timeout of its own, every occurrence runs to GitHub's six-hour job limit. This removes the one Windows-only cluster of unbounded waits that matches every symptom, and adds the guardrails that make the next hang — from anywhere — cost twenty minutes and leave evidence.

## What was happening

| Run | Branch | Windows `Test` | Outcome |
|---|---|---|---|
| `30444149675` | `feat/remote-reopen-whole` | 5h 50m | cancelled at the job limit |
| `30502566782` | `feat/daemon-workspace-tree` | 3h 43m | `the hosted runner lost communication with the server` |
| `30513851385` | `main` | 1h 12m | cancelled by hand |

The same step across the other ~26 runs in that window: **75 seconds warm, 3.5 minutes when it also compiles the test targets** — on every platform, including the branches above. Two costs beyond the wall-clock: the job reported *nothing* about which test was stuck, and while the zombies held slots an unrelated PR's macOS job queued **2h 24m** before it could start.

It is not a recent regression. `feat/daemon-workspace-tree` passed this step in 74 seconds on the same commit that later hung, and the earliest occurrence predates that branch entirely.

## The unbounded waits

`daemon/transport.rs`'s test module — inside `#[cfg(windows)] mod imp_windows`, so **only** Windows runs it and no developer's macOS `cargo test` ever does — held five `listener.accept().unwrap()` calls, each paired with a client thread that `unwrap()`s its `connect`:

```rust
let good = std::thread::spawn(move || {
    let mut s = TcpStream::connect(loopback(port)).unwrap();  // panics here…
    s.write_all(&token).unwrap();
    s
});
let (mut server_side, _) = listener.accept().unwrap();        // …and nothing wakes this
```

When that thread panics — a transient loopback refusal on a loaded runner is enough — nothing is left to wake the accept, and nothing is left to feed the handshake read after it. The test does not fail. The whole test binary stops. libtest names a test only once it *finishes*, which is why no log ever said which one.

The Unix half of the same module documents the sibling hazard and structurally avoids it — *"One test drives the whole endpoint lifecycle so the shared `daemon.sock` file isn't raced by parallel tests"* — but the Windows half never got the equivalent bound on its waits.

## Before / After

| | Before | After |
|---|---|---|
| A client thread that never connects | `accept()` blocks forever; test binary hangs | Fails in 10s naming the deadline it missed |
| Handshake read with no bytes coming | Blocks forever | Read timeout, bounded by the same 10s |
| A hung `Test` step (from anywhere) | Runs to the 6-hour job limit | Step fails at 20 minutes |
| A hung `Build` step | Same | Fails at 30 minutes |
| Anything else wedging a `build` job | Same | 60-minute job backstop |
| Diagnosing a future hang | Nothing in the log | Windows-only post-mortem dumps the process table on failure; the surviving test binary names its crate and test target |
| Pushing twice to a PR | Both runs keep going, both hold runner slots | The superseded run is cancelled |
| Pushing to `main` | — | Unchanged; each commit's run is the record of whether that commit was green |

`accept_within` polls a non-blocking listener against the deadline, then restores blocking mode and sets a read timeout on the accepted socket. Winsock hands an accepted socket the listening socket's blocking mode, so clearing it on the returned stream is a real step rather than a no-op.

## Honest limits

Whether these accepts are the exact hang CI hit is **unproven**. It cannot be reproduced off a Windows runner, and the Windows target will not even `cargo check` on a mac — `aws-lc-sys` wants the Windows SDK's `windows.h`. What is established: this is the only Windows-only cluster of unbounded network waits in the tree, and it matches every observed property (Windows-only, intermittent, mute, predating the branches it appeared on). The CI guardrails cover the case where it is something else.

## Testing

- The new helper's logic is platform-independent std code, so it was verified on the host target: a real client is still accepted and its handshake read still works, and a client that never arrives fails in **10.002s** instead of never.
- `cargo fmt --check` clean. The five call sites are the only behavioural change to the tests; each returns the same `TcpStream` the destructured `accept()` did.
- CI on this branch: all seven checks green, Windows `Build` 7m47s (cold cache) and `Test` 2m17s — both well inside the new budgets, and the post-mortem step correctly skipped.
- The post-mortem step itself is only exercised by a real Windows failure, and is guarded by `failure() && runner.os == 'Windows'`, so it cannot affect a green run.
