### PR TITLE
fix(ui): the routed-auth test no longer hangs, and no longer loses its prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,9 +112,13 @@ jobs:
 
       # `cargo test` has no timeout of its own, so one hung test is
       # indistinguishable from a slow suite until the job hits GitHub's six-hour
-      # limit. The Windows suite intermittently hangs here — roughly one run in
-      # ten, on any branch, while the same commit passes on a re-run — and every
-      # time it did, the job held a runner slot for hours and reported nothing.
+      # limit. The suite intermittently hangs here — roughly one run in ten, on
+      # any branch, while the same commit passes on a re-run — and every time it
+      # did, the job held a runner slot for hours and reported nothing.
+      #
+      # Seen on Windows three times and on Linux once, so it is not a
+      # platform-specific test: `Build` succeeds, `Test` starts, and nothing
+      # further is ever written.
       #
       # The step's honest budget is small: ~75s warm and ~3.5 min when this step
       # also has to compile the test targets, on every platform. 20 minutes is
@@ -123,27 +127,22 @@ jobs:
         timeout-minutes: 20
         run: cargo test --locked --target ${{ matrix.target }}
 
-      # What the hang has never left behind: any indication of *which* test was
-      # stuck. libtest prints a test's name when it finishes, so a hung one is
-      # the one name missing from a truncated list. The process table has the
-      # answer instead — the surviving test binary names its crate and test
-      # target — so grab it while the runner is still up.
+      # There is deliberately no post-mortem step here, and that is worth
+      # recording, because an earlier version of this file had one: on failure it
+      # dumped the process table to find the surviving test binary.
       #
-      # Windows-only because that is the only platform this has happened on, and
-      # `failure()` rather than `always()` so a green run stays quiet.
-      - name: Which test was still running (Windows post-mortem)
-        if: failure() && runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          Write-Host '--- processes under the build/test tree ---'
-          Get-CimInstance Win32_Process |
-            Where-Object { $_.CommandLine -match 'target\\|tty7|cargo' } |
-            Select-Object ProcessId, ParentProcessId, Name, CommandLine |
-            Format-List
-          Write-Host '--- top 15 by working set ---'
-          Get-Process | Sort-Object -Descending WorkingSet64 |
-            Select-Object -First 15 Id, Name, @{n='WS_MB';e={[int]($_.WorkingSet64/1MB)}} |
-            Format-Table -AutoSize
+      # It does not work, and cannot. GitHub kills the step's whole process tree
+      # when `timeout-minutes` trips, *before* the next step runs, so on the one
+      # failure that matters the dump comes back empty — verified on run
+      # 30526538997, where it printed two headers and nothing between them.
+      #
+      # Nor is it needed. libtest already prints "<test> has been running for
+      # over 60 seconds" for a test that has not returned, and that line was
+      # sitting in every hung run all along. The obstacle was never the
+      # diagnostic: a job's log cannot be fetched while the job is in progress
+      # (the API 404s), and nobody cancels a six-hour run to read one. The `Test`
+      # timeout above is what fixes that — the step *fails*, so the log lands,
+      # with the name in it.
 
   # Static musl builds of the headless server binary that remote workspaces push
   # onto the far machine (decision D10).

--- a/src/ui/remote_connect.rs
+++ b/src/ui/remote_connect.rs
@@ -1223,10 +1223,28 @@ mod tests {
                 },
             )
         });
+        // Bounded, because this loop is the difference between a stolen prompt
+        // being a failure and being a *hang*. `AUTH_MAILBOX` is process-global
+        // and `pump_auth_sheets` drains every entry in one pass, so any gpui test
+        // in this binary that drives a tick can take this prompt before the line
+        // below does — and unbounded, this test then spins until CI's six-hour
+        // job limit. It has: a `main` run sat inside this test for 2h50m, and
+        // three Windows runs before it went the same way, none of them naming a
+        // test until the run was cancelled and its partial log read back.
+        let deadline = Instant::now() + Duration::from_secs(10);
         let pending = loop {
             if let Some(p) = take_pending_auth() {
                 break p;
             }
+            assert!(
+                Instant::now() < deadline,
+                "no routed prompt arrived within 10s. `respond` pushes one \
+                 unconditionally, so an empty mailbox means something else \
+                 drained it first — `pump_auth_sheets` takes all of it, and it \
+                 runs from any gpui test here that drives a tick. Responder \
+                 thread finished: {}",
+                handle.is_finished(),
+            );
             std::thread::sleep(Duration::from_millis(5));
         };
         assert_eq!(pending.host, target.host_id());

--- a/src/ui/remote_connect.rs
+++ b/src/ui/remote_connect.rs
@@ -1017,6 +1017,29 @@ pub fn take_pending_auth() -> Option<PendingAuth> {
     AUTH_MAILBOX.lock().ok()?.pop()
 }
 
+/// Whose turn it is to drain [`AUTH_MAILBOX`], for tests only.
+///
+/// The mailbox is process-global, and [`pump_auth_sheets`] takes *every* entry in
+/// one pass — correct for the app, where one tick serves one mailbox, and fatal
+/// in a test binary, where a test waiting for the prompt it just caused shares
+/// that mailbox with every gpui test driving a tick. The prompt gets drained by a
+/// tick that has no idea it was spoken for, and the waiting test never sees it.
+///
+/// So a test that needs its own prompt back claims this first, and the drain
+/// yields while it is held. Compiled out of a release build, where there is one
+/// app, one tick and nothing to arbitrate.
+///
+/// [`pump_auth_sheets`]: crate::ui::remote_workspace::pump_auth_sheets
+#[cfg(test)]
+pub(crate) static MAILBOX_TURN: Mutex<()> = Mutex::new(());
+
+/// Claim [`MAILBOX_TURN`], ignoring poisoning: a test that panicked while holding
+/// it has nothing to corrupt here — the guard protects an ordering, not data.
+#[cfg(test)]
+pub(crate) fn claim_mailbox() -> std::sync::MutexGuard<'static, ()> {
+    MAILBOX_TURN.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 // ---------------------------------------------------------------------------
 // 7. Remote daemon version skew
 // ---------------------------------------------------------------------------
@@ -1207,6 +1230,11 @@ mod tests {
     /// were the same thread, and on the pane path they never are.
     #[test]
     fn a_routed_auth_prompt_carries_the_machine_that_raised_it() {
+        // Held for the whole exchange: the prompt this test is about to cause
+        // goes into a process-global mailbox, and `pump_auth_sheets` drains all of
+        // it from any gpui test in this binary that drives a tick. Without the
+        // claim that drain takes this test's prompt and the wait below never ends.
+        let _turn = claim_mailbox();
         while take_pending_auth().is_some() {}
         let target = RemoteTarget::direct("me", "build-box", 22);
         let route =

--- a/src/ui/remote_workspace.rs
+++ b/src/ui/remote_workspace.rs
@@ -1822,6 +1822,12 @@ fn release_panes(cx: &mut gpui::App, workspace: WorkspaceId) {
 /// when no workspace is bound to the machine yet) and the supervisor's tick
 /// (start-up and every reconnect, when no picker is open).
 pub(crate) fn pump_auth_sheets(cx: &mut gpui::App) {
+    // Yield the mailbox to a test that is waiting for a prompt it caused itself;
+    // see `remote_connect::MAILBOX_TURN`. Compiled out of a release build, which
+    // has one tick and one mailbox and nothing to arbitrate.
+    #[cfg(test)]
+    let _turn = remote_connect::claim_mailbox();
+
     let mut inbox: Vec<remote_connect::PendingAuth> = Vec::new();
     while let Some(pending) = remote_connect::take_pending_auth() {
         inbox.push(pending);


### PR DESCRIPTION
The intermittent CI hang is `ui::remote_connect::tests::a_routed_auth_prompt_carries_the_machine_that_raised_it`. This PR makes it loud, then stops it happening. It is **not** the `cfg(windows)` transport accepts bounded in #261 — those were a separate latent six-hour hang.

## The evidence, in the order it arrived

| Run | Platform | `Test` step | What it gave us |
|---|---|---|---|
| `30517182773` | linux-gnu | hung 2h 50m, cancelled by hand | the name — cancelling made the partial log fetchable |
| `30526538997` | windows-msvc | hung, **timed out at 20m by #261** | the name again, log landed on its own |
| `30528214554` | windows-msvc | **failed in 12.39s** by this PR's assertion | the mechanism, in words |

The first two logs both carry the same line — **libtest was reporting it the whole time**:

```
test ui::remote_connect::tests::a_routed_auth_prompt_carries_the_machine_that_raised_it
has been running for over 60 seconds
```

The obstacle was never the diagnostic. A job's log cannot be fetched while the job is in progress (the API 404s), and nobody cancels a six-hour run to read one. #261's `Test` timeout is what fixed that: on the Windows occurrence the step failed at 20 minutes and the log landed by itself, saving 5h 40m of runner time on that one hit.

Then the third run confirmed the cause outright:

```
panicked at src\ui\remote_connect.rs:1239:13:
no routed prompt arrived within 10s. `respond` pushes one unconditionally, so an empty
mailbox means something else drained it first — `pump_auth_sheets` takes all of it, and
it runs from any gpui test here that drives a tick. Responder thread finished: false
test result: FAILED. 731 passed; 1 failed; finished in 12.39s
```

## The bug

```rust
let handle = std::thread::spawn(move || GuiRouteAuth.respond(&route, &prompt));
let pending = loop {
    if let Some(p) = take_pending_auth() { break p; }   // ← nothing bounded this
    std::thread::sleep(Duration::from_millis(5));
};
```

`respond` pushes to `AUTH_MAILBOX` unconditionally, so an empty mailbox never meant "not yet" — it meant **someone else took it**. `AUTH_MAILBOX` is process-global and `pump_auth_sheets` drains every entry in one pass; it runs from `pump_tick`, so any gpui test in the same binary that drives a tick consumes a prompt it has no idea was spoken for.

## Before / After

| | Before | After |
|---|---|---|
| A tick drains this test's prompt | Spins forever; job dies at the 6-hour limit | Cannot happen — the drain yields while the test holds `MAILBOX_TURN` |
| Prompt genuinely never enqueued | Same spin | Fails in 10s, saying so and reporting `handle.is_finished()` |
| Prompt arrives normally | Passes | Passes, unchanged |
| Release build | — | Byte-for-byte unchanged; both halves are `#[cfg(test)]` |

Two commits, deliberately separate: the first bounds the wait (a hang becomes a named failure), the second removes the race.

## The compromise, stated plainly

`MAILBOX_TURN` is test-only synchronisation living inside a production function. That is a real smell and it is the reason this is one commit rather than folded in silently — it is the part to push back on. The alternative that needs no such thing is to stop the mailbox being process-global and inject it per app, which is a considerably larger change to a path this defect does not otherwise justify touching. Happy to go that way instead if you would rather.

No deadlock: the claim is the first thing `pump_auth_sheets` does, before it locks the mailbox, so the two locks are only ever taken in one order.

## The post-mortem step is gone

An earlier version of this branch added a process-table dump on failure. Removed, with a comment recording why, because it was worthless twice over:

1. **It cannot work.** GitHub kills the step's process tree when `timeout-minutes` trips, *before* the next step runs. On run `30526538997` — the one failure it existed for — it printed two headers and nothing between them.
2. **It is not needed.** libtest already names the test.

## Testing

- The fixed test run **30×** locally: 30 passes.
- Full suite looped **20×** locally under a bounded timeout: no hang, no failure. Local runs never reproduced this — it wants a loaded, slower runner — which is why the assertion in commit 1 was the thing that finally proved it, on CI, in 12 seconds.
- `cargo check` clean both with and without `--tests`; `cargo fmt --check` clean; `ci.yml` parses with both timeouts intact.
