### PR TITLE
fix(input): copy and paste answer Ctrl+Shift+C/V, and Paste is rebindable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,8 +148,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   when the editor does not have focus, so a shell still receives XOFF.
   Ctrl+C, Ctrl+V and Ctrl+X are unchanged — Ctrl+C still copies only when there
   is a selection and sends SIGINT otherwise — and **Shift+Insert** now pastes.
-  macOS bindings are untouched. Anything you rebound yourself still wins; only
-  the defaults moved. (#269)
+  With Alt+←/→ focusing panes (Windows Terminal's default), word-by-word
+  movement in the prompt editor lives on Ctrl+←/→ — the Windows/Linux text
+  convention, which already worked — with Ctrl+Shift+←/→ and Alt+Shift+←/→
+  both selecting by word. macOS bindings are untouched. Anything you rebound
+  yourself still wins; only the defaults moved. (#269)
+
+- **Ctrl+Shift+C and Ctrl+Shift+V copy and paste, like every GUI terminal** —
+  the chord GNOME Terminal, Konsole, Windows Terminal and WezTerm all teach.
+  Ctrl+C/Ctrl+V still work as before; Shift+Insert stays a second paste chord,
+  and moving Paste to a key of your own retires both defaults together. Copy
+  and Paste now sit in the default keymap table rather than being installed
+  behind the scenes, so Settings → Keybindings lists them, records new chords
+  for them, and warns when another binding would collide — previously
+  Shift+Insert was invisible there and could not be reassigned. (#269)
 
 - **The machine that runs your panes now owns their layout** — the workspace,
   tab and pane tree has moved out of the app and into the background service, so

--- a/src/ui/keymap.rs
+++ b/src/ui/keymap.rs
@@ -3,7 +3,7 @@ use gpui::{App, Global, KeyBinding, Keystroke, NoAction};
 use crate::core::actions::*;
 use crate::core::config::Config;
 use crate::terminal::view::{
-    ClearScrollback, FindInTerminal, FindNext, FindPrevious, InsertNewline, PasteText,
+    ClearScrollback, CopyText, FindInTerminal, FindNext, FindPrevious, InsertNewline, PasteText,
 };
 use crate::ui::theme::set_menus;
 
@@ -17,9 +17,6 @@ pub fn init(cx: &mut App) {
     bindings.push(KeyBinding::new("secondary-+", IncreaseFontSize, None));
     bindings.push(KeyBinding::new("tab", SendTab, Some("Terminal")));
     bindings.push(KeyBinding::new("shift-tab", SendBackTab, Some("Terminal")));
-    if cfg!(not(target_os = "macos")) {
-        bindings.push(KeyBinding::new("shift-insert", PasteText, Some("Terminal")));
-    }
     cx.bind_keys(bindings);
     cx.set_global(BoundKeystrokes(bound_keystrokes(&effective)));
 
@@ -50,15 +47,31 @@ const INSERT_NEWLINE_DEFAULT: &str = "shift-enter";
 
 const INSERT_NEWLINE_ALT_DEFAULT: &str = "alt-enter";
 
+const PASTE_ALT_DEFAULT: &str = "shift-insert";
+
+fn paste_text_default() -> &'static str {
+    per_platform("", "ctrl-shift-v")
+}
+
+fn extra_defaults() -> Vec<(&'static str, &'static str, &'static str)> {
+    vec![
+        (
+            "InsertNewline",
+            INSERT_NEWLINE_DEFAULT,
+            INSERT_NEWLINE_ALT_DEFAULT,
+        ),
+        ("PasteText", paste_text_default(), PASTE_ALT_DEFAULT),
+    ]
+}
+
 fn extra_keystrokes(effective: &[(String, String)]) -> Vec<(&'static str, &'static str)> {
-    let on_default = effective
-        .iter()
-        .any(|(a, k)| a == "InsertNewline" && k == INSERT_NEWLINE_DEFAULT);
-    if on_default {
-        vec![("InsertNewline", INSERT_NEWLINE_ALT_DEFAULT)]
-    } else {
-        Vec::new()
-    }
+    extra_defaults()
+        .into_iter()
+        .filter(|(action, primary, _)| {
+            !primary.is_empty() && effective.iter().any(|(a, k)| a == action && k == primary)
+        })
+        .map(|(action, _, extra)| (action, extra))
+        .collect()
 }
 
 pub(crate) fn extra_bindings(cx: &App) -> Vec<(String, String)> {
@@ -240,6 +253,8 @@ pub(crate) fn default_bindings() -> Vec<(&'static str, &'static str)> {
             per_platform("secondary-k", "secondary-shift-k"),
         ),
         ("InsertNewline", INSERT_NEWLINE_DEFAULT),
+        ("CopyText", per_platform("", "ctrl-shift-c")),
+        ("PasteText", paste_text_default()),
         ("OpenSettings", "secondary-,"),
         (
             "ShowKeyboardShortcuts",
@@ -479,9 +494,8 @@ fn keystroke_is_valid(s: &str) -> bool {
 
 fn action_context(action: &str) -> Option<&'static str> {
     match action {
-        "FindInTerminal" | "FindNext" | "FindPrevious" | "ClearScrollback" | "InsertNewline" => {
-            Some("Terminal")
-        }
+        "FindInTerminal" | "FindNext" | "FindPrevious" | "ClearScrollback" | "InsertNewline"
+        | "CopyText" | "PasteText" => Some("Terminal"),
         _ => None,
     }
 }
@@ -560,6 +574,8 @@ fn make_binding(action: &str, keystroke: &str) -> Option<KeyBinding> {
         "FindPrevious" => KeyBinding::new(keystroke, FindPrevious, action_context(action)),
         "ClearScrollback" => KeyBinding::new(keystroke, ClearScrollback, action_context(action)),
         "InsertNewline" => KeyBinding::new(keystroke, InsertNewline, action_context(action)),
+        "CopyText" => KeyBinding::new(keystroke, CopyText, action_context(action)),
+        "PasteText" => KeyBinding::new(keystroke, PasteText, action_context(action)),
         "OpenSettings" => KeyBinding::new(keystroke, OpenSettings, None),
         "ShowKeyboardShortcuts" => KeyBinding::new(keystroke, ShowKeyboardShortcuts, None),
         "About" => KeyBinding::new(keystroke, About, None),
@@ -669,10 +685,7 @@ mod tests {
                 .map(|(_, k)| k.as_str()),
             Some("shift-enter")
         );
-        assert_eq!(
-            extra_keystrokes(&effective),
-            vec![("InsertNewline", "alt-enter")]
-        );
+        assert!(extra_keystrokes(&effective).contains(&("InsertNewline", "alt-enter")));
         for key in ["shift-enter", "alt-enter"] {
             assert!(keystroke_is_valid(key), "{key} does not parse");
             assert!(make_binding("InsertNewline", key).is_some());
@@ -682,6 +695,53 @@ mod tests {
             );
         }
         assert_eq!(key_tokens("shift-enter"), vec![SHIFT, "⏎"]);
+    }
+
+    #[test]
+    fn paste_ships_both_terminal_chords_off_macos_and_retires_together() {
+        let effective: Vec<(String, String)> = default_bindings()
+            .into_iter()
+            .map(|(a, k)| (a.to_string(), k.to_string()))
+            .collect();
+        if cfg!(target_os = "macos") {
+            assert!(
+                !extra_keystrokes(&effective)
+                    .iter()
+                    .any(|(a, _)| *a == "PasteText"),
+                "macOS pastes with Cmd+V; no extra chord should install there"
+            );
+            return;
+        }
+        assert_eq!(
+            effective
+                .iter()
+                .find(|(a, _)| a == "PasteText")
+                .map(|(_, k)| k.as_str()),
+            Some("ctrl-shift-v")
+        );
+        assert_eq!(
+            effective
+                .iter()
+                .find(|(a, _)| a == "CopyText")
+                .map(|(_, k)| k.as_str()),
+            Some("ctrl-shift-c")
+        );
+        assert!(extra_keystrokes(&effective).contains(&("PasteText", "shift-insert")));
+        for key in ["ctrl-shift-v", "shift-insert"] {
+            assert!(
+                bound_keystrokes(&effective)
+                    .iter()
+                    .any(|(k, c)| k == key && *c == Some("Terminal")),
+                "{key} must be installed in the Terminal context and remembered for rebind"
+            );
+        }
+        let rebound = vec![("PasteText".to_string(), "ctrl-alt-v".to_string())];
+        assert!(
+            !extra_keystrokes(&rebound)
+                .iter()
+                .any(|(a, _)| *a == "PasteText"),
+            "moving Paste off its default must retire Shift+Insert with it"
+        );
     }
 
     #[test]
@@ -782,16 +842,15 @@ mod tests {
                     continue;
                 }
                 let steals = ks.key.len() == 1
-                    && ks
-                        .key
-                        .chars()
-                        .next()
-                        .is_some_and(|c| c.is_ascii_alphabetic() || "[]\\".contains(c))
+                    && ks.key.chars().next().is_some_and(|c| {
+                        c.is_ascii_alphabetic() || "[]\\`".contains(c) || ('2'..='8').contains(&c)
+                    })
                     || ks.key == "space";
                 assert!(
                     !steals,
                     "{action} is bound to {chord}, which the shell needs as a control code \
-                     (Ctrl+[ is ESC, Ctrl+D is EOF, Ctrl+W deletes a word). \
+                     (Ctrl+[ is ESC, Ctrl+D is EOF, Ctrl+W deletes a word, \
+                     Ctrl+2..8 are NUL/ESC/FS/GS/RS/US/DEL). \
                      Window actions belong on ctrl-shift-* off macOS."
                 );
             }


### PR DESCRIPTION
Follow-ups from the #270 acceptance review, all in the name of unsurprising defaults.

## Ctrl+Shift+C / Ctrl+Shift+V

GNOME Terminal, Konsole, Windows Terminal and WezTerm all copy on Ctrl+Shift+C and paste on Ctrl+Shift+V — the one chord pair every Linux/Windows terminal user carries between terminals. tty7 answered neither. Both are defaults now, off macOS only; Ctrl+C (copy with selection, SIGINT without) and Ctrl+V are unchanged.

## Shift+Insert becomes visible and rebindable

It was pushed as a hardcoded binding in `init()`, outside the default table — so Settings could not list it, record over it, or warn on a collision, and a user's own `shift-insert` binding silently lost to it while a terminal was focused. Copy and Paste are now ordinary rows in the table ("Copy Text" / "Paste Text" in Settings). Shift+Insert rides along as Paste's second chord via the same mechanism that gives InsertNewline its Alt+Enter, generalized from a one-action special case into a table — rebinding Paste retires both defaults together.

## Guard tightening

`no_default_binding_sits_on_a_terminal_control_code` now also rejects Ctrl+2..8 (NUL, ESC, FS, GS, RS, US, DEL in xterm-style terminals) and Ctrl+` (NUL).

## The word-motion trade, written down

The changelog entry for #270 now states what Alt+←/→ focusing panes costs and what covers it: word movement in the prompt editor is Ctrl+←/→ (already the Windows/Linux text convention, already working), and both Ctrl+Shift+←/→ and Alt+Shift+←/→ select by word.

## Testing

`cargo test --bin tty7` on Windows: 743 passed, 0 failed. New test `paste_ships_both_terminal_chords_off_macos_and_retires_together` pins the double chord, the Terminal scope, and joint retirement on rebind; the existing meta-tests (binding-builder arm, context agreement, chord uniqueness) pick the new rows up automatically. `cargo fmt --check` clean.

Refs #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)