### PR TITLE
fix(input): stop a Tab on a detached remote pane from eating the line

### DIFF
--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -2472,6 +2472,10 @@ impl TerminalView {
         None
     }
 
+    fn link_inactive_reason(&self, cx: &gpui::App) -> Option<&'static str> {
+        (!self.accepts_input(cx)).then_some("the remote link is not attached")
+    }
+
     fn shell_vi_prompt(&self) -> bool {
         self.terminal.shell_vi_mode() && self.terminal.at_prompt() && !self.on_alt_screen()
     }
@@ -2885,7 +2889,8 @@ impl TerminalView {
             cx.propagate();
             return;
         }
-        if !self.accepts_input(cx) {
+        if let Some(reason) = self.link_inactive_reason(cx) {
+            log::debug!(target: "tty7::completion", "Tab does nothing and the line stays: {reason}");
             return;
         }
         if let Some(reason) = self.input_inactive_reason() {
@@ -3049,7 +3054,7 @@ impl TerminalView {
             let entries = listed.unwrap_or_else(|e| {
                 log::warn!(
                     target: "tty7::completion",
-                    "remote listing failed, so the shell gets the line: {e}"
+                    "remote listing failed, treating it as no candidates: {e}"
                 );
                 Vec::new()
             });
@@ -3071,7 +3076,10 @@ impl TerminalView {
         forward: bool,
         cx: &mut Context<Self>,
     ) {
-        if let Some(reason) = self.input_inactive_reason() {
+        if let Some(reason) = self
+            .link_inactive_reason(cx)
+            .or_else(|| self.input_inactive_reason())
+        {
             log::debug!(
                 target: "tty7::completion",
                 "dropping a remote listing for {line:?}: {reason}"
@@ -5982,6 +5990,11 @@ mod gpui_tests {
                 );
             })
             .unwrap();
+        assert_eq!(
+            next_input_until_timeout(&mut daemon),
+            None,
+            "not one byte reached the wire"
+        );
     }
 
     #[gpui::test]
@@ -6981,6 +6994,7 @@ mod gpui_tests {
     ) {
         crate::core::config::pin_test_config_dir();
         let (window, mut daemon) = harness(cx);
+        cx.update(|cx| crate::ui::keymap::init(cx));
         DaemonMsg::Prompt {
             active: true,
             at_prompt: true,
@@ -6991,15 +7005,23 @@ mod gpui_tests {
         wait_for_input_active(&window, cx);
 
         window
-            .update(cx, |view, _, cx| {
+            .update(cx, |view, window, cx| {
+                window.activate_window();
+                view.focus_handle.focus(window, cx);
                 view.cmd.set("zzqqx");
                 bind_to_a_disconnected_remote_workspace(view, cx);
+            })
+            .unwrap();
 
-                view.tab_pressed(true, cx);
+        let mut vcx = gpui::VisualTestContext::from_window(window.into(), cx);
+        vcx.simulate_keystrokes("tab");
+
+        window
+            .update(cx, |view, _, cx| {
                 assert_eq!(
                     view.cmd.text(),
                     "zzqqx",
-                    "a Tab that cannot reach the shell must not empty the line"
+                    "a Tab dispatched through SendTab must not empty the line"
                 );
                 assert!(
                     view.editor_handoff.is_none(),
@@ -7010,7 +7032,7 @@ mod gpui_tests {
                 assert_eq!(
                     view.cmd.text(),
                     "zzqqx",
-                    "Enter on a read-only window must not swallow the line either"
+                    "submit_command guards the link too, even though on_key_down already does"
                 );
             })
             .unwrap();
@@ -7019,6 +7041,56 @@ mod gpui_tests {
             None,
             "not one byte reached the wire"
         );
+    }
+
+    #[gpui::test]
+    fn a_tab_on_a_detached_remote_pane_never_asks_for_a_listing(cx: &mut TestAppContext) {
+        use std::io::Write as _;
+        crate::core::config::pin_test_config_dir();
+        let (window, mut daemon) = harness(cx);
+        DaemonMsg::Prompt {
+            active: true,
+            at_prompt: true,
+            last_exit: None,
+        }
+        .encode(&mut daemon)
+        .unwrap();
+        DaemonMsg::Cwd(std::path::PathBuf::from("/home/me/proj"))
+            .encode(&mut daemon)
+            .unwrap();
+        daemon.flush().unwrap();
+        wait_for_input_active(&window, cx);
+        for _ in 0..200 {
+            if window
+                .update(cx, |view, _, _| view.cwd().is_some())
+                .unwrap()
+            {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+
+        window
+            .update(cx, |view, _, cx| {
+                view.cmd.set("ls /home/me/");
+                bind_to_a_disconnected_remote_workspace(view, cx);
+                assert!(
+                    view.remote_ssh_cwd().is_some(),
+                    "the pane has to look remote enough to want a listing at all"
+                );
+
+                view.tab_pressed(true, cx);
+                assert!(
+                    !view.remote_completion_inflight,
+                    "a Tab must not send an SFTP listing down a link that is not attached"
+                );
+                assert_eq!(
+                    view.cmd.text(),
+                    "ls /home/me/",
+                    "and the line stays where it was"
+                );
+            })
+            .unwrap();
     }
 
     #[gpui::test]

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -2596,7 +2596,7 @@ impl TerminalView {
     }
 
     fn submit_command(&mut self, cx: &mut Context<Self>) {
-        if self.terminal.exited {
+        if self.terminal.exited || !self.accepts_input(cx) {
             return;
         }
         if let Some(net) = self.hold.engage() {
@@ -2855,6 +2855,9 @@ impl TerminalView {
     }
 
     fn handoff_line_to_shell(&mut self, chord: &[u8], cx: &mut Context<Self>) {
+        if !self.accepts_input(cx) {
+            return;
+        }
         if let Some(net) = self.hold.engage() {
             self.cmd.prepend_str(&net);
         }
@@ -2880,6 +2883,9 @@ impl TerminalView {
     fn tab_pressed(&mut self, forward: bool, cx: &mut Context<Self>) {
         if self.search_focused {
             cx.propagate();
+            return;
+        }
+        if !self.accepts_input(cx) {
             return;
         }
         if let Some(reason) = self.input_inactive_reason() {
@@ -3040,19 +3046,16 @@ impl TerminalView {
         log::debug!(target: "tty7::completion", "listing {dir} over the remote's own connection");
         cx.spawn(async move |this, cx| {
             let listed = cx.background_spawn(async move { route.list(&dir) }).await;
-            if let Err(e) = &listed {
-                log::warn!(target: "tty7::completion", "remote listing failed: {e}");
-            }
+            let entries = listed.unwrap_or_else(|e| {
+                log::warn!(
+                    target: "tty7::completion",
+                    "remote listing failed, so the shell gets the line: {e}"
+                );
+                Vec::new()
+            });
             let _ = this.update(cx, |view, cx| {
                 view.remote_completion_inflight = false;
-                view.remote_path_results(
-                    req,
-                    &line,
-                    cursor,
-                    listed.unwrap_or_default(),
-                    forward,
-                    cx,
-                )
+                view.remote_path_results(req, &line, cursor, entries, forward, cx);
             });
         })
         .detach();
@@ -3068,6 +3071,13 @@ impl TerminalView {
         forward: bool,
         cx: &mut Context<Self>,
     ) {
+        if let Some(reason) = self.input_inactive_reason() {
+            log::debug!(
+                target: "tty7::completion",
+                "dropping a remote listing for {line:?}: {reason}"
+            );
+            return;
+        }
         if self.cmd.text() != line || self.cmd.cursor() != cursor {
             log::debug!(
                 target: "tty7::completion",
@@ -5941,6 +5951,40 @@ mod gpui_tests {
     }
 
     #[gpui::test]
+    fn a_late_remote_listing_leaves_a_line_the_editor_no_longer_owns_alone(
+        cx: &mut TestAppContext,
+    ) {
+        crate::core::config::pin_test_config_dir();
+        let (window, mut daemon) = harness(cx);
+        DaemonMsg::Prompt {
+            active: true,
+            at_prompt: true,
+            last_exit: None,
+        }
+        .encode(&mut daemon)
+        .unwrap();
+        wait_for_input_active(&window, cx);
+
+        window
+            .update(cx, |view, _, cx| {
+                view.cmd.set("ls /nope/");
+                view.editor_handoff = Some(view.terminal.prompt_cycle());
+                assert!(!view.input_active(), "the shell owns this prompt already");
+
+                let req =
+                    super::completion::remote_path_request("ls /nope/", 9, "/home/u").unwrap();
+                view.remote_path_results(req, "ls /nope/", 9, Vec::new(), true, cx);
+
+                assert_eq!(
+                    view.cmd.text(),
+                    "ls /nope/",
+                    "an empty listing must not hand off a line the editor no longer drives"
+                );
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
     fn tab_completion_off_sends_every_tab_to_the_shell(cx: &mut TestAppContext) {
         let (window, mut daemon) = harness(cx);
         cx.update(|cx| {
@@ -6929,6 +6973,52 @@ mod gpui_tests {
             )),
         }));
         id
+    }
+
+    #[gpui::test]
+    fn a_disconnected_remote_pane_keeps_the_line_instead_of_handing_it_to_nowhere(
+        cx: &mut TestAppContext,
+    ) {
+        crate::core::config::pin_test_config_dir();
+        let (window, mut daemon) = harness(cx);
+        DaemonMsg::Prompt {
+            active: true,
+            at_prompt: true,
+            last_exit: None,
+        }
+        .encode(&mut daemon)
+        .unwrap();
+        wait_for_input_active(&window, cx);
+
+        window
+            .update(cx, |view, _, cx| {
+                view.cmd.set("zzqqx");
+                bind_to_a_disconnected_remote_workspace(view, cx);
+
+                view.tab_pressed(true, cx);
+                assert_eq!(
+                    view.cmd.text(),
+                    "zzqqx",
+                    "a Tab that cannot reach the shell must not empty the line"
+                );
+                assert!(
+                    view.editor_handoff.is_none(),
+                    "nothing was handed off, so the editor keeps the prompt"
+                );
+
+                view.submit_command(cx);
+                assert_eq!(
+                    view.cmd.text(),
+                    "zzqqx",
+                    "Enter on a read-only window must not swallow the line either"
+                );
+            })
+            .unwrap();
+        assert_eq!(
+            next_input_until_timeout(&mut daemon),
+            None,
+            "not one byte reached the wire"
+        );
     }
 
     #[gpui::test]


### PR DESCRIPTION
A Tab that fails to complete on a remote pane whose link is down no longer clears the line and leaves the pane unusable.

| | Before | After |
|---|---|---|
| Tab on a remote pane with a detached link | Line is cleared, bytes go to a writer nobody reads, editor stands down for the rest of the prompt cycle | Nothing happens; the line stays in the editor, and the log says why |
| Typing after that Tab | Swallowed by the read-only guard — the pane looks frozen | The line is still there and typing resumes once the link is back |
| Tab on a remote path with a detached link | Starts an SFTP listing over a link that cannot carry it | Never asked for |
| Tab that fails while the link is fine | Line goes to the shell (local editor stands down until the next prompt) | Unchanged |
| A remote SFTP listing that lands seconds late | Acts on the line even if the editor no longer owns it, or the link died meanwhile | Dropped, with the reason logged |
| A remote SFTP listing that fails | Treated as "no candidates", line goes to the shell | Unchanged, but the log says so |

## Why

`Tab` reaches the view through the `SendTab` / `SendBackTab` actions, so it never passes the `accepts_input` check that `on_key_down` applies to ordinary typing. On a remote workspace that is reconnecting, a completion with no candidates therefore ran `handoff_line_to_shell` anyway: `cmd.clear()` plus a write to a dead link. From the user's side the command vanished, the editor was down for the rest of the prompt cycle, and every following keystroke — Enter included — was eaten by the very guard the Tab had skipped. A local pane has no workspace, so `accepts_input` is always true there and only the intended handoff was visible.

```mermaid
flowchart TD
    K[Ordinary keystroke] --> G{accepts_input?}
    G -- no --> D[dropped, line untouched]
    T[Tab via SendTab action] -.->|before: skipped the guard| H[handoff_line_to_shell]
    T ==>|after| G
    G -- yes --> C{completion candidates?}
    C -- none --> H
    H --> S[line to the shell, editor stands down]
```

The Tab path is the only one that reached a writer without asking. The same check now also sits in `submit_command` and `handoff_line_to_shell`, but purely as depth: every production caller of those already goes through `on_key_down`, which has been guarding since before this change.

## Testing

- `cargo test` — full suite green.
- New `a_disconnected_remote_pane_keeps_the_line_instead_of_handing_it_to_nowhere`: a Tab dispatched through the real `SendTab` binding on a detached remote pane leaves the line alone and puts nothing on the wire. Verified it fails with the guards removed.
- New `a_tab_on_a_detached_remote_pane_never_asks_for_a_listing`: the same Tab does not start an SFTP listing. This is the one effect only the Tab-path guard has — the others are covered downstream — and it was verified to fail without it.
- New `a_late_remote_listing_leaves_a_line_the_editor_no_longer_owns_alone`: a listing that lands after the line was handed off does not touch it, and nothing reaches the wire. Verified it fails without the guard.
- Manual: isolated dev instance (`--config-dir`) against a real remote workspace, local and remote panes.
