### PR TITLE
fix(completion): escape inserted candidates, close spent menus, keep PATH local

### DIFF
--- a/src/terminal/completion.rs
+++ b/src/terminal/completion.rs
@@ -84,16 +84,12 @@ fn current_command(chars: &[char], word_start: usize) -> Option<String> {
 pub fn complete(line: &str, cursor: usize, cwd: Option<&Path>) -> Option<Completion> {
     let chars: Vec<char> = line.chars().collect();
     let cursor = cursor.min(chars.len());
-
-    let mut word_start = cursor;
-    while word_start > 0 && !chars[word_start - 1].is_whitespace() {
-        word_start -= 1;
-    }
+    let word_start = shell_word_start(&chars, cursor);
     let word: String = chars[word_start..cursor].iter().collect();
 
     let is_command = chars[..word_start].iter().all(|c| c.is_whitespace());
     let (word_cands, pending) = if is_command && !word.contains('/') {
-        (complete_command(&word), Vec::new())
+        (complete_command(&word, cwd.is_some()), Vec::new())
     } else {
         match complete_signature(&chars, word_start, &word, cwd) {
             Some(sig) => (sig.cands, sig.pending),
@@ -129,7 +125,30 @@ pub fn complete(line: &str, cursor: usize, cwd: Option<&Path>) -> Option<Complet
     }
 }
 
-fn complete_command(word: &str) -> Vec<WordCand> {
+/// Finds the start of the shell word at `cursor`. A whitespace character
+/// preceded by an odd-length run of backslashes belongs to the word, as in
+/// `My\ Documents/` after a path candidate has been inserted.
+fn shell_word_start(chars: &[char], cursor: usize) -> usize {
+    let mut start = cursor.min(chars.len());
+    while start > 0 {
+        if !chars[start - 1].is_whitespace() {
+            start -= 1;
+            continue;
+        }
+        let escapes = chars[..start - 1]
+            .iter()
+            .rev()
+            .take_while(|&&c| c == '\\')
+            .count();
+        if escapes % 2 == 0 {
+            break;
+        }
+        start -= 1;
+    }
+    start
+}
+
+fn complete_command(word: &str, local: bool) -> Vec<WordCand> {
     if word.is_empty() {
         return Vec::new();
     }
@@ -139,7 +158,7 @@ fn complete_command(word: &str) -> Vec<WordCand> {
             set.insert((*b).to_string());
         }
     }
-    if let Some(path) = std::env::var_os("PATH") {
+    if let Some(path) = std::env::var_os("PATH").filter(|_| local) {
         for dir in std::env::split_paths(&path) {
             let Ok(rd) = std::fs::read_dir(&dir) else {
                 continue;
@@ -207,10 +226,7 @@ pub fn remote_path_request(
     }
     let chars: Vec<char> = line.chars().collect();
     let cursor = cursor.min(chars.len());
-    let mut word_start = cursor;
-    while word_start > 0 && !chars[word_start - 1].is_whitespace() {
-        word_start -= 1;
-    }
+    let word_start = shell_word_start(&chars, cursor);
     let word: String = chars[word_start..cursor].iter().collect();
 
     let is_command = chars[..word_start].iter().all(|c| c.is_whitespace());
@@ -221,6 +237,7 @@ pub fn remote_path_request(
         return None;
     }
 
+    let word = unescape_path_word(&word);
     let (dir_part, prefix) = match word.rfind('/') {
         Some(i) => (&word[..=i], &word[i + 1..]),
         None => ("", word.as_str()),
@@ -281,9 +298,13 @@ pub fn remote_path_candidates(req: &RemotePathRequest, entries: &[RemoteEntry]) 
 }
 
 fn complete_path(word: &str, cwd: &Path, dirs_only: bool) -> Vec<WordCand> {
+    // Candidates are emitted unescaped and escaped at insertion time. Undo the
+    // corresponding backslash quoting for lookup, so a second Tab after
+    // inserting `My\ Documents/` still enters the real directory.
+    let word = unescape_path_word(word);
     let (dir_part, prefix) = match word.rfind(std::path::is_separator) {
         Some(i) => (&word[..=i], &word[i + 1..]),
-        None => ("", word),
+        None => ("", word.as_str()),
     };
     let base = resolve_dir(dir_part, cwd);
 
@@ -322,6 +343,25 @@ fn complete_path(word: &str, cwd: &Path, dirs_only: bool) -> Vec<WordCand> {
             .cmp(&b.text.chars().count())
             .then_with(|| a.text.cmp(&b.text))
     });
+    out
+}
+
+fn unescape_path_word(word: &str) -> String {
+    let mut out = String::with_capacity(word.len());
+    let mut escaped = false;
+    for ch in word.chars() {
+        if escaped {
+            out.push(ch);
+            escaped = false;
+        } else if ch == '\\' {
+            escaped = true;
+        } else {
+            out.push(ch);
+        }
+    }
+    if escaped {
+        out.push('\\');
+    }
     out
 }
 
@@ -527,6 +567,7 @@ pub(super) struct CompletionSession {
     pub(super) all: Vec<Candidate>,
     pub(super) filtered: Vec<usize>,
     pub(super) index: Option<usize>,
+    pub(super) pending_generators: usize,
 }
 
 pub(super) struct Replacement {
@@ -549,7 +590,12 @@ impl Replacement {
 }
 
 impl CompletionSession {
-    pub(super) fn new(word_start: usize, open_word: String, all: Vec<Candidate>) -> Self {
+    pub(super) fn new(
+        word_start: usize,
+        open_word: String,
+        all: Vec<Candidate>,
+        pending_generators: usize,
+    ) -> Self {
         let filtered = (0..all.len()).collect();
         Self {
             word_start,
@@ -557,7 +603,16 @@ impl CompletionSession {
             all,
             filtered,
             index: Some(0),
+            pending_generators,
         }
+    }
+
+    pub(super) fn generator_answered(&mut self) {
+        self.pending_generators = self.pending_generators.saturating_sub(1);
+    }
+
+    pub(super) fn is_spent(&self) -> bool {
+        self.pending_generators == 0 && self.filtered.is_empty()
     }
 
     pub(super) fn selected(&self) -> Option<&Candidate> {
@@ -744,6 +799,7 @@ mod tests {
             0,
             "f".into(),
             vec![cand("feature", CandidateKind::Value, 0, 1)],
+            0,
         );
         let new = vec![
             cand("feature", CandidateKind::Value, 0, 1),
@@ -765,6 +821,7 @@ mod tests {
                 cand("branch-a", CandidateKind::Value, 0, 1),
                 cand("branch-b", CandidateKind::Value, 0, 1),
             ],
+            0,
         );
         s.select(true);
         assert_eq!(s.selected().unwrap().text, "branch-b");
@@ -833,7 +890,7 @@ mod tests {
             .iter()
             .map(|w| cand(w, CandidateKind::Command, 0, 1))
             .collect();
-        CompletionSession::new(0, "a".into(), cands)
+        CompletionSession::new(0, "a".into(), cands, 0)
     }
 
     #[test]
@@ -886,7 +943,9 @@ mod tests {
             if *is_dir {
                 std::fs::create_dir_all(dir.join(name)).unwrap();
             } else {
-                std::fs::write(dir.join(name), b"").unwrap();
+                let path = dir.join(name);
+                std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+                std::fs::write(path, b"").unwrap();
             }
         }
         dir
@@ -913,6 +972,18 @@ mod tests {
         let assets = c.candidates.iter().find(|c| c.text == "assets").unwrap();
         assert!(assets.is_dir());
         assert_eq!((assets.start, assets.end), (4, 5));
+    }
+
+    #[test]
+    fn completion_reenters_a_directory_inserted_with_an_escaped_space() {
+        let dir = temp_tree("escaped-path", &[("My Documents/notes.txt", false)]);
+        let line = r"cat My\ Documents/no";
+        let c = complete(line, line.chars().count(), Some(dir.as_path())).unwrap();
+        assert_eq!(c.candidates[0].text, "My Documents/notes.txt");
+        assert_eq!(
+            (c.candidates[0].start, c.candidates[0].end),
+            (4, line.chars().count())
+        );
     }
 
     #[test]
@@ -963,6 +1034,30 @@ mod tests {
 
         let c = complete("ech", 3, None).expect("command completion needs no cwd");
         assert!(c.candidates.iter().any(|c| c.text == "echo"));
+    }
+
+    #[test]
+    fn a_remote_pane_offers_builtins_but_never_this_machines_binaries() {
+        let remote: Vec<String> = complete("l", 1, None)
+            .map(|c| c.candidates.into_iter().map(|c| c.text).collect())
+            .unwrap_or_default();
+        assert!(
+            remote.iter().all(|n| BUILTINS.contains(&n.as_str())),
+            "a builtin is true on any POSIX shell, but a PATH scan reads *this* machine \
+             and its names do not exist on the remote: {remote:?}"
+        );
+
+        #[cfg(unix)]
+        {
+            let local: Vec<String> = complete("l", 1, Some(Path::new("/")))
+                .map(|c| c.candidates.into_iter().map(|c| c.text).collect())
+                .unwrap_or_default();
+            assert!(
+                local.iter().any(|n| n == "ls"),
+                "a local pane still scans PATH: {local:?}"
+            );
+            assert!(!remote.iter().any(|n| n == "ls"));
+        }
     }
 
     #[test]
@@ -1024,7 +1119,7 @@ mod tests {
         );
 
         let r = remote_path_request(r"cat a\b", 7, "/home/me").unwrap();
-        assert_eq!((r.dir.as_str(), r.prefix.as_str()), ("/home/me", r"a\b"));
+        assert_eq!((r.dir.as_str(), r.prefix.as_str()), ("/home/me", "ab"));
     }
 
     #[test]

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -383,6 +383,13 @@ fn shell_escape_path(path: &str) -> String {
     out
 }
 
+fn escape_candidate(text: &str) -> String {
+    match text.strip_prefix("~/") {
+        Some(rest) => format!("~/{}", shell_escape_path(rest)),
+        None => shell_escape_path(text),
+    }
+}
+
 fn clipboard_paste_text(item: &ClipboardItem) -> Option<String> {
     let escaped: Vec<String> = item
         .entries()
@@ -2978,7 +2985,7 @@ impl TerminalView {
             return;
         };
 
-        let has_pending = !comp.pending.is_empty();
+        let pending_generators = comp.pending.len();
 
         let (word_start, word_end) = match comp.candidates.first() {
             Some(c) => (c.start, c.end),
@@ -2989,7 +2996,7 @@ impl TerminalView {
             word_start,
             word_end,
             comp.candidates,
-            has_pending,
+            pending_generators,
             cx,
         ) else {
             return;
@@ -3004,9 +3011,6 @@ impl TerminalView {
                     .background_executor()
                     .spawn(async move { super::generator::run(&script, &cwd) })
                     .await;
-                if results.is_empty() {
-                    return;
-                }
                 let _ = this.update(cx, |view, cx| {
                     view.completion_merge(generation, results, cx);
                 });
@@ -3021,9 +3025,10 @@ impl TerminalView {
         word_start: usize,
         word_end: usize,
         cands: Vec<completion::Candidate>,
-        has_pending: bool,
+        pending_generators: usize,
         cx: &mut Context<Self>,
     ) -> Option<u64> {
+        let has_pending = pending_generators > 0;
         if !has_pending && cands.len() == 1 {
             let c = cands[0].clone();
             self.completion_insert(&c, c.start);
@@ -3036,10 +3041,11 @@ impl TerminalView {
             .skip(word_start)
             .take(word_end - word_start)
             .collect();
-        let s = CompletionSession::new(word_start, word.clone(), cands);
+        let s = CompletionSession::new(word_start, word.clone(), cands, pending_generators);
         if !has_pending
             && let Some(lcp) = s.common_prefix()
             && lcp.chars().count() > word.chars().count()
+            && escape_candidate(&lcp) == lcp
         {
             self.apply_candidate(line, word_start, word_end, &lcp);
         }
@@ -3149,7 +3155,7 @@ impl TerminalView {
             self.handoff_tab_to_shell(!forward, cx);
             return;
         }
-        self.offer_candidates(line, req.word_start, req.cursor, cands, false, cx);
+        self.offer_candidates(line, req.word_start, req.cursor, cands, 0, cx);
     }
 
     fn open_completion(&mut self, session: CompletionSession) -> u64 {
@@ -3199,10 +3205,18 @@ impl TerminalView {
                 icon: None,
             })
             .collect();
-        if let Some(s) = self.completion.as_mut() {
-            s.merge(new, &live_word);
-            cx.notify();
+        let spent = match self.completion.as_mut() {
+            Some(s) => {
+                s.generator_answered();
+                s.merge(new, &live_word);
+                s.is_spent()
+            }
+            None => false,
+        };
+        if spent {
+            self.close_completion();
         }
+        cx.notify();
     }
 
     fn completion_tab_step(&mut self, forward: bool, cx: &mut Context<Self>) {
@@ -3218,12 +3232,14 @@ impl TerminalView {
             {
                 if lone {
                     self.completion_accept(cx);
-                } else {
+                    return;
+                }
+                if escape_candidate(&lcp) == lcp {
                     self.apply_candidate(&line, word_start, cursor, &lcp);
                     self.cursor_visible = true;
                     cx.notify();
+                    return;
                 }
-                return;
             }
         }
         self.completion_select(forward, cx);
@@ -3252,7 +3268,7 @@ impl TerminalView {
         let line = self.cmd.text();
         let len = line.chars().count();
         let cursor = self.cmd.cursor().min(len);
-        let mut text = cand.text.clone();
+        let mut text = escape_candidate(&cand.text);
         if cand.is_dir() {
             if !text.ends_with('/') {
                 text.push('/');
@@ -4843,8 +4859,8 @@ mod tests {
         display_width, loopback_plan,
     };
     use super::{
-        drag_scroll_step, encode_mouse, expand_file_command_template, fallback_chain,
-        fig_icon_emoji, fig_icon_glyph, focus_report_bytes, input_overflow_shift,
+        drag_scroll_step, encode_mouse, escape_candidate, expand_file_command_template,
+        fallback_chain, fig_icon_emoji, fig_icon_glyph, focus_report_bytes, input_overflow_shift,
         input_overlay_rows, menu_layout, paste_bytes, select_end_copy, shell_escape_path,
         smooth_scroll_step, submit_bytes, trim_trailing_spaces, wheel_route, wrapped_click_index,
     };
@@ -5372,6 +5388,24 @@ mod tests {
         );
         assert_eq!(shell_escape_path(""), "''");
         assert_eq!(shell_escape_path("a\nb"), "'a\nb'");
+    }
+
+    #[test]
+    fn escape_candidate_quotes_what_the_shell_would_resplit() {
+        assert_eq!(escape_candidate("notes.txt"), "notes.txt");
+        assert_eq!(escape_candidate("--message"), "--message");
+        assert_eq!(escape_candidate("My Documents"), "My\\ Documents");
+        assert_eq!(escape_candidate("a(1)&b"), "a\\(1\\)\\&b");
+        assert_eq!(
+            escape_candidate("~/My Documents"),
+            "~/My\\ Documents",
+            "a leading ~/ is the user's own text and must stay expandable"
+        );
+        assert_eq!(
+            escape_candidate("~weird name"),
+            "\\~weird\\ name",
+            "a bare ~ that is not a home prefix is just a filename character"
+        );
     }
 
     #[test]
@@ -6131,6 +6165,159 @@ mod gpui_tests {
         assert_eq!(next_input_until_timeout(&mut daemon), Some(b"\t".to_vec()));
     }
 
+    fn dir_candidate(text: &str, start: usize, end: usize) -> completion::Candidate {
+        completion::Candidate {
+            text: text.into(),
+            kind: CandidateKind::Dir,
+            start,
+            end,
+            description: None,
+            icon: None,
+        }
+    }
+
+    #[gpui::test]
+    fn accepting_a_candidate_escapes_it_for_the_shell(cx: &mut TestAppContext) {
+        crate::core::config::pin_test_config_dir();
+        let (window, _daemon) = harness(cx);
+        window
+            .update(cx, |view, _, _| {
+                view.cmd.set("cd My");
+                view.completion_insert(&dir_candidate("My Documents", 3, 5), 3);
+                assert_eq!(
+                    view.cmd.text(),
+                    "cd My\\ Documents/",
+                    "an unescaped candidate resplits into two arguments and the command breaks"
+                );
+
+                view.cmd.set("cd ~/My");
+                view.completion_insert(&dir_candidate("~/My Documents", 3, 6), 3);
+                assert_eq!(view.cmd.text(), "cd ~/My\\ Documents/");
+
+                view.cmd.set("git commit --mess");
+                view.completion_insert(
+                    &completion::Candidate {
+                        text: "--message".into(),
+                        kind: CandidateKind::Flag,
+                        start: 11,
+                        end: 17,
+                        description: None,
+                        icon: None,
+                    },
+                    11,
+                );
+                assert_eq!(view.cmd.text(), "git commit --message ");
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
+    fn a_candidate_needing_escapes_is_never_half_applied(cx: &mut TestAppContext) {
+        crate::core::config::pin_test_config_dir();
+        let (window, _daemon) = harness(cx);
+        window
+            .update(cx, |view, _, cx| {
+                view.cmd.set("cd My");
+                let offered = view.offer_candidates(
+                    "cd My",
+                    3,
+                    5,
+                    vec![
+                        dir_candidate("My Documents", 3, 5),
+                        dir_candidate("My Music", 3, 5),
+                    ],
+                    0,
+                    cx,
+                );
+                assert!(offered.is_some(), "two candidates open a menu");
+                assert_eq!(
+                    view.cmd.text(),
+                    "cd My",
+                    "the common prefix here is `My ` — writing it raw would break the line \
+                     and the trailing space would close the menu on the next keystroke"
+                );
+            })
+            .unwrap();
+    }
+
+    fn parsed(text: &str) -> super::super::generator::Parsed {
+        super::super::generator::Parsed {
+            text: text.into(),
+            description: None,
+        }
+    }
+
+    #[gpui::test]
+    fn a_generator_that_supplies_no_match_closes_the_menu(cx: &mut TestAppContext) {
+        crate::core::config::pin_test_config_dir();
+        let (window, _daemon) = harness(cx);
+        window
+            .update(cx, |view, _, cx| {
+                // `git ckout<Tab>`: no subcommand matches, but git's alias generator
+                // is in flight, so the session opens empty and waits for it.
+                view.cmd.set("ckout");
+                let generation =
+                    view.open_completion(CompletionSession::new(0, "ckout".into(), Vec::new(), 1));
+                assert!(
+                    view.completion.is_some(),
+                    "the menu waits for its generator"
+                );
+
+                view.completion_merge(generation, Vec::new(), cx);
+                assert!(
+                    view.completion.is_none(),
+                    "a menu that never got a candidate must not stay armed — it swallows \
+                     every later Tab instead of handing the line to the shell"
+                );
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
+    fn generator_results_that_match_nothing_close_the_menu(cx: &mut TestAppContext) {
+        crate::core::config::pin_test_config_dir();
+        let (window, _daemon) = harness(cx);
+        window
+            .update(cx, |view, _, cx| {
+                view.cmd.set("ckout");
+                let generation =
+                    view.open_completion(CompletionSession::new(0, "ckout".into(), Vec::new(), 1));
+
+                view.completion_merge(generation, vec![parsed("main"), parsed("release")], cx);
+                assert!(
+                    view.completion.is_none(),
+                    "branches that match nothing typed are as good as no candidates at all"
+                );
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
+    fn a_menu_waits_while_another_generator_is_still_in_flight(cx: &mut TestAppContext) {
+        crate::core::config::pin_test_config_dir();
+        let (window, _daemon) = harness(cx);
+        window
+            .update(cx, |view, _, cx| {
+                view.cmd.set("ck");
+                let generation =
+                    view.open_completion(CompletionSession::new(0, "ck".into(), Vec::new(), 2));
+
+                view.completion_merge(generation, Vec::new(), cx);
+                assert!(
+                    view.completion.is_some(),
+                    "one generator came back empty, the other has not answered yet"
+                );
+
+                view.completion_merge(generation, vec![parsed("ckout-fix")], cx);
+                let s = view
+                    .completion
+                    .as_ref()
+                    .expect("the second one supplied a match");
+                assert_eq!(s.filtered.len(), 1);
+            })
+            .unwrap();
+    }
+
     #[gpui::test]
     fn shell_vi_mode_prompt_input_is_not_typeahead(cx: &mut TestAppContext) {
         let (window, mut daemon) = harness(cx);
@@ -6398,6 +6585,7 @@ mod gpui_tests {
                     4,
                     String::new(),
                     vec![candidate("status")],
+                    0,
                 ));
 
                 view.insert_newline_action(cx);
@@ -6412,6 +6600,7 @@ mod gpui_tests {
                     4,
                     String::new(),
                     vec![candidate("status")],
+                    0,
                 ));
                 view.handle_editor_key(&key("enter"), cx);
                 assert_eq!(view.cmd.text(), "git status ");
@@ -7883,7 +8072,7 @@ mod gpui_tests {
         window
             .update(cx, |view, _, cx| {
                 view.cmd.set_with_cursor("git checkout ma", 15);
-                let session = CompletionSession::new(13, String::new(), Vec::new());
+                let session = CompletionSession::new(13, String::new(), Vec::new(), 1);
                 let generation = view.open_completion(session);
 
                 let results = vec![
@@ -7918,7 +8107,7 @@ mod gpui_tests {
         window
             .update(cx, |view, _, cx| {
                 view.cmd.set_with_cursor("git checkout ", 13);
-                let session = CompletionSession::new(13, String::new(), Vec::new());
+                let session = CompletionSession::new(13, String::new(), Vec::new(), 1);
                 let stale = view.open_completion(session);
                 view.close_completion();
 
@@ -7936,7 +8125,7 @@ mod gpui_tests {
                 );
 
                 let fresh =
-                    view.open_completion(CompletionSession::new(13, String::new(), Vec::new()));
+                    view.open_completion(CompletionSession::new(13, String::new(), Vec::new(), 1));
                 assert_ne!(stale, fresh);
                 view.completion_merge(
                     stale,


### PR DESCRIPTION
Fixes three defects in the inline completion menu, each of which produced something *wrong* rather than merely unhelpful.

| | Before | After |
|---|---|---|
| `cd My<Tab>` (dir is `My Documents`) | `cd My Documents/` — resplits into two arguments, command breaks | `cd My\ Documents/` |
| `cd ~/My<Tab>` | `cd ~/My Documents/` | `cd ~/My\ Documents/` — the `~/` stays expandable |
| Two candidates sharing the prefix `My ` | Writes `cd My ` — a broken line, and the space closes the menu on the next keystroke | Leaves the line alone and steps through the candidates |
| `git ckout<Tab>` | Menu opens empty waiting on git's alias generator, never closes, swallows every later Tab | Last generator to answer closes a menu that still has nothing in it, so the next Tab reaches the shell |
| `system_prof<Tab>` in an SSH pane to Linux | Offers macOS's `system_profiler` | Offers shell builtins only; the position falls through to the remote's own compsys |

## Why

**Escaping.** Candidates were inserted verbatim. `shell_escape_path` already existed for drag-and-drop paths but completion never reached for it. `escape_candidate` wraps it and leaves a leading `~/` alone — that prefix is the user's own text, and escaping it would defeat the home expansion it was typed for.

The same check now gates the common-prefix step. A prefix that needs escaping can't be written raw, and writing `My ` would also put a space inside the open word — which closes the menu on the next keystroke and leaves the user worse off than before they pressed Tab.

**Spent menus.** A position with no static candidates but a live generator opens an empty session on purpose and waits (this is what makes `git checkout <Tab>` work). The callback that would have closed it returned early on an empty result, so a menu whose generators all came back with nothing never learned they were done. Sessions now count their in-flight generators; the last one to answer closes a menu that is still empty.

**Remote PATH.** The remote isolation in `08ca3a3` covered paths and generators but deliberately kept command completion running — right for the builtins half (`echo` is true on any POSIX shell), wrong for the PATH half. It also failed *inconsistently*: with no local match the position already fell through to the remote's compsys and answered correctly, so the bug only surfaced when this machine happened to have a match, which made it hard to notice.

## Scope

Quoting is fixed on the **insert** side only. The parser still splits words on bare whitespace, so `cd "My Doc<Tab>`, `cat a b.t<Tab>`, `cd ~roo<Tab>` and `cd $HOME/<Tab>` still yield nothing and hand the line to the shell — unchanged behaviour, and a proper lexer is a separate change. Wrapper commands (`sudo git <Tab>` offering filenames instead of git's subcommands) are also left for a follow-up.

## Testing

- `escape_candidate_quotes_what_the_shell_would_resplit` — plain text and flags pass through, spaces/metacharacters escape, `~/` prefix survives, a bare `~foo` does not
- `accepting_a_candidate_escapes_it_for_the_shell` — insertion for a dir, a `~/` dir, and a flag
- `a_candidate_needing_escapes_is_never_half_applied` — the `My ` common prefix is not written
- `a_generator_that_supplies_no_match_closes_the_menu` / `generator_results_that_match_nothing_close_the_menu` — an empty menu does not stay armed
- `a_menu_waits_while_another_generator_is_still_in_flight` — one empty generator does not close a menu another may still fill
- `a_remote_pane_offers_builtins_but_never_this_machines_binaries` — remote candidates are all builtins; a local pane still scans PATH. Before the fix this failed with 200+ names from this machine (`lazygit`, `langchain`, …)
- Full workspace suite green (882 + 757 + …), `cargo fmt --check` clean, no new clippy warnings
