### PR TITLE
fix(pane): the macOS locale fallback must set LANG, not LC_CTYPE

### DIFF
--- a/crates/tty7-core/src/daemon/pane.rs
+++ b/crates/tty7-core/src/daemon/pane.rs
@@ -210,6 +210,19 @@ const LOCALE_DEFINITION_DIR: &str = "/usr/share/locale";
 #[cfg(any(target_os = "macos", test))]
 const FALLBACK_CHARACTER_LOCALES: [&str; 2] = ["C.UTF-8", "en_US.UTF-8"];
 
+/// The variable the locale fallback sets.
+///
+/// It has to be one a shell consults for *every* category. `LC_CTYPE` alone
+/// fixes character handling and leaves collation, time and numbers at `C`; a
+/// shell that then asks `setlocale(LC_COLLATE, "")` finds no variable to read
+/// and bash warns `setlocale: LC_COLLATE: cannot change locale ()` once per
+/// category. (zsh and fish swallow the failure, so they look fine while being
+/// just as half-configured.) `LC_ALL` would also cover everything, but it wins
+/// over every `LC_*` the user's own rc files set afterwards — `LANG` loses to
+/// them, which is what a fallback should do.
+#[cfg(any(target_os = "macos", test))]
+const LOCALE_FALLBACK_KEY: &str = "LANG";
+
 #[cfg(any(target_os = "macos", test))]
 fn character_locale(identifier: Option<&str>, exists: impl Fn(&str) -> bool) -> Option<String> {
     identifier
@@ -350,7 +363,7 @@ fn apply_common_command_setup(
                 .is_dir()
         })
     {
-        cmd.env("LC_CTYPE", locale);
+        cmd.env(LOCALE_FALLBACK_KEY, locale);
     }
 }
 
@@ -4218,6 +4231,22 @@ mod tests {
             &[("LANG", "")],
             &[("LANG", "en_US.UTF-8")]
         ));
+    }
+
+    #[test]
+    fn locale_fallback_sets_a_variable_that_backs_every_category() {
+        let injected =
+            std::iter::once((LOCALE_FALLBACK_KEY.to_string(), "en_US.UTF-8".to_string()))
+                .collect::<std::collections::HashMap<_, _>>();
+
+        // Whatever we inject has to satisfy the check that gated it, or every
+        // pane would keep re-deriving a fallback that is already in place.
+        assert!(!locale_fallback_is_needed(&injected, |_| None));
+
+        // And it has to back every category, not just character handling — see
+        // LOCALE_FALLBACK_KEY. LC_CTYPE here would leave a shell warning about
+        // LC_COLLATE and friends on every launch.
+        assert_eq!(LOCALE_FALLBACK_KEY, "LANG");
     }
 
     #[test]


### PR DESCRIPTION
Inject the derived UTF-8 locale as `LANG` instead of `LC_CTYPE`, so a pane that inherits no locale gets *every* category configured rather than just character handling.

| | Before | After |
|---|---|---|
| Variable injected when nothing is inherited | `LC_CTYPE` | `LANG` |
| `LC_CTYPE` (character handling) | derived UTF-8 locale | same, via `LANG` |
| `LC_COLLATE` / `LC_TIME` / `LC_NUMERIC` / `LC_MESSAGES` | stuck at `C` | derived locale |
| bash on launch | warns `setlocale: LC_COLLATE: cannot change locale ()`, once per unset category | no warning |
| A user `LC_*` set later in their own rc files | wins | still wins (`LANG` is the fallback, not `LC_ALL`) |

## Why

`locale_fallback_is_needed` fires only when `LC_ALL`, `LC_CTYPE` and `LANG` are all absent or empty — the normal situation for a GUI-launched process on macOS. The intent is right; the injection was just too narrow.

A shell resolves each category by consulting `LC_ALL` → `LC_<category>` → `LANG`. With only `LC_CTYPE` set, that chain finds nothing for every other category. bash calls `setlocale(cat, "")` per category and prints a warning for each miss — hence the empty parentheses in `cannot change locale ()`, which is the empty string it ended up passing. zsh and fish discard the return value silently, so they look fine while being equally half-configured: `locale` still reports `C` for collation, time and numbers.

`LANG` is the right lever. It backs every category, and it is the *lowest* precedence one, so anything the user's own `.bashrc`/`.zshrc` exports afterwards still overrides it. `LC_ALL` would also cover every category but would clobber exactly those user settings.

Note this does mean `LC_MESSAGES` now follows the derived locale too, so program messages can come out localized where they previously stayed English. That only applies to panes that inherited *no* locale configuration at all, where the alternative is a half-`C` environment; a user who wants English messages can set `LC_MESSAGES` or `LANG` themselves and the fallback stops firing entirely.

## Testing

- New `locale_fallback_sets_a_variable_that_backs_every_category`: asserts the injected variable satisfies the very check that gated it (otherwise every pane would re-derive a fallback that is already in place), and pins it to a whole-category variable.
- Existing `locale_fallback_respects_inherited_and_configured_environments`, `character_locale_only_returns_installed_locales` and `derived_character_locale_is_installed_on_this_machine` still pass — the derivation logic is untouched, only the variable it lands in changed.
- `cargo test -p tty7-core --lib locale` — 5 passed.
- `cargo fmt --check` clean; `cargo build -p tty7-core` clean (the two dead-code warnings are pre-existing Windows-only constants).
- Verified by hand on macOS: with no locale inherited, bash previously printed three `setlocale` warnings at startup and `locale` reported `C` for everything but `LC_CTYPE`.
