### PR TITLE
fix(ui): soften overlay scrollbars

### DIFF
--- a/src/ui/scrollbar.rs
+++ b/src/ui/scrollbar.rs
@@ -19,6 +19,11 @@ pub(crate) fn with_vertical_scrollbar(
                 .left_0()
                 .right_0()
                 .bottom_0()
+                // No `scrollbar_show` override: it falls back to
+                // `cx.theme().scrollbar_show`, which `apply_theme` derives from
+                // `should_auto_hide_scrollbars()` — the OS "show scroll bars"
+                // preference. Pinning it here would take that choice away from
+                // everyone who asked for always-visible bars.
                 .child(Scrollbar::vertical(handle).id(id)),
         )
         .into_any_element()

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -398,8 +398,8 @@ pub(crate) fn apply_theme(mut window: Option<&mut Window>, cx: &mut App) {
     t.caret = rgb(m.caret).into();
     t.selection = rgb(m.selection).into();
 
-    let scrollbar_thumb: Hsla = rgb(presets::mix(m.background, m.foreground, 0.26)).into();
-    let scrollbar_thumb_hover: Hsla = rgb(presets::mix(m.background, m.foreground, 0.42)).into();
+    let scrollbar_thumb: Hsla = rgb(presets::mix(m.background, m.foreground, 0.18)).into();
+    let scrollbar_thumb_hover: Hsla = rgb(presets::mix(m.background, m.foreground, 0.34)).into();
     t.scrollbar = gpui::transparent_black();
     t.scrollbar_thumb = scrollbar_thumb;
     t.scrollbar_thumb_hover = scrollbar_thumb_hover;


### PR DESCRIPTION
## Summary

- make tty7's overlay scrollbars use the scrolling-only presentation instead of inheriting the platform's always-visible mode
- reduce the resting and hover thumb contrast so scrollbars sit more quietly over sidebar and panel content

## Why

On macOS, `preferredScrollerStyle` can switch away from overlay mode depending on the system input-device configuration. tty7 mapped that state to `ScrollbarShow::Always`, and gpui-component renders that mode with an 8 px active thumb inside a 16 px hit area. The result was a wide, permanently visible gray bar in the tab sidebar.

These scrollbars are intentionally overlaid on content, so using the scrolling-only presentation keeps them discoverable while scrolling without leaving heavy chrome over the list at rest.

## Verification

- `cargo fmt --check`
- `cargo check -p tty7`
- manually verified the sidebar in a dev build with an isolated config directory
