### PR TITLE
fix(deps): pick up the gpui fix for the portal-triggered borrow panic on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,7 +1459,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -2023,7 +2023,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3182,7 +3182,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -3373,7 +3373,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -3424,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -3471,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3482,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -3495,7 +3495,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "schemars",
  "serde",
@@ -3505,7 +3505,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "anyhow",
  "log",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -3538,7 +3538,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3567,7 +3567,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "http_client_tls"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "rustls",
  "rustls-platform-verifier",
@@ -5039,7 +5039,7 @@ checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -6143,7 +6143,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "collections",
  "serde",
@@ -7116,7 +7116,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "derive_refineable",
 ]
@@ -7159,7 +7159,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 [[package]]
 name = "reqwest_client"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7693,7 +7693,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "async-task",
  "backtrace",
@@ -8506,7 +8506,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "heapless",
  "log",
@@ -9971,7 +9971,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "anyhow",
  "async-fs",
@@ -10010,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "perf",
  "quote",
@@ -11825,7 +11825,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11870,7 +11870,7 @@ dependencies = [
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -11881,7 +11881,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/l0ng-ai/zed?branch=tty7#faeb8732b2ae508022740505a27222d2f61ece5f"
+source = "git+https://github.com/l0ng-ai/zed?branch=tty7#3a4acfdf38ea7ee5e9f6f13b5e53fe0dd22cc62f"
 
 [[package]]
 name = "zune-core"


### PR DESCRIPTION
26.8.1 dies on launch under Wayland on a VMware Ubuntu guest, before any window shows:

```
thread 'main' panicked at crates/gpui_linux/src/linux/wayland/client.rs:924:23:
RefCell already borrowed
```

## Cause

`gpui_linux`'s xdg-desktop-portal event source held `client.borrow_mut()` across
`set_appearance` / `set_button_layout`. Those run the window callbacks, which re-enter GPUI —
and anything the app does there that reaches a platform method routed through `with_common`
borrows the same `RefCell` again.

The portal answers its initial color-scheme and button-layout queries asynchronously, so it
only bites when the reply lands *after* window creation. On a fast machine the reply usually
wins that race and `client.windows` is still empty; in a VM it loses every time.

## Fix

Fixed upstream in our fork — l0ng-ai/zed@3a4acfd — by collecting the window pointers, dropping
the borrow, then notifying. The X11 client had the same shape and got the same treatment, so
falling back with `WAYLAND_DISPLAY=` doesn't just move the crash.

This PR is only the lockfile re-pin onto that commit.

## Scope

`gpui_linux` is pulled in under `cfg(any(target_os = "linux", target_os = "freebsd"))` only, so
Windows and macOS never compile the changed code. Verified with `cargo check` on the crate under
WSL Ubuntu.