### PR TITLE
fix(core): make Codex hook commands work under PowerShell on Windows

### DIFF
--- a/crates/tty7-core/Cargo.toml
+++ b/crates/tty7-core/Cargo.toml
@@ -141,7 +141,6 @@ getrandom = "0.3"
 # tree on hangup (ConPTY's `kill` only reaches the shell itself).
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
-    "Win32_Storage_FileSystem",
     "Win32_System_Console",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_Threading",

--- a/crates/tty7-core/Cargo.toml
+++ b/crates/tty7-core/Cargo.toml
@@ -141,6 +141,7 @@ getrandom = "0.3"
 # tree on hangup (ConPTY's `kill` only reaches the shell itself).
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
+    "Win32_Storage_FileSystem",
     "Win32_System_Console",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_Threading",

--- a/crates/tty7-core/src/core/agent_hooks.rs
+++ b/crates/tty7-core/src/core/agent_hooks.rs
@@ -1206,9 +1206,12 @@ mod tests {
         let local = local_host();
         let here = HookTarget::local(&*local).expect("home resolves in tests");
         let exe = std::env::current_exe().unwrap();
+        let command_exe = here
+            .hook_command_exe()
+            .unwrap_or_else(|| format!("\"{}\"", exe.display()));
         assert_eq!(
             here.hook_command(HookAgent::Claude, "stop"),
-            format!("\"{}\" agent-hook claude stop", exe.display())
+            format!("{command_exe} agent-hook claude stop")
         );
     }
 
@@ -1250,6 +1253,9 @@ mod tests {
         let exe = exe_json.trim_matches('"').to_string();
         let host = local_host();
         let target = HookTarget::local(&*host).expect("home resolves in tests");
+        let hook_exe_raw = target.hook_command_exe().unwrap_or_else(|| exe_raw.clone());
+        let hook_exe_json = serde_json::to_string(&hook_exe_raw).unwrap();
+        let hook_exe = hook_exe_json.trim_matches('"');
 
         let copilot = copilot_hooks_json(&target).expect("copilot content builds");
         let parsed: serde_json::Value = serde_json::from_str(&copilot).expect("valid JSON");
@@ -1267,11 +1273,11 @@ mod tests {
                 "copilot {event} carries the emitter"
             );
         }
-        assert!(copilot.contains(&exe));
+        assert!(copilot.contains(hook_exe));
 
         let opencode = opencode_plugin_js(&target).expect("opencode content builds");
         assert!(opencode.contains("agent-hook opencode"));
-        assert!(opencode.contains(&exe));
+        assert!(opencode.contains(hook_exe));
         assert!(opencode.contains(r#"process.env["TTY7"]"#));
 
         let pi = pi_extension_ts(&target).expect("pi content builds");
@@ -1300,7 +1306,7 @@ mod tests {
                 "grok {event} matcher"
             );
         }
-        assert!(grok.contains(&exe));
+        assert!(grok.contains(hook_exe));
     }
 
     #[test]

--- a/crates/tty7-core/src/core/agent_hooks.rs
+++ b/crates/tty7-core/src/core/agent_hooks.rs
@@ -354,16 +354,18 @@ impl<'a> HookTarget<'a> {
     /// path containing spaces, so the usual `"C:\Program Files\..."` form is
     /// parsed as `C:\Program` and fails — and even a quoted path without
     /// spaces is a syntax error in PowerShell (invoking a quoted path requires
-    /// the `&` call operator). Resolving the space-free 8.3 short path lets us
-    /// emit the path bare, which both `cmd.exe` and PowerShell execute.
+    /// the `&` call operator). When the executable resolves by its bare file
+    /// name from PATH, we can emit the name without any quoting, which every
+    /// shell (`cmd.exe`, PowerShell, bash) executes correctly.
     ///
-    /// Returns `None` when no space-free short path is available; callers then
-    /// fall back to the quoted long path.
+    /// Returns `None` when the executable is not resolvable by name from PATH,
+    /// or when the first PATH match is a different binary; callers then fall
+    /// back to the quoted full path.
     fn hook_command_exe(&self) -> Option<String> {
         #[cfg(windows)]
         if self.is_local() {
-            if let Some(short) = short_path(&self.exe) {
-                return Some(short);
+            if let Some(name) = path_resolvable_name(&self.exe) {
+                return Some(name);
             }
         }
         None
@@ -680,30 +682,32 @@ fn marker_command<'a>(matcher: &'a serde_json::Value, marker: &str) -> Option<&'
         })
 }
 
-/// Resolves `path` to its Windows 8.3 short form when one exists and is free
-/// of spaces, so generated hook commands survive PowerShell's `-Command`
-/// quoting. Returns `None` when short names are unavailable or the short path
-/// still contains spaces; callers then fall back to the long path.
+/// Returns the bare file name of `exe` when resolving that name from PATH
+/// yields the same binary. Returns `None` when the name does not resolve, or
+/// when an earlier PATH entry contains a different file with the same name
+/// (a bare-name command would then invoke the wrong binary).
 #[cfg(windows)]
-fn short_path(path: &Path) -> Option<String> {
-    use std::os::windows::ffi::OsStrExt;
-    use windows_sys::Win32::Storage::FileSystem::GetShortPathNameW;
-
-    let wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
-    unsafe {
-        let len = GetShortPathNameW(wide.as_ptr(), std::ptr::null_mut(), 0);
-        if len == 0 {
-            return None;
+fn path_resolvable_name(exe: &Path) -> Option<String> {
+    let name = exe.file_name()?.to_str()?;
+    let path_var = std::env::var_os("PATH")?;
+    let exe_canonical = std::fs::canonicalize(exe).ok()?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(name);
+        let Ok(candidate_canonical) = std::fs::canonicalize(&candidate) else {
+            continue;
+        };
+        if same_windows_path(&candidate_canonical, &exe_canonical) {
+            return Some(name.to_string());
         }
-        let mut buf = vec![0u16; len as usize];
-        let written = GetShortPathNameW(wide.as_ptr(), buf.as_mut_ptr(), len);
-        if written == 0 {
-            return None;
-        }
-        let short = String::from_utf16(&buf[..written as usize]).ok()?;
-        let short = short.trim_end_matches('\0');
-        (!short.contains(' ')).then(|| short.to_string())
+        return None;
     }
+    None
+}
+
+#[cfg(windows)]
+fn same_windows_path(a: &Path, b: &Path) -> bool {
+    a.to_string_lossy()
+        .eq_ignore_ascii_case(&b.to_string_lossy())
 }
 
 fn enable_codex_hooks_feature() -> Result<(), String> {
@@ -1151,9 +1155,9 @@ mod tests {
         let host = local_host();
         let target = HookTarget::local(&*host).expect("home resolves in tests");
         let cmd = target.hook_command(HookAgent::Claude, "stop");
-        // On Windows the executable may be rewritten to a space-free 8.3 short
-        // path, which must be emitted bare: PowerShell cannot invoke a quoted
-        // path without the `&` call operator.
+        // On Windows the executable may be emitted as a bare PATH-resolvable
+        // name: PowerShell cannot invoke a quoted path without the `&` call
+        // operator, so quoting is avoided whenever possible.
         #[cfg(not(windows))]
         assert!(cmd.starts_with('"'));
         assert!(cmd.ends_with("agent-hook claude stop"));

--- a/crates/tty7-core/src/core/agent_hooks.rs
+++ b/crates/tty7-core/src/core/agent_hooks.rs
@@ -337,11 +337,36 @@ impl<'a> HookTarget<'a> {
     }
 
     fn hook_command(&self, agent: HookAgent, event: &str) -> String {
+        if let Some(exe) = self.hook_command_exe() {
+            return format!("{exe} agent-hook {} {event}", agent.slug());
+        }
         format!(
             "\"{}\" agent-hook {} {event}",
             self.exe.display(),
             agent.slug()
         )
+    }
+
+    /// A shell-safe executable path for generated hook commands.
+    ///
+    /// On Windows, Codex runs hook commands through the session's shell, which
+    /// is frequently PowerShell. `pwsh -Command` drops the quotes around a
+    /// path containing spaces, so the usual `"C:\Program Files\..."` form is
+    /// parsed as `C:\Program` and fails — and even a quoted path without
+    /// spaces is a syntax error in PowerShell (invoking a quoted path requires
+    /// the `&` call operator). Resolving the space-free 8.3 short path lets us
+    /// emit the path bare, which both `cmd.exe` and PowerShell execute.
+    ///
+    /// Returns `None` when no space-free short path is available; callers then
+    /// fall back to the quoted long path.
+    fn hook_command_exe(&self) -> Option<String> {
+        #[cfg(windows)]
+        if self.is_local() {
+            if let Some(short) = short_path(&self.exe) {
+                return Some(short);
+            }
+        }
+        None
     }
 
     fn read(&self, p: &Path) -> io::Result<String> {
@@ -653,6 +678,32 @@ fn marker_command<'a>(matcher: &'a serde_json::Value, marker: &str) -> Option<&'
                 .and_then(|c| c.as_str())
                 .filter(|c| c.contains(marker))
         })
+}
+
+/// Resolves `path` to its Windows 8.3 short form when one exists and is free
+/// of spaces, so generated hook commands survive PowerShell's `-Command`
+/// quoting. Returns `None` when short names are unavailable or the short path
+/// still contains spaces; callers then fall back to the long path.
+#[cfg(windows)]
+fn short_path(path: &Path) -> Option<String> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::GetShortPathNameW;
+
+    let wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    unsafe {
+        let len = GetShortPathNameW(wide.as_ptr(), std::ptr::null_mut(), 0);
+        if len == 0 {
+            return None;
+        }
+        let mut buf = vec![0u16; len as usize];
+        let written = GetShortPathNameW(wide.as_ptr(), buf.as_mut_ptr(), len);
+        if written == 0 {
+            return None;
+        }
+        let short = String::from_utf16(&buf[..written as usize]).ok()?;
+        let short = short.trim_end_matches('\0');
+        (!short.contains(' ')).then(|| short.to_string())
+    }
 }
 
 fn enable_codex_hooks_feature() -> Result<(), String> {
@@ -1100,6 +1151,10 @@ mod tests {
         let host = local_host();
         let target = HookTarget::local(&*host).expect("home resolves in tests");
         let cmd = target.hook_command(HookAgent::Claude, "stop");
+        // On Windows the executable may be rewritten to a space-free 8.3 short
+        // path, which must be emitted bare: PowerShell cannot invoke a quoted
+        // path without the `&` call operator.
+        #[cfg(not(windows))]
         assert!(cmd.starts_with('"'));
         assert!(cmd.ends_with("agent-hook claude stop"));
     }


### PR DESCRIPTION
## Summary

Fixes #297: on Windows, the Codex hooks generated by tty7 fail when Codex executes them through a PowerShell session.

Codex runs hook commands through the session's environment shell. On a PowerShell pane that means:

```
pwsh -NoProfile -Command "C:\Program Files\tty7\tty7-app.exe" agent-hook codex session-start
```

PowerShell's `-Command` parsing drops the quotes around the path, so PowerShell tries to execute `C:\Program` and exits with code 1. Codex reports `hook: SessionStart Failed` and tty7 never receives the `session-start` / `prompt-submit` / `stop` events.

## Change (Option A, per review discussion)

For local Windows installs, when the executable resolves by its bare file name from PATH — tty7 adds its install directory to PATH via `install_cli_on_path` — generate the hook command without any path quoting:

```
tty7-app.exe agent-hook codex session-start
```

The bare name has no spaces and no shell metacharacters, so it is executed correctly by `cmd.exe`, PowerShell, and bash alike, with no dependency on 8.3 short names. The PATH lookup verifies that the first resolvable match is the same binary (`self.exe`); otherwise the command falls back to the existing quoted full path (unchanged behavior for non-PATH installs and remote targets).

## Verification

- The bare-name command `tty7-app.exe agent-hook codex session-start` exits 0 under both `cmd /C` and `pwsh -NoProfile -Command` (verified with the real binary; the name resolves on a default install).
- The PATH resolution helper is verified: the real exe resolves to `tty7-app.exe`, and a file in a non-PATH directory correctly does not.
- The previous long-path template fails under PowerShell with `C:\Program: The term 'C:\Program' is not recognized...`.
- The previously proposed 8.3 short-path form was dropped per review: it depends on short-name generation and can still contain shell metacharacters (verified: `dev&ops(50%)$` → `DEV&OP~1`).
- `cargo fmt --check` passes; the PATH-resolution logic was verified in a standalone Windows build. Full `cargo check` could not run locally because the machine lacks NASM/CMake (`aws-lc-sys`), so CI is the authoritative build check.

## Notes

- PATH changes only affect newly started processes; users should restart Codex sessions after (re)installing hooks.
- Remote Windows targets need their own PATH handling (left as future work in #297).
- Any template change invalidates Codex's persisted `trusted_hash` for the installed hooks, so users will need to re-trust the hooks after upgrading (worth a note in the install UX or changelog).
