### PR TITLE
fix(input): forward macOS editing shortcuts to foreground TUIs

### DIFF
--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -45,7 +45,8 @@ actions!(
         FindNext,
         FindPrevious,
         ClearScrollback,
-        InsertNewline
+        InsertNewline,
+        InsertNewlineFallback
     ]
 );
 
@@ -1184,6 +1185,17 @@ impl TerminalView {
         }
     }
 
+    fn send_shortcut_bytes(&mut self, bytes: &[u8], key: &str, cx: &mut Context<Self>) {
+        let shell_owns_prompt = self.shell_owns_prompt();
+        self.release_hold();
+        self.send_to_pty(bytes, cx);
+        if !shell_owns_prompt {
+            let alt = self.on_alt_screen();
+            self.typeahead
+                .observe(RawInput::Key { key, plain: false }, alt);
+        }
+    }
+
     fn handle_cmd_shortcut(
         &mut self,
         ks: &gpui::Keystroke,
@@ -1222,6 +1234,8 @@ impl TerminalView {
                 if self.input_active() {
                     self.editor_move_edge(false, m.shift);
                     cx.notify();
+                } else if cfg!(target_os = "macos") && self.accepts_input(cx) {
+                    self.send_shortcut_bytes(&[0x01], "a", cx);
                 }
                 CmdKey::Consumed
             }
@@ -1229,6 +1243,8 @@ impl TerminalView {
                 if self.input_active() {
                     self.editor_move_edge(true, m.shift);
                     cx.notify();
+                } else if cfg!(target_os = "macos") && self.accepts_input(cx) {
+                    self.send_shortcut_bytes(&[0x05], "e", cx);
                 }
                 CmdKey::Consumed
             }
@@ -1241,19 +1257,7 @@ impl TerminalView {
                     self.cursor_visible = true;
                     cx.notify();
                 } else if cfg!(target_os = "macos") && self.accepts_input(cx) {
-                    let shell_owns_prompt = self.shell_owns_prompt();
-                    self.release_hold();
-                    self.send_to_pty(&[0x15], cx);
-                    if !shell_owns_prompt {
-                        let alt = self.on_alt_screen();
-                        self.typeahead.observe(
-                            RawInput::Key {
-                                key: "u",
-                                plain: false,
-                            },
-                            alt,
-                        );
-                    }
+                    self.send_shortcut_bytes(&[0x15], "u", cx);
                 }
                 CmdKey::Consumed
             }
@@ -1265,6 +1269,8 @@ impl TerminalView {
                     self.close_completion();
                     self.cursor_visible = true;
                     cx.notify();
+                } else if cfg!(target_os = "macos") && self.accepts_input(cx) {
+                    self.send_shortcut_bytes(&[0x0b], "k", cx);
                 }
                 CmdKey::Consumed
             }
@@ -2641,6 +2647,19 @@ impl TerminalView {
         self.editor_goal_col = None;
         self.last_word_nav = None;
         cx.notify();
+    }
+
+    fn insert_newline_fallback_action(&mut self, cx: &mut Context<Self>) {
+        if self.input_active() {
+            self.insert_newline_action(cx);
+        } else if (self.search.is_some() && self.search_focused)
+            || self.kitty_flags().active()
+            || !self.accepts_input(cx)
+        {
+            cx.propagate();
+        } else {
+            self.send_shortcut_bytes(b"\n", "enter", cx);
+        }
     }
 
     fn accept_line(&mut self, cx: &mut Context<Self>) {
@@ -4359,6 +4378,9 @@ impl Render for TerminalView {
             .on_action(cx.listener(|this, _: &ClearScrollback, _w, cx| this.clear_scrollback(cx)))
             .on_action(cx.listener(|this, _: &InsertNewline, _w, cx| {
                 this.insert_newline_action(cx);
+            }))
+            .on_action(cx.listener(|this, _: &InsertNewlineFallback, _w, cx| {
+                this.insert_newline_fallback_action(cx);
             }))
             .on_action(cx.listener(|this, _: &SendTab, _w, cx| {
                 this.tab_pressed(true, cx);
@@ -6623,6 +6645,82 @@ mod gpui_tests {
     }
 
     #[gpui::test]
+    fn shift_enter_reaches_a_foreground_tui_with_kitty_encoding(cx: &mut TestAppContext) {
+        crate::core::config::pin_test_config_dir();
+        let (window, mut daemon) = harness(cx);
+        cx.update(|cx| crate::ui::keymap::init(cx));
+        DaemonMsg::Output(b"\x1b[>1u".to_vec())
+            .encode(&mut daemon)
+            .unwrap();
+        for _ in 0..200 {
+            cx.run_until_parked();
+            if window
+                .update(cx, |view, _, _| view.kitty_flags().active())
+                .unwrap()
+            {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        window
+            .update(cx, |view, window, cx| {
+                assert!(!view.input_active(), "the foreground TUI owns input");
+                window.activate_window();
+                view.focus_handle.focus(window, cx);
+            })
+            .unwrap();
+
+        let mut vcx = gpui::VisualTestContext::from_window(window.into(), cx);
+        vcx.simulate_keystrokes("shift-enter");
+
+        assert_eq!(
+            next_input_until_timeout(&mut daemon),
+            Some(b"\x1b[13;2u".to_vec())
+        );
+    }
+
+    #[gpui::test]
+    fn shift_enter_reaches_a_foreground_tui_as_lf_without_kitty(cx: &mut TestAppContext) {
+        crate::core::config::pin_test_config_dir();
+        let (window, mut daemon) = harness(cx);
+        cx.update(|cx| crate::ui::keymap::init(cx));
+        window
+            .update(cx, |view, window, cx| {
+                assert!(!view.input_active(), "the foreground TUI owns input");
+                window.activate_window();
+                view.focus_handle.focus(window, cx);
+            })
+            .unwrap();
+
+        let mut vcx = gpui::VisualTestContext::from_window(window.into(), cx);
+        vcx.simulate_keystrokes("shift-enter");
+
+        assert_eq!(next_input_until_timeout(&mut daemon), Some(b"\n".to_vec()));
+    }
+
+    #[gpui::test]
+    fn alt_enter_keeps_its_legacy_encoding_in_a_foreground_tui(cx: &mut TestAppContext) {
+        crate::core::config::pin_test_config_dir();
+        let (window, mut daemon) = harness(cx);
+        cx.update(|cx| crate::ui::keymap::init(cx));
+        window
+            .update(cx, |view, window, cx| {
+                assert!(!view.input_active(), "the foreground TUI owns input");
+                window.activate_window();
+                view.focus_handle.focus(window, cx);
+            })
+            .unwrap();
+
+        let mut vcx = gpui::VisualTestContext::from_window(window.into(), cx);
+        vcx.simulate_keystrokes("alt-enter");
+
+        assert_eq!(
+            next_input_until_timeout(&mut daemon),
+            Some(b"\x1b\r".to_vec())
+        );
+    }
+
+    #[gpui::test]
     fn insert_newline_action_declines_when_the_editor_is_not_live(cx: &mut TestAppContext) {
         let (window, _daemon) = harness(cx);
         window
@@ -7896,6 +7994,38 @@ mod gpui_tests {
             .unwrap();
 
         assert_eq!(next_input_until_timeout(&mut daemon), Some(vec![0x15]));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[gpui::test]
+    fn cmd_navigation_reaches_a_foreground_tui_as_readline_controls(cx: &mut TestAppContext) {
+        crate::core::config::pin_test_config_dir();
+        let (window, mut daemon) = harness(cx);
+
+        for (key, expected) in [("left", 0x01), ("right", 0x05), ("delete", 0x0b)] {
+            window
+                .update(cx, |view, window, cx| {
+                    assert!(!view.input_active(), "the foreground TUI owns input");
+                    view.on_key_down(
+                        &KeyDownEvent {
+                            keystroke: gpui::Keystroke {
+                                modifiers: Modifiers {
+                                    platform: true,
+                                    ..Modifiers::default()
+                                },
+                                key: key.into(),
+                                key_char: None,
+                            },
+                            is_held: false,
+                            prefer_character_input: false,
+                        },
+                        window,
+                        cx,
+                    );
+                })
+                .unwrap();
+            assert_eq!(next_input_until_timeout(&mut daemon), Some(vec![expected]));
+        }
     }
 
     #[cfg(target_os = "macos")]

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -1240,6 +1240,20 @@ impl TerminalView {
                     self.close_completion();
                     self.cursor_visible = true;
                     cx.notify();
+                } else if cfg!(target_os = "macos") && self.accepts_input(cx) {
+                    let shell_owns_prompt = self.shell_owns_prompt();
+                    self.release_hold();
+                    self.send_to_pty(&[0x15], cx);
+                    if !shell_owns_prompt {
+                        let alt = self.on_alt_screen();
+                        self.typeahead.observe(
+                            RawInput::Key {
+                                key: "u",
+                                plain: false,
+                            },
+                            alt,
+                        );
+                    }
                 }
                 CmdKey::Consumed
             }
@@ -7849,6 +7863,98 @@ mod gpui_tests {
             .unwrap();
         let text = cx.update(|cx| cx.read_from_clipboard().and_then(|item| item.text()));
         assert_eq!(text.as_deref(), Some("hello"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[gpui::test]
+    fn cmd_backspace_reaches_a_foreground_tui_as_ctrl_u(cx: &mut TestAppContext) {
+        crate::core::config::pin_test_config_dir();
+        let (window, mut daemon) = harness(cx);
+        window
+            .update(cx, |view, window, cx| {
+                assert!(
+                    !view.input_active(),
+                    "the foreground process, not tty7's editor, owns input"
+                );
+                view.on_key_down(
+                    &KeyDownEvent {
+                        keystroke: gpui::Keystroke {
+                            modifiers: Modifiers {
+                                platform: true,
+                                ..Modifiers::default()
+                            },
+                            key: "backspace".into(),
+                            key_char: None,
+                        },
+                        is_held: false,
+                        prefer_character_input: false,
+                    },
+                    window,
+                    cx,
+                );
+            })
+            .unwrap();
+
+        assert_eq!(next_input_until_timeout(&mut daemon), Some(vec![0x15]));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[gpui::test]
+    fn cmd_backspace_releases_held_input_before_ctrl_u(cx: &mut TestAppContext) {
+        crate::core::config::pin_test_config_dir();
+        let (window, mut daemon) = harness(cx);
+        DaemonMsg::Prompt {
+            active: true,
+            at_prompt: false,
+            last_exit: None,
+        }
+        .encode(&mut daemon)
+        .unwrap();
+        for _ in 0..200 {
+            cx.run_until_parked();
+            let gap = window
+                .update(cx, |view, _, _| {
+                    view.terminal.shell_active() && !view.terminal.at_prompt()
+                })
+                .unwrap();
+            if gap {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+
+        window
+            .update(cx, |view, window, cx| {
+                view.commit_text("ls", cx);
+                view.on_key_down(
+                    &KeyDownEvent {
+                        keystroke: gpui::Keystroke {
+                            modifiers: Modifiers {
+                                platform: true,
+                                ..Modifiers::default()
+                            },
+                            key: "backspace".into(),
+                            key_char: None,
+                        },
+                        is_held: false,
+                        prefer_character_input: false,
+                    },
+                    window,
+                    cx,
+                );
+            })
+            .unwrap();
+
+        assert_eq!(
+            next_input_until_timeout(&mut daemon),
+            Some(b"ls".to_vec()),
+            "held text must reach the PTY before the line-kill"
+        );
+        assert_eq!(
+            next_input_until_timeout(&mut daemon),
+            Some(vec![0x15]),
+            "Ctrl-U must follow the text it clears"
+        );
     }
 
     #[gpui::test]

--- a/src/ui/keymap.rs
+++ b/src/ui/keymap.rs
@@ -3,7 +3,8 @@ use gpui::{App, Global, KeyBinding, Keystroke, NoAction};
 use crate::core::actions::*;
 use crate::core::config::Config;
 use crate::terminal::view::{
-    ClearScrollback, CopyText, FindInTerminal, FindNext, FindPrevious, InsertNewline, PasteText,
+    ClearScrollback, CopyText, FindInTerminal, FindNext, FindPrevious, InsertNewline,
+    InsertNewlineFallback, PasteText,
 };
 use crate::ui::theme::set_menus;
 
@@ -74,6 +75,10 @@ fn extra_keystrokes(effective: &[(String, String)]) -> Vec<(&'static str, &'stat
         .collect()
 }
 
+fn is_default_insert_newline_binding(action: &str, key: &str) -> bool {
+    action == "InsertNewline" && key == INSERT_NEWLINE_DEFAULT
+}
+
 pub(crate) fn extra_bindings(cx: &App) -> Vec<(String, String)> {
     extra_keystrokes(&effective_bindings(cx))
         .into_iter()
@@ -97,7 +102,16 @@ fn action_bindings(effective: &[(String, String)]) -> Vec<KeyBinding> {
             continue;
         }
         match make_binding(action, key) {
-            Some(b) => bindings.push(b),
+            Some(b) => {
+                bindings.push(b);
+                if is_default_insert_newline_binding(action, key) {
+                    bindings.push(KeyBinding::new(
+                        INSERT_NEWLINE_DEFAULT,
+                        InsertNewlineFallback,
+                        Some("Terminal"),
+                    ));
+                }
+            }
             None => log::warn!("ignoring keybinding: unknown action '{action}'"),
         }
     }
@@ -695,6 +709,52 @@ mod tests {
             );
         }
         assert_eq!(key_tokens("shift-enter"), vec![SHIFT, "⏎"]);
+    }
+
+    #[test]
+    fn shift_enter_fallback_retires_with_an_insert_newline_rebind() {
+        assert!(is_default_insert_newline_binding(
+            "InsertNewline",
+            "shift-enter"
+        ));
+        assert!(!is_default_insert_newline_binding(
+            "InsertNewline",
+            "ctrl-o"
+        ));
+        assert!(!is_default_insert_newline_binding("InsertNewline", ""));
+    }
+
+    #[test]
+    fn shift_enter_prefix_binding_still_waits_for_its_second_key() {
+        let mut effective = default_bindings()
+            .into_iter()
+            .map(|(action, key)| (action.to_string(), key.to_string()))
+            .collect::<Vec<_>>();
+        effective
+            .iter_mut()
+            .find(|(action, _)| action == "OpenSettings")
+            .unwrap()
+            .1 = "shift-enter x".to_string();
+
+        let mut keymap = gpui::Keymap::default();
+        keymap.add_bindings(action_bindings(&effective));
+        let input = [gpui::Keystroke::parse("shift-enter").unwrap()];
+        let context = [gpui::KeyContext::parse("Terminal").unwrap()];
+        let (_, pending) = keymap.bindings_for_input(&input, &context);
+
+        assert!(pending, "the keymap must wait for the second key");
+
+        let input = [
+            gpui::Keystroke::parse("shift-enter").unwrap(),
+            gpui::Keystroke::parse("x").unwrap(),
+        ];
+        let (matched, pending) = keymap.bindings_for_input(&input, &context);
+        assert!(!pending);
+        assert!(
+            matched
+                .first()
+                .is_some_and(|binding| binding.action().partial_eq(&OpenSettings))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve tty7's existing inline-editor behavior when it owns the shell prompt
- forward macOS foreground-TUI editing chords as readline controls: Cmd+Left -> Ctrl+A, Cmd+Right -> Ctrl+E, Cmd+Backspace -> Ctrl+U, and Cmd+Forward Delete -> Ctrl+K
- send LF for the default Shift+Enter binding when a foreground TUI has not enabled the Kitty keyboard protocol, while preserving Kitty's `CSI 13;2u` encoding when negotiated
- release held input before shortcut bytes and taint typeahead where needed so input ordering and cleared text stay correct
- keep Alt+Enter legacy encoding, custom InsertNewline rebindings, and multi-key Shift+Enter prefixes intact

## Testing

- `cargo +1.97.1 fmt --check`
- `git diff --check`
- `cargo +1.97.1 test --locked` (all test binaries passed; main suite: 919 passed, 3 ignored)
- Rust LSP diagnostics on the changed files (no errors)
- three rounds of `codex review --uncommitted`; the final review found no functional issues
- manual validation on macOS 26.1 / Apple Silicon using an ad-hoc arm64 DMG, covering foreground TUI mappings and tty7 inline-editor regressions

Fixes #301
