### PR TITLE
fix(settings): make hover highlights respond immediately

### DIFF
--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -36,6 +36,10 @@ use crate::ui::presets;
 use crate::ui::rounding;
 use crate::ui::rounding::RoundedCorners as _;
 
+fn settings_row_id(label: &str, _desc: &str) -> SharedString {
+    SharedString::from(format!("settings-row-{label}"))
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SettingsSection {
     Appearance,
@@ -962,7 +966,9 @@ impl Tty7App {
         let theme = cx.theme();
         let label = label.into();
         let desc = desc.into();
-        let element_id = SharedString::from(format!("settings-row-{label}:{desc}"));
+        // Descriptions can contain live status (for example an agent hook target), so they
+        // must not participate in the identity that preserves GPUI's hover state.
+        let element_id = settings_row_id(&label, &desc);
         h_flex()
             .id(element_id)
             .items_center()
@@ -4672,6 +4678,18 @@ impl Tty7App {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn settings_row_identity_depends_only_on_its_stable_label() {
+        assert_eq!(
+            settings_row_id("Claude Code", "Installingâ€¦"),
+            settings_row_id("Claude Code", "Installed in C:\\tools")
+        );
+        assert_ne!(
+            settings_row_id("Claude Code", "Installed"),
+            settings_row_id("Codex", "Installed")
+        );
+    }
 
     #[test]
     fn every_section_has_search_entries() {

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -958,10 +958,13 @@ impl Tty7App {
         desc: impl Into<String>,
         control: AnyElement,
         cx: &Context<Self>,
-    ) -> Div {
+    ) -> Stateful<Div> {
         let theme = cx.theme();
+        let label = label.into();
         let desc = desc.into();
+        let element_id = SharedString::from(format!("settings-row-{label}:{desc}"));
         h_flex()
+            .id(element_id)
             .items_center()
             .justify_between()
             .gap_8()
@@ -970,6 +973,7 @@ impl Tty7App {
             .mx_neg_2p5()
             .rounded_lg()
             .hover(|h| h.bg(gpui::rgb(cx.global::<presets::Surfaces>().window.hover)))
+            .on_hover(cx.listener(|_this, _hovered, _window, cx| cx.notify()))
             .child(
                 v_flex()
                     .gap_0p5()
@@ -979,7 +983,7 @@ impl Tty7App {
                             .text_sm()
                             .font_weight(FontWeight::MEDIUM)
                             .text_color(theme.foreground)
-                            .child(label.into()),
+                            .child(label),
                     )
                     .when(!desc.is_empty(), |col| {
                         col.child(


### PR DESCRIPTION
## Summary

This change fixes delayed or missing hover highlights on settings rows. Each row now has a stable element ID, and hover transitions explicitly invalidate `Tty7App`, ensuring the highlight updates immediately when the pointer enters, leaves, or moves between rows. Existing layouts and theme colors remain unchanged.


## Root Cause

Settings rows previously relied on stateless hover styling and GPUI's indirect current-view notification. Inside the scrollable settings container, this did not reliably invalidate the settings view, causing hover highlights to appear late or not appear at all.
