### PR TITLE
fix(install): prefer bundled server over release download for SSH remotes

### DIFF
--- a/crates/tty7-core/src/daemon/install/mod.rs
+++ b/crates/tty7-core/src/daemon/install/mod.rs
@@ -128,6 +128,9 @@ pub trait ServerBinarySource: Send + Sync {
 pub struct BundledOrRelease<'a> {
     pub fetch: &'a dyn AssetFetcher,
     pub bundled: Option<wsl::BundledServerBinary>,
+    /// When a bundled directory is configured but the requested asset is absent,
+    /// fall back to the release download instead of failing with `MissingBundled`.
+    pub fallback_on_missing: bool,
 }
 
 impl<'a> BundledOrRelease<'a> {
@@ -135,6 +138,18 @@ impl<'a> BundledOrRelease<'a> {
         Self {
             fetch,
             bundled: wsl::BundledServerBinary::from_env_only(),
+            fallback_on_missing: false,
+        }
+    }
+
+    /// Prefer a server binary shipped next to the client executable (see
+    /// `wsl::BundledServerBinary::discover`), falling back to the GitHub release
+    /// download when no matching bundled asset is present.
+    pub fn discover(fetch: &'a dyn AssetFetcher) -> Self {
+        Self {
+            fetch,
+            bundled: Some(wsl::BundledServerBinary::discover()),
+            fallback_on_missing: true,
         }
     }
 }
@@ -151,7 +166,17 @@ impl ServerBinarySource for BundledOrRelease<'_> {
         on_progress: &dyn Fn(u64, Option<u64>),
     ) -> Result<LoadedBinary, InstallError> {
         match &self.bundled {
-            Some(bundled) => bundled.load(version, asset),
+            Some(bundled) => match bundled.load(version, asset) {
+                Ok(binary) => Ok(binary),
+                Err(InstallError::MissingBundled { .. }) if self.fallback_on_missing => {
+                    ReleaseDownload { fetch: self.fetch }.load_with_progress(
+                        version,
+                        asset,
+                        on_progress,
+                    )
+                }
+                Err(e) => Err(e),
+            },
             None => ReleaseDownload { fetch: self.fetch }.load_with_progress(
                 version,
                 asset,
@@ -1017,7 +1042,7 @@ pub fn ensure_remote_server_labeled(conn: &Arc<SshConnection>, host: &str) -> io
     let ops = ssh_ops::SshRemoteOps::new(conn.clone());
     let fetch = default_fetcher();
     let confirm = install_confirm();
-    let source = BundledOrRelease::from_env(fetch.as_ref());
+    let source = BundledOrRelease::discover(fetch.as_ref());
     let report = Installer::with_source(&ops, &source, confirm.as_ref(), host).run()?;
     log::info!(
         "remote {host}: {} at {} ({}{})",
@@ -1055,7 +1080,7 @@ pub fn replace_remote_server(conn: &Arc<SshConnection>) -> io::Result<()> {
     let ops = ssh_ops::SshRemoteOps::new(conn.clone());
     let fetch = default_fetcher();
     let confirm = install_confirm();
-    let source = BundledOrRelease::from_env(fetch.as_ref());
+    let source = BundledOrRelease::discover(fetch.as_ref());
     Installer::with_source(&ops, &source, confirm.as_ref(), host).replace()?;
     Ok(())
 }

--- a/crates/tty7-core/src/daemon/install/tests.rs
+++ b/crates/tty7-core/src/daemon/install/tests.rs
@@ -1055,7 +1055,9 @@ fn discover_falls_back_to_release_when_bundled_is_missing() {
         bundled: Some(wsl::BundledServerBinary::in_dirs(vec![dir.clone()])),
         fallback_on_missing: true,
     };
-    let loaded = source.load("26.7.5", ASSET_X86_64).expect("falls back to release");
+    let loaded = source
+        .load("26.7.5", ASSET_X86_64)
+        .expect("falls back to release");
     assert_eq!(loaded.bytes, SERVER_BYTES);
     assert_eq!(
         release.fetched().len(),
@@ -1067,7 +1069,10 @@ fn discover_falls_back_to_release_when_bundled_is_missing() {
 
 #[test]
 fn discover_uses_bundled_when_it_is_present() {
-    let dir = std::env::temp_dir().join(format!("tty7-bundle-discover-present-{}", std::process::id()));
+    let dir = std::env::temp_dir().join(format!(
+        "tty7-bundle-discover-present-{}",
+        std::process::id()
+    ));
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     std::fs::write(dir.join(ASSET_X86_64), b"\x7fELF discovered build").unwrap();

--- a/crates/tty7-core/src/daemon/install/tests.rs
+++ b/crates/tty7-core/src/daemon/install/tests.rs
@@ -980,6 +980,7 @@ fn without_a_bundle_the_source_is_the_plain_download() {
     let source = BundledOrRelease {
         fetch: &release,
         bundled: None,
+        fallback_on_missing: false,
     };
     let loaded = source.load("26.7.5", ASSET_X86_64).expect("downloads");
     assert_eq!(loaded.bytes, SERVER_BYTES);
@@ -1001,6 +1002,7 @@ fn a_bundle_is_used_instead_of_downloading() {
     let source = BundledOrRelease {
         fetch: &release,
         bundled: Some(wsl::BundledServerBinary::in_dirs(vec![dir.clone()])),
+        fallback_on_missing: false,
     };
     let loaded = source.load("26.7.5", ASSET_X86_64).expect("loads locally");
     assert_eq!(loaded.bytes, b"\x7fELF local build");
@@ -1026,6 +1028,7 @@ fn a_bundle_that_lacks_the_asset_does_not_fall_back_to_the_network() {
     let source = BundledOrRelease {
         fetch: &release,
         bundled: Some(wsl::BundledServerBinary::in_dirs(vec![dir.clone()])),
+        fallback_on_missing: false,
     };
     let err = source.load("26.7.5", ASSET_X86_64).expect_err("no binary");
     assert!(matches!(err, InstallError::MissingBundled { .. }), "{err}");
@@ -1036,6 +1039,50 @@ fn a_bundle_that_lacks_the_asset_does_not_fall_back_to_the_network() {
     assert!(
         release.fetched().is_empty(),
         "no silent fallback to the network"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn discover_falls_back_to_release_when_bundled_is_missing() {
+    let dir = std::env::temp_dir().join(format!("tty7-bundle-discover-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let release = FakeRelease::new();
+    let source = BundledOrRelease {
+        fetch: &release,
+        bundled: Some(wsl::BundledServerBinary::in_dirs(vec![dir.clone()])),
+        fallback_on_missing: true,
+    };
+    let loaded = source.load("26.7.5", ASSET_X86_64).expect("falls back to release");
+    assert_eq!(loaded.bytes, SERVER_BYTES);
+    assert_eq!(
+        release.fetched().len(),
+        2,
+        "the manifest and the asset must be fetched when the bundled binary is absent"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn discover_uses_bundled_when_it_is_present() {
+    let dir = std::env::temp_dir().join(format!("tty7-bundle-discover-present-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(ASSET_X86_64), b"\x7fELF discovered build").unwrap();
+
+    let release = FakeRelease::new();
+    let source = BundledOrRelease {
+        fetch: &release,
+        bundled: Some(wsl::BundledServerBinary::in_dirs(vec![dir.clone()])),
+        fallback_on_missing: true,
+    };
+    let loaded = source.load("26.7.5", ASSET_X86_64).expect("loads locally");
+    assert_eq!(loaded.bytes, b"\x7fELF discovered build");
+    assert!(
+        release.fetched().is_empty(),
+        "a discovered bundled install must not touch the network"
     );
     let _ = std::fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary

SSH remote installs now prefer a `tty7-server` binary bundled with the Windows client and fall back to the GitHub release download only when no matching local asset exists.

## Problem

`ensure_remote_server` / `replace_remote_server` used `BundledOrRelease::from_env()`, which only honors the `TTY7_BUNDLED_SERVER_DIR` environment variable. The server binaries already staged by `bundle-windows.ps1` under `<exe-dir>/server/` were never considered, so every SSH remote install hit the network even when the binary was sitting right next to the executable.

WSL already uses `BundledServerBinary::discover()` to locate the same staged binaries.

## Change

- Added `BundledOrRelease::discover()` to auto-discover bundled server binaries next to the client executable.
- `discover()` falls back to `ReleaseDownload` when the bundled asset is missing.
- Kept `BundledOrRelease::from_env()` strict (no fallback) so an explicitly configured but missing bundle still fails loudly instead of silently downloading.
- Switched `ensure_remote_server_labeled()` and `replace_remote_server()` to `BundledOrRelease::discover()`.
- Added unit tests covering both the fallback and the bundled-hit paths.

## Behavior matrix

| Source | Bundled found | Bundled missing |
|--------|---------------|-----------------|
| `from_env()` | use bundled | `MissingBundled` error |
| `discover()` (now used by SSH) | use bundled | download from release |
| WSL `BundledServerBinary::discover()` | use bundled | `MissingBundled` error |

## Testing

- `cargo test -p tty7-core install::` passes (98 tests).
- New tests:
  - `discover_falls_back_to_release_when_bundled_is_missing`
  - `discover_uses_bundled_when_it_is_present`

## Notes

This change only affects the runtime source selection. The release workflow / `bundle-windows.ps1` already has the infrastructure to stage `server/` binaries; this PR makes that infrastructure actually effective for SSH remotes.

Fixes #343