### PR TITLE
feat(bell): add combined visual + audible terminal bell mode

### DIFF
--- a/crates/tty7-core/src/core/config.rs
+++ b/crates/tty7-core/src/core/config.rs
@@ -328,6 +328,7 @@ pub enum BellMode {
     #[default]
     Visual,
     Audible,
+    Both,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -1070,8 +1071,13 @@ mod tests {
         assert!(!cfg.mouse_reporting);
         assert_eq!(cfg.bell, BellMode::Audible);
 
+        let cfg: Config = serde_json::from_str(r#"{"bell": "both"}"#).unwrap();
+        assert_eq!(cfg.bell, BellMode::Both);
+
         let cfg: Config = serde_json::from_str(r#"{"bell": "loud"}"#).unwrap();
         assert_eq!(cfg.bell, BellMode::Visual);
+
+        assert_eq!(serde_json::to_string(&BellMode::Both).unwrap(), "\"both\"");
     }
 
     #[test]

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -1153,6 +1153,10 @@ impl TerminalView {
                         self.flash_bell(cx);
                     }
                 }
+                BellMode::Both => {
+                    ring_system_bell();
+                    self.flash_bell(cx);
+                }
             },
             AlacEvent::TextAreaSizeRequest(fmt) => {
                 let size = self.terminal.size();

--- a/src/ui/i18n.rs
+++ b/src/ui/i18n.rs
@@ -1453,8 +1453,8 @@ fn translate(locale: Locale, key: L10nKey) -> &'static str {
         L10nKey::SettingsBell => ("Bell", "铃声"),
         L10nKey::SettingsTerminalBell => ("Terminal bell", "终端铃声"),
         L10nKey::SettingsTerminalBellDesc => (
-            "How a bell (^G) is signalled: silenced, a brief flash, or the system sound.",
-            "铃声（^G）的通知方式：静音、短暂闪烁或系统声音。",
+            "How a bell (^G) is signalled: silenced, a brief flash, the system sound, or both.",
+            "铃声（^G）的通知方式：静音、短暂闪烁、系统声音，或两者同时。",
         ),
         L10nKey::SettingsLinks => ("Links", "链接"),
         L10nKey::DetectUrls => ("Detect URLs", "检测 URL"),
@@ -1956,8 +1956,8 @@ fn translate(locale: Locale, key: L10nKey) -> &'static str {
             "Tab补全 补全 菜单 建议 tab completion suggestions prompt",
         ),
         L10nKey::SettingsSearchTerminalBellKeywords => (
-            "bell audible visual flash sound silence beep ^g",
-            "终端铃声 铃声 提示音 闪烁 静音 beep bell terminal audible visual",
+            "bell audible visual flash sound silence beep both ^g",
+            "终端铃声 铃声 提示音 闪烁 静音 两者 同时 beep bell terminal audible visual both",
         ),
         L10nKey::SettingsSearchThemeKeywords => (
             "appearance color colours scheme dark light palette background foreground accent sync system os auto follow",

--- a/src/ui/i18n.rs
+++ b/src/ui/i18n.rs
@@ -265,6 +265,7 @@ pub enum L10nKey {
     SettingsBellModeOff,
     SettingsBellModeVisual,
     SettingsBellModeAudible,
+    SettingsBellModeBoth,
     SettingsPrompt,
     SettingsPromptIntro,
     SettingsTabCompletion,
@@ -1474,6 +1475,7 @@ fn translate(locale: Locale, key: L10nKey) -> &'static str {
         L10nKey::SettingsBellModeOff => ("Off", "关"),
         L10nKey::SettingsBellModeVisual => ("Visual", "闪烁"),
         L10nKey::SettingsBellModeAudible => ("Audible", "声音"),
+        L10nKey::SettingsBellModeBoth => ("Both", "闪烁 + 声音"),
         L10nKey::SettingsPrompt => ("Prompt", "提示符"),
         L10nKey::SettingsPromptIntro => (
             "tty7's own menus at the shell prompt. Turn one off to hand the key back to the shell.",
@@ -3189,6 +3191,7 @@ mod tests {
             L10nKey::SettingsBellModeOff,
             L10nKey::SettingsBellModeVisual,
             L10nKey::SettingsBellModeAudible,
+            L10nKey::SettingsBellModeBoth,
             L10nKey::SettingsPrompt,
             L10nKey::SettingsPromptIntro,
             L10nKey::SettingsTabCompletionDesc,

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -3516,7 +3516,8 @@ impl Tty7App {
                     0 => BellMode::None,
                     1 => BellMode::Visual,
                     2 => BellMode::Audible,
-                    _ => BellMode::Both,
+                    3 => BellMode::Both,
+                    _ => BellMode::default(),
                 };
                 this.set_bell_mode(mode, cx);
             },

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -3499,6 +3499,7 @@ impl Tty7App {
             BellMode::None => 0,
             BellMode::Visual => 1,
             BellMode::Audible => 2,
+            BellMode::Both => 3,
         };
         let bell_control = self.segmented(
             "term-bell",
@@ -3506,6 +3507,7 @@ impl Tty7App {
                 t(L10nKey::SettingsBellModeOff),
                 t(L10nKey::SettingsBellModeVisual),
                 t(L10nKey::SettingsBellModeAudible),
+                t(L10nKey::SettingsBellModeBoth),
             ],
             bell_idx,
             cx,
@@ -3513,7 +3515,8 @@ impl Tty7App {
                 let mode = match ix {
                     0 => BellMode::None,
                     1 => BellMode::Visual,
-                    _ => BellMode::Audible,
+                    2 => BellMode::Audible,
+                    _ => BellMode::Both,
                 };
                 this.set_bell_mode(mode, cx);
             },


### PR DESCRIPTION
Closes #356.

Adds a `BellMode::Both` option so the terminal bell can flash the pane *and* ring the system bell at the same time, instead of choosing one or the other.

Changes:
- New `BellMode::Both` variant (serialized as `\"both\"`).
- Bell event handler rings `ring_system_bell()` and calls `flash_bell(cx)` together.
- Settings → Terminal → Bell segmented control gains a fourth option.
- i18n keys, translations, and the key coverage test list updated.

Backward compatible: existing `none`/`visual`/`audible` values keep their current behavior.