### PR TITLE
fix(bell): ring the system bell on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,10 @@ windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",
     "Win32_System_Registry",
+    # `MessageBeep` (the terminal bell in `terminal::view`) is a user32 export,
+    # but the Win32 metadata files it under Diagnostics::Debug, so that is the
+    # module the binding needs — nothing here pulls in dbghelp.
+    "Win32_System_Diagnostics_Debug",
     "Win32_System_Threading",
     "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -310,13 +310,31 @@ fn notify_agent_finished(agent: crate::core::cli_agent::CLIAgent, elapsed: std::
     super::remote::notify_desktop(Some(agent.display_name()), &body);
 }
 
+/// Ring the platform's alert sound, reporting whether one was actually made —
+/// `Audible` falls back to a flash when it wasn't, so a silent `false` is the
+/// difference between "you heard the bell" and "you saw it instead".
+///
+/// Linux has no equivalent worth the dependency: the desktop sound APIs
+/// (libcanberra, PipeWire) are a runtime link away and X11's `XBell` does
+/// nothing under Wayland, so the flash fallback stays the answer there.
 fn ring_system_bell() -> bool {
     #[cfg(target_os = "macos")]
     {
         objc2_app_kit::NSBeep();
         true
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "windows")]
+    {
+        // MB_OK is the "Default Beep" scheme entry, so this follows whatever
+        // the user picked in Sound Settings — including "None", which is a
+        // deliberate silence and still reports success. Deliberately not
+        // `Beep()`, which synthesizes a fixed tone straight at the speaker and
+        // ignores the scheme. Returns immediately; the sound plays async.
+        use windows_sys::Win32::System::Diagnostics::Debug::MessageBeep;
+        use windows_sys::Win32::UI::WindowsAndMessaging::MB_OK;
+        unsafe { MessageBeep(MB_OK) != 0 }
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
         false
     }


### PR DESCRIPTION
## Problem

`ring_system_bell()` (`src/terminal/view.rs`) has only ever had a macOS
implementation — everywhere else it returns `false`:

```rust
#[cfg(not(target_os = "macos"))]
{
    false
}
```

`BellMode::Audible` treats that `false` as "the bell could not ring" and falls
back to a flash, so on Windows **Visual and Audible are the same behavior**.
Since #357 added `Both`, that is three of the four bell modes doing the exact
same thing on the platform tty7 is developed on. The setting reads as broken:
you pick "Audible", nothing makes a sound, and there is no way to tell whether
the feature is missing or your machine is muted.

## Fix

Implement the Windows arm with `MessageBeep(MB_OK)`.

`MB_OK` is the **Default Beep** scheme entry, so the bell follows whatever the
user chose in Sound Settings — including setting it to *None*, which is a
deliberate silence and correctly reports success rather than degrading to a
flash. Deliberately not `Beep()`, which synthesizes a fixed tone straight at
the speaker and ignores the user's sound scheme entirely. The call returns
immediately and plays asynchronously, so it is safe on the UI thread.

The Win32 metadata files `MessageBeep` under `System::Diagnostics::Debug`
despite it being a plain `user32.dll` export, so the binding needs that
module's feature flag. `windows-sys` is already a dependency and the binding is
`windows_link::link!` — no new crate, and nothing here pulls in dbghelp.

## Linux

Left on the flash fallback on purpose. The desktop sound APIs (libcanberra,
PipeWire) are a runtime link away rather than a compile-time one, and X11's
`XBell` does nothing under Wayland — neither is worth a dependency for a bell.
`ring_system_bell`'s doc comment now says so, so the next reader does not have
to rediscover it.

## Verification

- `cargo check -p tty7 --bin tty7-app` passes on Windows; `cargo fmt --check` clean.
- **Not verified locally: whether a sound is actually audible.** That needs a
  running app and a speaker — `printf '\a'` in a pane with Bell set to Audible.
  CI proves it compiles and links, not that it makes noise.
- No test added: a unit test for this would beep on every `cargo test` run, and
  a CI runner without an audio device may legitimately return `FALSE`, which
  would make the test flaky rather than useful.

Follow-up to #357 / #356.
