### PR TITLE
fix(release): keep the Inno payload for the package verifier to read

### DIFF
--- a/.github/scripts/bundle-windows.ps1
+++ b/.github/scripts/bundle-windows.ps1
@@ -107,6 +107,10 @@ if (-not $Iscc) { $Iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" }
     .github/scripts/windows-installer.iss
 if ($LASTEXITCODE -ne 0) { throw "ISCC exited with $LASTEXITCODE" }
 
-Remove-Item -Recurse -Force $Stage
+# The staging directory stays. It is what ISCC compiled the installer from, and
+# reading the compiled setup.exe back would need innoextract, which the runners
+# do not carry — so `verify-windows-package.ps1` reads the payload here instead.
+# It never reaches the release: both workflows upload named file globs
+# (*.zip, *-setup.exe, …), and a directory matches none of them.
 Write-Host "OK dist/$Name.zip"
 Write-Host "OK dist/$Name-setup.exe"


### PR DESCRIPTION
## What

`bundle-windows.ps1` deleted its Inno staging directory as its last act. `verify-windows-package.ps1` reads that directory — the compiled `setup.exe` cannot be read back without innoextract, which the runners do not carry — so the verifier has failed on every Windows build since the check landed in #330:

```
##[error]the Inno staging directory is missing: dist/tty7-26.8.2-nightly.20260806-windows-x86_64
Exception: the Windows release package would not be updatable in place (1 problem(s))
```

## Blast radius

- Nightly red two nights running: [Aug 5](https://github.com/l0ng-ai/tty7/actions/runs/31038592129) and [Aug 6](https://github.com/l0ng-ai/tty7/actions/runs/31070571824), both at `Verify Windows update package`. The Aug 4 nightly was green — #330 merged 2026-08-05 02:27, between the two.
- `release.yml` runs the same step, so the next stable tag would fail the same way. This is not nightly-only.
- The Windows job is `needs`-upstream of `publish`, so a failure means no nightly assets at all — not a partial set.

## Why drop the removal rather than let the verifier tolerate a missing payload

Tolerating it would retire the check #330 added. And both workflows already expect the directory to survive: their upload steps name it among the `dist/` intermediates the asset globs deliberately skip (`release.yml:154`, `nightly.yml:194`). The removal was the odd one out — it predates the verifier, from the initial commit.

Nothing leaks into the release: both jobs upload named file globs (`*.dmg`, `*.tar.gz`, `*.zip`, `*-setup.exe`, `*.AppImage`), and a directory matches none of them. The publish jobs checksum a fresh `dist/` assembled from those artifacts, not the build job's.

## Verification

Reasoning above plus the real test: a nightly `workflow_dispatch` once this is on `main`, which exercises `bundle-windows.ps1` → `verify-windows-package.ps1` end to end. Not verifiable locally — no ISCC here.

https://claude.ai/code/session_01H9QqEZ6JH3dGS6atEcf6ab