### PR TITLE
feat(ui): switch workspaces in place by default (#370)

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -897,11 +897,7 @@ impl Tty7App {
             let _ = handle.update(cx, |_, other, _| other.activate_window());
             return;
         }
-        if self.tabs.is_empty() {
-            self.switch_workspace(id, window, cx);
-        } else {
-            crate::ui::windows::open(cx, Some(id));
-        }
+        self.switch_workspace(id, window, cx);
     }
 
     pub(crate) fn switch_workspace(
@@ -6609,6 +6605,33 @@ mod ssh_rebuild_gpui_tests {
                     _ => false,
                 }),
                 "the remote pane's existing view is reused, not re-attached"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn reveal_workspace_with_tabs_switches_in_place(cx: &mut TestAppContext) {
+        let (app, mut vcx, _pane_stream) = harness_with_pane(cx);
+
+        let other = WindowView::default();
+        let other_id = other.id;
+        app.update_in(&mut vcx, |app, window, cx| {
+            crate::ui::windows::WindowRegistry::init(cx);
+            WorkspaceStore::install_for_test(
+                cx,
+                WindowViews {
+                    views: vec![other],
+                    active: None,
+                },
+            );
+            assert!(
+                !app.tabs.is_empty(),
+                "the harness window must hold tabs for this regression test"
+            );
+            app.reveal_workspace(other_id, window, cx);
+            assert_eq!(
+                app.workspace, other_id,
+                "reveal must switch in place even when the window already has tabs"
             );
         });
     }

--- a/src/ui/remote_workspace.rs
+++ b/src/ui/remote_workspace.rs
@@ -390,12 +390,13 @@ impl Tty7App {
         &mut self,
         target: RemoteTarget,
         row: RemoteWorkspaceRow,
+        new_window: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         let host = RemoteRef::new(target, row.id);
         let id = WorkspaceStore::claim_remote(cx, host);
-        self.enter_remote_workspace(id, window, cx);
+        self.enter_remote_workspace(id, new_window, window, cx);
     }
 
     pub(crate) fn create_remote_workspace(
@@ -411,23 +412,24 @@ impl Tty7App {
             "new remote workspace on {target} rooted at {}",
             home.display()
         );
-        self.enter_remote_workspace(id, window, cx);
+        self.enter_remote_workspace(id, false, window, cx);
     }
 
     fn enter_remote_workspace(
         &mut self,
         id: WorkspaceId,
+        new_window: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         self.connect = None;
         RemoteLinks::ensure_running(cx);
-        if self.tabs.is_empty() {
+        if new_window {
+            crate::ui::windows::open(cx, Some(id));
+        } else {
             let previous = self.spawn_host(cx);
             self.switch_workspace(id, window, cx);
             self.rebind_host(previous, cx);
-        } else {
-            crate::ui::windows::open(cx, Some(id));
         }
         cx.notify();
     }

--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -354,7 +354,9 @@ impl Tty7App {
     ) {
         self.close_switcher(window, cx);
         match row.adopt {
-            Some((target, remote)) => self.open_remote_workspace(target, *remote, window, cx),
+            Some((target, remote)) => {
+                self.open_remote_workspace(target, *remote, new_window, window, cx)
+            }
             None if new_window => crate::ui::windows::open(cx, Some(row.id)),
             None => self.reveal_workspace(row.id, window, cx),
         }


### PR DESCRIPTION
Closes #370.

Implements the narrowed scope of #370 per the maintainer's last comment: clicking a workspace now switches to it **in the current window** instead of spawning a new OS window whenever the window already holds tabs — the root cause of window counts growing linearly with workspace hops. The persistent Activity Bar / Workspaces panel from the original proposal is not part of this PR.

## Behavior

| Target | Left click | Ctrl/Cmd + click |
|---|---|---|
| Local workspace row | Switch in place | New window |
| Remote (adopt) workspace row | Switch in place | New window |
| Already open in another window | Activate that window | Activate that window* |

\* `windows::open` only activates when the workspace already has a window, so force-preempting into the current window (the issue's phase-2 idea) is deliberately left out.

Existing `switch_workspace` semantics carry the rest: the current workspace's session is saved before the switch, and remote workspaces keep their server-side `supervise` so switching back is fast. Ctrl/Cmd+click and the row menu's **Open in New Window** keep the old spawn-a-window behavior.

## Changes

- `src/ui/app.rs` — `reveal_workspace`: drop the `tabs.is_empty()` branch; always `switch_workspace` when the workspace isn't open in another window. Also fixes `SelectWorkspace1..9` / the Window menu, which routed through the same fallback.
- `src/ui/remote_workspace.rs` — `enter_remote_workspace`: same in-place default, with a `new_window` escape hatch threaded through `open_remote_workspace`. Remote (adopt) rows previously ignored the Ctrl/Cmd modifier entirely.
- `src/ui/switcher.rs` — pass the click's platform modifier into the adopt path.
- Regression test (`ssh_rebuild_gpui_tests::reveal_workspace_with_tabs_switches_in_place`): a window holding tabs still switches in place.

## Verification

- `cargo test` full suite green on Linux: 992 + 856 + 96 + … passed, 0 failed, including the new regression test.
- `cargo test --bin tty7-app` green on Windows: 861 passed, 0 failed.
- Manual GUI smoke (switcher left-click / Ctrl+click / context menu on local and remote rows) not yet done — happy to run through it before this leaves draft.