### PR TITLE
ci: keep reviewing a fork PR after the label goes on

### DIFF
--- a/.github/workflows/claude-review-fork.yml
+++ b/.github/workflows/claude-review-fork.yml
@@ -14,7 +14,16 @@ name: Claude Code Review (fork)
 # What keeps it honest, in the order the steps below apply it:
 #
 #   1. A label, not the PR opening, starts the run. Applying one needs write
-#      access, so a maintainer decides. This is the approval gate.
+#      access, so a maintainer decides. The label then stays on as a
+#      subscription: later pushes re-review, and removing it stops that.
+#
+#      Worth being clear about what this gate is and is not, because a
+#      subscription that survives the next push plainly does not gate the next
+#      push's code. It is not the security boundary -- 2 through 4 are, and they
+#      hold on the hundredth push exactly as on the first. What it gates is
+#      spend and attention: whose pull request is worth the tokens, and which
+#      ones we care to keep watching. If safety rested here, re-reviewing
+#      automatically would be indefensible.
 #   2. The workspace root is the base branch. This is the whole game: the root
 #      is what Claude Code reads as *the project*, so a fork checked out there
 #      would supply its own `CLAUDE.md` through the channel meant for
@@ -43,7 +52,7 @@ name: Claude Code Review (fork)
 
 on:
   pull_request_target:
-    types: [labeled]
+    types: [labeled, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -54,7 +63,13 @@ jobs:
     name: claude review (fork)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.event.label.name == 'claude-review'
+    # `labeled` carries the label that was just applied; `synchronize` carries
+    # none, so it has to look at what the PR is already wearing. The two need
+    # separate clauses: testing only the label list would spend a review every
+    # time any other label -- `bug`, `blocked` -- landed on a subscribed PR.
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'claude-review') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'claude-review'))
     permissions:
       contents: read
       pull-requests: write # the last step posts the review comment


### PR DESCRIPTION
Makes the `claude-review` label a subscription rather than a one-shot trigger, so a fork PR gets re-reviewed when the contributor pushes.

| | Before | After |
|---|---|---|
| Applying the label | Reviews once | Reviews, and keeps reviewing |
| Contributor pushes a fix | Nothing — the label is already on, so it can't fire again | Re-review |
| Getting a second look | Remove the label, re-apply it | Nothing to do |
| Removing the label | No effect after the first run | Stops re-reviewing |
| Adding an unrelated label (`bug`, `blocked`) | Nothing | Nothing |

## Why this doesn't undo the approval gate

It plainly doesn't gate the next push's code: approve a benign PR and the contributor can push whatever they like into a job holding our token, with nobody looking first. That is worth stating rather than glossing.

The gate was never the security boundary. The three constraints that are hold identically on the hundredth push and the first:

- the workspace root is the base branch, so the project files Claude Code loads are ours
- the tool allowlist has no `Bash`, so no `curl`, so nothing an injected instruction could reach
- nothing from the pull request is executed — no cargo, no build, no scripts

What the label actually gates is spend and attention: whose PR is worth the tokens, and which ones we care to keep watching. If safety rested on it, re-reviewing automatically would be indefensible — so the header comment in the file now says which job it is doing.

## The `if` needs two clauses

`labeled` carries the label that was just applied; `synchronize` carries none and has to look at what the PR is already wearing. Testing only the label list would spend a review every time an unrelated label landed on a subscribed PR.

`concurrency` already cancels a superseded run, so a burst of pushes costs one review rather than one per commit.

## Testing

- Workflow parses; the trigger is `[labeled, synchronize]` and the `if` resolves as written.
- Not exercisable from this PR — the action refuses a workflow whose content differs from the default branch. Verification is a push to #388, which is currently labelled: it should review without anyone touching the label. The label-driven path is already known good, from [31189716351](https://github.com/l0ng-ai/tty7/actions/runs/31189716351).
