### PR TITLE
ci: keep the fork review to forks

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,10 +17,21 @@ name: Claude Code Review
 
 on:
   pull_request:
-    # `labeled` is the manual re-run: a PR opened before this workflow existed
-    # has no run to re-run from the Actions tab, and reopening fires `reopened`
-    # rather than `opened`. Applying the label needs write access, so the same
-    # label doubles as the approval gate in claude-review-fork.yml.
+    # `labeled` is the manual re-run: reopening a PR fires `reopened`, not
+    # `opened`, and a PR that predates this file has no run to restart from the
+    # Actions tab. Applying the label needs write access, so the same label
+    # doubles as the approval gate in claude-review-fork.yml.
+    #
+    # It does not reach the PRs that need it most, and the reason is worth
+    # knowing before you conclude the label is broken. A `pull_request` workflow
+    # is read from the PR's merge ref, which GitHub recomputes on a push and not
+    # otherwise. A PR whose last push predates this file therefore has a merge
+    # ref that does not contain it, and no label will summon a workflow that,
+    # from that ref's point of view, does not exist. Push to the branch and the
+    # merge ref catches up -- though by then the push has triggered
+    # `synchronize` anyway, which is why the empty-commit trick works and the
+    # label appears not to. `claude-review-fork.yml` is exempt: a
+    # `pull_request_target` workflow is read from the base branch.
     types: [opened, synchronize, labeled]
 
 # Same reasoning as ci.yml: a superseded review is dead weight, and unlike a

--- a/.github/workflows/claude-review-fork.yml
+++ b/.github/workflows/claude-review-fork.yml
@@ -69,13 +69,22 @@ jobs:
     name: claude review (fork)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # `labeled` carries the label that was just applied; `synchronize` carries
-    # none, so it has to look at what the PR is already wearing. The two need
-    # separate clauses: testing only the label list would spend a review every
-    # time any other label -- `bug`, `blocked` -- landed on a subscribed PR.
+    # First clause: forks only. Everything below trades review quality for
+    # safety against code we do not control -- no plugin, no whole-repo context,
+    # read-only tools -- and a branch in this repository has earned none of that.
+    # `pull_request_target` does not care where the head is, so if this job does
+    # not say so, labelling one of our own PRs lands it here and it silently
+    # gets the weaker review instead of the one in claude-code-review.yml.
+    #
+    # Then: `labeled` carries the label that was just applied; `synchronize`
+    # carries none, so it has to look at what the PR is already wearing. Those
+    # two need separate clauses, because testing only the label list would spend
+    # a review every time an unrelated label -- `bug`, `blocked` -- landed on a
+    # subscribed PR.
     if: >-
-      (github.event.action == 'labeled' && github.event.label.name == 'claude-review') ||
-      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'claude-review'))
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      ((github.event.action == 'labeled' && github.event.label.name == 'claude-review') ||
+       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'claude-review')))
     permissions:
       contents: read
       pull-requests: write # the last step posts the review comment


### PR DESCRIPTION
Labelling #389 — a branch in this repository — ran the **fork** review on it. That is a bug, and this fixes it.

| | Before | After |
|---|---|---|
| Label a fork PR | Fork review | Fork review |
| Label one of our own PRs | Fork review — the weaker one, silently | Nothing here; `claude-code-review.yml` owns it |
| `claude-code-review.yml` behaviour | Unchanged | Unchanged — only a comment is corrected |

## The bug

`claude-review-fork.yml` never checked where the head branch lived. It was written as the fork path and reads like one, so the omission was invisible — but `pull_request_target` fires on every pull request, fork or not, and the `if` only tested the label.

Everything in that job trades review quality for safety against code we do not control: no `code-review` plugin, no whole-repo context, a read-only tool allowlist, nothing executed. A branch in this repository has earned none of those restrictions. #389 got a diff-and-subdirectory review from the fork path instead of the multi-agent review it should have had, and nothing said so.

Fixed by requiring `head.repo.full_name != github.repository`.

## The `labeled` comment was promising something impossible

Separately, labelling #389 produced no `claude-code-review.yml` run at all, and the comment in that file claimed the label existed precisely for PRs like it.

A `pull_request` workflow is read from the PR's **merge ref**, which GitHub recomputes on a push and not otherwise. #389's last push was 13:54; `claude-code-review.yml` landed on main at 14:18. Its merge ref therefore does not contain the file, and no label can summon a workflow that, from that ref's point of view, does not exist.

This is also why the label looked broken while the empty-commit trick looked fine: pushing recomputes the merge ref, and by then the push has fired `synchronize` on its own. `claude-review-fork.yml` is exempt — a `pull_request_target` workflow is read from the base branch, which is why the same label reached it and not the other one.

Both facts are now in the comment, so the next person to conclude the label is broken finds the reason next to it.

## Testing

- Both workflows parse; the fork `if` resolves with the new clause.
- The behaviour this fixes was observed live: [31191554445](https://github.com/l0ng-ai/tty7/actions/runs/31191554445) is the fork job running against #389.
- Not exercisable from this PR — the action refuses a workflow whose content differs from the default branch. After merge: labelling a same-repo PR should produce no fork run, and labelling #388 should still produce one.
