### PR TITLE
fix(windows): carry launch flags into agent resume commands

### DIFF
--- a/crates/tty7-core/src/core/cli_agent.rs
+++ b/crates/tty7-core/src/core/cli_agent.rs
@@ -404,16 +404,28 @@ impl CLIAgent {
         command: &str,
         custom: &HashMap<String, String>,
     ) -> Option<CLIAgent> {
-        let mut argv: Vec<String> = command
-            .split_whitespace()
-            .map(|t| t.trim_matches(['"', '\'']).to_ascii_lowercase())
-            .filter(|t| !t.is_empty())
+        let argv: Vec<String> = command_argv(command)
+            .iter()
+            .map(|t| t.to_ascii_lowercase())
             .collect();
-        if argv.first().is_some_and(|t| t == "&") {
-            argv.remove(0);
-        }
         Self::detect_from_argv_with(&argv, custom)
     }
+}
+
+/// Splits a shell-integration command capture into argv tokens, preserving
+/// case so the result can serve as `launch_argv` for flag replay on resume.
+/// Quoted arguments containing spaces come out split; `replay_flags` rejects
+/// such tokens rather than replaying them wrong.
+pub fn command_argv(command: &str) -> Vec<String> {
+    let mut argv: Vec<String> = command
+        .split_whitespace()
+        .map(|t| t.trim_matches(['"', '\'']).to_string())
+        .filter(|t| !t.is_empty())
+        .collect();
+    if argv.first().is_some_and(|t| t == "&") {
+        argv.remove(0);
+    }
+    argv
 }
 
 fn is_env_assignment(token: &str) -> bool {
@@ -857,6 +869,34 @@ mod tests {
         assert_eq!(
             CLIAgent::detect_from_command_with("cc -c", &custom),
             Some(CLIAgent::Claude)
+        );
+    }
+
+    #[test]
+    fn command_argv_preserves_case_for_flag_replay() {
+        assert_eq!(
+            command_argv("claude --dangerously-skip-permissions"),
+            ["claude", "--dangerously-skip-permissions"]
+        );
+        assert_eq!(
+            command_argv("claude --model Opus --resume Abc-123"),
+            ["claude", "--model", "Opus", "--resume", "Abc-123"]
+        );
+        assert_eq!(
+            command_argv(r#"& "C:\Tools\claude.exe" --continue"#),
+            [r"C:\Tools\claude.exe", "--continue"]
+        );
+        assert_eq!(command_argv("  "), [""; 0]);
+        assert_eq!(
+            CLIAgent::Claude
+                .resume_command(
+                    "abc",
+                    Some(&command_argv("claude --dangerously-skip-permissions"))
+                )
+                .as_deref(),
+            Some("claude --dangerously-skip-permissions --resume abc"),
+            "a shell-integration command capture must round-trip into a resume \
+             command that keeps the launch flags"
         );
     }
 

--- a/crates/tty7-core/src/daemon/pane.rs
+++ b/crates/tty7-core/src/daemon/pane.rs
@@ -1819,8 +1819,7 @@ fn apply_signals(st: &mut PaneState, signals: SniffSignals) {
         if shell_mark_capture_changed(&st.shell, &shell) {
             apply_agent(
                 st,
-                agent_from_shell_mark(&shell, crate::core::config::agent_commands_cached())
-                    .map(|agent| (agent, Vec::new())),
+                agent_from_shell_mark(&shell, crate::core::config::agent_commands_cached()),
             );
         }
         st.shell = shell.clone();
@@ -1845,11 +1844,10 @@ fn shell_mark_capture_changed(prev: &ShellState, next: &ShellState) -> bool {
 fn agent_from_shell_mark(
     shell: &ShellState,
     custom: &std::collections::HashMap<String, String>,
-) -> Option<crate::core::cli_agent::CLIAgent> {
-    shell
-        .command
-        .as_deref()
-        .and_then(|cmd| crate::core::cli_agent::CLIAgent::detect_from_command_with(cmd, custom))
+) -> Option<(crate::core::cli_agent::CLIAgent, Vec<String>)> {
+    let cmd = shell.command.as_deref()?;
+    let agent = crate::core::cli_agent::CLIAgent::detect_from_command_with(cmd, custom)?;
+    Some((agent, crate::core::cli_agent::command_argv(cmd)))
 }
 
 fn apply_agent_signals(
@@ -2827,7 +2825,10 @@ mod tests {
         assert_eq!(shell.command.as_deref(), Some("claude --help"));
         assert_eq!(
             agent_from_shell_mark(shell, &custom),
-            Some(crate::core::cli_agent::CLIAgent::Claude)
+            Some((
+                crate::core::cli_agent::CLIAgent::Claude,
+                vec!["claude".to_string(), "--help".to_string()],
+            ))
         );
 
         let d = s.feed(b"\x1b]133;D;0\x07");
@@ -2857,6 +2858,41 @@ mod tests {
 
         let c = s.feed(b"\x1b]133;C;%20%20\x07");
         assert_eq!(c.shell.last().unwrap().command, None);
+    }
+
+    #[test]
+    fn shell_mark_agent_detection_keeps_launch_argv_for_resume() {
+        let custom = std::collections::HashMap::new();
+        let mut s = OscSniffer::new();
+
+        let c = s.feed(b"\x1b]133;C;claude%20--dangerously-skip-permissions\x07");
+        let (agent, argv) = agent_from_shell_mark(c.shell.last().unwrap(), &custom).unwrap();
+        assert_eq!(agent, crate::core::cli_agent::CLIAgent::Claude);
+        assert_eq!(
+            agent.resume_command("abc-123", Some(&argv)).as_deref(),
+            Some("claude --dangerously-skip-permissions --resume abc-123")
+        );
+
+        // Case must survive capture: a lowercased path or model name would
+        // replay the wrong flags.
+        let c = s.feed(b"\x1b]133;C;claude%20--model%20Opus\x07");
+        let (agent, argv) = agent_from_shell_mark(c.shell.last().unwrap(), &custom).unwrap();
+        assert_eq!(argv, ["claude", "--model", "Opus"]);
+        assert_eq!(
+            agent.resume_command("abc", Some(&argv)).as_deref(),
+            Some("claude --model Opus --resume abc")
+        );
+
+        // PowerShell call-operator launches keep working end to end.
+        let c = s.feed(b"\x1b]133;C;%26%20%22C%3A%5Ctools%5Cclaude.exe%22%20--continue\x07");
+        let (agent, argv) = agent_from_shell_mark(c.shell.last().unwrap(), &custom).unwrap();
+        assert_eq!(agent, crate::core::cli_agent::CLIAgent::Claude);
+        assert_eq!(argv, [r"C:\tools\claude.exe", "--continue"]);
+        assert_eq!(
+            agent.resume_command("abc", Some(&argv)).as_deref(),
+            Some("claude --resume abc"),
+            "stale session flags are dropped, not replayed"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Resuming an agent pane on Windows always relaunched it bare — `claude --resume <id>` without `--dangerously-skip-permissions`, `--model`, or any other launch flag. The same flow works on macOS/Linux.

## Root cause

`resume_command` replays flags from the pane's recorded `launch_argv`. On mac/linux that argv comes from reading the foreground process's real command line (`KERN_PROCARGS2` / `/proc/<pid>/cmdline`). The Windows path instead detects the agent from the OSC 133;C shell-integration command capture — but discarded the captured command line and stamped an empty argv:

```rust
agent_from_shell_mark(&shell, ...).map(|agent| (agent, Vec::new()))
```

`stamp_launch_argv` early-returns on an empty argv, so `launch_argv` was never recorded on Windows and there was nothing to replay.

## Fix

- `cli_agent.rs`: add `command_argv()` — a case-preserving tokenizer for shell-integration command captures (trims quotes, drops the PowerShell `&` call operator). `detect_from_command_with` reuses it and lowercases only its own detection copy; the previous implementation lowercased everything, which would have mangled case-sensitive values like `--model Opus` or paths if used as argv.
- `pane.rs`: `agent_from_shell_mark` now returns `(agent, argv)` and the Windows path stamps the real tokens.

## Same-class audit of the resume flow

Everything downstream consumes this one source, so the single fix closes the loop:

- **fork** shares `session_command_flags` with resume — fixed by the same change.
- **machine.json facts** (`observed_facts`) already fall back to `st.agent_argv`; it was just never populated on Windows. Home-screen restore of closed workspaces now carries flags too.
- **Session save/restore, tree_sync, pending panes** are pass-through; the remaining `launch_argv: None` sites are tests and `Pane::Empty`.
- **Re-resume closes the loop**: resume types the command via `run_command_line`, so OSC 133 re-captures it with the replayed flags.
- **Safety**: `replay_flags`' allowlist rejects tokens a whitespace split would mangle (spaces/quotes/semicolons), falling back to the bare resume command exactly as before — no injection surface added.

Known remaining gap (unchanged): with no shell integration installed, Windows still can't learn the command line from agent OSC events alone; covering that would need reading the remote process PEB.

## Tests

- `command_argv` unit tests (case preserved, quotes, `&`, empty).
- End-to-end: OSC capture → `claude --dangerously-skip-permissions --resume abc-123`, including the `& "C:\tools\claude.exe"` PowerShell form and stale-session-flag shedding.
- Full `tty7-core` suite (782) and GUI agent tests pass on Windows.