### PR TITLE
fix(sidebar): put a new tab in its repo group on the first frame

### DIFF
--- a/src/terminal/remote.rs
+++ b/src/terminal/remote.rs
@@ -267,6 +267,7 @@ impl RemoteTerminal {
         let win = win_size(size, cell_w, cell_h);
 
         let workspace = spawn_workspace(owner.as_deref(), route);
+        let spawned_in = cwd.clone();
 
         let owner = owner.filter(|_| {
             route.is_local()
@@ -297,7 +298,22 @@ impl RemoteTerminal {
 
         let mut term = Self::from_stream(stream, size)?;
         term.route = route.clone();
+        term.seed_cwd(spawned_in);
         Ok((term, pane_id))
+    }
+
+    /// Remember the directory the daemon was asked to spawn in, so everything
+    /// that keys off a pane's cwd — the sidebar's repo grouping above all —
+    /// has an answer before the shell gets far enough to report its own via
+    /// OSC 7. The reader thread is already running, so a report that beat us
+    /// here wins: it describes where the shell actually landed, which is not
+    /// always where we asked (a missing directory sends the daemon home, an
+    /// rc file may `cd` on its own).
+    fn seed_cwd(&self, cwd: Option<PathBuf>) {
+        let Some(cwd) = cwd else { return };
+        if let Ok(mut guard) = self.cwd.lock() {
+            guard.get_or_insert(cwd);
+        }
     }
 
     pub fn attach(size: TermSize, cell_w: u16, cell_h: u16, pane_id: u64) -> anyhow::Result<Self> {
@@ -3051,6 +3067,65 @@ mod tests {
             .unwrap();
         daemon_side.flush().unwrap();
         assert!(poll(&|s| s.is_none()), "a None report clears the session");
+    }
+
+    #[test]
+    fn the_spawn_directory_answers_until_the_shell_reports_its_own() {
+        crate::core::config::pin_test_config_dir();
+        let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
+        let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
+        let poll = |want: Option<&str>| {
+            let want = want.map(PathBuf::from);
+            for _ in 0..200 {
+                if term.foreground_cwd() == want {
+                    return true;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+            false
+        };
+
+        assert_eq!(term.foreground_cwd(), None, "nothing known before the seed");
+        term.seed_cwd(Some(PathBuf::from("/repo/tty7")));
+        assert_eq!(
+            term.foreground_cwd(),
+            Some(PathBuf::from("/repo/tty7")),
+            "the sidebar can group this pane without waiting for the shell"
+        );
+
+        DaemonMsg::Cwd(PathBuf::from("/repo/tty7/crates"))
+            .encode(&mut daemon_side)
+            .unwrap();
+        daemon_side.flush().unwrap();
+        assert!(
+            poll(Some("/repo/tty7/crates")),
+            "the shell's own report replaces the seed"
+        );
+    }
+
+    #[test]
+    fn a_shell_report_that_beat_the_seed_wins() {
+        crate::core::config::pin_test_config_dir();
+        let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
+        let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
+
+        DaemonMsg::Cwd(PathBuf::from("/somewhere/else"))
+            .encode(&mut daemon_side)
+            .unwrap();
+        daemon_side.flush().unwrap();
+        for _ in 0..200 {
+            if term.foreground_cwd().is_some() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+
+        term.seed_cwd(Some(PathBuf::from("/repo/tty7")));
+        assert_eq!(
+            term.foreground_cwd(),
+            Some(PathBuf::from("/somewhere/else")),
+            "where the shell actually landed beats where we asked it to"
+        );
     }
 
     #[test]

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -2312,9 +2312,9 @@ impl Tty7App {
         if !self.guard_local_spawn(window, cx) {
             return;
         }
-        let pane_ws = self.window_workspace(cx);
+        let group = self.spawn_group(cwd.as_deref(), cx);
         let tab = match new_terminal(
-            pane_ws,
+            self.window_workspace(cx),
             Some(self.workspace),
             self.font_size,
             cwd,
@@ -2336,7 +2336,11 @@ impl Tty7App {
         self.remember_active_pane(window, cx);
         self.maximized = None;
         let insert_at = self.new_tab_insert_at(cx);
-        self.tabs.insert(insert_at, Tab::new(Pane::leaf(tab)));
+        let new_tab = Tab::new(Pane::leaf(tab));
+        if let Some(group) = group {
+            *new_tab.sidebar_group.borrow_mut() = group;
+        }
+        self.tabs.insert(insert_at, new_tab);
         self.active = insert_at;
         self.focus_active(window, cx);
         self.save_session(cx);
@@ -2968,6 +2972,7 @@ impl Tty7App {
             let view = source.read(cx);
             (view.local_cwd(), view.shell_spec())
         };
+        let group = self.spawn_group(cwd.as_deref(), cx);
         let new = match new_terminal(
             self.window_workspace(cx),
             Some(self.workspace),
@@ -3000,7 +3005,11 @@ impl Tty7App {
                 self.remember_active_pane(window, cx);
                 self.maximized = None;
                 let insert_at = self.new_tab_insert_at(cx);
-                self.tabs.insert(insert_at, Tab::new(Pane::leaf(new)));
+                let tab = Tab::new(Pane::leaf(new));
+                if let Some(group) = group {
+                    *tab.sidebar_group.borrow_mut() = group;
+                }
+                self.tabs.insert(insert_at, tab);
                 self.active = insert_at;
                 self.focus_active(window, cx);
             }

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -746,6 +746,28 @@ impl Tty7App {
             self.activate(i, window, cx);
         }
     }
+
+    /// Which group a tab about to be spawned in `cwd` belongs to, when the
+    /// repo probe for that directory has already landed. `Some(None)` means
+    /// the cache knows it is not a repo; a bare `None` means it never looked.
+    ///
+    /// A tab's group otherwise starts empty and only fills in once its shell
+    /// has started and reported a cwd, which parks every new tab in the
+    /// scratch group at the bottom of the sidebar until then. A tab spawned
+    /// from one already sitting in a repo inherits a warm cache, so seeding
+    /// it here lands the tab in its group on the first frame.
+    pub(crate) fn spawn_group(
+        &self,
+        cwd: Option<&Path>,
+        cx: &gpui::App,
+    ) -> Option<Option<PathBuf>> {
+        let host = self
+            .window_workspace(cx)
+            .as_ref()
+            .map_or(crate::ui::host_ops::HostId::LOCAL, |ws| ws.target.host_id());
+        cx.try_global::<GitStatusCache>()?
+            .known_repo_for(host, cwd?)
+    }
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
A new tab used to appear at the very bottom of the sidebar and jump into its repo group a moment later, once its shell had started. It now lands in the right group on the first frame.

| | Before | After |
|---|---|---|
| Open a tab next to one already in a repo | Appears in the scratch group at the bottom, jumps up once the shell reports a cwd | Appears inside the repo group immediately |
| Open a tab in a directory that is not a repo | Same visible flicker on the way to the scratch group | Stays in the scratch group, no movement |
| Fork an agent session into a new tab | Same flicker | Lands in its group directly |
| A pane's cwd before its shell says anything | Unknown | The directory the daemon was asked to spawn in |

## Why

The sidebar groups tabs by repo, and a tab's group key comes from `Tab::sidebar_group`, which `Tab::new` always left empty. `sidebar_sections()` puts every key-less tab in the scratch group, which is pushed to the end of the list unconditionally — so a fresh tab was always at the bottom until its group filled in.

Filling it in needed two things to happen asynchronously: the pane's `git_status_cwd` had to be set from `foreground_cwd()`, which stayed `None` until the shell emitted OSC 7; and the repo probe for that cwd had to be in `GitStatusCache`. The second one is normally already true — a new tab inherits the cwd of the tab it was opened from, so the cache is warm. Only the first was actually being waited on, and it waits for the shell.

Two changes:

- `RemoteTerminal::spawn_once` now seeds the pane's cwd with the directory it asked the daemon to spawn in, instead of leaving it `None` until OSC 7 arrives. It uses `get_or_insert`, so a report that beat the seed wins — the shell may land somewhere else (a missing directory sends the daemon home, an rc file may `cd` on its own).
- `Tty7App::spawn_group()` looks up the repo root the cache already knows for that cwd, and the two spawn-a-new-tab paths seed `Tab::sidebar_group` with it. A cache miss seeds nothing and the old behavior applies, so a directory nobody has probed yet is never guessed at.

```mermaid
sequenceDiagram
    participant UI as new_tab_with_cwd
    participant T as Tab
    participant P as pane/shell
    participant S as sidebar

    rect rgb(250, 235, 235)
    note over UI,S: Before
    UI->>T: Tab::new (sidebar_group = None)
    S-->>S: renders it in the scratch group, at the bottom
    P->>P: shell starts, emits OSC 7
    P-->>S: git_status_cwd set, group resolves
    S-->>S: tab jumps into its repo group
    end

    rect rgb(235, 245, 235)
    note over UI,S: After
    UI->>UI: spawn_group(cwd) hits the warm GitStatusCache
    UI->>T: Tab::new + seeded sidebar_group
    S-->>S: renders it in its repo group already
    P->>P: shell starts and confirms (or corrects) the cwd
    end
```

## Testing

- New unit tests in `src/terminal/remote.rs`: `the_spawn_directory_answers_until_the_shell_reports_its_own` (seed answers immediately, a later report replaces it) and `a_shell_report_that_beat_the_seed_wins` (an earlier report is not clobbered).
- Full `cargo test` green, `cargo fmt --check` clean.
- Manual A/B on an isolated dev instance, same starting state each run, opening a tab through `tty7 <PATH>` (the CLI path into `new_tab_at` → `new_tab_with_cwd`) and reading the new tab's `sidebar_group` the moment it first appeared in `machine.json`:

  | | group at birth |
  |---|---|
  | before this change | `None`, still `None` six seconds later |
  | after | `/Users/thomas/repo/025/tty7` |
  | after, opened in `/private/tmp` | `None` — correctly left in the scratch group |
