### PR TITLE
fix(terminal): resize ConPTY panes with conhost's semantics, in stream order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,22 +130,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Maximizing a pane mid-burst no longer garbles it** — the client reflowed
-  its grid the instant the window changed, then went on parsing whatever the
-  daemon still had queued for it, and that backlog (up to the 16 MiB the
-  output gate allows) was produced at the old width. Old-width bytes laid
-  out on a new-width grid, topped by ConPTY's own post-resize repaint, left
-  command output interleaved with prompts and the cursor stranded
-  mid-screen. Reattach never had this bug: its replay tags every ring
-  segment with the geometry it was recorded at. A live resize now works the
-  same way — the daemon echoes a `Size` frame to the controller at the
-  exact stream position where the PTY changed geometry, and the client
-  defers its reflow to that marker, so every queued byte still parses into
-  the grid it was rendered for. Observers, which already got live `Size`
-  frames but only ever applied them after a replay snapshot, now follow the
-  controller's resizes at the right moment too. A client facing an older
-  daemon that never echoes keeps the reflow-at-request-time behavior (new
-  `resize-echo` feature probe).
+- **Maximizing a Windows pane no longer shreds it** — two separate resize
+  disagreements stacked up here, and the visible one was the second.
+
+  ConPTY emits no repaint after a resize; conhost silently re-anchors its
+  own layout and keeps painting with absolute cursor addresses computed
+  against it. Measured against a live ConPTY: growing the window keeps
+  rows and cursor pinned and opens blank rows at the bottom — nothing is
+  restored from scrollback — and shrinking scrolls the last *written* row
+  (PSReadLine parks a continuation hint below the prompt) to the new
+  bottom. The grid resized the alacritty way instead: growing pulled
+  scrollback back into view and pushed the cursor down by that many rows.
+  After a maximize the two layouts disagreed by exactly the pulled row
+  count, so every later absolute-CUP paint — PSReadLine redraws the prompt
+  that way per keystroke — landed mid-screen inside the old output. The
+  vendored `alacritty_terminal` now has a `conpty_resize` mode that
+  mirrors conhost's model for the primary screen (the alternate screen
+  keeps stock behavior; its application repaints itself), and every pane
+  on Windows opts in — a shell, `wsl.exe`, and `ssh.exe` are all presented
+  through conhost alike. The cost is Windows-Terminal-standard behavior:
+  maximizing no longer reveals extra scrollback below the fold.
+
+  Separately, a resize during a burst of output reflowed the grid ahead of
+  the backlog: the daemon can hold up to 16 MiB of queued old-width bytes,
+  and the client parsed them into the already-resized grid. The daemon now
+  echoes a `Size` frame to the controller at the exact stream position
+  where the PTY changed geometry — the same geometry-tagging the reattach
+  replay has always used — and the client defers its reflow to that
+  marker, so every queued byte parses into the grid it was rendered for.
+  Observers, which already received live `Size` frames but only applied
+  them after a replay snapshot, follow the controller's resizes at the
+  right moment too. The client keeps the reflow-at-request-time path
+  against an older daemon that never echoes (new `resize-echo` feature
+  probe), and on remote routes, where only the local daemon's features are
+  known — a current remote daemon's echo lands there as a harmless
+  same-size no-op, and probing per connection is the follow-up that
+  extends deferral to remote panes.
 
 - **Pasting a screenshot into a remote pane works on macOS too** — the
   clipboard-image paste that stages a file and hands the agent its path was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Maximizing a pane mid-burst no longer garbles it** — the client reflowed
+  its grid the instant the window changed, then went on parsing whatever the
+  daemon still had queued for it, and that backlog (up to the 16 MiB the
+  output gate allows) was produced at the old width. Old-width bytes laid
+  out on a new-width grid, topped by ConPTY's own post-resize repaint, left
+  command output interleaved with prompts and the cursor stranded
+  mid-screen. Reattach never had this bug: its replay tags every ring
+  segment with the geometry it was recorded at. A live resize now works the
+  same way — the daemon echoes a `Size` frame to the controller at the
+  exact stream position where the PTY changed geometry, and the client
+  defers its reflow to that marker, so every queued byte still parses into
+  the grid it was rendered for. Observers, which already got live `Size`
+  frames but only ever applied them after a replay snapshot, now follow the
+  controller's resizes at the right moment too. A client facing an older
+  daemon that never echoes keeps the reflow-at-request-time behavior (new
+  `resize-echo` feature probe).
+
 - **Pasting a screenshot into a remote pane works on macOS too** — the
   clipboard-image paste that stages a file and hands the agent its path was
   built off macOS only, because a local macOS agent reads the system

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "alacritty_terminal"
 version = "0.26.1-dev"
-source = "git+https://github.com/l0ng-ai/alacritty?rev=b79e70484b13308ce766a763531ac25a8302c012#b79e70484b13308ce766a763531ac25a8302c012"
+source = "git+https://github.com/l0ng-ai/alacritty?rev=1276f128fbaa8832cbc66210675cbe8aeb570499#1276f128fbaa8832cbc66210675cbe8aeb570499"
 dependencies = [
  "base64",
  "bitflags 2.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,7 +299,7 @@ gpui_platform = { git = "https://github.com/zed-industries/zed", rev = "1d217ee3
 #
 # Each patch has a guard test in `src/terminal/remote.rs`; drop this fork once
 # both land upstream.
-alacritty_terminal = { git = "https://github.com/l0ng-ai/alacritty", rev = "b79e70484b13308ce766a763531ac25a8302c012" }
+alacritty_terminal = { git = "https://github.com/l0ng-ai/alacritty", rev = "1276f128fbaa8832cbc66210675cbe8aeb570499" }
 
 anyhow = "1"
 log = "0.4"

--- a/crates/tty7-core/src/daemon/pane.rs
+++ b/crates/tty7-core/src/daemon/pane.rs
@@ -612,6 +612,27 @@ fn notify(st: &mut PaneState, msg: DaemonMsg) {
     });
 }
 
+/// Apply a resize to the pane's shared state: seal the replay ring's segment
+/// and tell every connected client the new geometry.
+///
+/// The controller's `Size` echo has to be sent while the state lock is held —
+/// output is fanned out under the same lock, so the frame lands in the stream
+/// after every byte produced at the old size and before the repaint the PTY
+/// emits once it is actually resized (which happens after the lock is
+/// released). A client that speaks `FEATURE_RESIZE_ECHO` defers its grid
+/// reflow to this marker instead of reflowing the moment its window changed:
+/// the channel can hold megabytes of old-width output (the pane gate allows
+/// 16 MiB), and reflowing ahead of it parsed old-width bytes into a new-width
+/// grid, garbling the pane on maximize during a burst of output.
+fn resize_state(st: &mut PaneState, size: WinSize) {
+    st.ring.resize(size);
+    if let Some(sub) = &st.subscriber {
+        let _ = sub.send(DaemonMsg::Size(size));
+    }
+    st.observers
+        .retain(|obs| obs.tx.send(DaemonMsg::Size(size)).is_ok());
+}
+
 /// One gated message to the controller and to every observer.
 ///
 /// A send error just means that client is gone; ignore it and let the next
@@ -1385,12 +1406,7 @@ impl DaemonPane {
     }
 
     pub fn resize(&self, size: WinSize) {
-        {
-            let mut st = self.state.lock().unwrap();
-            st.ring.resize(size);
-            st.observers
-                .retain(|obs| obs.tx.send(DaemonMsg::Size(size)).is_ok());
-        }
+        resize_state(&mut self.state.lock().unwrap(), size);
         match &self.backend {
             PaneBackend::Pty(p) => {
                 if let Ok(master) = p.master.lock() {
@@ -3646,6 +3662,32 @@ mod tests {
             "an observer that keeps draining must stay subscribed"
         );
         assert_eq!(got, sends * chunk.len(), "and must miss no bytes");
+    }
+
+    #[test]
+    fn resize_echoes_size_to_the_controller_between_old_and_new_output() {
+        let mut st = test_state(true);
+        let (controller_tx, controller_rx) = mpsc::channel();
+        attach_subscriber(&mut st, controller_tx);
+        drain(&controller_rx);
+
+        let pane_gate = OutputGate::new();
+        fan_out_output(&mut st, b"old-width bytes", Vec::new(), &pane_gate);
+        resize_state(&mut st, ws(120, 30));
+        fan_out_output(&mut st, b"new-width bytes", Vec::new(), &pane_gate);
+
+        match controller_rx.try_recv().unwrap() {
+            DaemonMsg::Output(b) => assert_eq!(b, b"old-width bytes"),
+            other => panic!("expected the pre-resize Output first, got {other:?}"),
+        }
+        match controller_rx.try_recv().unwrap() {
+            DaemonMsg::Size(size) => assert_eq!((size.cols, size.rows), (120, 30)),
+            other => panic!("expected the Size echo in stream order, got {other:?}"),
+        }
+        match controller_rx.try_recv().unwrap() {
+            DaemonMsg::Output(b) => assert_eq!(b, b"new-width bytes"),
+            other => panic!("expected the post-resize Output last, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/tty7-core/src/daemon/pane.rs
+++ b/crates/tty7-core/src/daemon/pane.rs
@@ -624,6 +624,15 @@ fn notify(st: &mut PaneState, msg: DaemonMsg) {
 /// the channel can hold megabytes of old-width output (the pane gate allows
 /// 16 MiB), and reflowing ahead of it parsed old-width bytes into a new-width
 /// grid, garbling the pane on maximize during a burst of output.
+///
+/// The marker is deliberately not airtight. Old-width bytes the reader thread
+/// has read but not yet fanned out — and bytes still sitting in the kernel
+/// pipe, which conhost keeps producing until it processes the resize — land
+/// after the echo and parse at the new width. That residue is bounded by one
+/// 64 KiB read plus the pipe, cannot be attributed to a geometry from here
+/// (the bytes carry no tags and ConPTY emits no sync marker of its own), and
+/// is the same ambiguity every ConPTY terminal accepts on a mid-output
+/// resize. The echo exists to close the 16 MiB window, not that one.
 fn resize_state(st: &mut PaneState, size: WinSize) {
     st.ring.resize(size);
     if let Some(sub) = &st.subscriber {

--- a/crates/tty7-core/src/daemon/protocol.rs
+++ b/crates/tty7-core/src/daemon/protocol.rs
@@ -9,6 +9,13 @@ pub const PROTOCOL_VERSION: u32 = 5;
 
 pub const FEATURE_PANE_OWNER: &str = "pane-owner";
 
+/// The daemon echoes a `DaemonMsg::Size` to the controlling subscriber, in
+/// stream order, when it applies a `ClientMsg::Resize`. A client that sees
+/// this feature defers its local grid reflow to that echo so the reflow lands
+/// at the stream position where the PTY actually changed geometry; against an
+/// older daemon it must keep reflowing locally at request time.
+pub const FEATURE_RESIZE_ECHO: &str = "resize-echo";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DaemonVersion {
     pub protocol: u32,
@@ -25,7 +32,10 @@ impl DaemonVersion {
         DaemonVersion {
             protocol: PROTOCOL_VERSION,
             build: env!("CARGO_PKG_VERSION").to_string(),
-            features: vec![FEATURE_PANE_OWNER.to_string()],
+            features: vec![
+                FEATURE_PANE_OWNER.to_string(),
+                FEATURE_RESIZE_ECHO.to_string(),
+            ],
             instance: process_instance().to_string(),
         }
     }

--- a/src/terminal/remote.rs
+++ b/src/terminal/remote.rs
@@ -193,6 +193,10 @@ pub struct RemoteTerminal {
     /// flag under the term lock before every grid mutation, so once it is set
     /// the abandoned thread can only exit, never write.
     reader_quit: Arc<AtomicBool>,
+    /// Test hook: pretend the daemon advertised `FEATURE_RESIZE_ECHO`.
+    /// Production code probes the real daemon per call in [`Self::resize`].
+    #[cfg(test)]
+    force_resize_echo: bool,
 }
 
 /// The workspace id a spawn carries, so the pane's shell gets `$TTY7_WS` and a
@@ -510,6 +514,8 @@ impl RemoteTerminal {
             proxy,
             reader_thread: Some(reader_thread),
             reader_quit,
+            #[cfg(test)]
+            force_resize_echo: false,
         })
     }
 
@@ -578,7 +584,6 @@ impl RemoteTerminal {
                 let mut cursor_scan = ParkedCursorScanner::new();
                 let mut parked_cursor = ParkedCursorRepair::default();
                 let mut pending: Vec<u8> = buffered;
-                let mut pending_size: Option<WinSize> = None;
                 // Kitty-graphics decode runs on its own thread with newest-frame
                 // coalescing (issue #213): inflating a full-window browser frame
                 // is ~42 ms, and doing it inline here would block PTY output and
@@ -724,9 +729,26 @@ impl RemoteTerminal {
                             }
                         };
                         match msg {
+                            // Geometry, applied at this exact stream position.
+                            // During replay each ring segment is preceded by
+                            // its Size; live, the daemon echoes one when it
+                            // applies our Resize (FEATURE_RESIZE_ECHO), which
+                            // is the point in the stream where the bytes stop
+                            // being old-width — everything still queued before
+                            // this frame must be parsed into the old grid.
                             DaemonMsg::Size(ws) => {
                                 flush_batch!();
-                                pending_size = Some(ws);
+                                {
+                                    let mut term = term.lock();
+                                    if quit.load(Ordering::SeqCst) {
+                                        return;
+                                    }
+                                    term.resize(TermSize::new(
+                                        ws.cols as usize,
+                                        ws.rows as usize,
+                                    ));
+                                }
+                                proxy.send_event(AlacEvent::Wakeup);
                             }
                             DaemonMsg::Snapshot(bytes) => {
                                 flush_batch!();
@@ -737,12 +759,6 @@ impl RemoteTerminal {
                                     let mut term = term.lock();
                                     if quit.load(Ordering::SeqCst) {
                                         return;
-                                    }
-                                    if let Some(ws) = pending_size.take() {
-                                        term.resize(TermSize::new(
-                                            ws.cols as usize,
-                                            ws.rows as usize,
-                                        ));
                                     }
                                     processor.advance(&mut *term, &bytes);
                                     if processor.sync_timeout().sync_timeout().is_some() {
@@ -996,7 +1012,27 @@ impl RemoteTerminal {
         }
     }
 
+    /// Whether the daemon behind this pane echoes a `DaemonMsg::Size` into the
+    /// output stream when it applies our `ClientMsg::Resize`. When it does, the
+    /// local grid reflow is deferred to that echo on the reader thread: any
+    /// backlog still queued between daemon and client was produced at the old
+    /// geometry, and reflowing before it drains parses old-width bytes into a
+    /// new-width grid (maximize during a burst of output garbled the pane).
+    /// Non-local routes and older daemons never send the echo, so those keep
+    /// the reflow-at-request-time behavior.
+    fn resize_echoed(&self) -> bool {
+        #[cfg(test)]
+        if self.force_resize_echo {
+            return true;
+        }
+        self.route.is_local()
+            && crate::daemon::spawn::local_daemon_supports(
+                crate::daemon::protocol::FEATURE_RESIZE_ECHO,
+            )
+    }
+
     pub fn resize(&mut self, size: TermSize, cell_w: u16, cell_h: u16) {
+        let echoed = self.resize_echoed();
         // The cell size has to be part of the early-out, not just cols/rows: it
         // is reported in *device* pixels, so moving the window between a 2x and
         // a 1x display changes `ws_xpixel`/`ws_ypixel` while the grid stays
@@ -1004,6 +1040,12 @@ impl RemoteTerminal {
         // and leave a pixel-aware child rendering for the old framebuffer.
         let cell = (cell_w, cell_h);
         if self.synced_size && size == self.size && cell == self.synced_cell {
+            if echoed {
+                // The grid follows the daemon's Size echoes; disagreement here
+                // just means an echo is still in flight (or a replay segment is
+                // mid-apply), not that the request needs re-sending.
+                return;
+            }
             use alacritty_terminal::grid::Dimensions as _;
             let term = self.term.lock();
             if term.columns() == size.cols && term.screen_lines() == size.rows {
@@ -1013,7 +1055,9 @@ impl RemoteTerminal {
         self.synced_size = true;
         self.size = size;
         self.synced_cell = cell;
-        self.term.lock().resize(size);
+        if !echoed {
+            self.term.lock().resize(size);
+        }
 
         let win = win_size(size, cell_w, cell_h);
         if let Ok(mut writer) = self.writer.lock() {
@@ -3091,6 +3135,68 @@ mod tests {
             }
             other => panic!("expected Resize, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn echoed_resize_defers_the_grid_reflow_to_the_daemons_size_frame() {
+        use alacritty_terminal::grid::Dimensions as _;
+        use alacritty_terminal::index::{Column, Line};
+
+        let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
+        let mut term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
+        term.force_resize_echo = true;
+
+        term.resize(TermSize::new(120, 30), 8, 17);
+        assert!(matches!(
+            ClientMsg::read(&mut daemon_side).unwrap(),
+            ClientMsg::Resize(ws) if ws.cols == 120 && ws.rows == 30
+        ));
+        assert_eq!(
+            term.term.lock().columns(),
+            80,
+            "the grid keeps the old geometry until the daemon's echo arrives"
+        );
+
+        // Old-width bytes still in flight ahead of the echo: a CUP to column
+        // 100 must clamp on the 80-col grid. The same addressing after the
+        // echo reaches the real column on the 120-col grid.
+        DaemonMsg::Output(b"\x1b[1;100HA".to_vec())
+            .encode(&mut daemon_side)
+            .unwrap();
+        DaemonMsg::Size(WinSize {
+            cols: 120,
+            rows: 30,
+            cell_w: 8,
+            cell_h: 17,
+        })
+        .encode(&mut daemon_side)
+        .unwrap();
+        DaemonMsg::Output(b"\x1b[2;100HB".to_vec())
+            .encode(&mut daemon_side)
+            .unwrap();
+        daemon_side.flush().unwrap();
+
+        for _ in 0..400 {
+            {
+                let t = term.term.lock();
+                if t.columns() == 120 && t.grid()[Line(1)][Column(99)].c == 'B' {
+                    break;
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        let t = term.term.lock();
+        let grid = t.grid();
+        assert_eq!(
+            grid[Line(0)][Column(79)].c,
+            'A',
+            "bytes queued before the echo parse at the old width"
+        );
+        assert_eq!(
+            grid[Line(1)][Column(99)].c,
+            'B',
+            "bytes after the echo parse at the new width"
+        );
     }
 
     #[test]

--- a/src/terminal/remote.rs
+++ b/src/terminal/remote.rs
@@ -1018,8 +1018,16 @@ impl RemoteTerminal {
     /// backlog still queued between daemon and client was produced at the old
     /// geometry, and reflowing before it drains parses old-width bytes into a
     /// new-width grid (maximize during a burst of output garbled the pane).
-    /// Non-local routes and older daemons never send the echo, so those keep
-    /// the reflow-at-request-time behavior.
+    ///
+    /// Older daemons never echo, so those keep the reflow-at-request-time
+    /// behavior. Non-local routes keep it too, for a weaker reason: only the
+    /// local daemon's feature set is probed, so the client cannot *rely* on an
+    /// echo arriving. A current remote daemon does send one — the router
+    /// forwards frames it does not parse, and the reader applies it as a
+    /// same-size no-op after the eager reflow — but deferral can't hang on a
+    /// maybe. Follow-up: carry the remote daemon's advertised features on the
+    /// route handshake and consult them here; remote panes then get the
+    /// deferred path for free.
     fn resize_echoed(&self) -> bool {
         #[cfg(test)]
         if self.force_resize_echo {


### PR DESCRIPTION
Maximizing a pane after (or during) a burst of output garbled it: old output interleaved with later prompts, cursor stranded mid-screen. Two distinct resize disagreements stacked up.

## 1. Semantics: conhost re-anchors, the grid disagreed (the visible bug)

ConPTY emits **no repaint** after `ResizePseudoConsole` - measured against a live pane, a quiescent resize produces zero bytes. Conhost just re-anchors its own layout and keeps painting with absolute cursor addresses computed against it:

- **Grow**: rows and cursor stay pinned; blank rows open below. Nothing returns from scrollback. (Measured: prompt at row 29 of 30; after growing to 50 rows, PSReadLine still paints at `\e[29;36H`.)
- **Shrink**: the last *written* row scrolls to the new bottom - PSReadLine parks a continuation hint below the prompt, and conhost counts it. (Measured: cursor 37 of 50 -> row 19 of 20, one row above the alacritty-style answer.)

The vendored grid resized the alacritty way: growing pulled scrollback into view and pushed the cursor down by that many rows. After a maximize every absolute-CUP paint - PSReadLine redraws the prompt per keystroke - landed that many rows off, mid-screen inside the old output.

Fix: `alacritty_terminal` fork gains a `conpty_resize` mode (l0ng-ai/alacritty@1276f128, on the `tty7` branch, with grid tests) mirroring conhost's model for the primary screen; the alt screen keeps stock behavior since its application repaints itself. Every Windows pane opts in - shells, `wsl.exe`, `ssh.exe` are all presented through conhost alike. Cost: maximizing no longer reveals extra scrollback below the fold, same as Windows Terminal.

## 2. Stream order: reflow raced the output backlog

The client reflowed its grid the instant the window changed, then kept parsing whatever the daemon still had queued - up to the gate's 16 MiB of old-width bytes - into the new-width grid. The daemon now echoes a `Size` frame to the controlling subscriber *from inside the pane state lock*, i.e. at the exact stream position where the PTY geometry changes (after every old-width byte, before the post-resize output), and the client defers its reflow to that marker - the same geometry-tagging the reattach replay has always used. Observers apply live `Size` frames at the right moment now too instead of holding them for a snapshot that never comes.

Gated on a new `resize-echo` daemon feature: against an older daemon (the normal state right after an in-place update) the client keeps the old reflow-at-request-time path.

## Verification

- Fork: 141 `alacritty_terminal` tests pass incl. 3 new ConPTY grid tests.
- Daemon: unit test asserts `Output -> Size -> Output` stream order; live probe against an isolated daemon confirms exactly one echo with correct geometry mid-flood.
- Client: new cfg(unix) test asserts pre-echo bytes parse at the old width and post-echo bytes at the new width.
- Manual acceptance in an isolated dev instance: maximize after/during heavy output stays clean; post-maximize commands paint at the prompt; shrink and drag-resize track correctly.