### PR TITLE
fix(terminal): re-engage conpty_resize - the opt-in line never landed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The ConPTY resize fix now actually engages** — the one-line opt-in that
+  switches Windows panes onto conhost's resize model was lost from the
+  working tree between verification and commit, and nothing caught it: the
+  field defaults to off in the vendored `alacritty_terminal`, so the build,
+  the test suite, and CI all stayed green while the previous nightly
+  shipped with the semantics half of the fix disabled and the maximize
+  garbling intact. The flag is back, and a regression test now pins the
+  wiring itself so the flag can't silently drop again.
+
 - **Maximizing a Windows pane no longer shreds it** — two separate resize
   disagreements stacked up here, and the visible one was the second.
 

--- a/src/terminal/remote.rs
+++ b/src/terminal/remote.rs
@@ -2085,7 +2085,33 @@ fn terminal_config_from_user(user_config: &crate::core::config::Config) -> Confi
         default_cursor_style: alacritty_cursor_style(user_config.cursor_style),
         semantic_escape_chars: user_config.word_separators.clone(),
         kitty_keyboard: true,
+        // Every pane on Windows is presented through ConPTY (a shell, wsl.exe,
+        // ssh.exe — conhost mediates them all), which repaints nothing after a
+        // resize and keeps addressing the screen against its own re-anchored
+        // layout: grow keeps rows/cursor pinned and opens blank rows below,
+        // shrink scrolls the last written row to the new bottom. The grid must
+        // resize the same way or every later absolute-CUP paint (PSReadLine
+        // redraws its prompt that way per keystroke) lands rows off, shredding
+        // the screen the first time a maximized pane draws anything.
+        conpty_resize: cfg!(windows),
         ..Config::default()
+    }
+}
+
+#[cfg(test)]
+mod config_tests {
+    use super::*;
+
+    /// The whole conhost-semantics fix hangs on this one field: it defaults to
+    /// off in `alacritty_terminal`, so dropping the line compiles clean, passes
+    /// every other test, and quietly resurrects the maximize garbling — which
+    /// is exactly how it shipped disabled once (#415 follow-up).
+    #[test]
+    fn windows_panes_opt_into_conpty_resize_semantics() {
+        let config = terminal_config_from_user(&crate::core::config::Config::default());
+        assert_eq!(config.conpty_resize, cfg!(windows));
+        #[cfg(windows)]
+        assert!(config.conpty_resize);
     }
 }
 


### PR DESCRIPTION
The conhost-semantics half of #415 hangs on one line: `terminal_config_from_user` setting `conpty_resize` on Windows. That line was verified in the acceptance build but lost from the working tree before the commit landed, and nothing could catch it: the field defaults to **off** in the vendored `alacritty_terminal`, so the build, both test suites, and CI stayed green while nightly `202608081441` shipped with the semantics fix disabled and the maximize garbling intact. (The stream-order `Size` echo half of #415 did ship and works.)

This restores the flag and adds a Windows-runnable regression test that pins the wiring itself — `terminal_config_from_user` must opt Windows panes into ConPTY resize semantics — so the flag can't silently drop again.

Verified: `git show HEAD` contains the flag; `config_tests::windows_panes_opt_into_conpty_resize_semantics` passes locally.