### PR TITLE
feat(terminal): include fish_history in command history search

### DIFF
--- a/src/terminal/history.rs
+++ b/src/terminal/history.rs
@@ -106,8 +106,12 @@ pub fn load_with_shell_files(scope: &Scope, shell_files: Vec<Vec<u8>>) -> Histor
     normalize(raw)
 }
 
-pub fn shell_history_names() -> [&'static str; 2] {
-    [".zsh_history", ".bash_history"]
+pub fn shell_history_names() -> [&'static str; 3] {
+    [
+        ".zsh_history",
+        ".bash_history",
+        ".local/share/fish/fish_history",
+    ]
 }
 
 fn looks_absolute(p: &str) -> bool {
@@ -298,6 +302,13 @@ fn load_shell_history() -> Vec<Raw> {
         add(home.join(".zsh_history"));
         add(home.join(".bash_history"));
     }
+    // XDG_DATA_HOME is independent of HOME (and the only reliable signal on
+    // Windows runners, where HOME may be unset); fall back to ~/.local/share.
+    if let Some(xdg) = std::env::var_os("XDG_DATA_HOME").filter(|d| !d.is_empty()) {
+        add(PathBuf::from(xdg).join("fish/fish_history"));
+    } else if let Some(home) = std::env::var_os("HOME") {
+        add(PathBuf::from(home).join(".local/share/fish/fish_history"));
+    }
     files.sort_by_key(|p| {
         std::fs::metadata(p)
             .and_then(|m| m.modified())
@@ -307,10 +318,65 @@ fn load_shell_history() -> Vec<Raw> {
     let mut out = Vec::new();
     for path in files {
         if let Ok(bytes) = std::fs::read(&path) {
-            parse_shell_history(&String::from_utf8_lossy(&bytes), &mut out);
+            let content = String::from_utf8_lossy(&bytes);
+            if path.file_name().is_some_and(|n| n == "fish_history") {
+                parse_fish_history(&content, &mut out);
+            } else {
+                parse_shell_history(&content, &mut out);
+            }
         }
     }
     out
+}
+
+#[derive(serde::Deserialize)]
+struct FishEntry {
+    #[serde(default)]
+    cmd: String,
+    #[serde(default)]
+    when: Option<serde_yaml::Value>,
+}
+
+/// fish's `fish_history` is a YAML list of `- cmd: <text>` / `when: <epoch>`
+/// pairs. `when` is an integer epoch; tolerate strings and missing values.
+///
+/// The file grows across fish versions (3.x and 4.x writers differ) and a
+/// single malformed record must not sink the whole file — parse record by
+/// record, skipping the bad ones.
+fn parse_fish_history(content: &str, out: &mut Vec<Raw>) {
+    let mut start = 0;
+    while let Some(rel) = content[start..].find("\n- cmd:") {
+        let end = start + rel;
+        parse_fish_record(&content[start..end], out);
+        start = end + 1;
+    }
+    parse_fish_record(&content[start..], out);
+}
+
+fn parse_fish_record(block: &str, out: &mut Vec<Raw>) {
+    // A record is a YAML sequence item (`- cmd: …`); it only parses as a
+    // one-element sequence, not as a bare mapping.
+    let Ok(entries) = serde_yaml::from_str::<Vec<FishEntry>>(block.trim()) else {
+        return;
+    };
+    let Some(entry) = entries.into_iter().next() else {
+        return;
+    };
+    let cmd = entry.cmd.trim();
+    if cmd.is_empty() {
+        return;
+    }
+    let ts = entry.when.as_ref().and_then(|w| match w {
+        serde_yaml::Value::Number(n) => n.as_u64(),
+        serde_yaml::Value::String(s) => s.parse().ok(),
+        _ => None,
+    });
+    out.push(Raw {
+        cmd: cmd.to_string(),
+        cwd: None,
+        ts,
+        exit: None,
+    });
 }
 
 fn parse_shell_history(content: &str, out: &mut Vec<Raw>) {
@@ -376,6 +442,102 @@ mod tests {
         let mut out = Vec::new();
         parse_shell_history(content, &mut out);
         out.into_iter().map(|r| (r.cmd, r.ts)).collect()
+    }
+
+    fn parse_fish(content: &str) -> Vec<(String, Option<u64>)> {
+        let mut out = Vec::new();
+        parse_fish_history(content, &mut out);
+        out.into_iter().map(|r| (r.cmd, r.ts)).collect()
+    }
+
+    // Serializes tests that mutate process-wide env (XDG_DATA_HOME).
+    static HISTORY_ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn fish_history_entries_carry_cmd_and_timestamp() {
+        let content =
+            "- cmd: git status\n  when: 1700000000\n- cmd: cargo build\n  when: 1700000005\n";
+        assert_eq!(
+            parse_fish(content),
+            [
+                ("git status".to_string(), Some(1_700_000_000)),
+                ("cargo build".to_string(), Some(1_700_000_005)),
+            ]
+        );
+    }
+
+    #[test]
+    fn fish_history_multiline_cmd_is_joined_with_newlines() {
+        // fish writes multiline commands with YAML double-quote escapes
+        let content = r#"- cmd: "for f in *; do\necho $f\ndone"
+  when: 1700000000
+"#;
+        assert_eq!(
+            parse_fish(content),
+            [(
+                "for f in *; do\necho $f\ndone".to_string(),
+                Some(1_700_000_000)
+            )]
+        );
+    }
+
+    #[test]
+    fn fish_history_missing_or_string_when_is_tolerated() {
+        let content = "- cmd: ls\n- cmd: pwd\n  when: '1700000000'\n";
+        assert_eq!(
+            parse_fish(content),
+            [
+                ("ls".to_string(), None),
+                ("pwd".to_string(), Some(1_700_000_000)),
+            ]
+        );
+    }
+
+    #[test]
+    fn fish_history_garbage_is_skipped() {
+        assert_eq!(parse_fish("not yaml at all\n- cmd:\n"), []);
+        assert_eq!(parse_fish(""), []);
+    }
+
+    #[test]
+    fn a_bad_fish_record_does_not_sink_the_rest_of_the_file() {
+        // Real fish_history files accumulate records across fish versions;
+        // a malformed one (e.g. an unquoted `: ` inside a bare cmd) must not
+        // discard every other record.
+        let content = "- cmd: ok one\n  when: 1700000000\n- cmd: this: is: broken\n- cmd: ok two\n  when: 1700000001\n";
+        assert_eq!(
+            parse_fish(content),
+            [
+                ("ok one".to_string(), Some(1_700_000_000)),
+                ("ok two".to_string(), Some(1_700_000_001)),
+            ]
+        );
+    }
+
+    #[test]
+    fn load_shell_history_includes_fish() {
+        let _guard = HISTORY_ENV.lock().unwrap_or_else(|e| e.into_inner());
+        crate::core::config::pin_test_config_dir();
+
+        let tmp = std::env::temp_dir().join(format!("tty7-fish-{}", std::process::id()));
+        let fish_dir = tmp.join("fish");
+        std::fs::create_dir_all(&fish_dir).unwrap();
+        let marker = format!("tty7_fish_marker_{}", std::process::id());
+        std::fs::write(
+            fish_dir.join("fish_history"),
+            format!("- cmd: {marker}\n  when: 1700000000\n"),
+        )
+        .unwrap();
+
+        unsafe { std::env::set_var("XDG_DATA_HOME", &tmp) };
+        let raw = load_shell_history();
+        unsafe { std::env::remove_var("XDG_DATA_HOME") };
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert!(
+            raw.iter().any(|r| r.cmd == marker),
+            "fish_history should be merged into local history"
+        );
     }
 
     #[test]

--- a/src/terminal/history.rs
+++ b/src/terminal/history.rs
@@ -88,13 +88,16 @@ pub fn load(scope: &Scope) -> History {
     load_with_shell_files(scope, Vec::new())
 }
 
-pub fn load_with_shell_files(scope: &Scope, shell_files: Vec<Vec<u8>>) -> History {
+/// `shell_files` are the far end's own history files, each paired with the file
+/// name it was read from — the name is what picks the reader, so fetching a
+/// file the bash reader cannot parse is not enough to corrupt the list.
+pub fn load_with_shell_files(scope: &Scope, shell_files: Vec<(String, Vec<u8>)>) -> History {
     let mut raw: Vec<Raw> = if scope.is_local() {
         load_shell_history()
     } else {
         let mut out = Vec::new();
-        for bytes in &shell_files {
-            parse_shell_history(&String::from_utf8_lossy(bytes), &mut out);
+        for (name, bytes) in &shell_files {
+            parse_history_file(name, &String::from_utf8_lossy(bytes), &mut out);
         }
         out
     };
@@ -106,12 +109,19 @@ pub fn load_with_shell_files(scope: &Scope, shell_files: Vec<Vec<u8>>) -> Histor
     normalize(raw)
 }
 
+const FISH_HISTORY_FILE: &str = "fish_history";
+
+/// fish's history relative to the XDG data dir, and relative to `$HOME` when
+/// that dir is the default `~/.local/share`. `shell_history_names` returns the
+/// second, so a test pins the two spellings to each other.
+const FISH_HISTORY_UNDER_DATA_DIR: &str = "fish/fish_history";
+const FISH_HISTORY_UNDER_HOME: &str = ".local/share/fish/fish_history";
+
+/// History files worth fetching from a remote host, relative to its home dir.
+/// `load_with_shell_files` reads the file name back off these to pick a parser,
+/// so a name added here needs a reader in `parse_history_file`.
 pub fn shell_history_names() -> [&'static str; 3] {
-    [
-        ".zsh_history",
-        ".bash_history",
-        ".local/share/fish/fish_history",
-    ]
+    [".zsh_history", ".bash_history", FISH_HISTORY_UNDER_HOME]
 }
 
 fn looks_absolute(p: &str) -> bool {
@@ -302,12 +312,12 @@ fn load_shell_history() -> Vec<Raw> {
         add(home.join(".zsh_history"));
         add(home.join(".bash_history"));
     }
-    // XDG_DATA_HOME is independent of HOME (and the only reliable signal on
-    // Windows runners, where HOME may be unset); fall back to ~/.local/share.
+    // fish keeps its history under the XDG data dir, which is set independently
+    // of HOME, so ~/.local/share is only the fallback.
     if let Some(xdg) = std::env::var_os("XDG_DATA_HOME").filter(|d| !d.is_empty()) {
-        add(PathBuf::from(xdg).join("fish/fish_history"));
+        add(PathBuf::from(xdg).join(FISH_HISTORY_UNDER_DATA_DIR));
     } else if let Some(home) = std::env::var_os("HOME") {
-        add(PathBuf::from(home).join(".local/share/fish/fish_history"));
+        add(PathBuf::from(home).join(FISH_HISTORY_UNDER_HOME));
     }
     files.sort_by_key(|p| {
         std::fs::metadata(p)
@@ -318,65 +328,96 @@ fn load_shell_history() -> Vec<Raw> {
     let mut out = Vec::new();
     for path in files {
         if let Ok(bytes) = std::fs::read(&path) {
-            let content = String::from_utf8_lossy(&bytes);
-            if path.file_name().is_some_and(|n| n == "fish_history") {
-                parse_fish_history(&content, &mut out);
-            } else {
-                parse_shell_history(&content, &mut out);
-            }
+            let name = path.file_name().unwrap_or_default().to_string_lossy();
+            parse_history_file(&name, &String::from_utf8_lossy(&bytes), &mut out);
         }
     }
     out
 }
 
-#[derive(serde::Deserialize)]
-struct FishEntry {
-    #[serde(default)]
-    cmd: String,
-    #[serde(default)]
-    when: Option<serde_yaml::Value>,
+/// Which reader a history file gets, by file name. The remote side has only
+/// bytes and a name, so the choice has to hang off the name in both paths.
+fn parse_history_file(name: &str, content: &str, out: &mut Vec<Raw>) {
+    if name == FISH_HISTORY_FILE {
+        parse_fish_history(content, out);
+    } else {
+        parse_shell_history(content, out);
+    }
 }
 
-/// fish's `fish_history` is a YAML list of `- cmd: <text>` / `when: <epoch>`
-/// pairs. `when` is an integer epoch; tolerate strings and missing values.
+/// `fish_history` looks like YAML and is not.
 ///
-/// The file grows across fish versions (3.x and 4.x writers differ) and a
-/// single malformed record must not sink the whole file — parse record by
-/// record, skipping the bad ones.
+/// fish writes a command with exactly two characters escaped — a literal
+/// backslash becomes `\\` and a newline becomes `\n` — and nothing else. It
+/// does not quote, so `git commit -m "fix: crash"` goes to disk verbatim, and
+/// a YAML parser rejects that record outright ("mapping values are not allowed
+/// here"). `echo a: b`, any `[ ... ]` test, and any command with a ` #` in it
+/// fail or truncate the same way, silently, because a record that fails to
+/// parse is a record that vanishes from history search.
+///
+/// So read it the way fish's own reader does: a record starts at `- cmd:` in
+/// column 0, its keys are indented under it, and everything after `- cmd:` on
+/// that line is the command.
 fn parse_fish_history(content: &str, out: &mut Vec<Raw>) {
-    let mut start = 0;
-    while let Some(rel) = content[start..].find("\n- cmd:") {
-        let end = start + rel;
-        parse_fish_record(&content[start..end], out);
-        start = end + 1;
+    let mut pending: Option<Raw> = None;
+    for raw in content.split('\n') {
+        let line = raw.strip_suffix('\r').unwrap_or(raw);
+        if let Some(cmd) = line.strip_prefix("- cmd:") {
+            out.extend(pending.take());
+            let cmd = unescape_fish(cmd.trim());
+            // Everything downstream treats an entry as one line: `append`
+            // refuses embedded newlines, handing a line off to the shell bails
+            // on them, and the reverse-search menu draws one row per entry. A
+            // multiline command is skipped rather than half-supported — the
+            // same place bash and zsh multiline entries already land.
+            if !cmd.is_empty() && !cmd.contains('\n') {
+                pending = Some(Raw::bare(cmd));
+            }
+            continue;
+        }
+        if pending.is_none() {
+            continue;
+        }
+        // Keys are indented under their record; anything else ends it.
+        let Some(key) = line.strip_prefix("  ") else {
+            out.extend(pending.take());
+            continue;
+        };
+        if let Some(when) = key.strip_prefix("when:")
+            && let Ok(ts) = when.trim().trim_matches('\'').parse::<u64>()
+            && let Some(entry) = pending.as_mut()
+        {
+            entry.ts = Some(ts);
+        }
     }
-    parse_fish_record(&content[start..], out);
+    out.extend(pending);
 }
 
-fn parse_fish_record(block: &str, out: &mut Vec<Raw>) {
-    // A record is a YAML sequence item (`- cmd: …`); it only parses as a
-    // one-element sequence, not as a bare mapping.
-    let Ok(entries) = serde_yaml::from_str::<Vec<FishEntry>>(block.trim()) else {
-        return;
-    };
-    let Some(entry) = entries.into_iter().next() else {
-        return;
-    };
-    let cmd = entry.cmd.trim();
-    if cmd.is_empty() {
-        return;
+/// Reverse `escape_yaml_fish_2_0`: `\\` is a backslash and `\n` is a newline.
+/// A backslash before anything else is not an escape and stays as written.
+fn unescape_fish(s: &str) -> String {
+    if !s.contains('\\') {
+        return s.to_string();
     }
-    let ts = entry.when.as_ref().and_then(|w| match w {
-        serde_yaml::Value::Number(n) => n.as_u64(),
-        serde_yaml::Value::String(s) => s.parse().ok(),
-        _ => None,
-    });
-    out.push(Raw {
-        cmd: cmd.to_string(),
-        cwd: None,
-        ts,
-        exit: None,
-    });
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\\') {
+        out.push_str(&rest[..at]);
+        let mut tail = rest[at..].chars();
+        tail.next();
+        match tail.next() {
+            Some('\\') => out.push('\\'),
+            Some('n') => out.push('\n'),
+            _ => {
+                out.push('\\');
+                rest = &rest[at + 1..];
+                continue;
+            }
+        }
+        rest = &rest[at + 2..];
+    }
+    out.push_str(rest);
+    out
 }
 
 fn parse_shell_history(content: &str, out: &mut Vec<Raw>) {
@@ -450,9 +491,6 @@ mod tests {
         out.into_iter().map(|r| (r.cmd, r.ts)).collect()
     }
 
-    // Serializes tests that mutate process-wide env (XDG_DATA_HOME).
-    static HISTORY_ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     #[test]
     fn fish_history_entries_carry_cmd_and_timestamp() {
         let content =
@@ -467,22 +505,63 @@ mod tests {
     }
 
     #[test]
-    fn fish_history_multiline_cmd_is_joined_with_newlines() {
-        // fish writes multiline commands with YAML double-quote escapes
-        let content = r#"- cmd: "for f in *; do\necho $f\ndone"
-  when: 1700000000
-"#;
+    fn fish_writes_commands_unquoted_so_yaml_punctuation_is_just_text() {
+        // Every one of these is what fish actually puts on disk, and every one
+        // of them is a YAML parse error. Read as YAML they vanish from history
+        // search without a trace; read as fish reads them they are commands.
+        let content = concat!(
+            "- cmd: git commit -m \"fix: crash on start\"\n  when: 1700000000\n",
+            "- cmd: echo foo: bar\n  when: 1700000001\n",
+            "- cmd: [ -f x ]; and echo y\n  when: 1700000002\n",
+            "- cmd: rg --files # every file\n  when: 1700000003\n",
+            "- cmd: this: is: not: broken\n  when: 1700000004\n",
+        );
         assert_eq!(
             parse_fish(content),
-            [(
-                "for f in *; do\necho $f\ndone".to_string(),
-                Some(1_700_000_000)
-            )]
+            [
+                (
+                    "git commit -m \"fix: crash on start\"".to_string(),
+                    Some(1_700_000_000)
+                ),
+                ("echo foo: bar".to_string(), Some(1_700_000_001)),
+                ("[ -f x ]; and echo y".to_string(), Some(1_700_000_002)),
+                // A YAML reader drops everything from ` #` on; fish has no
+                // comments in its history file.
+                ("rg --files # every file".to_string(), Some(1_700_000_003)),
+                ("this: is: not: broken".to_string(), Some(1_700_000_004)),
+            ]
         );
     }
 
     #[test]
-    fn fish_history_missing_or_string_when_is_tolerated() {
+    fn fish_escapes_only_backslash_and_newline() {
+        // `escape_yaml_fish_2_0` doubles a backslash and turns a newline into
+        // `\n`. Leaving that undone hands back a command the user never ran.
+        assert_eq!(
+            parse_fish("- cmd: grep \"a\\\\b\" f\n  when: 1700000000\n"),
+            [("grep \"a\\b\" f".to_string(), Some(1_700_000_000))]
+        );
+        // `\t` is not an escape fish writes, so it stays two characters.
+        assert_eq!(
+            parse_fish("- cmd: printf 'a\\tb'\n"),
+            [("printf 'a\\tb'".to_string(), None)]
+        );
+    }
+
+    #[test]
+    fn a_multiline_fish_command_is_skipped_not_half_recalled() {
+        // fish stores this as one line with an escaped newline. Every consumer
+        // here is single-line — `append` refuses embedded newlines — so the
+        // entry is dropped rather than offered as something that cannot be run.
+        let content = "- cmd: for f in *\\necho $f\\nend\n  when: 1700000000\n- cmd: ls\n  when: 1700000001\n";
+        assert_eq!(
+            parse_fish(content),
+            [("ls".to_string(), Some(1_700_000_001))]
+        );
+    }
+
+    #[test]
+    fn fish_history_missing_or_quoted_when_is_tolerated() {
         let content = "- cmd: ls\n- cmd: pwd\n  when: '1700000000'\n";
         assert_eq!(
             parse_fish(content),
@@ -494,49 +573,40 @@ mod tests {
     }
 
     #[test]
-    fn fish_history_garbage_is_skipped() {
-        assert_eq!(parse_fish("not yaml at all\n- cmd:\n"), []);
-        assert_eq!(parse_fish(""), []);
-    }
-
-    #[test]
-    fn a_bad_fish_record_does_not_sink_the_rest_of_the_file() {
-        // Real fish_history files accumulate records across fish versions;
-        // a malformed one (e.g. an unquoted `: ` inside a bare cmd) must not
-        // discard every other record.
-        let content = "- cmd: ok one\n  when: 1700000000\n- cmd: this: is: broken\n- cmd: ok two\n  when: 1700000001\n";
+    fn fish_paths_and_stray_lines_never_become_commands() {
+        // fish 3.x writes a `paths:` block under a record; nothing in it is a
+        // command, and a truncated tail must not resurrect the record either.
+        let content = concat!(
+            "- cmd: vim src/main.rs\n",
+            "  when: 1700000000\n",
+            "  paths:\n",
+            "    - src/main.rs\n",
+            "\n",
+            "  when: 9999999999\n",
+        );
         assert_eq!(
             parse_fish(content),
-            [
-                ("ok one".to_string(), Some(1_700_000_000)),
-                ("ok two".to_string(), Some(1_700_000_001)),
-            ]
+            [("vim src/main.rs".to_string(), Some(1_700_000_000))]
         );
     }
 
     #[test]
-    fn load_shell_history_includes_fish() {
-        let _guard = HISTORY_ENV.lock().unwrap_or_else(|e| e.into_inner());
-        crate::core::config::pin_test_config_dir();
+    fn fish_history_garbage_is_skipped() {
+        assert_eq!(parse_fish("not a record at all\n- cmd:\n"), []);
+        assert_eq!(parse_fish(""), []);
+    }
 
-        let tmp = std::env::temp_dir().join(format!("tty7-fish-{}", std::process::id()));
-        let fish_dir = tmp.join("fish");
-        std::fs::create_dir_all(&fish_dir).unwrap();
-        let marker = format!("tty7_fish_marker_{}", std::process::id());
-        std::fs::write(
-            fish_dir.join("fish_history"),
-            format!("- cmd: {marker}\n  when: 1700000000\n"),
-        )
-        .unwrap();
-
-        unsafe { std::env::set_var("XDG_DATA_HOME", &tmp) };
-        let raw = load_shell_history();
-        unsafe { std::env::remove_var("XDG_DATA_HOME") };
-        let _ = std::fs::remove_dir_all(&tmp);
-
+    #[test]
+    fn the_fish_history_path_is_spelled_the_same_way_everywhere() {
+        assert_eq!(
+            FISH_HISTORY_UNDER_HOME,
+            format!(".local/share/{FISH_HISTORY_UNDER_DATA_DIR}"),
+            "the XDG-relative and HOME-relative spellings have drifted apart"
+        );
+        assert!(FISH_HISTORY_UNDER_HOME.ends_with(FISH_HISTORY_FILE));
         assert!(
-            raw.iter().any(|r| r.cmd == marker),
-            "fish_history should be merged into local history"
+            shell_history_names().contains(&FISH_HISTORY_UNDER_HOME),
+            "a remote host must be asked for the same file the local side reads"
         );
     }
 
@@ -915,7 +985,13 @@ mod tests {
         let scope = Scope::remote("me@readfile");
         let zsh = b": 1700000000:0;systemctl status nginx\n".to_vec();
         let bash = b"journalctl -u nginx\n".to_vec();
-        let loaded = load_with_shell_files(&scope, vec![zsh, bash]);
+        let loaded = load_with_shell_files(
+            &scope,
+            vec![
+                (".zsh_history".to_string(), zsh),
+                (".bash_history".to_string(), bash),
+            ],
+        );
 
         assert!(
             loaded.entries.iter().any(|e| e == "systemctl status nginx"),
@@ -929,6 +1005,41 @@ mod tests {
                 exit: None,
             }),
             "zsh's second field is elapsed seconds, not an exit code"
+        );
+    }
+
+    #[test]
+    fn a_remote_fish_history_is_read_as_fish_not_as_bash_lines() {
+        crate::core::config::pin_test_config_dir();
+
+        let scope = Scope::remote("me@fishbox");
+        let fish = b"- cmd: systemctl restart nginx\n  when: 1700000000\n".to_vec();
+        let loaded = load_with_shell_files(&scope, vec![(FISH_HISTORY_FILE.to_string(), fish)]);
+
+        assert!(
+            loaded
+                .entries
+                .iter()
+                .any(|e| e == "systemctl restart nginx"),
+            "the far end's fish history should be searchable: {:?}",
+            loaded.entries
+        );
+        assert!(
+            !loaded.entries.iter().any(|e| e.starts_with("- cmd:")),
+            "fish records must not reach the menu as raw file lines: {:?}",
+            loaded.entries
+        );
+        assert!(
+            !loaded.entries.iter().any(|e| e.starts_with("when:")),
+            "a record's keys are not commands: {:?}",
+            loaded.entries
+        );
+        assert_eq!(
+            loaded.meta.get("systemctl restart nginx"),
+            Some(&EntryMeta {
+                ts: Some(1_700_000_000),
+                exit: None,
+            })
         );
     }
 

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -2738,7 +2738,12 @@ impl TerminalView {
                 .background_spawn(async move {
                     let files = shell_files
                         .into_iter()
-                        .filter_map(|(host, path)| host.read_file(&path, MAX_HISTORY_BYTES).ok())
+                        .filter_map(|(host, path)| {
+                            // The name comes along: it is what tells the loader
+                            // which shell's format the bytes are in.
+                            let name = path.file_name()?.to_string_lossy().into_owned();
+                            Some((name, host.read_file(&path, MAX_HISTORY_BYTES).ok()?))
+                        })
                         .collect();
                     super::history::load_with_shell_files(&loading, files)
                 })


### PR DESCRIPTION
Ctrl+R command history currently only reads .zsh_history / .bash_history; fish users' fish_history (YAML - cmd: / when: records) is never parsed or read, locally or on remote panes.
- parse_fish_history: record-by-record tolerant YAML parsing — a single malformed record (common in files accumulated across fish 3.x/4.x writers) no longer discards the whole history
- load_shell_history: includes $XDG_DATA_HOME/fish/fish_history, falling back to ~/.local/share/fish/fish_history
- shell_history_names: remote panes' far-end history sources now include fish
- 6 new tests; full suite: 1073 passed

## Manual verification

1. **Seed a unique command into fish's own history** — in a plain terminal
   (Terminal.app / iTerm, *not* tty7), run it in an **interactive** fish shell
   (note: `fish -c '…'` is non-interactive and does not write history):

   ```sh
   echo tty7_fish_probe_$(date +%s)
 ```

 2. Confirm it reached the history file (fish 4 writes it out promptly):
    ```sh
tail -3 ~/.local/share/fish/fish_history
# → a `- cmd: echo tty7_fish_probe_…` record appears
    ```
 3. Build and run tty7 from this branch (the dev alias uses a throwaway
    config dir so nothing in your real ~/.config/tty7 is touched):
    ```sh
cargo dev
    ```
 4. Search in a fish pane: open a pane running fish, press Ctrl+R at the
    prompt and type tty7_fish_probe:
   - Before this change: the marker never appears — tty7 only read
     .zsh_history / .bash_history, never fish_history.
   - After: the marker shows up, alongside your regular fish history.
 5. Regression: Ctrl+R still lists zsh/bash history as before, and commands
    typed inside tty7 panes are still recorded as usual.