### PR TITLE
fix(wsl): fix WSL pane startup when fish is the default shell

### DIFF
--- a/crates/tty7-core/src/daemon/install/wsl.rs
+++ b/crates/tty7-core/src/daemon/install/wsl.rs
@@ -71,7 +71,13 @@ pub fn validate_distro(name: &str) -> Result<(), DistroNameError> {
 }
 
 pub fn wsl_args(distro: &str, argv: &[&str]) -> Vec<String> {
-    let mut args = vec!["-d".to_string(), distro.to_string(), "--".to_string()];
+    let mut args = vec!["-d".to_string(), distro.to_string()];
+    // `--` hands the rest of the line to the distro's default shell, which
+    // re-parses it before the program ever runs — fish chokes on the POSIX
+    // command lines we send, and every shell re-globs the arguments. `--exec`
+    // runs the argv itself. With no argv there is nothing to exec, and `--`
+    // keeps its other meaning there: start the default shell.
+    args.push(if argv.is_empty() { "--" } else { "--exec" }.to_string());
     args.extend(argv.iter().map(|a| (*a).to_string()));
     args
 }
@@ -672,7 +678,7 @@ mod tests {
     fn the_transport_command_line_is_the_designs() {
         assert_eq!(
             wsl_args("Ubuntu", &["tty7-server", "--stdio"]),
-            vec!["-d", "Ubuntu", "--", "tty7-server", "--stdio"]
+            vec!["-d", "Ubuntu", "--exec", "tty7-server", "--stdio"]
         );
         assert_eq!(
             wsl_args(
@@ -685,7 +691,7 @@ mod tests {
             vec![
                 "-d",
                 "Ubuntu-22.04",
-                "--",
+                "--exec",
                 "/home/me/.local/share/tty7/bin/tty7-server-26.7.5",
                 "--stdio",
             ]
@@ -701,8 +707,29 @@ mod tests {
         let args = wsl_args("Ubuntu", &["sh", "-s"]);
         assert!(
             args.iter().position(|a| a == "Ubuntu").unwrap()
-                < args.iter().position(|a| a == "--").unwrap()
+                < args.iter().position(|a| a == "--exec").unwrap()
         );
+    }
+
+    #[test]
+    fn no_transport_command_is_re_parsed_by_the_distro_s_default_shell() {
+        // A fish (or any non-POSIX) default shell must never see these lines:
+        // it parses them before the program runs. Every argv-carrying form has
+        // to go out under `--exec`, never `--`.
+        for argv in [
+            vec!["tty7-server", "--stdio"],
+            vec!["tty7-server", "--stdio", "--pane"],
+            vec!["sh", "-s"],
+            vec!["tee", "/home/me/.local/share/tty7/bin/tty7-server"],
+            vec!["sh", "-c", "exec my-server --stdio"],
+        ] {
+            let args = wsl_args("Ubuntu", &argv);
+            assert!(
+                !args.iter().any(|a| a == "--"),
+                "{argv:?} still goes through the default shell: {args:?}"
+            );
+            assert_eq!(args[2], "--exec", "{argv:?}");
+        }
     }
 
     #[test]

--- a/crates/tty7-core/src/daemon/shell_integration.rs
+++ b/crates/tty7-core/src/daemon/shell_integration.rs
@@ -829,7 +829,10 @@ fn setup_wsl(args: &[String]) -> Option<Injection> {
         argv.push("--cd".to_string());
         argv.push(cd);
     }
-    argv.push("--".to_string());
+    // `--` forwards the command through the distro's default shell, which makes
+    // shells such as fish parse the POSIX bootstrap before `sh` can receive it.
+    // `--exec` bypasses that shell and executes the bootstrap interpreter itself.
+    argv.push("--exec".to_string());
     argv.push("sh".to_string());
     argv.push("-c".to_string());
     argv.push(WSL_EXEC_SCRIPT.to_string());
@@ -1259,7 +1262,10 @@ mod tests {
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
                 Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
             }
-            if String::from_utf8_lossy(&out).contains("133;D") {
+            // Fish can emit an initial OSC 133 D while drawing its first prompt.
+            // Wait for the failing command's status so the prompt cycle under test
+            // has actually completed instead of accepting that startup marker.
+            if String::from_utf8_lossy(&out).contains("133;D;1") {
                 break;
             }
         }
@@ -1377,7 +1383,11 @@ mod tests {
         let inj = setup(Some("wsl.exe"), &args, false)
             .expect("setup must not depend on reaching the distro");
 
-        let sep = inj.args.iter().position(|a| a == "--").expect("`--`");
+        let sep = inj
+            .args
+            .iter()
+            .position(|a| a == "--exec")
+            .expect("`--exec`");
         assert_eq!(
             &inj.args[..sep],
             &[

--- a/crates/tty7-core/src/daemon/shell_integration.rs
+++ b/crates/tty7-core/src/daemon/shell_integration.rs
@@ -806,12 +806,33 @@ fn setup_bash() -> Option<Injection> {
 
 const WSL_RCFILE_ENV: &str = "TTY7_RC";
 
-const WSL_EXEC_SCRIPT: &str = concat!(
-    r#"case "${SHELL:-}" in "#,
-    r#"*/bash) exec "$SHELL" --rcfile "$TTY7_RC" -i ;; "#,
-    r#"*) exec "${SHELL:-/bin/sh}" -l ;; "#,
-    "esac"
-);
+/// POSIX single-quoting, for a body some other shell has to re-parse.
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
+/// The bootstrap `sh` runs inside the distro. `$SHELL` is the only place the
+/// user's real shell is named, so every arm dispatches on it: bash re-execs
+/// through the rcfile written on the Windows side, fish carries its integration
+/// inline the way `remote::bootstrap_command` does over SSH, and anything else
+/// falls back to a plain login shell.
+///
+/// `sh` parses this script, so the fish body is POSIX-quoted here — unlike the
+/// SSH path, where the far end's own login shell parses the bootstrap and
+/// `remote::fish_bootstrap` has to quote it the way fish reads quotes.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn wsl_exec_script() -> String {
+    format!(
+        concat!(
+            r#"case "${{SHELL:-}}" in "#,
+            r#"*/bash) exec "$SHELL" --rcfile "$TTY7_RC" -i ;; "#,
+            r#"*/fish) exec "$SHELL" -C {} -l ;; "#,
+            r#"*) exec "${{SHELL:-/bin/sh}}" -l ;; "#,
+            "esac"
+        ),
+        shell_quote(FISH_INTEGRATION)
+    )
+}
 
 #[cfg(windows)]
 fn setup_wsl(args: &[String]) -> Option<Injection> {
@@ -835,7 +856,7 @@ fn setup_wsl(args: &[String]) -> Option<Injection> {
     argv.push("--exec".to_string());
     argv.push("sh".to_string());
     argv.push("-c".to_string());
-    argv.push(WSL_EXEC_SCRIPT.to_string());
+    argv.push(wsl_exec_script());
 
     let mut env = HashMap::new();
     env.insert(
@@ -894,7 +915,7 @@ pub fn setup(program: Option<&str>, args: &[String], has_custom_args: bool) -> O
 }
 
 pub mod remote {
-    use super::{FISH_INTEGRATION, bash_rcfile, zsh_redirectors};
+    use super::{FISH_INTEGRATION, bash_rcfile, shell_quote, zsh_redirectors};
 
     pub const PROBE_COMMAND: &str = "echo __tty7_shell; echo $SHELL";
 
@@ -939,10 +960,6 @@ pub mod remote {
             RemoteShell::Bash => bash_bootstrap(shell_path),
             RemoteShell::Fish => fish_bootstrap(shell_path),
         }
-    }
-
-    fn shell_quote(s: &str) -> String {
-        format!("'{}'", s.replace('\'', r"'\''"))
     }
 
     fn fish_quote(s: &str) -> String {
@@ -1219,6 +1236,16 @@ mod tests {
         assert!(!is_our_zdotdir("/tmp/not-tty7-zdotdir-1"));
     }
 
+    /// `\e]133;D;1\a` — what a shell reports for the `false` these tests type.
+    ///
+    /// The trailing BEL is the point. `contains("133;D;1")` is a prefix match on
+    /// the exit status, so it also accepts `133;D;127` (the bootstrap exec'd a
+    /// shell that could not find `false`) and `133;D;130` (interrupted) — a
+    /// bootstrap that never ran the command at all would pass every assertion
+    /// below. Matching through the terminator pins the status whole.
+    #[cfg(windows)]
+    const FAILED_COMMAND_MARK: &str = "133;D;1\u{7}";
+
     #[cfg(windows)]
     fn prompt_cycle_over_pty(program: &str, injection: &Injection) -> String {
         use portable_pty::{CommandBuilder, PtySize, native_pty_system};
@@ -1262,10 +1289,11 @@ mod tests {
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
                 Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
             }
-            // Fish can emit an initial OSC 133 D while drawing its first prompt.
-            // Wait for the failing command's status so the prompt cycle under test
-            // has actually completed instead of accepting that startup marker.
-            if String::from_utf8_lossy(&out).contains("133;D;1") {
+            // Stop only once the typed command's own D report lands. A shell can
+            // emit an unpaired D while drawing its first prompt, and breaking on
+            // that would sample the transcript before the prompt cycle under test
+            // has run at all.
+            if String::from_utf8_lossy(&out).contains(FAILED_COMMAND_MARK) {
                 break;
             }
         }
@@ -1297,10 +1325,10 @@ mod tests {
         let injection = setup(Some(&bash), &[], false).expect("bash integration");
         let text = prompt_cycle_over_pty(&bash, &injection);
 
-        for mark in ["133;A", "133;B", "133;C", "133;D;1"] {
+        for mark in ["133;A", "133;B", "133;C", FAILED_COMMAND_MARK] {
             assert!(
                 text.contains(mark),
-                "Git Bash must report {mark}; got:\n{text}"
+                "Git Bash must report {mark:?}; got:\n{text}"
             );
         }
         let cwd = reported_cwd(&text);
@@ -1327,10 +1355,10 @@ mod tests {
         let injection = setup(Some("wsl.exe"), &args, false).expect("wsl integration");
         let text = prompt_cycle_over_pty("wsl.exe", &injection);
 
-        for mark in ["133;A", "133;B", "133;C", "133;D;1"] {
+        for mark in ["133;A", "133;B", "133;C", FAILED_COMMAND_MARK] {
             assert!(
                 text.contains(mark),
-                "WSL ({distro}) must report {mark}; got:\n{text}"
+                "WSL ({distro}) must report {mark:?}; got:\n{text}"
             );
         }
         let cwd = reported_cwd(&text);
@@ -1402,6 +1430,52 @@ mod tests {
         assert!(inj.args[sep + 3].contains("$SHELL"));
         assert!(inj.args[sep + 3].contains("--rcfile"));
         assert!(inj.replaces_argv);
+    }
+
+    #[test]
+    fn the_wsl_bootstrap_carries_integration_for_fish_not_just_bash() {
+        let script = wsl_exec_script();
+
+        assert!(script.contains(r#"*/bash) exec "$SHELL" --rcfile "$TTY7_RC" -i ;;"#));
+        assert!(script.contains(&format!(
+            r#"*/fish) exec "$SHELL" -C {} -l ;;"#,
+            shell_quote(FISH_INTEGRATION)
+        )));
+
+        // `sh` parses this script, so the body is POSIX-quoted — backslashes
+        // pass through untouched. `remote::fish_quote`, which the SSH path uses
+        // because the far end's own fish parses the bootstrap there, would
+        // double every one of them and hand fish `\\e]%s\\a`.
+        assert!(script.contains(r"printf '\''\e]%s\a'\'' $argv[1]"));
+    }
+
+    /// The distro runs this through `sh`, so a quoting slip is a pane that
+    /// never opens. CI's Linux and macOS legs have a real `sh` to ask.
+    #[cfg(unix)]
+    #[test]
+    fn the_wsl_bootstrap_is_valid_posix_sh() {
+        use std::io::Write as _;
+        use std::process::{Command, Stdio};
+
+        let mut child = Command::new("sh")
+            .arg("-n")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn sh -n");
+        child
+            .stdin
+            .take()
+            .expect("piped stdin")
+            .write_all(wsl_exec_script().as_bytes())
+            .expect("write script");
+        let out = child.wait_with_output().expect("wait for sh -n");
+        assert!(
+            out.status.success(),
+            "sh rejected the WSL bootstrap:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fix WSL panes failing immediately when the distribution uses fish or another non-POSIX shell as its default login shell.

tty7 previously launched its WSL bootstrap with:

```text
wsl.exe ... -- sh -c <bootstrap>
```

The `--` argument only ends WSL option parsing. WSL may still pass the remaining command through the distribution’s default shell. When fish is the default shell, fish parses the POSIX parameter expansions in the bootstrap before `sh` receives them and exits with an error such as:

```text
fish: ${ is not a valid variable in fish
```

The bootstrap now uses:

```text
wsl.exe ... --exec sh -c <bootstrap>
```

`--exec` bypasses the distribution’s default shell for the bootstrap command. The explicit `sh` process interprets the POSIX wrapper and then launches the user’s configured shell in login mode.

## Changes

- Replace the WSL bootstrap separator `--` with `--exec`.
- Preserve the selected WSL distribution and initial working directory.
- Preserve the existing `$SHELL`-based final login-shell selection.
- Preserve the Bash-specific rcfile integration path.
- Add a regression assertion requiring `--exec` in generated WSL arguments.
- Update the real PTY test to wait for `OSC 133 D` with the command exit status.
- Avoid treating fish’s initial status-less `OSC 133 D` prompt marker as command completion.

## Compatibility

The change only affects which interpreter parses tty7’s bootstrap script. It does not replace or bypass the user’s final login shell.

The resulting startup flow is:

```text
wsl.exe --exec sh -c <bootstrap>
  └─ user’s configured login shell
```

Common shells continue to use their existing final launch behavior:

- Bash: launched with tty7’s generated rcfile and interactive mode.
- fish: launched in login mode without parsing the POSIX bootstrap.
- zsh: launched in login mode.
- Nushell: launched in login mode.
- Other shells: launched through the existing generic login-shell fallback.
- Missing `$SHELL`: falls back to `/bin/sh -l`.

User-authored non-empty WSL arguments continue to disable automatic shell integration and are unaffected by this change.