### PR TITLE
fix(cli): stamp panes with the workspace that holds them, not the client's name

### DIFF
--- a/crates/tty7-cli/src/backend/real.rs
+++ b/crates/tty7-cli/src/backend/real.rs
@@ -124,14 +124,15 @@ impl Backend for RealBackend {
     }
 
     fn spawn_shell(&mut self, workspace: WorkspaceId, cwd: Option<String>) -> Result<u64> {
+        let workspace = workspace.to_string();
         let session = self
             .pane_client()?
             .spawn(
                 cwd.map(PathBuf::from),
                 SESSION_SIZE,
                 None,
-                Some("tty7-cli".into()),
-                Some(workspace.to_string()),
+                Some(workspace.clone()),
+                Some(workspace),
             )
             .context("spawning a shell")?;
         let pane = session.pane_id();
@@ -230,14 +231,18 @@ impl Backend for RealBackend {
             args: args.to_vec(),
             args_are_tty7_defaults: false,
         };
+        // A `run` with no workspace is nobody's pane, so it is left unowned
+        // rather than stamped: an owner names the workspace that may attach to
+        // it, and there is none until `--keep` files it into a tab.
+        let workspace = spec.workspace.map(|ws| ws.to_string());
         let session = self
             .pane_client()?
             .spawn(
                 spec.cwd.map(PathBuf::from),
                 SESSION_SIZE,
                 Some(shell),
-                Some("tty7-cli".into()),
-                spec.workspace.map(|ws| ws.to_string()),
+                workspace.clone(),
+                workspace,
             )
             .with_context(|| format!("spawning `{program}`"))?;
         let pane = session.pane_id();

--- a/crates/tty7-cli/src/output.rs
+++ b/crates/tty7-cli/src/output.rs
@@ -136,19 +136,32 @@ pub fn pane_table(machine: &Machine, only: Option<WorkspaceId>) -> String {
 /// The server's registry rather than the machine tree, so orphans appear. `held`
 /// answers which workspace holds a pane, if any; a pane with no holder is shown
 /// as `-` under WS, which is the whole point of the listing.
+///
+/// OWNER names the workspace allowed to attach to the pane, and for a pane in
+/// its own workspace's tree that is the WS beside it — so the column only
+/// speaks when the two disagree, which is the case worth reading: an orphan
+/// still remembering where it belongs, or a pane the holder cannot attach to.
 pub fn registry_table(panes: &[PaneInfo], held: &dyn Fn(u64) -> Option<String>) -> String {
     if panes.is_empty() {
         return "no panes\n".to_string();
     }
+    let short = |id: &str| -> String { id.chars().take(8).collect() };
     let rows: Vec<Vec<String>> = panes
         .iter()
         .map(|info| {
+            let holder = held(info.pane_id);
+            let owner = match (&info.owner, &holder) {
+                (None, _) => "-".to_string(),
+                (Some(owner), Some(holder)) if owner == holder => "-".to_string(),
+                (Some(owner), _) => short(owner),
+            };
             vec![
                 format!("%{}", info.pane_id),
-                held(info.pane_id)
-                    .map(|ws| ws.chars().take(8).collect())
+                holder
+                    .as_deref()
+                    .map(short)
                     .unwrap_or_else(|| "-".to_string()),
-                info.owner.clone().unwrap_or_else(|| "-".to_string()),
+                owner,
                 info.cwd
                     .as_ref()
                     .map(|p| p.display().to_string())
@@ -304,6 +317,55 @@ mod tests {
         assert!(
             rendered.lines().all(|l| l == l.trim_end()),
             "trailing spaces break naive downstream parsing"
+        );
+    }
+
+    #[test]
+    fn owner_speaks_only_when_it_disagrees_with_the_workspace_holding_the_pane() {
+        let held = "9fd8072f-465c-4016-9a81-8143bff1240c";
+        let elsewhere = "76698a44-3f13-4961-8fed-90d0b3defff1";
+        let pane = |id: u64, owner: Option<&str>| PaneInfo {
+            pane_id: id,
+            cwd: None,
+            title: "zsh".into(),
+            alive: true,
+            owner: owner.map(str::to_string),
+        };
+        let rendered = registry_table(
+            &[
+                pane(1, Some(held)),
+                pane(2, Some(elsewhere)),
+                pane(3, None),
+                pane(4, Some(elsewhere)),
+            ],
+            &|id| (id != 4).then(|| held.to_string()),
+        );
+
+        let owner_of = |pane: &str| -> String {
+            rendered
+                .lines()
+                .find(|line| line.starts_with(pane))
+                .unwrap_or_else(|| panic!("{pane} is listed: {rendered}"))
+                .split_whitespace()
+                .nth(2)
+                .expect("PANE WS OWNER")
+                .to_string()
+        };
+        assert_eq!(
+            owner_of("%1"),
+            "-",
+            "repeating the WS beside it says nothing"
+        );
+        assert_eq!(
+            owner_of("%2"),
+            "76698a44",
+            "a holder that may not attach is the whole reason to look"
+        );
+        assert_eq!(owner_of("%3"), "-", "nobody claims it");
+        assert_eq!(
+            owner_of("%4"),
+            "76698a44",
+            "an orphan still remembers where it belongs"
         );
     }
 

--- a/crates/tty7-cli/tests/cli_e2e.rs
+++ b/crates/tty7-cli/tests/cli_e2e.rs
@@ -39,6 +39,10 @@ fn main() {
             tab_close_terminates_every_pane_in_the_tab,
         ),
         (
+            "every_pane_the_cli_files_names_its_workspace_as_owner",
+            every_pane_the_cli_files_names_its_workspace_as_owner,
+        ),
+        (
             "run_streams_output_and_passes_the_exit_code",
             run_streams_output_and_passes_the_exit_code,
         ),
@@ -427,6 +431,47 @@ fn tab_close_terminates_every_pane_in_the_tab(daemon: &Daemon) {
             "tab close left one of panes %{first} and %{second} live: {listed}"
         );
         std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// A pane's owner is the workspace allowed to attach to it, and the GUI
+/// respawns over anything else — so every way the CLI makes a pane has to
+/// stamp that id, not a name of its own. It used to write a literal
+/// "tty7-cli", which left a CLI-built workspace rebuilt from scratch the
+/// first time a window opened on it: fresh shells, the live ones orphaned.
+fn every_pane_the_cli_files_names_its_workspace_as_owner(daemon: &Daemon) {
+    let created = daemon.run_json(&["new", &workdir()]);
+    let ws_id = created["id"]
+        .as_str()
+        .expect("new prints the workspace id")
+        .to_string();
+
+    let tab = daemon.run_json(&["tab", "new", &ws_id, "--cwd", &workdir()]);
+    let tabbed = tab["pane"].as_u64().expect("tab new prints the pane id");
+    daemon.run_json(&["split", &format!("%{tabbed}"), "--horizontal"]);
+
+    let listed = daemon.run_json(&["pane", "ls", "--all"]);
+    let panes = listed["panes"]
+        .as_array()
+        .expect("pane ls --all prints the daemon registry");
+    let ours: Vec<&serde_json::Value> = panes
+        .iter()
+        .filter(|p| p["workspace"].as_str() == Some(ws_id.as_str()))
+        .collect();
+    // `run --keep` files a pane the same way, but its command has to exit for
+    // the CLI to return, and the registry drops the pane with it — so the
+    // three that outlive their command are what can be read back here.
+    assert_eq!(
+        ours.len(),
+        3,
+        "new, tab new and split each filed one pane: {listed}"
+    );
+    for pane in ours {
+        assert_eq!(
+            pane["owner"].as_str(),
+            Some(ws_id.as_str()),
+            "a pane its workspace holds must name that workspace as owner: {pane}"
+        );
     }
 }
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -5767,7 +5767,15 @@ fn pane_attachable(
         None => false,
         Some(None) => true,
         Some(Some(recorded)) => {
-            let ours = *recorded == owner.to_string();
+            // Only a workspace id is a claim. Anything else is a client
+            // stamping its own name — `tty7` before this release wrote a
+            // literal "tty7-cli" — and refusing on it strands every pane the
+            // CLI ever made, respawning over a live shell the tree just told
+            // us belongs here.
+            let Ok(recorded) = recorded.parse::<crate::core::session::WorkspaceId>() else {
+                return true;
+            };
+            let ours = recorded == owner;
             if !ours {
                 log::warn!(
                     "restore: pane {id} is owned by workspace {recorded}, not {owner}; \
@@ -6499,6 +6507,7 @@ mod tests {
             (1, Some(ours.to_string())),
             (2, Some(theirs.to_string())),
             (3, None),
+            (5, Some("tty7-cli".to_string())),
         ]
         .into_iter()
         .collect();
@@ -6514,6 +6523,11 @@ mod tests {
         assert!(
             pane_attachable(Some(&alive), 3, ours),
             "an unowned pane is legacy"
+        );
+        assert!(
+            pane_attachable(Some(&alive), 5, ours),
+            "an owner that names no workspace is not a rival's claim: older CLIs \
+             wrote their own name there, and respawning strands the live pane"
         );
         assert!(
             !pane_attachable(Some(&alive), 4, ours),


### PR DESCRIPTION
Every pane the CLI makes now names the workspace holding it as its owner, so a window opening on a CLI-built workspace attaches to the shells that are already running instead of rebuilding the whole thing.

| | Before | After |
|---|---|---|
| Open a window on a workspace made by `tty7 new` | Every tab gets a brand-new shell; the running ones are orphaned | Every tab attaches to the pane that is already there |
| A pane whose tab ran a coding agent | The fresh shell is handed a `claude --resume <id>` for a session that was never on disk, so it opens on `No conversation found` | Nothing to resume — the agent is still running in the pane that was attached |
| `tty7 pane ls --all` after opening the window | The CLI's panes sit under "held by no workspace" | They stay filed under their workspace |
| Owner recorded by `tty7 new` / `tab new` / `split` / `run --keep` | The literal string `tty7-cli` | The workspace id |
| Restore meeting an owner that names no workspace | Refuses to attach, spawns fresh | Attaches — a client's own name was never a rival workspace's claim |
| OWNER column of `pane ls --all` | The owner verbatim on every row | A dash when it agrees with WS, so only the rows worth reading speak |

## Why

`owner` is the workspace permitted to attach to a pane, and `pane_attachable` compares it against the workspace doing the restoring. The CLI passed the workspace id in the `workspace` field — which is what gives the shell its `$TTY7_WS` — but stamped `owner` with its own name, so the comparison never matched and the GUI concluded each pane belonged to someone else.

Nothing before this point noticed, because the two clients rarely touched the same workspace: panes the GUI made carry the id and attach fine, and the CLI's own listings work off the workspace tree rather than `owner`. The failure only surfaces where the two meet — a workspace scripted from the CLI, then opened in a window.

The second half matters for workspaces that already exist: their panes are stamped `tty7-cli` on the daemon and nothing rewrites an owner after the spawn, so without the restore-side change they would keep respawning until every one of them had been closed by hand.

```mermaid
flowchart LR
    subgraph before[Before]
        A1[tty7 new] -->|owner: tty7-cli| P1[(pane)]
        P1 --> C1{pane_attachable?}
        C1 -->|"tty7-cli" != workspace id| S1[spawn fresh + --resume]
        S1 --> O1[live pane orphaned]
    end
    subgraph after[After]
        A2[tty7 new] -->|owner: workspace id| P2[(pane)]
        P2 --> C2{pane_attachable?}
        C2 -->|matches| S2[attach]
    end
```

## The OWNER column

With the fix, a filed pane's owner *is* the WS beside it, so printing both put the same id on the row twice and buried the rows that carry news. It now shows a dash when they agree — which leaves exactly the two cases worth looking at, and makes the panes still stamped by an older CLI stand out as the ones a window will rebuild:

```
PANE  WS        OWNER     CWD                                    LIVE
%289  9fd8072f  -         /Users/thomas/repo/025/gpui-component   yes
%269  -         tty7-cli  /Users/thomas/repo/rig                  yes
%295  9fd8072f  tty7-cli  /Users/thomas/repo/025/gpui-component   yes
```

## Testing

- `cli_e2e`: new `every_pane_the_cli_files_names_its_workspace_as_owner` drives a real daemon through `new`, `tab new` and `split`, then asserts every pane the workspace holds carries that workspace's id as its owner. Verified it fails when the old `"tty7-cli"` string is put back.
- `restore_only_attaches_panes_the_workspace_owns_or_nobody_claims` gains a case for an owner that names no workspace.
- `owner_speaks_only_when_it_disagrees_with_the_workspace_holding_the_pane` covers the four combinations the column has to distinguish.
- `cargo test --workspace` and `cargo build` clean. (`daemon::singleton::the_second_claim_is_refused_while_the_first_is_held` fails when it runs alongside the e2e daemon competing for the same seat, and passes on its own — unrelated to this change.)
- By hand: a four-tab workspace built with `tty7 new` + `tty7 tab new`, each pane running `claude`, reproduced the rebuild-and-fail-to-resume path before the fix; the listing above is the real output of the rebuilt CLI.
