### PR TITLE
feat(daemon): upgrade in place, keep pane screens across a crash, and give panes their own history

### DIFF
--- a/crates/tty7-core/src/client/pane.rs
+++ b/crates/tty7-core/src/client/pane.rs
@@ -160,6 +160,10 @@ impl PaneSession {
             shell,
             owner,
             workspace,
+            // Restoring a dead pane's screen is a window concern: it exists to
+            // put a workspace back the way its user left it. Nothing that
+            // scripts panes through this library has a screen to put back.
+            restore: None,
         }
         .encode(&mut stream)?;
         let mut session = PaneSession::over(stream, 0)?;

--- a/crates/tty7-core/src/client/pane.rs
+++ b/crates/tty7-core/src/client/pane.rs
@@ -86,6 +86,34 @@ impl PaneClient {
         ClientMsg::Kill { pane_id }.encode(&mut stream)
     }
 
+    /// Ask the daemon to become `exe` without stopping, keeping every pane.
+    ///
+    /// Success is the connection ending: the process that answers this socket
+    /// is replaced mid-call, and its replacement has never heard of the socket.
+    /// Anything actually written back is the reason it did not happen, and in
+    /// that case the daemon is still running, still serving, still on its old
+    /// binary.
+    ///
+    /// Returning does not mean the new image is listening yet — rebinding the
+    /// endpoint takes it a moment. Callers that need to talk to it again should
+    /// wait for its version to answer.
+    pub fn hand_off(&self, exe: &std::path::Path) -> io::Result<()> {
+        use std::io::Write as _;
+
+        let mut stream = self.open()?;
+        ClientMsg::Handoff {
+            exe: exe.to_path_buf(),
+        }
+        .encode(&mut stream)?;
+        stream.flush()?;
+        let _ = stream.set_read_timeout(Some(OPEN_REPLY_WAIT));
+        match DaemonMsg::read(&mut stream) {
+            Err(_) => Ok(()),
+            Ok(DaemonMsg::Error(message)) => Err(io::Error::other(message)),
+            Ok(other) => Err(unexpected_reply("Handoff", &other)),
+        }
+    }
+
     pub fn send_input(&self, pane_id: u64, bytes: &[u8]) -> io::Result<()> {
         let mut stream = self.open()?;
         ClientMsg::SendInput {

--- a/crates/tty7-core/src/core/config.rs
+++ b/crates/tty7-core/src/core/config.rs
@@ -268,6 +268,17 @@ pub struct Config {
     pub agent_commands: HashMap<String, String>,
     #[serde(default = "default_true")]
     pub restore_agent_sessions: bool,
+    /// Keep a capped tail of each pane's output on disk, so a daemon that dies
+    /// without getting to hand off — a crash, a `kill -9`, a reboot — comes
+    /// back to panes that still show what was in them.
+    ///
+    /// Off by default, and the default is the interesting part. What the ring
+    /// holds is whatever the pane printed, which routinely includes secrets:
+    /// an echoed token, the output of `env`, an agent's transcript. In memory
+    /// they die with the daemon. Writing them down is the entire feature and
+    /// also its entire cost, so it is the user who decides to pay it.
+    #[serde(default)]
+    pub persist_scrollback: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
@@ -524,6 +535,7 @@ impl Default for Config {
             command_frecency: HashMap::new(),
             agent_commands: HashMap::new(),
             restore_agent_sessions: true,
+            persist_scrollback: false,
         }
     }
 }

--- a/crates/tty7-core/src/core/config.rs
+++ b/crates/tty7-core/src/core/config.rs
@@ -279,6 +279,16 @@ pub struct Config {
     /// also its entire cost, so it is the user who decides to pay it.
     #[serde(default)]
     pub persist_scrollback: bool,
+    /// Give each pane its own shell history instead of one file every pane
+    /// appends to and reads back.
+    ///
+    /// Seeded from the shell's real history file, so a new pane is not blank,
+    /// and merged back into it when the pane closes, so nothing typed is lost.
+    /// Off by default because shared history is what a terminal has always
+    /// done, and someone who has not asked for the change would experience it
+    /// as their history mysteriously forgetting the other window.
+    #[serde(default)]
+    pub per_pane_history: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
@@ -536,6 +546,7 @@ impl Default for Config {
             agent_commands: HashMap::new(),
             restore_agent_sessions: true,
             persist_scrollback: false,
+            per_pane_history: false,
         }
     }
 }

--- a/crates/tty7-core/src/daemon/handoff.rs
+++ b/crates/tty7-core/src/daemon/handoff.rs
@@ -152,13 +152,23 @@ pub fn take_over(
     };
 
     // Past this point every descriptor the new image needs has to survive the
-    // exec, and Rust opens everything close-on-exec.
+    // exec, and Rust opens everything close-on-exec. Returning without the exec
+    // means putting every flag back: the daemon that keeps serving after a
+    // failed handoff spawns children of its own — `lsof`, ssh transports — and
+    // a pty master or the seat lock inherited by one of those outlives every
+    // assumption this module makes. A child holding the seat keeps the flock
+    // held after this daemon dies, and the next daemon would stand down in
+    // favour of a process that is not a daemon at all.
     let blob_fd = std::os::fd::AsRawFd::as_raw_fd(&blob);
-    for fd in std::iter::once(blob_fd)
+    let kept: Vec<RawFd> = std::iter::once(blob_fd)
         .chain(seat_fd)
         .chain(panes.iter().map(|p| p.master_fd))
-    {
-        if let Err(e) = keep_across_exec(fd) {
+        .collect();
+    for (i, fd) in kept.iter().enumerate() {
+        if let Err(e) = keep_across_exec(*fd) {
+            for fd in &kept[..i] {
+                let _ = close_on_exec_again(*fd);
+            }
             return anyhow::anyhow!("descriptor {fd} would not survive the exec: {e}");
         }
     }
@@ -178,9 +188,23 @@ pub fn take_over(
         panes.len(),
         exe.display()
     );
+    // `exec` resets this thread's signal mask and puts SIGPIPE back to its
+    // default before the attempt, and a failed attempt undoes neither — the
+    // std docs say as much. A daemon that keeps serving with SIGPIPE fatal
+    // dies on the first write to a client that hung up, which is to say: soon.
+    let mut mask: libc::sigset_t = unsafe { std::mem::zeroed() };
+    unsafe { libc::pthread_sigmask(libc::SIG_SETMASK, std::ptr::null(), &mut mask) };
+
     // Only ever returns an error: on success this process is already the new
     // program and this code no longer exists.
     let failure = std::os::unix::process::CommandExt::exec(&mut cmd);
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_IGN);
+        libc::pthread_sigmask(libc::SIG_SETMASK, &mask, std::ptr::null_mut());
+    }
+    for fd in &kept {
+        let _ = close_on_exec_again(*fd);
+    }
     anyhow::anyhow!("could not exec {}: {failure}", exe.display())
 }
 
@@ -259,11 +283,25 @@ fn anonymous_file() -> std::io::Result<std::fs::File> {
 }
 
 fn keep_across_exec(fd: RawFd) -> std::io::Result<()> {
+    set_cloexec(fd, false)
+}
+
+/// Put close-on-exec back on a descriptor a failed handoff had cleared it from.
+pub(crate) fn close_on_exec_again(fd: RawFd) -> std::io::Result<()> {
+    set_cloexec(fd, true)
+}
+
+fn set_cloexec(fd: RawFd, on: bool) -> std::io::Result<()> {
     let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
     if flags < 0 {
         return Err(std::io::Error::last_os_error());
     }
-    if unsafe { libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) } < 0 {
+    let flags = if on {
+        flags | libc::FD_CLOEXEC
+    } else {
+        flags & !libc::FD_CLOEXEC
+    };
+    if unsafe { libc::fcntl(fd, libc::F_SETFD, flags) } < 0 {
         return Err(std::io::Error::last_os_error());
     }
     Ok(())
@@ -443,6 +481,43 @@ mod tests {
             dir.display()
         );
         drop(file);
+    }
+
+    #[test]
+    fn a_failed_exec_puts_close_on_exec_back_on_every_descriptor() {
+        use std::os::fd::AsRawFd as _;
+
+        let master = std::fs::File::open("/dev/null").expect("a stand-in master");
+        let seat = std::fs::File::open("/dev/null").expect("a stand-in seat");
+        let err = take_over(
+            Path::new("/nonexistent/tty7-that-cannot-exec"),
+            vec![carried(1, master.as_raw_fd(), b"output")],
+            2,
+            Some(seat.as_raw_fd()),
+        );
+        assert!(
+            err.to_string().contains("could not exec"),
+            "the failure was {err}"
+        );
+        for (name, fd) in [("master", master.as_raw_fd()), ("seat", seat.as_raw_fd())] {
+            let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+            assert!(
+                flags >= 0 && flags & libc::FD_CLOEXEC != 0,
+                "the {name} descriptor is left inheritable: every child this daemon spawns \
+                 from now on — a shell, `lsof`, an ssh transport — would hold it open past \
+                 this daemon's death"
+            );
+        }
+        // `exec` also put SIGPIPE back to fatal on its way to the attempt. A
+        // daemon serving sockets with SIGPIPE fatal dies on the first client
+        // that hangs up mid-write.
+        let mut act: libc::sigaction = unsafe { std::mem::zeroed() };
+        unsafe { libc::sigaction(libc::SIGPIPE, std::ptr::null(), &mut act) };
+        assert_eq!(
+            act.sa_sigaction,
+            libc::SIG_IGN,
+            "a failed exec must put SIGPIPE back to ignored, the state every Rust process runs in"
+        );
     }
 
     #[test]

--- a/crates/tty7-core/src/daemon/handoff.rs
+++ b/crates/tty7-core/src/daemon/handoff.rs
@@ -1,0 +1,474 @@
+//! Replacing the daemon's binary without replacing the daemon.
+//!
+//! Every other way of upgrading the daemon ends with the shells dead, and not
+//! by oversight. A pty's master is a file descriptor held by this process; when
+//! this process goes, the descriptor closes, the slave side raises `SIGHUP`,
+//! and everything in the pane goes with it. Storing state does not help — see
+//! `daemon::scrollback`, which stores a great deal of it and still cannot bring
+//! back a single process.
+//!
+//! `execve` is the exception. It replaces the *image* while keeping the
+//! *process*: same pid, same children, same open descriptors — anything without
+//! `FD_CLOEXEC` — same file locks, same signal mask, same session and process
+//! group. So the ptys stay open, the shells never see a hangup, and the thing
+//! that changes is only which code is on the other end of the descriptor.
+//!
+//! What that costs is that nothing in memory survives. Threads, the pane
+//! registry, the rings, the client connections: all of it is gone the instant
+//! `execve` succeeds. Whatever the new image needs, this one has to write down
+//! first and pass along by descriptor number.
+//!
+//! The blob is written to a file that is unlinked before a byte goes into it,
+//! so it has no name for anything to read and the kernel frees it when the last
+//! descriptor closes. That matters here: it holds every pane's ring, which is
+//! the same terminal output `scrollback` makes people opt in to storing. A
+//! handoff should not be a way to write it to disk behind their back.
+//!
+//! Not everything can cross:
+//!
+//! - **Native SSH panes.** Their session is a cipher state and a set of tasks
+//!   in this process's memory. The socket descriptor would survive, but nothing
+//!   that knows how to speak on it would. They are hung up before the exec, so
+//!   the far end sees a clean disconnect rather than a stalled connection.
+//! - **Client connections.** A window is holding a socket to us; that socket
+//!   dies with the image. Clients reconnect and reattach by pane id, which is
+//!   the path they already use after any restart — except that this time the
+//!   attach finds the pane alive, with its ring and its running program.
+//! - **Windows.** There is no `execve`, and a ConPTY's pseudoconsole handle
+//!   cannot be handed to another process. There the daemon still stops and
+//!   starts, and `scrollback` is what softens it.
+
+use std::io::{Read as _, Seek as _, Write as _};
+use std::os::fd::RawFd;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::daemon::pane::Carried;
+use crate::daemon::protocol::WinSize;
+
+/// The flag that tells a starting daemon it is the far side of a handoff. Its
+/// value is the descriptor number the blob can be read from.
+pub const HANDOFF_FLAG: &str = "--handoff";
+
+/// The descriptor holding this daemon's claim to be *the* daemon.
+///
+/// Passed rather than re-taken: the lock is still held, by this very process,
+/// which is about to become the new one. Asking for it again from a second
+/// descriptor would be refused by the kernel, and the new image would stand
+/// down in favour of itself.
+///
+/// It travels on the command line rather than inside the blob because it is the
+/// one thing that still matters when the blob cannot be read. A daemon that has
+/// lost its panes is a bad afternoon; a daemon that exits because it cannot
+/// tell that the lock in its way is its own leaves the machine with no daemon
+/// at all.
+pub const SEAT_FLAG: &str = "--handoff-seat";
+
+#[derive(Serialize, Deserialize)]
+struct Manifest {
+    /// Where the new image resumes naming panes. Ids have to keep climbing:
+    /// a client that reconnects is holding the old ones, and handing the same
+    /// number to a different pane would attach a window to a stranger.
+    next_pane_id: u64,
+    panes: Vec<PaneRecord>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PaneRecord {
+    id: u64,
+    owner: Option<String>,
+    master_fd: RawFd,
+    child_pid: u32,
+    integration_dir: Option<PathBuf>,
+    size: WinSize,
+    cwd: Option<PathBuf>,
+    shell_active: bool,
+    at_prompt: bool,
+    last_exit: Option<i32>,
+    remote: Option<crate::daemon::protocol::RemoteContext>,
+    agent: Option<crate::core::cli_agent::CLIAgent>,
+    agent_argv: Option<Vec<String>>,
+    agent_session: Option<crate::core::cli_agent::AgentSessionState>,
+    /// Length of this pane's ring in the data section, which follows the
+    /// manifest in pane order.
+    ring_len: u32,
+}
+
+/// What this process was told on the command line, if it was started as the far
+/// side of a handoff.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Inheritance {
+    pub blob_fd: RawFd,
+    pub seat_fd: Option<RawFd>,
+}
+
+pub fn requested() -> Option<Inheritance> {
+    let args: Vec<std::ffi::OsString> = std::env::args_os().collect();
+    Some(Inheritance {
+        blob_fd: fd_arg(&args, HANDOFF_FLAG)?,
+        seat_fd: fd_arg(&args, SEAT_FLAG),
+    })
+}
+
+fn fd_arg(args: &[std::ffi::OsString], flag: &str) -> Option<RawFd> {
+    let mut args = args.iter();
+    while let Some(arg) = args.next() {
+        if arg.as_os_str() == std::ffi::OsStr::new(flag) {
+            return args.next()?.to_str()?.parse().ok();
+        }
+        if let Some(value) = arg
+            .to_str()
+            .and_then(|a| a.strip_prefix(flag).and_then(|r| r.strip_prefix('=')))
+        {
+            return value.parse().ok();
+        }
+    }
+    None
+}
+
+/// Everything the new image is handed.
+pub struct Adopted {
+    pub panes: Vec<Carried>,
+    pub next_pane_id: u64,
+}
+
+/// Become the new daemon: write down what the panes are, then `execve`.
+///
+/// Returns only when the exec did not happen, and in that case nothing has been
+/// broken — the descriptors are still open, the panes are still served, and the
+/// caller can keep running as if it had never been asked. That ordering is the
+/// whole safety argument: the state is staged first and the irreversible step
+/// is last, so a failure anywhere before it costs a log line.
+pub fn take_over(
+    exe: &Path,
+    panes: Vec<Carried>,
+    next_pane_id: u64,
+    seat_fd: Option<RawFd>,
+) -> anyhow::Error {
+    let blob = match stage(&panes, next_pane_id) {
+        Ok(blob) => blob,
+        Err(e) => return anyhow::anyhow!("could not stage the handoff: {e}"),
+    };
+
+    // Past this point every descriptor the new image needs has to survive the
+    // exec, and Rust opens everything close-on-exec.
+    let blob_fd = std::os::fd::AsRawFd::as_raw_fd(&blob);
+    for fd in std::iter::once(blob_fd)
+        .chain(seat_fd)
+        .chain(panes.iter().map(|p| p.master_fd))
+    {
+        if let Err(e) = keep_across_exec(fd) {
+            return anyhow::anyhow!("descriptor {fd} would not survive the exec: {e}");
+        }
+    }
+
+    let mut cmd = std::process::Command::new(exe);
+    cmd.arg("--daemon");
+    if let Some(dir) = crate::core::config::config_dir_path() {
+        cmd.arg("--config-dir").arg(dir);
+    }
+    cmd.arg(HANDOFF_FLAG).arg(blob_fd.to_string());
+    if let Some(seat) = seat_fd {
+        cmd.arg(SEAT_FLAG).arg(seat.to_string());
+    }
+
+    log::info!(
+        "handing {} pane(s) to {} in place; pids and ptys are kept",
+        panes.len(),
+        exe.display()
+    );
+    // Only ever returns an error: on success this process is already the new
+    // program and this code no longer exists.
+    let failure = std::os::unix::process::CommandExt::exec(&mut cmd);
+    anyhow::anyhow!("could not exec {}: {failure}", exe.display())
+}
+
+/// Write the blob into a file with no name.
+///
+/// Created and unlinked before anything is written, so the pane output it
+/// carries is reachable only through this descriptor and is freed the moment
+/// the last copy of it closes. A crash between here and the exec leaves nothing
+/// behind on disk.
+fn stage(panes: &[Carried], next_pane_id: u64) -> std::io::Result<std::fs::File> {
+    let mut records = Vec::with_capacity(panes.len());
+    let mut data = Vec::new();
+    for pane in panes {
+        let encoded = crate::daemon::scrollback::encode(&pane.ring);
+        records.push(PaneRecord {
+            id: pane.id,
+            owner: pane.owner.clone(),
+            master_fd: pane.master_fd,
+            child_pid: pane.child_pid,
+            integration_dir: pane.integration_dir.clone(),
+            size: pane.size,
+            cwd: pane.cwd.clone(),
+            shell_active: pane.shell_active,
+            at_prompt: pane.at_prompt,
+            last_exit: pane.last_exit,
+            remote: pane.remote.clone(),
+            agent: pane.agent,
+            agent_argv: pane.agent_argv.clone(),
+            agent_session: pane.agent_session.clone(),
+            ring_len: encoded.len() as u32,
+        });
+        data.extend_from_slice(&encoded);
+    }
+
+    let manifest = serde_json::to_vec(&Manifest {
+        next_pane_id,
+        panes: records,
+    })
+    .map_err(std::io::Error::other)?;
+
+    let mut file = anonymous_file()?;
+    file.write_all(&(manifest.len() as u32).to_le_bytes())?;
+    file.write_all(&manifest)?;
+    file.write_all(&data)?;
+    file.flush()?;
+    file.seek(std::io::SeekFrom::Start(0))?;
+    Ok(file)
+}
+
+fn anonymous_file() -> std::io::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    let dir = std::env::temp_dir();
+    for attempt in 0..8 {
+        let path = dir.join(format!("tty7-handoff-{}-{attempt}", std::process::id()));
+        match std::fs::OpenOptions::new()
+            .create_new(true)
+            .read(true)
+            .write(true)
+            .mode(0o600)
+            .open(&path)
+        {
+            Ok(file) => {
+                // Unlinked immediately: from here the bytes have no name, and
+                // the only way to them is the descriptor we are about to pass.
+                let _ = std::fs::remove_file(&path);
+                return Ok(file);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    Err(std::io::Error::other(
+        "no free name for the handoff file in the temp directory",
+    ))
+}
+
+fn keep_across_exec(fd: RawFd) -> std::io::Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Read back what the previous image left on `fd`.
+///
+/// A blob that cannot be read is not recoverable and not worth pretending
+/// about: the descriptors are still open and the shells are still running, but
+/// without the manifest there is no way to know which pane any of them is. The
+/// daemon starts empty, the ptys are closed by the kernel when it exits, and
+/// the panes read as gone — the same outcome as an ordinary restart.
+pub fn adopt(fd: RawFd) -> Option<Adopted> {
+    let mut file = unsafe { <std::fs::File as std::os::fd::FromRawFd>::from_raw_fd(fd) };
+    let mut raw = Vec::new();
+    if let Err(e) = file.read_to_end(&mut raw) {
+        log::error!("could not read the handoff blob on fd {fd}: {e}");
+        return None;
+    }
+    drop(file);
+
+    if raw.len() < 4 {
+        log::error!("the handoff blob on fd {fd} is empty");
+        return None;
+    }
+    let manifest_len = u32::from_le_bytes(raw[..4].try_into().ok()?) as usize;
+    let manifest: Manifest = match raw.get(4..4 + manifest_len).map(serde_json::from_slice) {
+        Some(Ok(manifest)) => manifest,
+        Some(Err(e)) => {
+            log::error!("the handoff manifest does not parse: {e}");
+            return None;
+        }
+        None => {
+            log::error!("the handoff blob is shorter than its own manifest");
+            return None;
+        }
+    };
+
+    let mut cursor = 4 + manifest_len;
+    let mut panes = Vec::with_capacity(manifest.panes.len());
+    for record in manifest.panes {
+        let end = cursor + record.ring_len as usize;
+        let ring = raw
+            .get(cursor..end)
+            .and_then(crate::daemon::scrollback::decode)
+            .unwrap_or_default();
+        cursor = end;
+        panes.push(Carried {
+            id: record.id,
+            owner: record.owner,
+            master_fd: record.master_fd,
+            child_pid: record.child_pid,
+            integration_dir: record.integration_dir,
+            size: record.size,
+            ring,
+            cwd: record.cwd,
+            shell_active: record.shell_active,
+            at_prompt: record.at_prompt,
+            last_exit: record.last_exit,
+            remote: record.remote,
+            agent: record.agent,
+            agent_argv: record.agent_argv,
+            agent_session: record.agent_session,
+        });
+    }
+
+    Some(Adopted {
+        panes,
+        next_pane_id: manifest.next_pane_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn size() -> WinSize {
+        WinSize {
+            cols: 80,
+            rows: 24,
+            cell_w: 8,
+            cell_h: 17,
+        }
+    }
+
+    fn carried(id: u64, fd: RawFd, output: &[u8]) -> Carried {
+        Carried {
+            id,
+            owner: Some("workspace".into()),
+            master_fd: fd,
+            child_pid: 4242,
+            integration_dir: Some(PathBuf::from("/tmp/tty7-int")),
+            size: size(),
+            ring: vec![crate::daemon::scrollback::Segment {
+                size: size(),
+                bytes: output.to_vec(),
+            }],
+            cwd: Some(PathBuf::from("/work")),
+            shell_active: true,
+            at_prompt: true,
+            last_exit: Some(0),
+            remote: None,
+            agent: None,
+            agent_argv: None,
+            agent_session: None,
+        }
+    }
+
+    #[test]
+    fn panes_cross_the_blob_with_their_descriptors_and_their_screens() {
+        let staged = stage(
+            &[
+                carried(7, 31, b"first pane"),
+                carried(9, 32, b"second pane"),
+            ],
+            10,
+        )
+        .expect("stage the blob");
+
+        let adopted = adopt(std::os::fd::IntoRawFd::into_raw_fd(staged)).expect("read it back");
+        assert_eq!(adopted.next_pane_id, 10, "ids must not be handed out twice");
+        assert_eq!(adopted.panes.len(), 2);
+
+        assert_eq!(adopted.panes[0].id, 7);
+        assert_eq!(
+            adopted.panes[0].master_fd, 31,
+            "the descriptor number is the pty: without it the new image has a pane id and no pane"
+        );
+        assert_eq!(adopted.panes[0].child_pid, 4242);
+        assert_eq!(adopted.panes[0].ring[0].bytes, b"first pane");
+        assert_eq!(adopted.panes[0].cwd, Some(PathBuf::from("/work")));
+        assert!(adopted.panes[0].at_prompt);
+        assert_eq!(
+            adopted.panes[1].ring[0].bytes, b"second pane",
+            "each pane's ring has to be read back at its own offset, not the first one's"
+        );
+    }
+
+    #[test]
+    fn a_pane_that_printed_nothing_still_crosses() {
+        let mut empty = carried(3, 20, b"");
+        empty.ring.clear();
+        let staged = stage(&[empty], 4).expect("stage");
+        let adopted = adopt(std::os::fd::IntoRawFd::into_raw_fd(staged)).expect("read back");
+        assert_eq!(
+            adopted.panes.len(),
+            1,
+            "a silent pane is still a live shell"
+        );
+        assert!(adopted.panes[0].ring.is_empty());
+    }
+
+    #[test]
+    fn a_blob_that_is_not_one_is_refused_rather_than_guessed_at() {
+        let mut file = anonymous_file().expect("temp file");
+        file.write_all(b"nothing like a manifest").expect("write");
+        file.seek(std::io::SeekFrom::Start(0)).expect("rewind");
+        assert!(
+            adopt(std::os::fd::IntoRawFd::into_raw_fd(file)).is_none(),
+            "without the manifest there is no way to say which shell is which pane"
+        );
+    }
+
+    #[test]
+    fn the_staged_file_has_no_name_to_read_it_by() {
+        let file = anonymous_file().expect("temp file");
+        let dir = std::env::temp_dir();
+        let leaked: Vec<_> = std::fs::read_dir(&dir)
+            .expect("read the temp directory")
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().starts_with("tty7-handoff-"))
+            .collect();
+        assert!(
+            leaked.is_empty(),
+            "every pane's output is in this file; it must not be sitting in {} under a name \
+             anyone can open",
+            dir.display()
+        );
+        drop(file);
+    }
+
+    #[test]
+    fn the_flags_are_read_in_both_spellings_and_only_when_present() {
+        let args = |v: &[&str]| v.iter().map(std::ffi::OsString::from).collect::<Vec<_>>();
+        assert_eq!(
+            fd_arg(&args(&["--daemon", "--handoff", "17"]), HANDOFF_FLAG),
+            Some(17)
+        );
+        assert_eq!(
+            fd_arg(&args(&["--daemon", "--handoff=17"]), HANDOFF_FLAG),
+            Some(17)
+        );
+        assert_eq!(fd_arg(&args(&["--daemon"]), HANDOFF_FLAG), None);
+        assert_eq!(
+            fd_arg(&args(&["--handoff", "not-a-number"]), HANDOFF_FLAG),
+            None,
+            "a daemon that cannot tell which descriptor to read starts clean instead of guessing"
+        );
+        assert_eq!(
+            fd_arg(
+                &args(&["--handoff", "17", "--handoff-seat", "18"]),
+                SEAT_FLAG
+            ),
+            Some(18),
+            "the seat is read separately, so it is still readable when the blob is not"
+        );
+    }
+}

--- a/crates/tty7-core/src/daemon/history.rs
+++ b/crates/tty7-core/src/daemon/history.rs
@@ -1,0 +1,388 @@
+//! A history file per pane, instead of one everybody writes into.
+//!
+//! Shells share history by sharing a file. Two panes running zsh with
+//! `share_history`, or bash with `histappend`, are appending to the same
+//! `~/.zsh_history` and reading each other's lines back — which is either the
+//! feature or the problem, depending on what the panes are for. Someone with a
+//! pane per task wants Up to walk *this* task's commands, not an interleaving
+//! of four.
+//!
+//! So each pane gets its own file, named after the pane, and the shell is told
+//! to use it. Two consequences follow from that being all it is:
+//!
+//! - **The pane does not start blank.** The file is seeded from whatever the
+//!   shell's real history file was, so Up still reaches last week's commands.
+//!   Only what is typed from now on stays local.
+//! - **Nothing is lost when the pane closes.** What the pane added is appended
+//!   back to the file it was seeded from. A per-pane history that evaporates
+//!   would be a way of losing commands, not of organising them.
+//!
+//! The seeding is done by the shell rather than by the daemon, and that is the
+//! only reason this works at all: the daemon cannot know where a given shell
+//! keeps its history. `HISTFILE` is set by the user's rc file, to anywhere they
+//! like, long after the pane's environment was decided. tty7's integration
+//! snippet runs *after* that rc — it is appended to the rc it wraps — so it is
+//! the one place where the real path is known. It copies the tail, records what
+//! it copied, and repoints `HISTFILE`; this module only has to clean up.
+//!
+//! A shell with no tty7 integration is simply not covered: nothing sets the
+//! variable, nothing reads it, and the pane keeps the history it always had.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// The pane's own history file, as handed to the shell.
+pub const FILE_ENV: &str = "TTY7_HISTFILE";
+
+/// Shells whose integration snippet knows what to do with [`FILE_ENV`].
+///
+/// The list is exactly the shells that get a `HISTFILE` *and* a tty7 snippet to
+/// repoint it in. fish keeps history in its own format under its own directory
+/// and names sessions rather than files; PowerShell's history belongs to
+/// PSReadLine, not to the shell. Plain `sh` gets no snippet at all, so naming a
+/// file for it would produce a variable nothing ever reads.
+fn understands(shell: &str) -> bool {
+    let stem = Path::new(shell)
+        .file_stem()
+        .map(|s| s.to_string_lossy().to_ascii_lowercase())
+        .unwrap_or_default();
+    matches!(stem.as_str(), "zsh" | "bash")
+}
+
+pub fn enabled() -> bool {
+    crate::core::config::Config::load().per_pane_history
+}
+
+fn dir() -> Option<PathBuf> {
+    crate::core::config::config_path("history")
+}
+
+pub fn path_for(pane: u64) -> Option<PathBuf> {
+    Some(dir()?.join(format!("pane-{pane}")))
+}
+
+/// What to put in a pane's environment, if it should have a history of its own.
+pub fn env_for(pane: u64, shell: &str) -> Option<(String, String)> {
+    if !understands(shell) || !enabled() {
+        return None;
+    }
+    let path = path_for(pane)?;
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            log::debug!("no history directory ({e}); pane {pane} shares the usual one");
+            return None;
+        }
+        // The files are written by the shell, under the user's umask, and a
+        // command history is not something to leave to that. Closing the
+        // directory is what makes the mode of what is inside it moot.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700));
+        }
+    }
+    Some((FILE_ENV.to_string(), path.to_string_lossy().into_owned()))
+}
+
+/// Hand a dead pane's history to the pane that replaces it.
+///
+/// A pane restored after the daemon died is a new pane with a new id, and
+/// without this its Up key would start from whatever the global file held when
+/// it was seeded — losing exactly the commands its predecessor ran, which are
+/// the ones the user is most likely to want back.
+pub fn carry(from: u64, to: u64) {
+    let (Some(old), Some(new)) = (path_for(from), path_for(to)) else {
+        return;
+    };
+    if !old.exists() {
+        return;
+    }
+    for suffix in ["", ".seed", ".origin"] {
+        let (a, b) = (with_suffix(&old, suffix), with_suffix(&new, suffix));
+        let _ = std::fs::rename(&a, &b);
+    }
+}
+
+/// Give a closed pane's commands back to the history file they came from.
+///
+/// Only what the pane added: the shell recorded how many bytes it seeded, and
+/// everything past that mark is this pane's own. Appending the whole file would
+/// duplicate the seed, and a pane that ran nothing would rewrite the user's
+/// history for no reason at all.
+pub fn retire(pane: u64) {
+    let Some(path) = path_for(pane) else {
+        return;
+    };
+    if !path.exists() {
+        return;
+    }
+    merge_back(&path);
+    for suffix in ["", ".seed", ".origin"] {
+        let _ = std::fs::remove_file(with_suffix(&path, suffix));
+    }
+}
+
+fn merge_back(path: &Path) {
+    use std::io::Write as _;
+
+    let Some(origin) = read_origin(&with_suffix(path, ".origin")) else {
+        return;
+    };
+    let seeded: usize = std::fs::read_to_string(with_suffix(path, ".seed"))
+        .ok()
+        .and_then(|text| text.trim().parse().ok())
+        .unwrap_or(0);
+    let Ok(body) = std::fs::read(path) else {
+        return;
+    };
+    // Shorter than its own seed means the file was replaced under us — by a
+    // shell that rewrote it wholesale on exit, say. There is no way to tell
+    // which part is new, and appending all of it would duplicate history the
+    // user already has.
+    let Some(added) = body.get(seeded..).filter(|added| !added.is_empty()) else {
+        return;
+    };
+    let appended = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&origin)
+        .and_then(|mut file| file.write_all(added));
+    if let Err(e) = appended {
+        log::debug!(
+            "pane history could not be merged into {}: {e}",
+            origin.display()
+        );
+    }
+}
+
+/// The path the shell said it seeded from, if it is one worth writing to.
+///
+/// It arrives from inside a pane, which is a place a user's rc file can put
+/// anything at all. A relative path would be resolved against the daemon's
+/// working directory rather than the pane's, so it would name a file nobody
+/// meant. A path that does not exist yet is fine and is the first-ever shell's
+/// case — its history file is created by this very append — but its directory
+/// has to be one already, so a typo cannot make this build a tree.
+fn read_origin(path: &Path) -> Option<PathBuf> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let origin = PathBuf::from(text.trim());
+    if !origin.is_absolute() || origin.is_dir() {
+        return None;
+    }
+    let parent_exists = origin.parent().is_some_and(Path::is_dir);
+    (origin.is_file() || parent_exists).then_some(origin)
+}
+
+fn with_suffix(path: &Path, suffix: &str) -> PathBuf {
+    if suffix.is_empty() {
+        return path.to_path_buf();
+    }
+    let mut name = path.as_os_str().to_owned();
+    name.push(suffix);
+    PathBuf::from(name)
+}
+
+/// Drop the files of panes that no longer exist.
+///
+/// A daemon killed outright never gets to retire anything, so its panes' files
+/// are still here the next time one starts. Their commands are lost either way
+/// — the mark that says which of them were new is only meaningful while the
+/// shell that wrote them is alive — so what is left is to not accumulate them.
+pub fn sweep(keep: &HashSet<u64>) {
+    let Some(dir) = dir() else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let stem = name
+            .split_once('.')
+            .map(|(stem, _)| stem)
+            .unwrap_or(name.as_ref());
+        let Some(id) = stem
+            .strip_prefix("pane-")
+            .and_then(|id| id.parse::<u64>().ok())
+        else {
+            continue;
+        };
+        if !keep.contains(&id) {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shared temp directory the rest of the suite pins, by the same name:
+    /// the override is a process-wide `OnceLock`, so agreeing on the path is
+    /// what keeps whoever gets there first from mattering.
+    fn pin_config_dir() {
+        let dir = std::env::temp_dir().join(format!("tty7-covtest-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).ok();
+        crate::core::config::set_config_dir(dir);
+    }
+
+    /// Stand in for the shell's half: seed the pane's file from `origin` and
+    /// record what was seeded, exactly as the integration snippet does.
+    fn seed(pane: u64, origin: &Path) -> PathBuf {
+        let path = path_for(pane).expect("a path under the config dir");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let seeded = std::fs::read(origin).unwrap_or_default();
+        std::fs::write(&path, &seeded).unwrap();
+        std::fs::write(with_suffix(&path, ".seed"), seeded.len().to_string()).unwrap();
+        std::fs::write(
+            with_suffix(&path, ".origin"),
+            format!("{}\n", origin.display()),
+        )
+        .unwrap();
+        path
+    }
+
+    fn a_global_history(name: &str, body: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!("tty7-history-{}-{name}", std::process::id()));
+        std::fs::write(&path, body).unwrap();
+        path
+    }
+
+    #[test]
+    fn a_closed_pane_gives_back_only_what_it_added() {
+        pin_config_dir();
+        let origin = a_global_history("added", "old command\n");
+        let pane = seed(80_001, &origin);
+        std::fs::write(&pane, "old command\nnew command\n").unwrap();
+
+        retire(80_001);
+
+        assert_eq!(
+            std::fs::read_to_string(&origin).unwrap(),
+            "old command\nnew command\n",
+            "the seed is already in the origin; appending it again would duplicate history"
+        );
+        assert!(!pane.exists(), "a closed pane leaves no file behind");
+        assert!(!with_suffix(&pane, ".seed").exists());
+        assert!(!with_suffix(&pane, ".origin").exists());
+        let _ = std::fs::remove_file(&origin);
+    }
+
+    #[test]
+    fn a_pane_that_ran_nothing_does_not_touch_the_users_history() {
+        pin_config_dir();
+        let origin = a_global_history("untouched", "old command\n");
+        seed(80_002, &origin);
+
+        retire(80_002);
+
+        assert_eq!(
+            std::fs::read_to_string(&origin).unwrap(),
+            "old command\n",
+            "opening a pane and closing it must not rewrite anything"
+        );
+        let _ = std::fs::remove_file(&origin);
+    }
+
+    #[test]
+    fn a_file_that_shrank_under_us_is_left_alone() {
+        pin_config_dir();
+        let origin = a_global_history("shrunk", "old command\n");
+        let pane = seed(80_003, &origin);
+        // What a shell that rewrites its history wholesale on exit leaves.
+        std::fs::write(&pane, "x\n").unwrap();
+
+        retire(80_003);
+
+        assert_eq!(
+            std::fs::read_to_string(&origin).unwrap(),
+            "old command\n",
+            "with no way to tell which lines are new, adding any of them is a guess"
+        );
+        let _ = std::fs::remove_file(&origin);
+    }
+
+    #[test]
+    fn an_origin_that_is_not_a_real_absolute_file_is_refused() {
+        pin_config_dir();
+        let path = path_for(80_004).expect("a path");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "some command\n").unwrap();
+        std::fs::write(with_suffix(&path, ".seed"), "0").unwrap();
+        std::fs::write(with_suffix(&path, ".origin"), "../relative/history\n").unwrap();
+
+        // The point is that it does not panic and does not create anything: the
+        // value came from inside a pane, where an rc file can put anything.
+        retire(80_004);
+        assert!(!Path::new("../relative/history").exists());
+    }
+
+    #[test]
+    fn a_restored_pane_inherits_its_predecessors_history() {
+        pin_config_dir();
+        let origin = a_global_history("carried", "old command\n");
+        let before = seed(80_005, &origin);
+        std::fs::write(&before, "old command\nfrom the dead pane\n").unwrap();
+
+        carry(80_005, 80_006);
+
+        assert!(
+            !before.exists(),
+            "the old name is not left behind as a copy"
+        );
+        let after = path_for(80_006).expect("a path");
+        assert_eq!(
+            std::fs::read_to_string(&after).unwrap(),
+            "old command\nfrom the dead pane\n",
+            "the replacement pane's Up key has to reach what its predecessor ran"
+        );
+        assert_eq!(
+            std::fs::read_to_string(with_suffix(&after, ".seed")).unwrap(),
+            "12",
+            "the mark has to travel too, or the merge would hand back the seed as new"
+        );
+
+        retire(80_006);
+        assert_eq!(
+            std::fs::read_to_string(&origin).unwrap(),
+            "old command\nfrom the dead pane\n"
+        );
+        let _ = std::fs::remove_file(&origin);
+    }
+
+    #[test]
+    fn the_sweep_keeps_only_the_panes_that_still_exist() {
+        pin_config_dir();
+        let origin = a_global_history("swept", "old\n");
+        let kept = seed(80_007, &origin);
+        let dropped = seed(80_008, &origin);
+
+        sweep(&HashSet::from([80_007]));
+
+        assert!(kept.exists(), "a live pane keeps its history");
+        assert!(!dropped.exists(), "a pane that is gone does not");
+        assert!(
+            !with_suffix(&dropped, ".seed").exists(),
+            "the sidecars go with it"
+        );
+        retire(80_007);
+        let _ = std::fs::remove_file(&origin);
+    }
+
+    #[test]
+    fn only_shells_whose_integration_knows_the_variable_are_offered_it() {
+        assert!(understands("/bin/zsh"));
+        assert!(understands("/opt/homebrew/bin/bash"));
+        assert!(
+            !understands("/bin/sh"),
+            "no integration snippet reaches a plain sh, so nothing would read the variable"
+        );
+        assert!(
+            !understands("/usr/local/bin/fish"),
+            "fish keeps sessions, not a HISTFILE; naming one would do nothing"
+        );
+        assert!(!understands("pwsh.exe"));
+        assert!(!understands("C:\\Windows\\System32\\cmd.exe"));
+    }
+}

--- a/crates/tty7-core/src/daemon/mod.rs
+++ b/crates/tty7-core/src/daemon/mod.rs
@@ -8,6 +8,7 @@ pub mod protocol;
 pub(crate) mod remote;
 pub mod remote_link;
 pub mod router;
+pub mod scrollback;
 pub mod server;
 pub mod singleton;
 pub mod spawn;

--- a/crates/tty7-core/src/daemon/mod.rs
+++ b/crates/tty7-core/src/daemon/mod.rs
@@ -7,6 +7,7 @@ pub mod duplex;
 /// There the daemon still stops and starts, and `scrollback` softens it.
 #[cfg(unix)]
 pub mod handoff;
+pub mod history;
 pub mod install;
 pub mod pane;
 pub mod pidfile;

--- a/crates/tty7-core/src/daemon/mod.rs
+++ b/crates/tty7-core/src/daemon/mod.rs
@@ -1,5 +1,12 @@
 pub mod control;
 pub mod duplex;
+/// Upgrading the daemon in place, keeping the ptys and the shells on them.
+///
+/// Unix only, and not for want of trying: `execve` is what makes it possible,
+/// and Windows has neither that nor a way to hand a ConPTY to another process.
+/// There the daemon still stops and starts, and `scrollback` softens it.
+#[cfg(unix)]
+pub mod handoff;
 pub mod install;
 pub mod pane;
 pub mod pidfile;

--- a/crates/tty7-core/src/daemon/pane.rs
+++ b/crates/tty7-core/src/daemon/pane.rs
@@ -461,6 +461,11 @@ fn pane_environment(
     if let Some(dir) = config_dir_env() {
         env.push((TTY7_CONFIG_DIR_ENV.to_string(), dir));
     }
+    // Names the pane's own history file; the integration snippet is what
+    // decides to use it, once the user's rc has said where their history was.
+    if let Some((key, value)) = crate::daemon::history::env_for(pane, shell) {
+        env.push((key, value));
+    }
     // Windows is deliberately left out. `SHELL` is not a native concept there —
     // neither cmd nor PowerShell reads it — and the tools that do read it are
     // the POSIX emulations: MSYS/Git Bash, Cygwin, and WSL, which take `WSLENV`
@@ -2089,6 +2094,12 @@ impl Drop for DaemonPane {
                 let _ = std::fs::remove_dir_all(&dir);
             }
         }
+        // The pane is over — by a kill, by the shell exiting, or by the daemon
+        // shutting down — so whatever it typed goes back to the history file it
+        // was seeded from. A handoff does not come through here: nothing is
+        // dropped across an `exec`, which is exactly right, because the pane on
+        // the other side is the same pane and still owns its file.
+        crate::daemon::history::retire(self.id);
     }
 }
 

--- a/crates/tty7-core/src/daemon/pane.rs
+++ b/crates/tty7-core/src/daemon/pane.rs
@@ -760,6 +760,17 @@ struct PtyBackend {
     integration_dir: Option<PathBuf>,
 }
 
+/// The pty half of a pane, before it is wired up: opened and spawned into by
+/// [`DaemonPane::spawn`], inherited across an `exec` by [`DaemonPane::adopt`].
+struct PtyParts {
+    master: Box<dyn MasterPty + Send>,
+    child: Arc<Mutex<Box<dyn Child + Send + Sync>>>,
+    shell_pid: Option<u32>,
+    integration_dir: Option<PathBuf>,
+    reader_handle: Box<dyn Read + Send>,
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
+}
+
 struct NativeSshBackend {
     handle: Arc<crate::daemon::ssh::SshSessionHandle>,
     connection: crate::daemon::ssh::SharedConnection,
@@ -921,6 +932,235 @@ fn push_image_frame(frames: &mut Vec<GraphicsFrame>, frame: Vec<u8>) {
     }
 }
 
+/// A live pane, reduced to what survives an `exec` plus what has to be written
+/// down because it does not.
+///
+/// The descriptor number and the child pid are the half the kernel keeps for
+/// us. Everything else here was in memory, and memory is exactly what `exec`
+/// replaces — so a pane's screen, its cwd, its prompt state and its agent are
+/// carried across by hand or not at all. See `daemon::handoff`.
+#[cfg(unix)]
+pub struct Carried {
+    pub id: u64,
+    pub owner: Option<String>,
+    pub master_fd: std::os::fd::RawFd,
+    pub child_pid: u32,
+    pub integration_dir: Option<PathBuf>,
+    pub size: WinSize,
+    pub ring: Vec<crate::daemon::scrollback::Segment>,
+    pub cwd: Option<PathBuf>,
+    pub shell_active: bool,
+    pub at_prompt: bool,
+    pub last_exit: Option<i32>,
+    pub remote: Option<RemoteContext>,
+    pub agent: Option<crate::core::cli_agent::CLIAgent>,
+    pub agent_argv: Option<Vec<String>>,
+    pub agent_session: Option<crate::core::cli_agent::AgentSessionState>,
+}
+
+/// A pty master this process inherited from its own previous image.
+///
+/// `portable-pty` can only hand out a master it opened, and after an `exec`
+/// there is nothing left of the one it opened except the descriptor number. The
+/// operations a pane actually performs on a master are few enough — resize, ask
+/// the size, clone a reader, take a writer, ask which process group is in the
+/// foreground — and all of them are ioctls on that descriptor.
+#[cfg(unix)]
+struct AdoptedMaster {
+    fd: std::os::fd::OwnedFd,
+}
+
+#[cfg(unix)]
+impl AdoptedMaster {
+    fn from_fd(fd: std::os::fd::RawFd) -> anyhow::Result<Self> {
+        use std::os::fd::FromRawFd as _;
+
+        // A descriptor that no longer refers to a terminal is one the previous
+        // image did not really hold — a number reused after a close, or a blob
+        // that named the wrong one. Adopting it would produce a pane whose
+        // every ioctl fails in a different way; refusing produces a pane that
+        // is simply gone, which is a thing the client already handles.
+        if unsafe { libc::isatty(fd) } != 1 {
+            anyhow::bail!("descriptor {fd} is not a terminal");
+        }
+        Ok(Self {
+            fd: unsafe { std::os::fd::OwnedFd::from_raw_fd(fd) },
+        })
+    }
+
+    fn dup(&self) -> std::io::Result<std::fs::File> {
+        Ok(std::fs::File::from(self.fd.try_clone()?))
+    }
+}
+
+#[cfg(unix)]
+impl MasterPty for AdoptedMaster {
+    fn resize(&self, size: PtySize) -> anyhow::Result<()> {
+        use std::os::fd::AsRawFd as _;
+
+        let ws = libc::winsize {
+            ws_row: size.rows,
+            ws_col: size.cols,
+            ws_xpixel: size.pixel_width,
+            ws_ypixel: size.pixel_height,
+        };
+        if unsafe { libc::ioctl(self.fd.as_raw_fd(), libc::TIOCSWINSZ, &ws as *const _) } != 0 {
+            anyhow::bail!("TIOCSWINSZ failed: {}", std::io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    fn get_size(&self) -> anyhow::Result<PtySize> {
+        use std::os::fd::AsRawFd as _;
+
+        let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
+        if unsafe { libc::ioctl(self.fd.as_raw_fd(), libc::TIOCGWINSZ, &mut ws as *mut _) } != 0 {
+            anyhow::bail!("TIOCGWINSZ failed: {}", std::io::Error::last_os_error());
+        }
+        Ok(PtySize {
+            rows: ws.ws_row,
+            cols: ws.ws_col,
+            pixel_width: ws.ws_xpixel,
+            pixel_height: ws.ws_ypixel,
+        })
+    }
+
+    fn try_clone_reader(&self) -> anyhow::Result<Box<dyn Read + Send>> {
+        Ok(Box::new(self.dup()?))
+    }
+
+    /// Deliberately a plain `File`, unlike the writer `portable-pty` hands out:
+    /// that one sends EOF to the shell when it is dropped. Correct for a pty
+    /// whose pane is being closed, wrong for one whose pane is only changing
+    /// which program serves it.
+    fn take_writer(&self) -> anyhow::Result<Box<dyn Write + Send>> {
+        Ok(Box::new(self.dup()?))
+    }
+
+    fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {
+        use std::os::fd::AsRawFd as _;
+        Some(self.fd.as_raw_fd())
+    }
+
+    fn process_group_leader(&self) -> Option<libc::pid_t> {
+        use std::os::fd::AsRawFd as _;
+        match unsafe { libc::tcgetpgrp(self.fd.as_raw_fd()) } {
+            pid if pid > 0 => Some(pid),
+            _ => None,
+        }
+    }
+}
+
+/// A child this process inherited from its own previous image.
+///
+/// Still genuinely our child — `exec` keeps the process, so the kernel's
+/// parent-child bookkeeping is untouched and `waitpid` works. What was lost is
+/// the `Child` value that knew how to ask.
+#[cfg(unix)]
+#[derive(Debug)]
+struct AdoptedChild {
+    pid: libc::pid_t,
+    exited: Option<portable_pty::ExitStatus>,
+}
+
+#[cfg(unix)]
+impl AdoptedChild {
+    fn new(pid: u32) -> Self {
+        Self {
+            pid: pid as libc::pid_t,
+            exited: None,
+        }
+    }
+
+    fn reap(&mut self, flags: libc::c_int) -> std::io::Result<Option<portable_pty::ExitStatus>> {
+        if let Some(status) = &self.exited {
+            return Ok(Some(status.clone()));
+        }
+        let mut raw: libc::c_int = 0;
+        let seen = unsafe { libc::waitpid(self.pid, &mut raw, flags) };
+        if seen == 0 {
+            return Ok(None);
+        }
+        if seen < 0 {
+            let e = std::io::Error::last_os_error();
+            // ECHILD means someone already reaped it, or it was never ours.
+            // Either way there is no status left to collect and no point in
+            // asking again — reporting an exit of zero is what an unknown but
+            // finished child amounts to.
+            if e.raw_os_error() == Some(libc::ECHILD) {
+                let status = portable_pty::ExitStatus::with_exit_code(0);
+                self.exited = Some(status.clone());
+                return Ok(Some(status));
+            }
+            return Err(e);
+        }
+        let code = if libc::WIFEXITED(raw) {
+            libc::WEXITSTATUS(raw) as u32
+        } else if libc::WIFSIGNALED(raw) {
+            128 + libc::WTERMSIG(raw) as u32
+        } else {
+            0
+        };
+        let status = portable_pty::ExitStatus::with_exit_code(code);
+        self.exited = Some(status.clone());
+        Ok(Some(status))
+    }
+}
+
+#[cfg(unix)]
+impl portable_pty::Child for AdoptedChild {
+    fn try_wait(&mut self) -> std::io::Result<Option<portable_pty::ExitStatus>> {
+        self.reap(libc::WNOHANG)
+    }
+
+    fn wait(&mut self) -> std::io::Result<portable_pty::ExitStatus> {
+        loop {
+            if let Some(status) = self.reap(0)? {
+                return Ok(status);
+            }
+        }
+    }
+
+    fn process_id(&self) -> Option<u32> {
+        Some(self.pid as u32)
+    }
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+struct AdoptedKiller {
+    pid: libc::pid_t,
+}
+
+#[cfg(unix)]
+impl portable_pty::ChildKiller for AdoptedChild {
+    fn kill(&mut self) -> std::io::Result<()> {
+        AdoptedKiller { pid: self.pid }.kill()
+    }
+
+    fn clone_killer(&self) -> Box<dyn portable_pty::ChildKiller + Send + Sync> {
+        Box::new(AdoptedKiller { pid: self.pid })
+    }
+}
+
+#[cfg(unix)]
+impl portable_pty::ChildKiller for AdoptedKiller {
+    fn kill(&mut self) -> std::io::Result<()> {
+        if unsafe { libc::kill(self.pid, libc::SIGKILL) } != 0 {
+            let e = std::io::Error::last_os_error();
+            // Already gone is the outcome kill was asked for.
+            if e.raw_os_error() != Some(libc::ESRCH) {
+                return Err(e);
+            }
+        }
+        Ok(())
+    }
+
+    fn clone_killer(&self) -> Box<dyn portable_pty::ChildKiller + Send + Sync> {
+        Box::new(AdoptedKiller { pid: self.pid })
+    }
+}
+
 /// The screen a restored pane opens with.
 ///
 /// `segments` is what some earlier pane — the one this one replaces after a
@@ -990,26 +1230,63 @@ impl DaemonPane {
             None => ReplayRing::new(size),
         };
 
-        let state = Arc::new(Mutex::new(PaneState {
-            id,
-            ring,
-            subscriber: None,
-            subscriber_epoch: 0,
-            observers: Vec::new(),
-            observer_seq: 0,
-            cwd: spawn.initial_cwd,
-            shell: ShellState::default(),
-            remote: spawn.remote.clone(),
-            agent: None,
-            agent_session: None,
-            agent_argv: None,
-            alive: true,
-            exit_code: None,
-        }));
+        Ok(Self::over_pty(
+            PtyParts {
+                master: pair.master,
+                child,
+                shell_pid,
+                integration_dir: spawn.integration_dir,
+                reader_handle,
+                writer,
+            },
+            PaneState {
+                id,
+                ring,
+                subscriber: None,
+                subscriber_epoch: 0,
+                observers: Vec::new(),
+                observer_seq: 0,
+                cwd: spawn.initial_cwd,
+                shell: ShellState::default(),
+                remote: spawn.remote.clone(),
+                agent: None,
+                agent_session: None,
+                agent_argv: None,
+                alive: true,
+                exit_code: None,
+            },
+            owner,
+            on_dead,
+        ))
+    }
+
+    /// Wire a pty, a child and a starting state into a running pane.
+    ///
+    /// Shared by the two ways a pty-backed pane comes to exist — one that opens
+    /// a pty and starts a shell in it, and one that inherits both from the
+    /// image it replaced. Everything below this line is identical for them, and
+    /// it is the part where getting it subtly wrong shows up as a pane that
+    /// never reports its death or never sees its own output.
+    fn over_pty(
+        parts: PtyParts,
+        state: PaneState,
+        owner: Option<String>,
+        on_dead: impl FnOnce() + Send + 'static,
+    ) -> Arc<Self> {
+        let PtyParts {
+            master,
+            child,
+            shell_pid,
+            integration_dir,
+            reader_handle,
+            writer,
+        } = parts;
+
+        let id = state.id;
+        let state = Arc::new(Mutex::new(state));
         let shutting_down = Arc::new(AtomicBool::new(false));
         let gate = Arc::new(OutputGate::new());
-
-        let master = Arc::new(Mutex::new(Some(pair.master)));
+        let master = Arc::new(Mutex::new(Some(master)));
 
         let pane = Arc::new(Self {
             id,
@@ -1018,7 +1295,7 @@ impl DaemonPane {
                 master: master.clone(),
                 child: child.clone(),
                 shell_pid,
-                integration_dir: spawn.integration_dir,
+                integration_dir,
             }),
             writer: writer.clone(),
             shutting_down: shutting_down.clone(),
@@ -1084,7 +1361,118 @@ impl DaemonPane {
         );
         *pane.reader.lock().unwrap() = Some(reader);
 
-        Ok(pane)
+        pane
+    }
+
+    /// Reduce a live pane to what can be handed to another program image.
+    ///
+    /// Nothing is taken: the descriptor number is copied out, not the
+    /// descriptor, and the pane keeps serving exactly as before. That is what
+    /// lets the caller stage a whole handoff and then abandon it — an `exec`
+    /// that fails costs a log line, not a machine's worth of shells.
+    ///
+    /// `None` for a native-SSH pane. Its session lives in this process's
+    /// memory, not in a descriptor, and no amount of copying descriptor numbers
+    /// would let the new image speak on the wire the old one had encrypted.
+    #[cfg(unix)]
+    pub fn carry(&self) -> Option<crate::daemon::pane::Carried> {
+        let PaneBackend::Pty(pty) = &self.backend else {
+            return None;
+        };
+        let master_fd = pty
+            .master
+            .lock()
+            .ok()?
+            .as_ref()
+            .and_then(|master| master.as_raw_fd())?;
+        let st = self.state.lock().unwrap();
+        Some(Carried {
+            id: self.id,
+            owner: self.owner.clone(),
+            master_fd,
+            child_pid: pty.shell_pid?,
+            integration_dir: pty.integration_dir.clone(),
+            size: st.ring.tail_size(),
+            ring: st.ring.snapshot(),
+            cwd: st.cwd.clone(),
+            shell_active: st.shell.active,
+            at_prompt: st.shell.at_prompt,
+            last_exit: st.shell.last_exit_code,
+            remote: st.remote.clone(),
+            agent: st.agent,
+            agent_argv: st.agent_argv.clone(),
+            agent_session: st.agent_session.clone(),
+        })
+    }
+
+    /// Rebuild a pane around a pty this process already holds.
+    ///
+    /// The descriptor and the child pid came through an `exec`, so both are
+    /// still ours in the only sense that matters: the kernel still has us down
+    /// as the pty's owner and the shell's parent. What is gone is everything
+    /// that was in memory, which is why the ring and the pane's status come
+    /// back from the handoff blob rather than from the shell.
+    #[cfg(unix)]
+    pub fn adopt(
+        carried: crate::daemon::pane::Carried,
+        on_dead: impl FnOnce() + Send + 'static,
+    ) -> anyhow::Result<Arc<Self>> {
+        let master = AdoptedMaster::from_fd(carried.master_fd)?;
+        let reader_handle = master.try_clone_reader()?;
+        let writer = Arc::new(Mutex::new(master.take_writer()?));
+        let shell_pid = carried.child_pid;
+        // The size the pty is actually at is the kernel's to answer, and it is
+        // the truth: nobody resized it while we were not running. The carried
+        // size only says where the ring's tail was cut.
+        let size = master
+            .get_size()
+            .map(|s| WinSize {
+                cols: s.cols,
+                rows: s.rows,
+                cell_w: carried.size.cell_w,
+                cell_h: carried.size.cell_h,
+            })
+            .unwrap_or(carried.size);
+
+        let mut ring = ReplayRing::seeded(carried.ring, size);
+        // Not a restore banner: nothing was lost, so there is nothing to
+        // announce and nothing to reset. The shell below these bytes is the
+        // same shell that wrote them.
+        ring.resize(size);
+
+        Ok(Self::over_pty(
+            PtyParts {
+                master: Box::new(master),
+                child: Arc::new(Mutex::new(Box::new(AdoptedChild::new(shell_pid)))),
+                shell_pid: Some(shell_pid),
+                integration_dir: carried.integration_dir,
+                reader_handle,
+                writer,
+            },
+            PaneState {
+                id: carried.id,
+                ring,
+                subscriber: None,
+                subscriber_epoch: 0,
+                observers: Vec::new(),
+                observer_seq: 0,
+                cwd: carried.cwd,
+                shell: ShellState {
+                    active: carried.shell_active,
+                    at_prompt: carried.at_prompt,
+                    last_exit_code: carried.last_exit,
+                    command: None,
+                },
+                remote: carried.remote,
+                agent: carried.agent,
+                agent_session: carried.agent_session,
+                agent_argv: carried.agent_argv,
+                alive: true,
+                exit_code: None,
+            },
+            carried.owner,
+            on_dead,
+        ))
     }
 
     pub fn spawn_native_ssh(
@@ -1796,6 +2184,14 @@ impl ReplayRing {
         // size, which is not necessarily the size the snapshot was taken at.
         ring.resize(size);
         ring
+    }
+
+    /// The geometry new output would be recorded at.
+    fn tail_size(&self) -> WinSize {
+        self.segments
+            .back()
+            .map(|seg| seg.size)
+            .expect("ring always has a tail")
     }
 
     fn snapshot(&self) -> Vec<crate::daemon::scrollback::Segment> {
@@ -2983,6 +3379,25 @@ mod tests {
             "the ring always has exactly one tail"
         );
         assert_eq!(ring.flatten(), b"output");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_descriptor_that_is_not_a_terminal_is_refused_rather_than_adopted() {
+        use std::os::fd::AsRawFd as _;
+
+        let file = std::fs::File::open("/dev/null").expect("open /dev/null");
+        let err = AdoptedMaster::from_fd(file.as_raw_fd())
+            .err()
+            .expect("a plain file is not a pty");
+        assert!(
+            err.to_string().contains("not a terminal"),
+            "the refusal was {err}"
+        );
+        // Refused means not taken: the caller still owns what it passed, and
+        // dropping `file` here is what closes it. Adopting first and failing
+        // later would have closed a descriptor belonging to someone else.
+        drop(file);
     }
 
     #[test]

--- a/crates/tty7-core/src/daemon/pane.rs
+++ b/crates/tty7-core/src/daemon/pane.rs
@@ -921,6 +921,41 @@ fn push_image_frame(frames: &mut Vec<GraphicsFrame>, frame: Vec<u8>) {
     }
 }
 
+/// The screen a restored pane opens with.
+///
+/// `segments` is what some earlier pane — the one this one replaces after a
+/// daemon died without handing off — last had on it. `banner` is the sentence
+/// that says so, supplied by the client because the daemon has no locale of its
+/// own. Both are decoration over a shell that is unambiguously new: nothing
+/// here revives a process.
+pub struct Restore {
+    pub segments: Vec<crate::daemon::scrollback::Segment>,
+    pub banner: Option<String>,
+}
+
+/// The bytes that separate restored output from the new shell's own.
+///
+/// The resets are not cosmetic. A snapshot is trimmed at the front, so it can
+/// begin in the middle of anything: an SGR run whose reset was cut, a hidden
+/// cursor, a disabled autowrap, an alternate screen whose `?1049h` survived but
+/// whose `?1049l` never came because the daemon died while `vim` was open.
+/// Replaying that leaves the emulator in a state the incoming shell did not ask
+/// for and cannot see. Leaving the alternate screen also does the useful thing
+/// in the common case: the primary buffer still holds the pre-`vim` scrollback
+/// from earlier in the same snapshot.
+fn restore_preamble(banner: Option<&str>) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"\x1b[?1049l\x1b[?25h\x1b[?7h\x1b[0m");
+    if let Some(banner) = banner.map(str::trim).filter(|b| !b.is_empty()) {
+        out.extend_from_slice(b"\r\n\x1b[2m\xe2\x94\x80\xe2\x94\x80 ");
+        // A newline inside the banner would be a client writing multiple lines
+        // through a one-line hole; the rest of the sequence assumes one line.
+        out.extend_from_slice(banner.replace(['\r', '\n'], " ").as_bytes());
+        out.extend_from_slice(b" \xe2\x94\x80\xe2\x94\x80\x1b[0m\r\n");
+    }
+    out
+}
+
 impl DaemonPane {
     pub fn spawn(
         id: u64,
@@ -929,6 +964,7 @@ impl DaemonPane {
         shell: Option<ShellSpec>,
         owner: Option<String>,
         workspace: Option<String>,
+        restore: Option<Restore>,
         on_dead: impl FnOnce() + Send + 'static,
     ) -> anyhow::Result<Arc<Self>> {
         let pty_size = pty_size(size);
@@ -945,9 +981,18 @@ impl DaemonPane {
         let reader_handle = pair.master.try_clone_reader()?;
         let writer = Arc::new(Mutex::new(pair.master.take_writer()?));
 
+        let ring = match restore {
+            Some(restore) => {
+                let mut ring = ReplayRing::seeded(restore.segments, size);
+                ring.append(&restore_preamble(restore.banner.as_deref()));
+                ring
+            }
+            None => ReplayRing::new(size),
+        };
+
         let state = Arc::new(Mutex::new(PaneState {
             id,
-            ring: ReplayRing::new(size),
+            ring,
             subscriber: None,
             subscriber_epoch: 0,
             observers: Vec::new(),
@@ -1485,6 +1530,21 @@ impl DaemonPane {
         cached.or_else(|| self.foreground_remote_context())
     }
 
+    /// The pane's screen, capped for storage, with the mark that says how much
+    /// output it had produced when the copy was taken.
+    ///
+    /// Both come from one acquisition of the state lock. Reading them apart
+    /// would let output land in between, and the writer would then record a
+    /// mark that claims to cover bytes its snapshot does not have — a pane
+    /// that stopped producing at that moment would keep the stale copy for
+    /// good, because its mark would never move again.
+    pub fn scrollback_snapshot(&self) -> (Vec<crate::daemon::scrollback::Segment>, u64) {
+        let st = self.state.lock().unwrap();
+        let mut segments = st.ring.snapshot();
+        crate::daemon::scrollback::trim_to(&mut segments, crate::daemon::scrollback::SNAPSHOT_CAP);
+        (segments, st.ring.appended)
+    }
+
     pub fn kill(&self) {
         self.hangup();
     }
@@ -1671,6 +1731,12 @@ fn pty_size(size: WinSize) -> PtySize {
 struct ReplayRing {
     segments: VecDeque<RingSegment>,
     len: usize,
+    /// Bytes ever appended, never reset — the mark the scrollback writer uses to
+    /// tell a ring that has moved from one that has not. Comparing lengths would
+    /// not do it: a ring at its cap stays exactly `RING_CAP` long no matter how
+    /// much output flows through it, which is precisely the busy pane whose
+    /// snapshot is most stale.
+    appended: u64,
 }
 
 struct RingSegment {
@@ -1700,7 +1766,47 @@ impl ReplayRing {
         Self {
             segments: VecDeque::from([RingSegment::empty(size)]),
             len: 0,
+            appended: 0,
         }
+    }
+
+    /// A ring that starts with output some earlier pane produced.
+    ///
+    /// Used when a pane is restored from disk: the saved segments go in ahead
+    /// of anything the new shell writes, so a client attaching sees the screen
+    /// it lost and then the new prompt below it. The seeded bytes are counted
+    /// into `len` — they are subject to the same cap as live output, and the
+    /// cap is far above what a snapshot can hold — but not into `appended`,
+    /// which exists to answer "has this pane produced anything since the last
+    /// snapshot?" and would otherwise answer yes for a pane that never ran.
+    fn seeded(segments: Vec<crate::daemon::scrollback::Segment>, size: WinSize) -> Self {
+        let mut ring = Self::new(size);
+        if segments.is_empty() {
+            return ring;
+        }
+        ring.segments.clear();
+        for seg in segments {
+            ring.len += seg.bytes.len();
+            ring.segments.push_back(RingSegment {
+                size: seg.size,
+                bytes: seg.bytes.into(),
+            });
+        }
+        // Whatever the shell writes from here was written at *this* pane's
+        // size, which is not necessarily the size the snapshot was taken at.
+        ring.resize(size);
+        ring
+    }
+
+    fn snapshot(&self) -> Vec<crate::daemon::scrollback::Segment> {
+        self.segments
+            .iter()
+            .filter(|seg| !seg.bytes.is_empty())
+            .map(|seg| crate::daemon::scrollback::Segment {
+                size: seg.size,
+                bytes: seg.to_vec(),
+            })
+            .collect()
     }
 
     fn tail(&mut self) -> &mut RingSegment {
@@ -1727,6 +1833,7 @@ impl ReplayRing {
     }
 
     fn append(&mut self, bytes: &[u8]) {
+        self.appended = self.appended.saturating_add(bytes.len() as u64);
         if bytes.len() >= RING_CAP {
             let size = self.tail().size;
             self.segments.clear();
@@ -2446,6 +2553,7 @@ mod tests {
             }),
             None,
             None,
+            None,
             || {},
         )
         .expect("spawn pane");
@@ -2817,6 +2925,107 @@ mod tests {
         assert!(matches!(rx.try_recv(), Ok(DaemonMsg::Size(s)) if s == ws(80, 24)));
         assert!(matches!(rx.try_recv(), Ok(DaemonMsg::Snapshot(b)) if b == b"narrow bytes"));
         assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn a_seeded_ring_replays_the_old_screen_at_the_size_it_was_written() {
+        use crate::daemon::scrollback::Segment;
+
+        let mut ring = ReplayRing::seeded(
+            vec![Segment {
+                size: ws(100, 24),
+                bytes: b"what the dead pane had on it".to_vec(),
+            }],
+            ws(80, 30),
+        );
+        ring.append(b"the new shell's prompt");
+
+        let (tx, rx) = mpsc::channel();
+        ring.replay(&tx);
+        assert!(matches!(rx.try_recv(), Ok(DaemonMsg::Size(s)) if s == ws(100, 24)));
+        assert!(
+            matches!(rx.try_recv(), Ok(DaemonMsg::Snapshot(b)) if b == b"what the dead pane had on it"),
+            "restored output has to be replayed at the width it was produced at, or the client \
+             rewraps it to whatever the window happens to be now"
+        );
+        assert!(matches!(rx.try_recv(), Ok(DaemonMsg::Size(s)) if s == ws(80, 30)));
+        assert!(
+            matches!(rx.try_recv(), Ok(DaemonMsg::Snapshot(b)) if b == b"the new shell's prompt")
+        );
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn seeding_does_not_make_an_untouched_pane_look_like_it_produced_output() {
+        use crate::daemon::scrollback::Segment;
+
+        let ring = ReplayRing::seeded(
+            vec![Segment {
+                size: ws(80, 24),
+                bytes: b"restored".to_vec(),
+            }],
+            ws(80, 24),
+        );
+        assert_eq!(
+            ring.appended, 0,
+            "the mark answers 'has this pane written anything since the last snapshot', and \
+             bytes it was handed at birth are not an answer of yes"
+        );
+    }
+
+    #[test]
+    fn an_empty_seed_leaves_an_ordinary_ring() {
+        let mut ring = ReplayRing::seeded(Vec::new(), ws(80, 24));
+        ring.append(b"output");
+        assert_eq!(
+            ring.segments.len(),
+            1,
+            "the ring always has exactly one tail"
+        );
+        assert_eq!(ring.flatten(), b"output");
+    }
+
+    #[test]
+    fn the_restore_preamble_hands_the_new_shell_a_terminal_it_can_use() {
+        let bytes = restore_preamble(Some("this shell is new"));
+        let text = String::from_utf8(bytes).expect("the preamble is text");
+        // A snapshot is cut at the front, so it can begin inside anything: an
+        // unterminated SGR run, a hidden cursor, an alternate screen whose exit
+        // never came because the daemon died while a full-screen app was up.
+        assert!(text.contains("\x1b[?1049l"), "leave any alternate screen");
+        assert!(text.contains("\x1b[?25h"), "give the cursor back");
+        assert!(text.contains("\x1b[?7h"), "put autowrap back");
+        assert!(text.contains("\x1b[0m"), "drop any colour left mid-run");
+        assert!(text.contains("this shell is new"));
+    }
+
+    #[test]
+    fn a_banner_cannot_smuggle_extra_lines_into_the_pane() {
+        let text = String::from_utf8(restore_preamble(Some("first\r\nsecond"))).unwrap();
+        assert!(
+            text.contains("first  second"),
+            "the rule is drawn as one line, so the words placed in it stay on one line"
+        );
+        assert_eq!(
+            text.matches("\r\n").count(),
+            2,
+            "one break before the rule and one after it, and no others"
+        );
+    }
+
+    #[test]
+    fn a_pane_with_nothing_to_say_still_gets_the_resets() {
+        for banner in [None, Some(""), Some("   ")] {
+            let text = String::from_utf8(restore_preamble(banner)).unwrap();
+            assert!(
+                text.starts_with("\x1b[?1049l"),
+                "the terminal still has to be handed back in a usable state"
+            );
+            assert!(
+                !text.contains('\n'),
+                "with no words there is no rule to draw, so no line is spent on one"
+            );
+        }
     }
 
     #[test]

--- a/crates/tty7-core/src/daemon/pane.rs
+++ b/crates/tty7-core/src/daemon/pane.rs
@@ -988,6 +988,14 @@ impl AdoptedMaster {
         if unsafe { libc::isatty(fd) } != 1 {
             anyhow::bail!("descriptor {fd} is not a terminal");
         }
+        // Crossing the exec required stripping close-on-exec; being across is
+        // when it goes back on. Children this daemon spawns from here — shells,
+        // `lsof`, ssh transports — must not inherit another pane's master: a
+        // child holding one keeps the pty open after this pane closes it, and
+        // the hangup the shell should see never comes.
+        if let Err(e) = crate::daemon::handoff::close_on_exec_again(fd) {
+            log::warn!("could not restore close-on-exec on adopted pty {fd}: {e}");
+        }
         Ok(Self {
             fd: unsafe { std::os::fd::OwnedFd::from_raw_fd(fd) },
         })
@@ -1931,6 +1939,16 @@ impl DaemonPane {
     /// mark that claims to cover bytes its snapshot does not have — a pane
     /// that stopped producing at that moment would keep the stale copy for
     /// good, because its mark would never move again.
+    /// The mark alone, for deciding whether a snapshot is worth taking:
+    /// [`scrollback_snapshot`](Self::scrollback_snapshot) clones the whole
+    /// ring under the state lock, which is a lot to pay every tick for the
+    /// answer "nothing changed". A pane that moves between this read and the
+    /// snapshot is fine — the snapshot returns its own mark, and that pair is
+    /// what gets recorded.
+    pub fn scrollback_mark(&self) -> u64 {
+        self.state.lock().unwrap().ring.appended
+    }
+
     pub fn scrollback_snapshot(&self) -> (Vec<crate::daemon::scrollback::Segment>, u64) {
         let st = self.state.lock().unwrap();
         let mut segments = st.ring.snapshot();
@@ -3409,6 +3427,31 @@ mod tests {
         // dropping `file` here is what closes it. Adopting first and failing
         // later would have closed a descriptor belonging to someone else.
         drop(file);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_adopted_master_goes_back_to_close_on_exec() {
+        let pair = native_pty_system()
+            .openpty(PtySize::default())
+            .expect("open a pty");
+        let fd = pair
+            .master
+            .as_raw_fd()
+            .expect("a fresh master has a descriptor");
+        // What crossing the exec leaves behind: `dup` hands out a descriptor
+        // with close-on-exec clear, exactly like one that was deliberately
+        // stripped to survive.
+        let inherited = unsafe { libc::dup(fd) };
+        assert!(inherited >= 0, "dup the master");
+        let master = AdoptedMaster::from_fd(inherited).expect("a pty is adoptable");
+        let flags = unsafe { libc::fcntl(inherited, libc::F_GETFD) };
+        assert!(
+            flags >= 0 && flags & libc::FD_CLOEXEC != 0,
+            "an adopted master left inheritable ends up in every child this daemon spawns, \
+             and a child holding it keeps the pty from ever hanging up"
+        );
+        drop(master);
     }
 
     #[test]

--- a/crates/tty7-core/src/daemon/protocol.rs
+++ b/crates/tty7-core/src/daemon/protocol.rs
@@ -23,6 +23,13 @@ pub const FEATURE_RESIZE_ECHO: &str = "resize-echo";
 /// claim a restore that never happened.
 pub const FEATURE_RESTORE_SCROLLBACK: &str = "restore-scrollback";
 
+/// The daemon can replace its own binary without stopping, keeping every pty
+/// and everything running on one — `ClientMsg::Handoff`. Advertised only where
+/// it can actually be done, which is where `execve` exists, so a client can use
+/// it to choose between offering an upgrade that costs the user nothing and one
+/// that costs them every running command.
+pub const FEATURE_HANDOFF: &str = "handoff";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DaemonVersion {
     pub protocol: u32,
@@ -36,14 +43,18 @@ pub struct DaemonVersion {
 
 impl DaemonVersion {
     pub fn current() -> DaemonVersion {
+        let mut features = vec![
+            FEATURE_PANE_OWNER.to_string(),
+            FEATURE_RESIZE_ECHO.to_string(),
+            FEATURE_RESTORE_SCROLLBACK.to_string(),
+        ];
+        if cfg!(unix) {
+            features.push(FEATURE_HANDOFF.to_string());
+        }
         DaemonVersion {
             protocol: PROTOCOL_VERSION,
             build: env!("CARGO_PKG_VERSION").to_string(),
-            features: vec![
-                FEATURE_PANE_OWNER.to_string(),
-                FEATURE_RESIZE_ECHO.to_string(),
-                FEATURE_RESTORE_SCROLLBACK.to_string(),
-            ],
+            features,
             instance: process_instance().to_string(),
         }
     }
@@ -614,6 +625,16 @@ pub enum ClientMsg {
     },
     List,
     Shutdown,
+    /// Become `exe` without stopping: the daemon rewrites itself in place and
+    /// keeps every pty, shell and pane id it is holding. The connection dies in
+    /// the process — the new image has never heard of it — so this is the last
+    /// thing a client can say on it, and the reply is the socket closing.
+    ///
+    /// Unix only. Elsewhere the daemon answers with an error and the caller
+    /// falls back to stopping and starting it.
+    Handoff {
+        exe: PathBuf,
+    },
     EnsureLoopbackForward(LoopbackForwardRequest),
     ListLoopbackForwards,
     CloseLoopbackForward(LoopbackForwardId),
@@ -750,6 +771,7 @@ mod kind {
     pub const SPAWN_OWNED: u8 = 53;
     pub const OBSERVE: u8 = 54;
     pub const SEND_INPUT: u8 = 55;
+    pub const HANDOFF: u8 = 56;
 
     pub const SPAWNED: u8 = 1;
     pub const SNAPSHOT: u8 = 2;
@@ -942,6 +964,7 @@ impl ClientMsg {
             ClientMsg::Kill { pane_id } => write_frame(w, kind::KILL, &to_json(pane_id)?),
             ClientMsg::List => write_frame(w, kind::LIST, &[]),
             ClientMsg::Shutdown => write_frame(w, kind::SHUTDOWN, &[]),
+            ClientMsg::Handoff { exe } => write_frame(w, kind::HANDOFF, &to_json(exe)?),
             ClientMsg::EnsureLoopbackForward(req) => {
                 write_frame(w, kind::ENSURE_LOOPBACK_FORWARD, &to_json(req)?)
             }
@@ -1055,6 +1078,9 @@ impl ClientMsg {
             },
             kind::LIST => ClientMsg::List,
             kind::SHUTDOWN => ClientMsg::Shutdown,
+            kind::HANDOFF => ClientMsg::Handoff {
+                exe: from_json(&payload)?,
+            },
             kind::ENSURE_LOOPBACK_FORWARD => ClientMsg::EnsureLoopbackForward(from_json(&payload)?),
             kind::LIST_LOOPBACK_FORWARDS => ClientMsg::ListLoopbackForwards,
             kind::CLOSE_LOOPBACK_FORWARD => ClientMsg::CloseLoopbackForward(from_json(&payload)?),

--- a/crates/tty7-core/src/daemon/protocol.rs
+++ b/crates/tty7-core/src/daemon/protocol.rs
@@ -16,6 +16,13 @@ pub const FEATURE_PANE_OWNER: &str = "pane-owner";
 /// older daemon it must keep reflowing locally at request time.
 pub const FEATURE_RESIZE_ECHO: &str = "resize-echo";
 
+/// The daemon can seed a new pane with the screen a dead one left behind, named
+/// by `ClientMsg::Spawn`'s `restore` field. A client that does not see this
+/// feature leaves the field out: an older daemon would ignore it and spawn a
+/// blank pane, which is the same outcome, but sending it would make the wire
+/// claim a restore that never happened.
+pub const FEATURE_RESTORE_SCROLLBACK: &str = "restore-scrollback";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DaemonVersion {
     pub protocol: u32,
@@ -35,6 +42,7 @@ impl DaemonVersion {
             features: vec![
                 FEATURE_PANE_OWNER.to_string(),
                 FEATURE_RESIZE_ECHO.to_string(),
+                FEATURE_RESTORE_SCROLLBACK.to_string(),
             ],
             instance: process_instance().to_string(),
         }
@@ -584,6 +592,7 @@ pub enum ClientMsg {
         shell: Option<ShellSpec>,
         owner: Option<String>,
         workspace: Option<String>,
+        restore: Option<RestoreFrom>,
     },
     Attach {
         pane_id: u64,
@@ -855,6 +864,29 @@ struct OwnedSpawn {
     owner: Option<String>,
     #[serde(default)]
     workspace: Option<String>,
+    #[serde(default)]
+    restore: Option<RestoreFrom>,
+}
+
+/// "This pane replaces one that died with the daemon."
+///
+/// Carried on a spawn rather than an attach because there is nothing to attach
+/// to: the process is gone. The daemon looks up what pane `pane_id` last had on
+/// its screen and seeds the new pane's ring with it, so the window shows the
+/// output it lost under a shell that is plainly new.
+///
+/// `banner` is the line drawn between the two, and it comes from the client
+/// because the daemon has no locale — it serves a GUI that might be running in
+/// any language, and a CLI whose output is always English. A client that has
+/// nothing to say can leave it out; the reset sequence is emitted either way.
+///
+/// Old daemons decode this frame without the field and simply spawn a blank
+/// pane, which is what they did before it existed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RestoreFrom {
+    pub pane_id: u64,
+    #[serde(default)]
+    pub banner: Option<String>,
 }
 
 impl ClientMsg {
@@ -866,6 +898,7 @@ impl ClientMsg {
                 shell: None,
                 owner: None,
                 workspace: None,
+                restore: None,
             } => write_frame(w, kind::SPAWN, &to_json(&(cwd, size))?),
             ClientMsg::Spawn {
                 cwd,
@@ -873,6 +906,7 @@ impl ClientMsg {
                 shell: shell @ Some(_),
                 owner: None,
                 workspace: None,
+                restore: None,
             } => write_frame(w, kind::SPAWN_SHELL, &to_json(&(cwd, size, shell))?),
             ClientMsg::Spawn {
                 cwd,
@@ -880,6 +914,7 @@ impl ClientMsg {
                 shell,
                 owner,
                 workspace,
+                restore,
             } => write_frame(
                 w,
                 kind::SPAWN_OWNED,
@@ -889,6 +924,7 @@ impl ClientMsg {
                     shell: shell.clone(),
                     owner: owner.clone(),
                     workspace: workspace.clone(),
+                    restore: restore.clone(),
                 })?,
             ),
             ClientMsg::Attach { pane_id, size } => {
@@ -967,6 +1003,7 @@ impl ClientMsg {
                     shell: None,
                     owner: None,
                     workspace: None,
+                    restore: None,
                 }
             }
             kind::SPAWN_SHELL => {
@@ -977,6 +1014,7 @@ impl ClientMsg {
                     shell,
                     owner: None,
                     workspace: None,
+                    restore: None,
                 }
             }
             kind::SPAWN_OWNED => {
@@ -986,6 +1024,7 @@ impl ClientMsg {
                     shell,
                     owner,
                     workspace,
+                    restore,
                 } = from_json(&payload)?;
                 ClientMsg::Spawn {
                     cwd,
@@ -993,6 +1032,7 @@ impl ClientMsg {
                     shell,
                     owner,
                     workspace,
+                    restore,
                 }
             }
             kind::ATTACH => {
@@ -1226,6 +1266,7 @@ mod tests {
                 shell: None,
                 owner: None,
                 workspace: None,
+                restore: None,
             },
             ClientMsg::Resize(SIZE),
             ClientMsg::Input(vec![b'l', b's', b'\r']),
@@ -1280,6 +1321,7 @@ mod tests {
                 shell: None,
                 owner: None,
                 workspace: None,
+                restore: None,
             },
             ClientMsg::Spawn {
                 cwd: None,
@@ -1287,6 +1329,7 @@ mod tests {
                 shell: None,
                 owner: None,
                 workspace: None,
+                restore: None,
             },
             ClientMsg::Spawn {
                 cwd: Some(PathBuf::from("/tmp/x")),
@@ -1298,6 +1341,7 @@ mod tests {
                 }),
                 owner: None,
                 workspace: None,
+                restore: None,
             },
             ClientMsg::Spawn {
                 cwd: Some(PathBuf::from("/tmp/x")),
@@ -1305,6 +1349,7 @@ mod tests {
                 shell: None,
                 owner: Some("bda10e44-02de-44a0-8412-ec1cda2b5f5b".into()),
                 workspace: None,
+                restore: None,
             },
             ClientMsg::Spawn {
                 cwd: Some(PathBuf::from("/tmp/x")),
@@ -1312,6 +1357,7 @@ mod tests {
                 shell: None,
                 owner: None,
                 workspace: Some("ws-main".into()),
+                restore: None,
             },
             ClientMsg::Observe {
                 pane_id: 42,
@@ -1615,6 +1661,7 @@ mod tests {
             shell: None,
             owner: None,
             workspace: None,
+            restore: None,
         };
         let mut buf = Vec::new();
         msg.encode(&mut buf).unwrap();
@@ -1634,6 +1681,7 @@ mod tests {
                 shell: None,
                 owner: None,
                 workspace: None,
+                restore: None,
             }
         );
     }
@@ -1651,6 +1699,7 @@ mod tests {
             shell: Some(shell.clone()),
             owner: None,
             workspace: None,
+            restore: None,
         };
         let mut buf = Vec::new();
         msg.encode(&mut buf).unwrap();
@@ -1665,6 +1714,7 @@ mod tests {
                 shell: Some(shell),
                 owner: None,
                 workspace: None,
+                restore: None,
             }
         );
     }
@@ -1681,6 +1731,7 @@ mod tests {
             }),
             owner: Some("bda10e44-02de-44a0-8412-ec1cda2b5f5b".into()),
             workspace: Some("ws-7".into()),
+            restore: None,
         };
         let mut buf = Vec::new();
         msg.encode(&mut buf).unwrap();
@@ -1710,6 +1761,7 @@ mod tests {
                 shell: None,
                 owner: None,
                 workspace: None,
+                restore: None,
             }
         );
     }
@@ -1722,6 +1774,7 @@ mod tests {
             shell: None,
             owner: None,
             workspace: Some("ws-main".into()),
+            restore: None,
         };
         let mut buf = Vec::new();
         msg.encode(&mut buf).unwrap();

--- a/crates/tty7-core/src/daemon/scrollback.rs
+++ b/crates/tty7-core/src/daemon/scrollback.rs
@@ -1,0 +1,410 @@
+//! What a pane looked like, kept where the daemon's own death cannot reach it.
+//!
+//! The replay ring already holds every pane's recent output so a reattaching
+//! client can be shown the screen it left. It holds it in this process, which
+//! makes it exactly as durable as this process: a crash, a `kill -9`, or a
+//! reboot takes the panes and their scrollback together, and the window comes
+//! back to a row of blank shells with no trace of what was in them.
+//!
+//! The planned upgrade path does not lose anything — see `daemon::handoff`,
+//! which carries the live ptys and their rings into the new binary without the
+//! shells ever noticing. This module is for the paths a handoff cannot cover,
+//! where the process does not get to run any code on its way out. It cannot
+//! keep the *processes*; nothing written to a file can. It keeps the picture.
+//!
+//! Consequences of that being the goal:
+//!
+//! - **The snapshot is periodic, not write-through.** Every pty byte reaching
+//!   the disk would be an enormous amount of write amplification to buy a few
+//!   seconds of freshness at the tail of a crash. The writer runs on a timer
+//!   and skips panes whose ring has not changed.
+//! - **It is capped far below the ring.** [`SNAPSHOT_CAP`] keeps what fills a
+//!   screen or two, not the ring's whole 8 MiB. The value of scrollback decays
+//!   steeply with distance from the bottom, and every byte here is a byte of
+//!   someone's terminal sitting on disk.
+//! - **It is off unless asked for.** These bytes include whatever was echoed
+//!   into the pane: tokens, `env` output, an agent's transcript. In memory
+//!   they die with the daemon. On disk they outlive it, which is the whole
+//!   point and also the whole risk, so the choice is the user's.
+//! - **It is dropped as soon as it is meaningless.** A pane that is closed, or
+//!   that no workspace refers to any more, has its file removed. Retention is
+//!   by relevance, not by calendar: a snapshot of a pane nobody will reopen is
+//!   not worth keeping for a month, or for an hour.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use crate::daemon::protocol::WinSize;
+
+/// How much of a pane's ring reaches the disk, per pane.
+///
+/// A screenful of dense output is on the order of 20 KiB once escape sequences
+/// are counted, so this is "the last several screens" rather than "everything".
+/// The in-memory ring stays at its own, much larger, cap: this bound is about
+/// what is worth persisting, not what is worth keeping while running.
+pub const SNAPSHOT_CAP: usize = 256 * 1024;
+
+/// How often the writer looks for panes whose ring has moved.
+pub const SNAPSHOT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+const MAGIC: &[u8; 8] = b"TTY7SB\x01\x00";
+
+/// One geometry-homogeneous run of pane output, the unit the replay ring is
+/// segmented into: replaying a segment means telling the client the size those
+/// bytes were written at, then handing it the bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Segment {
+    pub size: WinSize,
+    pub bytes: Vec<u8>,
+}
+
+/// Drop bytes from the oldest segments until the total fits `cap`.
+///
+/// Trimming from the front is what makes a truncated snapshot still make sense:
+/// terminal output is only interpretable forwards, so the tail can stand on its
+/// own in a way the head cannot. A partially eaten segment keeps its geometry —
+/// the bytes that remain were still written at that size.
+pub fn trim_to(segments: &mut Vec<Segment>, cap: usize) {
+    let total: usize = segments.iter().map(|s| s.bytes.len()).sum();
+    let mut over = total.saturating_sub(cap);
+    while over > 0 {
+        let Some(head) = segments.first_mut() else {
+            return;
+        };
+        let drop = over.min(head.bytes.len());
+        head.bytes.drain(..drop);
+        over -= drop;
+        if !head.bytes.is_empty() {
+            continue;
+        }
+        // The last segment is kept even when it is empty: the ring this feeds
+        // back into is defined by always having a tail to append to.
+        if segments.len() == 1 {
+            return;
+        }
+        segments.remove(0);
+    }
+}
+
+pub fn encode(segments: &[Segment]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(
+        MAGIC.len() + 4 + segments.iter().map(|s| s.bytes.len() + 12).sum::<usize>(),
+    );
+    out.extend_from_slice(MAGIC);
+    out.extend_from_slice(&(segments.len() as u32).to_le_bytes());
+    for seg in segments {
+        out.extend_from_slice(&seg.size.cols.to_le_bytes());
+        out.extend_from_slice(&seg.size.rows.to_le_bytes());
+        out.extend_from_slice(&seg.size.cell_w.to_le_bytes());
+        out.extend_from_slice(&seg.size.cell_h.to_le_bytes());
+        out.extend_from_slice(&(seg.bytes.len() as u32).to_le_bytes());
+        out.extend_from_slice(&seg.bytes);
+    }
+    out
+}
+
+/// `None` for anything that is not a snapshot this build wrote.
+///
+/// A truncated file is the ordinary failure here — the writer renames into
+/// place, but a filesystem that reordered the rename against the data, or a
+/// half-written file from an older scheme, both land as a short read. There is
+/// nothing to salvage and nothing at stake in refusing: the pane comes back
+/// blank, which is what it did before this module existed.
+pub fn decode(raw: &[u8]) -> Option<Vec<Segment>> {
+    let mut cur = raw.strip_prefix(MAGIC.as_slice())?;
+    let count = u32::from_le_bytes(take(&mut cur, 4)?.try_into().ok()?) as usize;
+    let mut segments = Vec::with_capacity(count.min(1024));
+    for _ in 0..count {
+        let cols = u16::from_le_bytes(take(&mut cur, 2)?.try_into().ok()?);
+        let rows = u16::from_le_bytes(take(&mut cur, 2)?.try_into().ok()?);
+        let cell_w = u16::from_le_bytes(take(&mut cur, 2)?.try_into().ok()?);
+        let cell_h = u16::from_le_bytes(take(&mut cur, 2)?.try_into().ok()?);
+        let len = u32::from_le_bytes(take(&mut cur, 4)?.try_into().ok()?) as usize;
+        let bytes = take(&mut cur, len)?.to_vec();
+        segments.push(Segment {
+            size: WinSize {
+                cols,
+                rows,
+                cell_w,
+                cell_h,
+            },
+            bytes,
+        });
+    }
+    Some(segments)
+}
+
+fn take<'a>(cur: &mut &'a [u8], n: usize) -> Option<&'a [u8]> {
+    if cur.len() < n {
+        return None;
+    }
+    let (head, rest) = cur.split_at(n);
+    *cur = rest;
+    Some(head)
+}
+
+/// Whether the user has asked for scrollback to outlive the daemon.
+pub fn enabled() -> bool {
+    crate::core::config::Config::load().persist_scrollback
+}
+
+fn dir() -> Option<PathBuf> {
+    crate::core::config::config_path("scrollback")
+}
+
+fn path_for(pane_id: u64) -> Option<PathBuf> {
+    Some(dir()?.join(format!("{pane_id}.bin")))
+}
+
+/// Write one pane's snapshot, replacing whatever was there.
+///
+/// Renamed into place so a reader never sees a half-written file, and mode 0600
+/// from creation rather than after the fact — a window in which someone else's
+/// terminal output is world-readable is not one worth leaving open.
+pub fn save(pane_id: u64, segments: &[Segment]) {
+    let Some(path) = path_for(pane_id) else {
+        return;
+    };
+    let Some(parent) = path.parent().map(|p| p.to_path_buf()) else {
+        return;
+    };
+    if let Err(e) = std::fs::create_dir_all(&parent) {
+        log::debug!("no scrollback directory ({e}); pane {pane_id} is not persisted");
+        return;
+    }
+    let temp = parent.join(format!("{pane_id}.{}.tmp", std::process::id()));
+    if let Err(e) = write_private(&temp, &encode(segments)) {
+        log::debug!("could not stage pane {pane_id}'s scrollback: {e}");
+        let _ = std::fs::remove_file(&temp);
+        return;
+    }
+    if let Err(e) = std::fs::rename(&temp, &path) {
+        log::debug!("could not store pane {pane_id}'s scrollback: {e}");
+        let _ = std::fs::remove_file(&temp);
+    }
+}
+
+#[cfg(unix)]
+fn write_private(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write as _;
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)?;
+    file.write_all(bytes)
+}
+
+#[cfg(not(unix))]
+fn write_private(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    // Windows inherits the config directory's ACL, which is already per-user.
+    std::fs::write(path, bytes)
+}
+
+pub fn load(pane_id: u64) -> Option<Vec<Segment>> {
+    let raw = std::fs::read(path_for(pane_id)?).ok()?;
+    match decode(&raw) {
+        Some(segments) => Some(segments),
+        None => {
+            log::debug!("pane {pane_id}'s stored scrollback is not readable by this build");
+            None
+        }
+    }
+}
+
+pub fn forget(pane_id: u64) {
+    if let Some(path) = path_for(pane_id) {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// Drop snapshots for panes that nothing refers to any more.
+///
+/// Called with the set of pane ids the machine tree still names. A file outside
+/// it belongs to a pane that was closed, or that lived in a workspace since
+/// deleted; either way nobody can ask to restore it, so keeping it is only a
+/// way to leave terminal output on disk indefinitely.
+pub fn sweep(keep: &HashSet<u64>) {
+    let Some(dir) = dir() else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let Some(id) = name
+            .strip_suffix(".bin")
+            .and_then(|stem| stem.parse::<u64>().ok())
+        else {
+            continue;
+        };
+        if !keep.contains(&id) {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn size(cols: u16, rows: u16) -> WinSize {
+        WinSize {
+            cols,
+            rows,
+            cell_w: 8,
+            cell_h: 17,
+        }
+    }
+
+    fn seg(cols: u16, bytes: &[u8]) -> Segment {
+        Segment {
+            size: size(cols, 24),
+            bytes: bytes.to_vec(),
+        }
+    }
+
+    #[test]
+    fn segments_survive_the_round_trip_with_their_geometry() {
+        let segments = vec![seg(80, b"before the resize"), seg(120, b"after it")];
+        let decoded = decode(&encode(&segments)).expect("what we wrote is readable");
+        assert_eq!(
+            decoded, segments,
+            "a replayed snapshot has to say which size each run of bytes was written at, \
+             or the client rewraps old output to the current width"
+        );
+    }
+
+    #[test]
+    fn a_truncated_or_foreign_file_decodes_to_nothing() {
+        let raw = encode(&[seg(80, b"hello")]);
+        assert!(
+            decode(&raw[..raw.len() - 2]).is_none(),
+            "a short read must not be mistaken for a shorter snapshot"
+        );
+        assert!(decode(b"").is_none(), "an empty file is not a snapshot");
+        assert!(
+            decode(b"PLAIN TEXT, NOT OURS").is_none(),
+            "only files this scheme wrote are read back"
+        );
+    }
+
+    #[test]
+    fn trimming_keeps_the_tail_and_the_geometry_of_what_it_keeps() {
+        let mut segments = vec![seg(80, b"0123456789"), seg(120, b"abcdefghij")];
+        trim_to(&mut segments, 12);
+        let kept: Vec<u8> = segments.iter().flat_map(|s| s.bytes.clone()).collect();
+        assert_eq!(
+            kept, b"89abcdefghij",
+            "terminal output only reads forwards, so a cap has to eat the head"
+        );
+        assert_eq!(
+            segments[0].size,
+            size(80, 24),
+            "the bytes left in a partly eaten segment were still written at its size"
+        );
+    }
+
+    #[test]
+    fn trimming_below_one_segment_still_leaves_something_to_replay() {
+        let mut segments = vec![seg(80, b"0123456789")];
+        trim_to(&mut segments, 0);
+        assert_eq!(
+            segments.len(),
+            1,
+            "the ring always has a tail; so does this"
+        );
+        assert!(segments[0].bytes.is_empty());
+    }
+
+    /// The same shared temp directory every other module's tests pin, by the
+    /// same name: the override is a process-wide `OnceLock`, so the first
+    /// caller decides for all of them and agreeing on the path is what keeps
+    /// that harmless.
+    fn pin_config_dir() {
+        let dir = std::env::temp_dir().join(format!("tty7-covtest-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).ok();
+        crate::core::config::set_config_dir(dir);
+    }
+
+    #[test]
+    fn a_stored_screen_comes_back_and_can_be_dropped() {
+        pin_config_dir();
+        let pane = 90_001;
+        save(pane, &[seg(80, b"what the pane had on it")]);
+        assert_eq!(
+            load(pane).expect("a saved screen is readable"),
+            vec![seg(80, b"what the pane had on it")],
+        );
+        forget(pane);
+        assert!(
+            load(pane).is_none(),
+            "a pane the user closed leaves nothing behind to restore"
+        );
+    }
+
+    #[test]
+    fn saving_twice_replaces_rather_than_appends() {
+        pin_config_dir();
+        let pane = 90_002;
+        save(pane, &[seg(80, b"first")]);
+        save(pane, &[seg(80, b"second")]);
+        assert_eq!(
+            load(pane).expect("still readable"),
+            vec![seg(80, b"second")],
+            "each write is the pane's current screen, not another slice of history"
+        );
+        forget(pane);
+    }
+
+    #[test]
+    fn the_sweep_keeps_only_panes_something_can_still_ask_for() {
+        pin_config_dir();
+        let (kept, dropped) = (90_003, 90_004);
+        save(kept, &[seg(80, b"in a workspace")]);
+        save(dropped, &[seg(80, b"in no workspace")]);
+        sweep(&HashSet::from([kept]));
+        assert!(
+            load(kept).is_some(),
+            "a pane a tree still names is restorable"
+        );
+        assert!(
+            load(dropped).is_none(),
+            "nobody can ask to restore a pane no tree refers to, so its output must not sit on disk"
+        );
+        forget(kept);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_stored_screen_is_not_readable_by_anyone_else() {
+        use std::os::unix::fs::PermissionsExt as _;
+        pin_config_dir();
+        let pane = 90_005;
+        save(pane, &[seg(80, b"a token someone echoed")]);
+        let mode = std::fs::metadata(path_for(pane).expect("a path under the config dir"))
+            .expect("the file exists")
+            .permissions()
+            .mode();
+        assert_eq!(
+            mode & 0o077,
+            0,
+            "this file is a copy of someone's terminal; group and other get nothing"
+        );
+        forget(pane);
+    }
+
+    #[test]
+    fn an_empty_snapshot_round_trips() {
+        assert_eq!(
+            decode(&encode(&[])).expect("still a valid snapshot"),
+            Vec::new(),
+            "a pane that has printed nothing is not a corrupt file"
+        );
+    }
+}

--- a/crates/tty7-core/src/daemon/server.rs
+++ b/crates/tty7-core/src/daemon/server.rs
@@ -539,11 +539,17 @@ fn run_with(registry: Arc<Registry>) -> anyhow::Result<()> {
     // so everything on disk belongs to panes the machine tree either still
     // names — those are the ones a window is about to ask to restore — or has
     // forgotten, and the latter are nobody's to restore any more.
+    let restorable = restorable_pane_ids(&registry);
     if crate::daemon::scrollback::enabled() {
-        crate::daemon::scrollback::sweep(&restorable_pane_ids(&registry));
+        crate::daemon::scrollback::sweep(&restorable);
     } else {
         crate::daemon::scrollback::sweep(&std::collections::HashSet::new());
     }
+    // A daemon that was killed outright never retired anything, so the files of
+    // panes that died with it are still here. Their commands cannot be
+    // recovered — the mark saying which were new belongs to a shell that is
+    // gone — so what is left is not to hoard them.
+    crate::daemon::history::sweep(&restorable);
     spawn_scrollback_writer(registry.clone());
 
     for stream in listener.incoming() {
@@ -636,6 +642,12 @@ fn handle_conn(stream: Stream, registry: Arc<Registry>) -> anyhow::Result<()> {
             restore,
         } => {
             let id = registry.alloc_id();
+            if let Some(dead) = restore.as_ref().map(|r| r.pane_id) {
+                // Before the spawn, because the spawn is what hands the shell
+                // the name of its history file — and this is what puts the
+                // predecessor's commands behind that name.
+                crate::daemon::history::carry(dead, id);
+            }
             let restore = restore.and_then(restored_screen);
             let on_dead = {
                 let registry = registry.clone();

--- a/crates/tty7-core/src/daemon/server.rs
+++ b/crates/tty7-core/src/daemon/server.rs
@@ -198,10 +198,10 @@ fn spawn_scrollback_writer(registry: Arc<Registry>) {
                 }
                 storing = true;
                 for pane in registry.all() {
-                    let (segments, mark) = pane.scrollback_snapshot();
-                    if marks.get(&pane.id) == Some(&mark) {
+                    if marks.get(&pane.id) == Some(&pane.scrollback_mark()) {
                         continue;
                     }
+                    let (segments, mark) = pane.scrollback_snapshot();
                     crate::daemon::scrollback::save(pane.id, &segments);
                     marks.insert(pane.id, mark);
                 }
@@ -420,6 +420,22 @@ fn run_adopting(inheritance: crate::daemon::handoff::Inheritance) -> anyhow::Res
 /// by then this program has been replaced by the one it was asked to become.
 #[cfg(unix)]
 fn hand_over(registry: &Registry, exe: &std::path::Path) -> anyhow::Error {
+    // Before anything is given up: the native-SSH panes below are hung up on
+    // the promise that this process is about to stop existing, and an exec
+    // that was never going to work must not collect on it. `execve` can still
+    // fail after this — a wrong architecture, a permission the metadata does
+    // not show — but the everyday failures, a path that is not there or not a
+    // program, are caught while everything is still intact.
+    match std::fs::metadata(exe) {
+        Err(e) => return anyhow::anyhow!("cannot become {}: {e}", exe.display()),
+        Ok(meta) => {
+            use std::os::unix::fs::PermissionsExt as _;
+            if !meta.is_file() || meta.permissions().mode() & 0o111 == 0 {
+                return anyhow::anyhow!("cannot become {}: not an executable file", exe.display());
+            }
+        }
+    }
+
     let mut carried = Vec::new();
     for pane in registry.all() {
         match pane.carry() {

--- a/crates/tty7-core/src/daemon/server.rs
+++ b/crates/tty7-core/src/daemon/server.rs
@@ -69,6 +69,10 @@ impl Registry {
         }
     }
 
+    fn all(&self) -> Vec<Arc<DaemonPane>> {
+        self.panes.lock().unwrap().values().cloned().collect()
+    }
+
     fn list(&self) -> Vec<crate::daemon::protocol::PaneInfo> {
         self.panes
             .lock()
@@ -133,6 +137,128 @@ fn spawn_orphan_sweep(registry: Arc<Registry>) {
     if let Err(e) = spawned {
         log::warn!("could not start the orphan-pane sweep: {e}");
     }
+}
+
+/// Pane ids that something can still ask to see again: every pane a workspace
+/// tree names, plus every pane this daemon is running.
+///
+/// The registry half matters for a pane spawned since the tree was last
+/// written — without it a sweep landing in that window would delete the
+/// snapshot of a pane that is very much alive, and the writer would put it
+/// back seconds later.
+fn restorable_pane_ids(registry: &Registry) -> std::collections::HashSet<u64> {
+    let mut ids: std::collections::HashSet<u64> =
+        registry.list().into_iter().map(|p| p.pane_id).collect();
+    if let Some(store) = crate::core::machine::observed_store() {
+        ids.extend(
+            store
+                .machine()
+                .workspaces
+                .iter()
+                .flat_map(|w| w.tabs.iter())
+                .flat_map(|t| t.root.pane_ids()),
+        );
+    }
+    ids
+}
+
+/// Keep each pane's stored screen roughly current.
+///
+/// Only panes whose ring has moved are written, so an idle machine does no IO
+/// at all, and the busy pane that most needs a fresh copy is the one that gets
+/// it. Turning the setting off mid-run is honoured here too: the next tick
+/// clears the directory rather than leaving terminal output on disk that the
+/// user has just said they do not want stored.
+fn spawn_scrollback_writer(registry: Arc<Registry>) {
+    let spawned = std::thread::Builder::new()
+        .name("tty7-scrollback".into())
+        .spawn(move || {
+            let mut marks: HashMap<u64, u64> = HashMap::new();
+            let mut storing = crate::daemon::scrollback::enabled();
+            loop {
+                std::thread::sleep(crate::daemon::scrollback::SNAPSHOT_INTERVAL);
+                let enabled = crate::daemon::scrollback::enabled();
+                if !enabled {
+                    if storing {
+                        log::info!("scrollback persistence turned off; dropping what was stored");
+                        crate::daemon::scrollback::sweep(&std::collections::HashSet::new());
+                        marks.clear();
+                        storing = false;
+                    }
+                    continue;
+                }
+                storing = true;
+                for pane in registry.all() {
+                    let (segments, mark) = pane.scrollback_snapshot();
+                    if marks.get(&pane.id) == Some(&mark) {
+                        continue;
+                    }
+                    crate::daemon::scrollback::save(pane.id, &segments);
+                    marks.insert(pane.id, mark);
+                }
+                crate::daemon::scrollback::sweep(&restorable_pane_ids(&registry));
+                marks.retain(|id, _| registry.get(*id).is_some());
+            }
+        });
+    if let Err(e) = spawned {
+        log::warn!("could not start the scrollback writer: {e}");
+    }
+}
+
+/// Write every pane's screen one last time, on the way out of a shutdown this
+/// process was told about.
+///
+/// The periodic writer covers the deaths nobody gets to prepare for; this
+/// covers the ones we do, and makes the copy exact rather than up to
+/// [`SNAPSHOT_INTERVAL`](crate::daemon::scrollback::SNAPSHOT_INTERVAL) stale.
+fn store_scrollback_now(registry: &Registry) {
+    if !crate::daemon::scrollback::enabled() {
+        return;
+    }
+    for pane in registry.all() {
+        let (segments, _) = pane.scrollback_snapshot();
+        crate::daemon::scrollback::save(pane.id, &segments);
+    }
+}
+
+/// Turn a client's restore request into the screen its new pane opens with.
+///
+/// The snapshot is dropped as it is handed out. It has been folded into a live
+/// pane's ring, which is where it will be persisted from now on — under that
+/// pane's own id — and a copy left behind could only ever be used to restore
+/// the same screen into a second pane.
+fn restored_screen(
+    request: crate::daemon::protocol::RestoreFrom,
+) -> Option<crate::daemon::pane::Restore> {
+    if !crate::daemon::scrollback::enabled() {
+        return None;
+    }
+    let segments = crate::daemon::scrollback::load(request.pane_id)?;
+    crate::daemon::scrollback::forget(request.pane_id);
+    if segments.is_empty() {
+        return None;
+    }
+    log::info!(
+        "pane {} is gone; its last screen is restored into a fresh pane",
+        request.pane_id
+    );
+    Some(crate::daemon::pane::Restore {
+        segments,
+        banner: request.banner,
+    })
+}
+
+/// Close a pane for good: stop it, drop it from the registry, and drop the copy
+/// of its screen.
+///
+/// A stored screen exists so a pane can survive a death nobody chose. A pane
+/// the user closed is not that; keeping its output on disk afterwards would
+/// only be a way for it to turn up in some later restore.
+fn kill_pane(registry: &Registry, pane_id: u64) {
+    if let Some(pane) = registry.remove(pane_id) {
+        pane.kill();
+    }
+    crate::daemon::scrollback::forget(pane_id);
 }
 
 fn ssh_connection_for(
@@ -280,6 +406,16 @@ fn run_with(registry: Arc<Registry>) -> anyhow::Result<()> {
     }
 
     spawn_orphan_sweep(registry.clone());
+    // Before the writer starts: a daemon that has just come up owns no panes,
+    // so everything on disk belongs to panes the machine tree either still
+    // names — those are the ones a window is about to ask to restore — or has
+    // forgotten, and the latter are nobody's to restore any more.
+    if crate::daemon::scrollback::enabled() {
+        crate::daemon::scrollback::sweep(&restorable_pane_ids(&registry));
+    } else {
+        crate::daemon::scrollback::sweep(&std::collections::HashSet::new());
+    }
+    spawn_scrollback_writer(registry.clone());
 
     for stream in listener.incoming() {
         match stream {
@@ -321,6 +457,10 @@ fn serve_sigterm(registry: Arc<Registry>) {
             let mut sig: libc::c_int = 0;
             if unsafe { libc::sigwait(&set, &mut sig) } == 0 {
                 log::info!("daemon shutting down on SIGTERM");
+                // Ahead of the kill: `drain_and_kill` hangs up every pty, and a
+                // pane whose shell has already been reaped has nothing left to
+                // photograph.
+                store_scrollback_now(&registry);
                 registry.drain_and_kill();
                 on_shutdown();
                 std::process::exit(0);
@@ -364,8 +504,10 @@ fn handle_conn(stream: Stream, registry: Arc<Registry>) -> anyhow::Result<()> {
             shell,
             owner,
             workspace,
+            restore,
         } => {
             let id = registry.alloc_id();
+            let restore = restore.and_then(restored_screen);
             let on_dead = {
                 let registry = registry.clone();
                 move || {
@@ -377,17 +519,18 @@ fn handle_conn(stream: Stream, registry: Arc<Registry>) -> anyhow::Result<()> {
                         .ok();
                 }
             };
-            let pane = match DaemonPane::spawn(id, cwd, size, shell, owner, workspace, on_dead) {
-                Ok(p) => p,
-                Err(e) => {
-                    let mut w = write_stream;
-                    // The daemon's own error is already a sentence; a second
-                    // "spawn failed:" in front of it only pads the one the
-                    // window ends up showing.
-                    let _ = DaemonMsg::Error(format!("{e}")).encode(&mut w);
-                    return Err(e);
-                }
-            };
+            let pane =
+                match DaemonPane::spawn(id, cwd, size, shell, owner, workspace, restore, on_dead) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        let mut w = write_stream;
+                        // The daemon's own error is already a sentence; a second
+                        // "spawn failed:" in front of it only pads the one the
+                        // window ends up showing.
+                        let _ = DaemonMsg::Error(format!("{e}")).encode(&mut w);
+                        return Err(e);
+                    }
+                };
             registry.insert(pane.clone());
 
             {
@@ -484,9 +627,7 @@ fn handle_conn(stream: Stream, registry: Arc<Registry>) -> anyhow::Result<()> {
         }
 
         ClientMsg::Kill { pane_id } => {
-            if let Some(pane) = registry.remove(pane_id) {
-                pane.kill();
-            }
+            kill_pane(&registry, pane_id);
             Ok(())
         }
 
@@ -797,9 +938,8 @@ fn run_stream(
                     if pane_id == id {
                         killed = true;
                         break 'conn;
-                    } else if let Some(other) = registry.remove(pane_id) {
-                        other.kill();
                     }
+                    kill_pane(&registry, pane_id);
                 }
                 _ => {}
             }
@@ -822,9 +962,7 @@ fn run_stream(
     let _ = writer.join();
 
     if killed {
-        if let Some(p) = registry.remove(id) {
-            p.kill();
-        }
+        kill_pane(&registry, id);
     } else if reclaimable {
         registry.remove(id);
     }

--- a/crates/tty7-core/src/daemon/server.rs
+++ b/crates/tty7-core/src/daemon/server.rs
@@ -386,6 +386,14 @@ fn run_adopting(inheritance: crate::daemon::handoff::Inheritance) -> anyhow::Res
             }
             startup_note!("tty7-server: adopted {kept} pane(s) from the previous build");
         }
+        // The blob is a file this process wrote and unlinked moments ago, so
+        // this is a bug rather than an accident. The shells are the cost: their
+        // ptys are still open here, held by descriptors nothing can now name,
+        // which leaves them running with no reader — #42's stranded sessions,
+        // arrived at from the other direction. They are released when this
+        // daemon exits, so a restart clears it; there is nothing safe to close
+        // in the meantime, because which descriptors they were is exactly what
+        // was lost.
         None => startup_note!(
             "tty7-server: the handoff blob was unreadable; the previous build's panes are lost"
         ),
@@ -750,6 +758,11 @@ fn handle_conn(stream: Stream, registry: Arc<Registry>) -> anyhow::Result<()> {
 
         ClientMsg::Shutdown => {
             log::info!("daemon shutting down on client request");
+            // This is the path a restart takes, so it is the one that decides
+            // whether panes come back showing anything. Ahead of the kill:
+            // `drain_and_kill` hangs up every pty, and a pane whose shell has
+            // been reaped has nothing left to photograph.
+            store_scrollback_now(&registry);
             registry.drain_and_kill();
             // The ConPTY hosts (OpenConsole.exe) are this process's children,
             // not the shells', so the per-pane kill never reaches them — and

--- a/crates/tty7-core/src/daemon/server.rs
+++ b/crates/tty7-core/src/daemon/server.rs
@@ -26,6 +26,15 @@ impl Registry {
         self.next_id.fetch_add(1, Ordering::Relaxed)
     }
 
+    /// Resume naming panes where the previous image left off.
+    ///
+    /// Reusing a number would be worse than skipping one: a client that
+    /// reconnects after a handoff is still holding the old ids, and an `Attach`
+    /// for one of them has to find the pane it means or nothing at all.
+    fn claim_ids_past(&self, next: u64) {
+        self.next_id.fetch_max(next, Ordering::Relaxed);
+    }
+
     fn seed_ids_past(&self, machine: &crate::core::machine::Machine) {
         let max = machine
             .panes
@@ -291,6 +300,11 @@ macro_rules! startup_note {
 }
 
 pub fn run_daemon() -> anyhow::Result<()> {
+    #[cfg(unix)]
+    if let Some(inheritance) = crate::daemon::handoff::requested() {
+        return run_adopting(inheritance);
+    }
+
     // Before either endpoint, and before the machine tree is opened. Whoever
     // holds this is the server; everyone else stands down while it lives.
     //
@@ -330,6 +344,121 @@ pub fn run_daemon() -> anyhow::Result<()> {
     log::info!("no control listener on this platform; serving panes only");
 
     run_with(registry)
+}
+
+/// Come up as the far side of a handoff: the panes are already running, and
+/// this image only has to recognise them.
+///
+/// The seat is adopted rather than claimed — the lock is held by this process,
+/// which is the process that held it before the exec. Claiming would ask the
+/// kernel for a lock our own descriptor already has, be refused, and take the
+/// "another server is already serving" exit, which would leave the machine with
+/// no daemon and a set of orphaned shells nobody can reach.
+#[cfg(unix)]
+fn run_adopting(inheritance: crate::daemon::handoff::Inheritance) -> anyhow::Result<()> {
+    let _seat = inheritance
+        .seat_fd
+        .map(|fd| unsafe { crate::daemon::singleton::adopt(fd) });
+    if _seat.is_none() {
+        startup_note!("tty7-server: handed over without a seat descriptor; serving unprotected");
+    }
+
+    let registry = Arc::new(Registry::new());
+
+    match crate::daemon::handoff::adopt(inheritance.blob_fd) {
+        Some(adopted) => {
+            registry.claim_ids_past(adopted.next_pane_id);
+            let mut kept = 0usize;
+            for carried in adopted.panes {
+                let id = carried.id;
+                let on_dead = reaper(registry.clone(), id);
+                match crate::daemon::pane::DaemonPane::adopt(carried, on_dead) {
+                    Ok(pane) => {
+                        registry.insert(pane);
+                        kept += 1;
+                    }
+                    // The shell is alive and this image cannot speak to its pty.
+                    // Saying so is all that can be done: the descriptor closes
+                    // when this process eventually exits, and the shell gets the
+                    // hangup it would have got from an ordinary restart.
+                    Err(e) => log::error!("pane {id} could not be adopted: {e}"),
+                }
+            }
+            startup_note!("tty7-server: adopted {kept} pane(s) from the previous build");
+        }
+        None => startup_note!(
+            "tty7-server: the handoff blob was unreadable; the previous build's panes are lost"
+        ),
+    }
+
+    {
+        let mut services = control_services();
+        services.panes = Some(registry.clone());
+        match crate::host::server::spawn_control_listener_with(
+            crate::host::local::LocalHost::shared(),
+            services,
+        ) {
+            Ok(path) => startup_note!("tty7-server: control socket at {}", path.display()),
+            Err(e) => startup_note!("tty7-server: control listener unavailable: {e}"),
+        }
+    }
+
+    run_with(registry)
+}
+
+/// Become `exe` in place, keeping every pane that can survive the crossing.
+///
+/// Returns the reason it did not happen; on success there is no return, because
+/// by then this program has been replaced by the one it was asked to become.
+#[cfg(unix)]
+fn hand_over(registry: &Registry, exe: &std::path::Path) -> anyhow::Error {
+    let mut carried = Vec::new();
+    for pane in registry.all() {
+        match pane.carry() {
+            Some(c) => carried.push(c),
+            None => {
+                // A native-SSH pane's session is cipher state in this process's
+                // memory; the socket would cross and nothing able to speak on
+                // it would. Hanging it up here means the far end sees a close
+                // rather than a connection that has stopped answering.
+                log::info!("pane {} cannot cross a handoff; closing it", pane.id);
+                kill_pane(registry, pane.id);
+            }
+        }
+    }
+
+    // The tree is what the window rebuilds itself from when it reconnects, and
+    // the reconnect happens milliseconds from now.
+    if let Some(store) = crate::core::machine::observed_store() {
+        store.flush();
+    }
+
+    crate::daemon::handoff::take_over(
+        exe,
+        carried,
+        registry.alloc_id(),
+        crate::daemon::singleton::held_fd(),
+    )
+}
+
+#[cfg(not(unix))]
+fn hand_over(_registry: &Registry, _exe: &std::path::Path) -> anyhow::Error {
+    anyhow::anyhow!(
+        "this platform has no way to replace a running program while keeping its \
+         open consoles, so the daemon has to be stopped and started"
+    )
+}
+
+/// What a pane does to the registry when its shell dies.
+fn reaper(registry: Arc<Registry>, id: u64) -> impl FnOnce() + Send + 'static {
+    move || {
+        std::thread::Builder::new()
+            .name("tty7-daemon-pane-reap".to_string())
+            .spawn(move || {
+                registry.remove(id);
+            })
+            .ok();
+    }
 }
 
 pub fn control_services() -> crate::host::server::Services {
@@ -628,6 +757,16 @@ fn handle_conn(stream: Stream, registry: Arc<Registry>) -> anyhow::Result<()> {
 
         ClientMsg::Kill { pane_id } => {
             kill_pane(&registry, pane_id);
+            Ok(())
+        }
+
+        ClientMsg::Handoff { exe } => {
+            let mut w = write_stream;
+            // Only ever returns having failed: a handoff that works replaces
+            // this program mid-call, and there is nobody left to write a reply.
+            let failure = hand_over(&registry, &exe);
+            log::error!("handoff to {} did not happen: {failure}", exe.display());
+            DaemonMsg::Error(failure.to_string()).encode(&mut w)?;
             Ok(())
         }
 

--- a/crates/tty7-core/src/daemon/shell_integration.rs
+++ b/crates/tty7-core/src/daemon/shell_integration.rs
@@ -30,6 +30,17 @@ if [[ -o interactive ]] && [[ -z "$TTY7_SHELL_INTEGRATION" ]]; then
         > "$TTY7_HISTFILE.seed" 2>/dev/null
     fi
     HISTFILE="$TTY7_HISTFILE"
+    # The exit rewrite keeps at most SAVEHIST entries, from a memory capped at
+    # HISTSIZE. Smaller than the seed, that rewrite leaves the pane's file
+    # shorter than its own seed mark — which the merge on close reads as "the
+    # file was replaced under us" and rightly refuses, losing this pane's
+    # commands. The caps only govern the pane's private file now, so raising
+    # them costs nothing. Left at zero: a user who saves no history has asked
+    # for exactly that.
+    if (( SAVEHIST > 0 )); then
+      (( SAVEHIST < 100000 )) && SAVEHIST=100000
+      (( HISTSIZE < SAVEHIST )) && HISTSIZE=$SAVEHIST
+    fi
   fi
 
   __tty7_osc() { builtin printf '\e]%s\a' "$1"; }
@@ -217,6 +228,19 @@ if [[ $- == *i* ]] && [[ -z "$TTY7_SHELL_INTEGRATION" ]]; then
         > "$TTY7_HISTFILE.seed" 2>/dev/null
     fi
     HISTFILE="$TTY7_HISTFILE"
+    # On exit bash rewrites the file from a memory capped at HISTSIZE, then
+    # truncates it to HISTFILESIZE lines — both default to 500, which is
+    # smaller than the seed. The result would be a file shorter than its own
+    # seed mark, which the merge on close reads as "replaced under us" and
+    # rightly refuses, losing this pane's commands. Both caps only govern the
+    # pane's private file now, so raising them costs nothing. Negative means
+    # unlimited and is already enough.
+    if (( ${HISTSIZE:-500} >= 0 && ${HISTSIZE:-500} < 100000 )) 2>/dev/null; then
+      HISTSIZE=100000
+    fi
+    if (( ${HISTFILESIZE:-500} >= 0 && ${HISTFILESIZE:-500} < 100000 )) 2>/dev/null; then
+      HISTFILESIZE=100000
+    fi
   fi
 
   __tty7_osc() { builtin printf '\e]%s\a' "$1"; }

--- a/crates/tty7-core/src/daemon/shell_integration.rs
+++ b/crates/tty7-core/src/daemon/shell_integration.rs
@@ -6,6 +6,32 @@ const ZSH_INTEGRATION: &str = r#"
 if [[ -o interactive ]] && [[ -z "$TTY7_SHELL_INTEGRATION" ]]; then
   export TTY7_SHELL_INTEGRATION=1
 
+  # Per-pane history, when the app asked for it. This runs after the user's
+  # .zshrc, which is the only reason it can work at all: $HISTFILE is theirs to
+  # set, wherever they like, and nothing outside this shell knew where it
+  # points until now. Seed once from there so the pane does not start blank,
+  # write down how much was seeded — everything past that mark is what this
+  # pane adds, and is what goes home when it closes — and only then repoint.
+  # zsh loads the history file after .zshrc, so the switch lands before the
+  # first line is read.
+  if [[ -n "$TTY7_HISTFILE" ]]; then
+    if [[ ! -e "$TTY7_HISTFILE" ]]; then
+      # The origin is recorded even when there is nothing to copy from it yet:
+      # a first-ever shell has no history file, and it is exactly that user
+      # whose commands would otherwise have nowhere to go when the pane closes.
+      if [[ -n "$HISTFILE" ]]; then
+        builtin printf '%s\n' "$HISTFILE" > "$TTY7_HISTFILE.origin" 2>/dev/null
+        if [[ -r "$HISTFILE" ]]; then
+          command tail -n 5000 "$HISTFILE" > "$TTY7_HISTFILE" 2>/dev/null
+        fi
+      fi
+      [[ -e "$TTY7_HISTFILE" ]] || : > "$TTY7_HISTFILE" 2>/dev/null
+      command wc -c < "$TTY7_HISTFILE" 2>/dev/null | command tr -d ' \n' \
+        > "$TTY7_HISTFILE.seed" 2>/dev/null
+    fi
+    HISTFILE="$TTY7_HISTFILE"
+  fi
+
   __tty7_osc() { builtin printf '\e]%s\a' "$1"; }
 
   # Vi mode links the `main` keymap to `viins` (`bindkey -A viins main`);
@@ -170,6 +196,28 @@ const BASH_INTEGRATION: &str = r#"
 # --- tty7 shell integration (bash) ---
 if [[ $- == *i* ]] && [[ -z "$TTY7_SHELL_INTEGRATION" ]]; then
   export TTY7_SHELL_INTEGRATION=1
+
+  # Per-pane history — see the zsh block for why this can only be done here,
+  # after the user's rc has decided where their history lives. bash loads the
+  # file after the startup files too, so repointing here still precedes the
+  # load.
+  if [[ -n "$TTY7_HISTFILE" ]]; then
+    if [[ ! -e "$TTY7_HISTFILE" ]]; then
+      # The origin is recorded even when there is nothing to copy from it yet:
+      # a first-ever shell has no history file, and it is exactly that user
+      # whose commands would otherwise have nowhere to go when the pane closes.
+      if [[ -n "$HISTFILE" ]]; then
+        builtin printf '%s\n' "$HISTFILE" > "$TTY7_HISTFILE.origin" 2>/dev/null
+        if [[ -r "$HISTFILE" ]]; then
+          command tail -n 5000 "$HISTFILE" > "$TTY7_HISTFILE" 2>/dev/null
+        fi
+      fi
+      [[ -e "$TTY7_HISTFILE" ]] || : > "$TTY7_HISTFILE" 2>/dev/null
+      command wc -c < "$TTY7_HISTFILE" 2>/dev/null | command tr -d ' \n' \
+        > "$TTY7_HISTFILE.seed" 2>/dev/null
+    fi
+    HISTFILE="$TTY7_HISTFILE"
+  fi
 
   __tty7_osc() { builtin printf '\e]%s\a' "$1"; }
   # `bind -v` reports readline's actual editing mode; `[[ -o vi ]]` misses

--- a/crates/tty7-core/src/daemon/singleton.rs
+++ b/crates/tty7-core/src/daemon/singleton.rs
@@ -52,6 +52,53 @@ fn lock_path() -> Option<PathBuf> {
     crate::core::config::config_path("daemon.lock")
 }
 
+/// The descriptor the seat is held on, for the one caller that needs it after
+/// the fact: a handoff, which has to pass it to the image it is becoming.
+///
+/// Recorded rather than threaded through because the seat is deliberately owned
+/// by `run_daemon`'s stack frame — it is released when the server stops serving,
+/// and that is the property worth keeping. `-1` means no seat is held.
+#[cfg(unix)]
+static HELD: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(-1);
+
+#[cfg(unix)]
+pub fn held_fd() -> Option<std::os::fd::RawFd> {
+    match HELD.load(std::sync::atomic::Ordering::Relaxed) {
+        -1 => None,
+        fd => Some(fd),
+    }
+}
+
+#[cfg(unix)]
+fn note_held(file: &File) {
+    HELD.store(
+        std::os::fd::AsRawFd::as_raw_fd(file),
+        std::sync::atomic::Ordering::Relaxed,
+    );
+}
+
+#[cfg(not(unix))]
+fn note_held(_file: &File) {}
+
+/// Take back a seat this process never gave up.
+///
+/// After `execve` the lock is still held — by this process, which is the same
+/// process, wearing a new program. Calling [`claim`] here would open the file a
+/// second time and ask the kernel for a lock the first descriptor still has, be
+/// told `Taken`, and stand down in favour of itself: the one way to end up with
+/// no daemon at all is to be too careful here.
+///
+/// # Safety
+///
+/// `fd` must be an open descriptor on the lock file, inherited across the exec
+/// and not owned by anything else.
+#[cfg(unix)]
+pub unsafe fn adopt(fd: std::os::fd::RawFd) -> Singleton {
+    let file = unsafe { <File as std::os::fd::FromRawFd>::from_raw_fd(fd) };
+    note_held(&file);
+    Singleton { _file: file }
+}
+
 /// Claims the right to be this machine's server.
 pub fn claim() -> Claim {
     let Some(path) = lock_path() else {
@@ -61,7 +108,10 @@ pub fn claim() -> Claim {
         let _ = std::fs::create_dir_all(parent);
     }
     match open_exclusive(&path) {
-        Ok(Some(file)) => Claim::Held(Singleton { _file: file }),
+        Ok(Some(file)) => {
+            note_held(&file);
+            Claim::Held(Singleton { _file: file })
+        }
         Ok(None) => Claim::Taken,
         Err(e) => Claim::Unavailable(format!("{} could not be locked: {e}", path.display())),
     }
@@ -79,16 +129,23 @@ fn open_exclusive(path: &std::path::Path) -> std::io::Result<Option<File>> {
         .write(true)
         .truncate(false)
         .open(path)?;
-    // LOCK_NB so a running server answers "taken" instead of parking this
-    // process on a lock it will hold until it exits.
-    let locked = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
-    if locked == 0 {
-        return Ok(Some(file));
-    }
-    let e = std::io::Error::last_os_error();
-    match e.raw_os_error() {
-        Some(libc::EWOULDBLOCK) => Ok(None),
-        _ => Err(e),
+    loop {
+        // LOCK_NB so a running server answers "taken" instead of parking this
+        // process on a lock it will hold until it exits.
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+            return Ok(Some(file));
+        }
+        let e = std::io::Error::last_os_error();
+        match e.raw_os_error() {
+            Some(libc::EWOULDBLOCK) => return Ok(None),
+            // A signal arriving mid-call says nothing about the lock. Reporting
+            // it as "could not be evaluated" would start a second server beside
+            // the first — the split machine this module exists to prevent —
+            // for no better reason than a `SIGCHLD` landing at the wrong
+            // microsecond.
+            Some(libc::EINTR) => continue,
+            _ => return Err(e),
+        }
     }
 }
 

--- a/crates/tty7-core/src/daemon/singleton.rs
+++ b/crates/tty7-core/src/daemon/singleton.rs
@@ -94,6 +94,14 @@ fn note_held(_file: &File) {}
 /// and not owned by anything else.
 #[cfg(unix)]
 pub unsafe fn adopt(fd: std::os::fd::RawFd) -> Singleton {
+    // The exec this descriptor crossed required stripping close-on-exec; put it
+    // back before anything is spawned. A child inheriting the seat holds the
+    // flock as long as it lives — an ssh transport that outlives a killed
+    // daemon would then keep every future daemon standing down in favour of a
+    // process that is not serving anyone.
+    if let Err(e) = crate::daemon::handoff::close_on_exec_again(fd) {
+        log::warn!("could not restore close-on-exec on the seat descriptor {fd}: {e}");
+    }
     let file = unsafe { <File as std::os::fd::FromRawFd>::from_raw_fd(fd) };
     note_held(&file);
     Singleton { _file: file }

--- a/crates/tty7-core/src/daemon/spawn.rs
+++ b/crates/tty7-core/src/daemon/spawn.rs
@@ -15,6 +15,13 @@ const STARTUP_TIMEOUT: Duration = Duration::from_secs(3);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(6);
+/// How long to wait for a refusal before assuming a handoff went through.
+///
+/// The daemon either execs — in which case this socket dies and the read fails
+/// at once — or writes back why it did not. Neither takes long; the timeout is
+/// only here so a daemon that hangs mid-handoff does not hang the window with
+/// it.
+const HANDOFF_TIMEOUT: Duration = Duration::from_secs(5);
 /// How long after the endpoint disappears the daemon process itself gets to
 /// finish exiting. Under a graceful shutdown this is milliseconds; the margin
 /// covers the Windows descendant reap that runs before `exit`.
@@ -317,6 +324,76 @@ fn dialect_of<S: io::Read + io::Write>(mut link: S) -> Option<DialectRefusal> {
 pub fn restart() -> anyhow::Result<()> {
     stop();
     ensure_running()
+}
+
+/// Ask the running daemon to become this build without stopping.
+///
+/// It keeps its pid, its ptys and everything running on them; what it loses is
+/// this connection, which its new image has never heard of. So the reply to a
+/// handoff that worked is the socket closing, and an actual message back means
+/// it did not happen.
+///
+/// Callers that only want the daemon to be on the current build should treat a
+/// failure here as "fall back to [`restart`]": every reason this can fail — an
+/// older daemon that does not know the message, a platform with no `execve`, an
+/// exec that was refused — leaves the daemon exactly as it was, still serving.
+pub fn hand_off() -> anyhow::Result<()> {
+    use std::io::Write as _;
+
+    if !local_daemon_supports(crate::daemon::protocol::FEATURE_HANDOFF) {
+        anyhow::bail!("the running daemon cannot replace itself in place");
+    }
+    let exe = std::env::current_exe()
+        .map_err(|e| anyhow::anyhow!("could not locate own executable: {e}"))?;
+
+    let mut stream = transport::connect()?;
+    ClientMsg::Handoff { exe: exe.clone() }.encode(&mut stream)?;
+    stream.flush()?;
+
+    let _ = stream.set_read_timeout(Some(HANDOFF_TIMEOUT));
+    match crate::daemon::protocol::DaemonMsg::read(&mut stream) {
+        // The far end is the new image, which never had this socket.
+        Err(_) => {}
+        Ok(crate::daemon::protocol::DaemonMsg::Error(why)) => {
+            anyhow::bail!("the daemon refused to hand over: {why}")
+        }
+        Ok(other) => anyhow::bail!("unexpected daemon reply to Handoff: {other:?}"),
+    }
+    drop(stream);
+
+    // The socket is rebound by the new image a moment after the exec. Until it
+    // is, connecting fails the same way it would against no daemon at all —
+    // which is exactly what `ensure_running` would misread as "start another
+    // one", so the wait belongs here rather than there.
+    let deadline = Instant::now() + STARTUP_TIMEOUT;
+    loop {
+        if let Ok(mut stream) = transport::connect() {
+            match query_daemon_version(&mut stream) {
+                VersionProbe::Speaks(v) => {
+                    let carried_on = v.build != env!("CARGO_PKG_VERSION");
+                    note_local_daemon(Some(v));
+                    if carried_on {
+                        anyhow::bail!("the daemon is still running its old build");
+                    }
+                    return Ok(());
+                }
+                _ => {
+                    note_local_daemon(None);
+                    anyhow::bail!(
+                        "the daemon that came back does not answer the version handshake"
+                    );
+                }
+            }
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "the daemon did not start listening again at {} within {:?}",
+                transport::endpoint_display(),
+                STARTUP_TIMEOUT
+            );
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
 }
 
 pub fn stop() {

--- a/crates/tty7-server/tests/handoff.rs
+++ b/crates/tty7-server/tests/handoff.rs
@@ -1,0 +1,258 @@
+//! The daemon replaces its own binary and the shells never notice.
+//!
+//! Everything else about a handoff can be checked in a unit test — the blob
+//! round-trips, the flags parse, the ids keep climbing. None of that answers
+//! the only question that matters, which is whether the process on the other
+//! end of the pty is still the same process afterwards. So this runs a real
+//! daemon, puts a real shell in a real pty, and asks the shell.
+//!
+//! The proof is a variable. `tty7_kept=…` lives in that shell's memory and
+//! nowhere else: no file has it, the daemon has never seen it, and a shell
+//! started after the handoff would answer with an empty string. Getting the
+//! value back is something only the original process can do.
+
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use tty7_core::client::PaneClient;
+use tty7_core::daemon::protocol::{DaemonMsg, ShellSpec, WinSize};
+
+const READY_WITHIN: Duration = Duration::from_secs(30);
+const STREAM_WITHIN: Duration = Duration::from_secs(30);
+
+struct Daemon {
+    child: Child,
+    dir: tempfile::TempDir,
+}
+
+impl Daemon {
+    fn start() -> Daemon {
+        let dir = tempfile::TempDir::new().unwrap();
+        let child = Command::new(Self::binary())
+            .arg("--daemon")
+            .arg("--config-dir")
+            .arg(dir.path())
+            .env("TTY7_DATA_DIR", dir.path())
+            .env("TTY7_CONTROL_SOCK", dir.path().join("control.sock"))
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("start tty7-server --daemon");
+        let daemon = Daemon { child, dir };
+        daemon.await_ready();
+        daemon
+    }
+
+    fn binary() -> PathBuf {
+        PathBuf::from(env!("CARGO_BIN_EXE_tty7-server"))
+    }
+
+    fn panes(&self) -> PaneClient {
+        PaneClient::at(self.dir.path().join("daemon.sock"))
+    }
+
+    /// The pid the daemon records for itself. An `exec` keeps it; stopping and
+    /// starting cannot.
+    fn recorded_pid(&self) -> Option<u32> {
+        std::fs::read_to_string(self.dir.path().join("daemon.pid"))
+            .ok()?
+            .trim()
+            .parse()
+            .ok()
+    }
+
+    /// A fresh uuid per program image: it is minted on first use and lives in
+    /// memory, so it survives anything except being replaced. Together with the
+    /// pid it pins down exactly what happened — same pid and a new instance is
+    /// an `exec` and nothing else.
+    fn instance(&self) -> String {
+        self.panes()
+            .version()
+            .expect("the daemon answers its version")
+            .instance
+    }
+
+    fn await_ready(&self) {
+        let deadline = Instant::now() + READY_WITHIN;
+        loop {
+            if self.panes().version().is_ok() {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "the daemon did not open its pane endpoint within {READY_WITHIN:?}"
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn size() -> WinSize {
+    WinSize {
+        cols: 100,
+        rows: 30,
+        cell_w: 8,
+        cell_h: 16,
+    }
+}
+
+fn interactive_shell() -> ShellSpec {
+    ShellSpec {
+        program: "/bin/sh".into(),
+        args: Vec::new(),
+        args_are_tty7_defaults: false,
+    }
+}
+
+fn windows_contain(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+fn collect_until(session: &mut tty7_core::client::PaneSession, marker: &[u8]) -> Vec<u8> {
+    let mut seen: Vec<u8> = Vec::new();
+    loop {
+        match session.recv() {
+            Ok(DaemonMsg::Output(bytes)) | Ok(DaemonMsg::Snapshot(bytes)) => {
+                seen.extend_from_slice(&bytes);
+                if windows_contain(&seen, marker) {
+                    return seen;
+                }
+            }
+            Ok(DaemonMsg::Exited { code }) => panic!(
+                "the pane exited ({code:?}) before {:?} appeared; saw {:?}",
+                String::from_utf8_lossy(marker),
+                String::from_utf8_lossy(&seen)
+            ),
+            Ok(_) => {}
+            Err(e) => panic!(
+                "the pane stream ended early: {e}; saw {:?}",
+                String::from_utf8_lossy(&seen)
+            ),
+        }
+    }
+}
+
+#[test]
+fn a_handoff_keeps_the_process_the_pty_and_the_shell_that_is_on_it() {
+    let daemon = Daemon::start();
+    let panes = daemon.panes();
+    let before_pid = daemon.recorded_pid().expect("the daemon records its pid");
+    let before_instance = daemon.instance();
+
+    let mut session = panes
+        .spawn(None, size(), Some(interactive_shell()), None, None)
+        .expect("spawn an interactive pane");
+    let pane_id = session.pane_id();
+    session
+        .set_recv_timeout(Some(STREAM_WITHIN))
+        .expect("bound the stream reads");
+
+    // Put something in this shell's memory that exists nowhere else, and print
+    // a marker so we know the shell has read its input before we hand over.
+    session
+        .input(b"tty7_kept=survivor; echo tty7_before_$tty7_kept\r")
+        .expect("the shell takes input");
+    collect_until(&mut session, b"tty7_before_survivor");
+    drop(session);
+
+    panes
+        .hand_off(&Daemon::binary())
+        .expect("the daemon hands over");
+    daemon.await_ready();
+
+    assert_eq!(
+        daemon.recorded_pid(),
+        Some(before_pid),
+        "an exec keeps the process; a different pid here would mean the daemon stopped and \
+         started, which is the thing this is supposed to avoid"
+    );
+    assert_ne!(
+        daemon.instance(),
+        before_instance,
+        "and a *new image* has to be what is answering — without this the test would pass just \
+         as well if the handoff had quietly done nothing at all"
+    );
+
+    let mut session = panes
+        .attach(pane_id, size())
+        .expect("the pane is still there under the same id");
+    session
+        .set_recv_timeout(Some(STREAM_WITHIN))
+        .expect("bound the stream reads");
+
+    // The replay is the ring the previous image was holding.
+    let replayed = collect_until(&mut session, b"tty7_before_survivor");
+    assert!(
+        windows_contain(&replayed, b"tty7_before_survivor"),
+        "the pane came back without the output it had before the handoff"
+    );
+
+    // And the variable. Only the shell that ran the first line can answer this;
+    // the command line echoes back unexpanded, so the expansion in the output
+    // is unambiguous.
+    session
+        .input(b"echo tty7_after_$tty7_kept\r")
+        .expect("the shell still takes input");
+    collect_until(&mut session, b"tty7_after_survivor");
+
+    session.kill().expect("kill the pane");
+}
+
+#[test]
+fn a_handoff_to_something_that_will_not_exec_leaves_the_daemon_serving() {
+    let daemon = Daemon::start();
+    let panes = daemon.panes();
+    let before_pid = daemon.recorded_pid().expect("the daemon records its pid");
+    let before_instance = daemon.instance();
+
+    let mut session = panes
+        .spawn(None, size(), Some(interactive_shell()), None, None)
+        .expect("spawn an interactive pane");
+    let pane_id = session.pane_id();
+    session
+        .set_recv_timeout(Some(STREAM_WITHIN))
+        .expect("bound the stream reads");
+    session
+        .input(b"echo tty7_still_here\r")
+        .expect("the shell takes input");
+    collect_until(&mut session, b"tty7_still_here");
+
+    let err = panes
+        .hand_off(Path::new("/nonexistent/tty7-that-is-not-there"))
+        .expect_err("a binary that cannot be executed must be reported, not assumed");
+    assert!(
+        err.to_string().contains("could not exec"),
+        "the refusal was {err}"
+    );
+
+    // The state is staged before the exec and the exec is the last step, so a
+    // failure at that step has to cost nothing at all.
+    assert_eq!(daemon.recorded_pid(), Some(before_pid));
+    assert_eq!(
+        daemon.instance(),
+        before_instance,
+        "nothing was replaced, so the same image has to still be answering"
+    );
+    session
+        .input(b"echo tty7_unharmed\r")
+        .expect("the pane still has its shell");
+    collect_until(&mut session, b"tty7_unharmed");
+    assert_eq!(
+        session.pane_id(),
+        pane_id,
+        "the pane the caller was holding is the pane it still holds"
+    );
+
+    session.kill().expect("kill the pane");
+}

--- a/crates/tty7-server/tests/handoff.rs
+++ b/crates/tty7-server/tests/handoff.rs
@@ -232,8 +232,8 @@ fn a_handoff_to_something_that_will_not_exec_leaves_the_daemon_serving() {
         .hand_off(Path::new("/nonexistent/tty7-that-is-not-there"))
         .expect_err("a binary that cannot be executed must be reported, not assumed");
     assert!(
-        err.to_string().contains("could not exec"),
-        "the refusal was {err}"
+        err.to_string().contains("cannot become"),
+        "a missing binary is refused before anything is given up; the refusal was {err}"
     );
 
     // The state is staged before the exec and the exec is the last step, so a

--- a/crates/tty7-server/tests/pane_history.rs
+++ b/crates/tty7-server/tests/pane_history.rs
@@ -27,19 +27,19 @@ impl Daemon {
     /// A daemon whose config asks for per-pane history, and whose panes get a
     /// `HOME` of their own with an rc file and a history file already in it.
     fn start() -> Daemon {
+        // Where this user keeps their history, said the way a user says it.
+        Self::with_home("HISTFILE=\"$HOME/.bash_history\"\n", "echo from_before\n")
+    }
+
+    fn with_home(bashrc: &str, history: &str) -> Daemon {
         let dir = tempfile::TempDir::new().unwrap();
         std::fs::write(
             dir.path().join("config.json"),
             r#"{"per_pane_history": true}"#,
         )
         .unwrap();
-        // Where this user keeps their history, said the way a user says it.
-        std::fs::write(
-            dir.path().join(".bashrc"),
-            "HISTFILE=\"$HOME/.bash_history\"\n",
-        )
-        .unwrap();
-        std::fs::write(dir.path().join(".bash_history"), "echo from_before\n").unwrap();
+        std::fs::write(dir.path().join(".bashrc"), bashrc).unwrap();
+        std::fs::write(dir.path().join(".bash_history"), history).unwrap();
 
         let child = Command::new(env!("CARGO_BIN_EXE_tty7-server"))
             .arg("--daemon")
@@ -211,6 +211,51 @@ fn a_pane_writes_its_own_history_and_hands_it_back_when_it_closes() {
     assert!(
         daemon.pane_history(pane_id).is_none(),
         "a closed pane leaves no file behind"
+    );
+}
+
+/// A user with more history than their caps allow — which is most users, since
+/// bash defaults both to 500. The exit rewrite keeps only the last
+/// HISTSIZE/HISTFILESIZE lines, so without the integration snippet raising the
+/// caps for the pane's private file, the file ends up shorter than its own seed
+/// mark, the merge reads that as "replaced under us", and the pane's commands
+/// silently never reach the history they were promised to.
+#[test]
+fn a_small_histfilesize_cannot_swallow_the_merge_back() {
+    let mut seed = String::new();
+    for i in 0..400 {
+        seed.push_str(&format!("echo seeded_{i}\n"));
+    }
+    let daemon = Daemon::with_home(
+        "HISTFILE=\"$HOME/.bash_history\"\nHISTSIZE=50\nHISTFILESIZE=50\n",
+        &seed,
+    );
+    let panes = daemon.panes();
+    let mut session = panes
+        .spawn(None, size(), Some(bash()), None, None)
+        .expect("spawn a bash pane");
+    session
+        .set_recv_timeout(Some(STREAM_WITHIN))
+        .expect("bound the stream reads");
+
+    session
+        .input(b"echo tty7_survives_truncation\r")
+        .expect("the shell takes input");
+    collect_until(&mut session, b"tty7_survives_truncation");
+
+    session.input(b"exit\r").expect("ask the shell to exit");
+    loop {
+        match session.recv() {
+            Ok(DaemonMsg::Exited { .. }) => break,
+            Ok(_) => {}
+            Err(e) => panic!("the pane stream ended before Exited: {e}"),
+        }
+    }
+    drop(session);
+
+    wait_until(
+        || daemon.global_history().contains("tty7_survives_truncation"),
+        "the exit rewrite truncated the pane's file below its seed and the merge dropped it",
     );
 }
 

--- a/crates/tty7-server/tests/pane_history.rs
+++ b/crates/tty7-server/tests/pane_history.rs
@@ -1,0 +1,287 @@
+//! Per-pane history, through a real shell.
+//!
+//! The daemon's half of this feature is a filename and some cleanup, and unit
+//! tests cover it. The half that can actually be wrong lives in the integration
+//! snippet: it has to run late enough to see the `HISTFILE` the user's rc set,
+//! seed from it, and repoint before the shell loads any history. Nothing but a
+//! real bash reading a real rc file can say whether that happened.
+
+#![cfg(unix)]
+
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use tty7_core::client::PaneClient;
+use tty7_core::daemon::protocol::{DaemonMsg, ShellSpec, WinSize};
+
+const READY_WITHIN: Duration = Duration::from_secs(30);
+const STREAM_WITHIN: Duration = Duration::from_secs(30);
+const SETTLE_WITHIN: Duration = Duration::from_secs(10);
+
+struct Daemon {
+    child: Child,
+    dir: tempfile::TempDir,
+}
+
+impl Daemon {
+    /// A daemon whose config asks for per-pane history, and whose panes get a
+    /// `HOME` of their own with an rc file and a history file already in it.
+    fn start() -> Daemon {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            r#"{"per_pane_history": true}"#,
+        )
+        .unwrap();
+        // Where this user keeps their history, said the way a user says it.
+        std::fs::write(
+            dir.path().join(".bashrc"),
+            "HISTFILE=\"$HOME/.bash_history\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join(".bash_history"), "echo from_before\n").unwrap();
+
+        let child = Command::new(env!("CARGO_BIN_EXE_tty7-server"))
+            .arg("--daemon")
+            .arg("--config-dir")
+            .arg(dir.path())
+            .env("HOME", dir.path())
+            .env("TTY7_DATA_DIR", dir.path())
+            .env("TTY7_CONTROL_SOCK", dir.path().join("control.sock"))
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("start tty7-server --daemon");
+        let daemon = Daemon { child, dir };
+        daemon.await_ready();
+        daemon
+    }
+
+    fn panes(&self) -> PaneClient {
+        PaneClient::at(self.dir.path().join("daemon.sock"))
+    }
+
+    fn global_history(&self) -> String {
+        std::fs::read_to_string(self.dir.path().join(".bash_history")).unwrap_or_default()
+    }
+
+    fn pane_history(&self, pane_id: u64) -> Option<String> {
+        std::fs::read_to_string(
+            self.dir
+                .path()
+                .join("history")
+                .join(format!("pane-{pane_id}")),
+        )
+        .ok()
+    }
+
+    fn await_ready(&self) {
+        let deadline = Instant::now() + READY_WITHIN;
+        loop {
+            if self.panes().version().is_ok() {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "the daemon did not open its pane endpoint within {READY_WITHIN:?}"
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn size() -> WinSize {
+    WinSize {
+        cols: 100,
+        rows: 30,
+        cell_w: 8,
+        cell_h: 16,
+    }
+}
+
+fn bash() -> ShellSpec {
+    ShellSpec {
+        program: "/bin/bash".into(),
+        args: Vec::new(),
+        args_are_tty7_defaults: false,
+    }
+}
+
+fn windows_contain(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+fn collect_until(session: &mut tty7_core::client::PaneSession, marker: &[u8]) -> Vec<u8> {
+    let mut seen: Vec<u8> = Vec::new();
+    loop {
+        match session.recv() {
+            Ok(DaemonMsg::Output(bytes)) | Ok(DaemonMsg::Snapshot(bytes)) => {
+                seen.extend_from_slice(&bytes);
+                if windows_contain(&seen, marker) {
+                    return seen;
+                }
+            }
+            Ok(DaemonMsg::Exited { code }) => panic!(
+                "the pane exited ({code:?}) before {:?} appeared; saw {:?}",
+                String::from_utf8_lossy(marker),
+                String::from_utf8_lossy(&seen)
+            ),
+            Ok(_) => {}
+            Err(e) => panic!(
+                "the pane stream ended early: {e}; saw {:?}",
+                String::from_utf8_lossy(&seen)
+            ),
+        }
+    }
+}
+
+fn wait_until(mut done: impl FnMut() -> bool, what: &str) {
+    let deadline = Instant::now() + SETTLE_WITHIN;
+    while !done() {
+        assert!(Instant::now() < deadline, "{what} within {SETTLE_WITHIN:?}");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[test]
+fn a_pane_writes_its_own_history_and_hands_it_back_when_it_closes() {
+    let daemon = Daemon::start();
+    let panes = daemon.panes();
+    let mut session = panes
+        .spawn(None, size(), Some(bash()), None, None)
+        .expect("spawn a bash pane");
+    let pane_id = session.pane_id();
+    session
+        .set_recv_timeout(Some(STREAM_WITHIN))
+        .expect("bound the stream reads");
+
+    session
+        .input(b"echo tty7_ran_here\r")
+        .expect("the shell takes input");
+    collect_until(&mut session, b"tty7_ran_here");
+
+    // Seeded from the user's file, so the pane is not starting blank.
+    wait_until(
+        || daemon.pane_history(pane_id).is_some(),
+        "the pane never got a history file of its own",
+    );
+    let seeded = daemon.pane_history(pane_id).unwrap();
+    assert!(
+        seeded.contains("echo from_before"),
+        "a pane whose history starts empty has lost the user their history; got {seeded:?}"
+    );
+
+    // Nothing has leaked into the shared file while the pane is open — that
+    // separation is the entire point of the feature.
+    assert!(
+        !daemon.global_history().contains("tty7_ran_here"),
+        "the command should be in this pane's file, not in everybody's"
+    );
+
+    // A clean exit is when bash writes its history out, and the pane closing is
+    // what makes the daemon hand it back.
+    session.input(b"exit\r").expect("ask the shell to exit");
+    loop {
+        match session.recv() {
+            Ok(DaemonMsg::Exited { .. }) => break,
+            Ok(_) => {}
+            Err(e) => panic!("the pane stream ended before Exited: {e}"),
+        }
+    }
+    drop(session);
+
+    wait_until(
+        || daemon.global_history().contains("tty7_ran_here"),
+        "the closed pane's commands never reached the history they came from",
+    );
+    let global = daemon.global_history();
+    assert_eq!(
+        global.matches("echo from_before").count(),
+        1,
+        "the seed is already there; handing it back would duplicate it. Got {global:?}"
+    );
+    assert!(
+        daemon.pane_history(pane_id).is_none(),
+        "a closed pane leaves no file behind"
+    );
+}
+
+#[test]
+fn two_panes_do_not_see_each_others_commands() {
+    let daemon = Daemon::start();
+    let panes = daemon.panes();
+
+    let mut first = panes
+        .spawn(None, size(), Some(bash()), None, None)
+        .expect("spawn the first pane");
+    let first_id = first.pane_id();
+    first
+        .set_recv_timeout(Some(STREAM_WITHIN))
+        .expect("bound the stream reads");
+    let mut second = panes
+        .spawn(None, size(), Some(bash()), None, None)
+        .expect("spawn the second pane");
+    let second_id = second.pane_id();
+    second
+        .set_recv_timeout(Some(STREAM_WITHIN))
+        .expect("bound the stream reads");
+
+    first
+        .input(b"echo tty7_first_pane\r")
+        .expect("the first shell takes input");
+    collect_until(&mut first, b"tty7_first_pane");
+    second
+        .input(b"echo tty7_second_pane\r")
+        .expect("the second shell takes input");
+    collect_until(&mut second, b"tty7_second_pane");
+
+    // `history -a` is what bash does at exit; asking for it now keeps the test
+    // from having to end either shell to look at what it has written.
+    first.input(b"history -a\r").expect("flush the first");
+    collect_until(&mut first, b"history -a");
+    second.input(b"history -a\r").expect("flush the second");
+    collect_until(&mut second, b"history -a");
+
+    wait_until(
+        || {
+            daemon
+                .pane_history(first_id)
+                .is_some_and(|h| h.contains("tty7_first_pane"))
+        },
+        "the first pane never recorded its own command",
+    );
+    wait_until(
+        || {
+            daemon
+                .pane_history(second_id)
+                .is_some_and(|h| h.contains("tty7_second_pane"))
+        },
+        "the second pane never recorded its own command",
+    );
+
+    assert!(
+        !daemon
+            .pane_history(first_id)
+            .unwrap()
+            .contains("tty7_second_pane"),
+        "the first pane is reading the second one's commands, which is the thing this replaces"
+    );
+    assert!(
+        !daemon
+            .pane_history(second_id)
+            .unwrap()
+            .contains("tty7_first_pane"),
+        "the second pane is reading the first one's commands"
+    );
+
+    panes.kill(first_id).expect("close the first pane");
+    panes.kill(second_id).expect("close the second pane");
+}

--- a/crates/tty7-server/tests/routed_pane.rs
+++ b/crates/tty7-server/tests/routed_pane.rs
@@ -110,6 +110,7 @@ fn a_routed_pane_spawns_takes_input_and_survives_a_reconnect() {
         shell: Some(plain_shell()),
         owner: None,
         workspace: None,
+        restore: None,
     }
     .encode(&mut sock)
     .unwrap();
@@ -178,6 +179,7 @@ fn a_routed_kill_reaches_the_pane_it_names() {
         shell: Some(plain_shell()),
         owner: None,
         workspace: None,
+        restore: None,
     }
     .encode(&mut sock)
     .unwrap();

--- a/src/terminal/remote.rs
+++ b/src/terminal/remote.rs
@@ -22,9 +22,9 @@ use crate::core::osc::OscTokenizer;
 use crate::daemon::protocol::{
     AuthPromptKind, AuthResponse, ClientMsg, DaemonMsg, KnownHostEntry, KnownHostId,
     LoopbackForward, LoopbackForwardId, LoopbackForwardInfo, LoopbackForwardRequest,
-    ManagedForward, NativeSshSpec, PaneProcs, RemoteContext, SftpEntry, SftpJobProgress, SftpOp,
-    SftpOpResult, SftpTransferSpec, ShellSpec, SshForwardRule, SshPhase, WinSize, WorkspaceOp,
-    WorkspaceRequest,
+    ManagedForward, NativeSshSpec, PaneProcs, RemoteContext, RestoreFrom, SftpEntry,
+    SftpJobProgress, SftpOp, SftpOpResult, SftpTransferSpec, ShellSpec, SshForwardRule, SshPhase,
+    WinSize, WorkspaceOp, WorkspaceRequest,
 };
 use crate::daemon::transport::{self, Stream};
 use gpui::EntityId;
@@ -223,7 +223,16 @@ impl RemoteTerminal {
         cwd: Option<PathBuf>,
         shell: Option<ShellSpec>,
     ) -> anyhow::Result<(Self, u64)> {
-        Self::spawn_on(&PaneRoute::Local, size, cell_w, cell_h, cwd, shell, None)
+        Self::spawn_on(
+            &PaneRoute::Local,
+            size,
+            cell_w,
+            cell_h,
+            cwd,
+            shell,
+            None,
+            None,
+        )
     }
 
     pub fn spawn_on(
@@ -234,11 +243,13 @@ impl RemoteTerminal {
         cwd: Option<PathBuf>,
         shell: Option<ShellSpec>,
         owner: Option<String>,
+        restore: Option<RestoreFrom>,
     ) -> anyhow::Result<(Self, u64)> {
         let retry_cwd = cwd.clone();
         let retry_shell = shell.clone();
         let retry_owner = owner.clone();
-        match Self::spawn_once(route, size, cell_w, cell_h, cwd, shell, owner) {
+        let retry_restore = restore.clone();
+        match Self::spawn_once(route, size, cell_w, cell_h, cwd, shell, owner, restore) {
             Ok(term) => Ok(term),
             Err(first_err) if daemon_not_listening(&first_err) => {
                 if let Err(start_err) = crate::daemon::spawn::ensure_running() {
@@ -246,7 +257,7 @@ impl RemoteTerminal {
                         "daemon not running ({first_err}); starting one failed: {start_err}"
                     ));
                 }
-                Self::spawn_once(route, size, cell_w, cell_h, retry_cwd, retry_shell, retry_owner)
+                Self::spawn_once(route, size, cell_w, cell_h, retry_cwd, retry_shell, retry_owner, retry_restore)
                     .map_err(|second_err| {
                         anyhow::anyhow!(
                             "daemon not running ({first_err}); started one but Spawn still failed: {second_err}"
@@ -261,7 +272,7 @@ impl RemoteTerminal {
                         "daemon disconnected before Spawn reply ({first_err}); restart failed: {restart_err}"
                     ));
                 }
-                Self::spawn_once(route, size, cell_w, cell_h, retry_cwd, retry_shell, retry_owner).map_err(|second_err| {
+                Self::spawn_once(route, size, cell_w, cell_h, retry_cwd, retry_shell, retry_owner, retry_restore).map_err(|second_err| {
                     anyhow::anyhow!(
                         "daemon disconnected before Spawn reply ({first_err}); restarted daemon but Spawn still failed: {second_err}"
                     )
@@ -271,6 +282,7 @@ impl RemoteTerminal {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn spawn_once(
         route: &PaneRoute,
         size: TermSize,
@@ -279,6 +291,7 @@ impl RemoteTerminal {
         cwd: Option<PathBuf>,
         shell: Option<ShellSpec>,
         owner: Option<String>,
+        restore: Option<RestoreFrom>,
     ) -> anyhow::Result<(Self, u64)> {
         let mut stream = connect_routed(route)?;
         let win = win_size(size, cell_w, cell_h);
@@ -293,12 +306,25 @@ impl RemoteTerminal {
                 )
         });
 
+        // Only the local daemon's feature list is known here; a routed spawn
+        // reaches a server whose build we have not asked about, and one that
+        // predates the field would silently drop it. Sending it anyway would
+        // cost nothing but would make the log claim a restore that never
+        // happened, so the local case is the only one that asks.
+        let restore = restore.filter(|_| {
+            route.is_local()
+                && crate::daemon::spawn::local_daemon_supports(
+                    crate::daemon::protocol::FEATURE_RESTORE_SCROLLBACK,
+                )
+        });
+
         ClientMsg::Spawn {
             cwd,
             size: win,
             shell,
             owner,
             workspace,
+            restore,
         }
         .encode(&mut stream)?;
         let pane_id = match DaemonMsg::read(&mut stream)? {

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -856,6 +856,18 @@ impl TerminalView {
         let (terminal, pane_id, shell_spec) = match attached {
             Some(parts) => parts,
             None => {
+                // The pane this one stands in for is gone, but its screen may
+                // not be: if the daemon kept a copy, the new pane opens showing
+                // it, under a line saying the shell below is new. Asking costs
+                // nothing when there is no copy — the daemon answers by
+                // spawning the blank pane it would have spawned anyway.
+                let restore = restore_pane.map(|pane_id| crate::daemon::protocol::RestoreFrom {
+                    pane_id,
+                    banner: Some(
+                        crate::ui::i18n::t(crate::ui::i18n::L10nKey::PaneRestoredScreenBanner)
+                            .to_string(),
+                    ),
+                });
                 let (terminal, id) = RemoteTerminal::spawn_on(
                     &route,
                     TermSize::new(80, 24),
@@ -864,6 +876,7 @@ impl TerminalView {
                     working_directory,
                     shell.clone(),
                     owner.map(|id| id.to_string()),
+                    restore,
                 )?;
                 (terminal, id, shell)
             }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1409,10 +1409,21 @@ impl Tty7App {
     }
 
     pub(crate) fn restart_daemon(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        // Two different actions wearing one name. Where the service can rewrite
+        // itself in place, nothing in a pane is interrupted and promising the
+        // user a bloodbath would be a lie that costs them the feature; where it
+        // cannot, every running command really does end, and that is the one
+        // thing they need to be told before they agree.
+        let in_place =
+            crate::daemon::spawn::local_daemon_supports(crate::daemon::protocol::FEATURE_HANDOFF);
         let answer = window.prompt(
             PromptLevel::Warning,
             t(L10nKey::AppRestartServerTitle),
-            Some(t(L10nKey::AppRestartServerBody)),
+            Some(t(if in_place {
+                L10nKey::AppRestartServerBodyInPlace
+            } else {
+                L10nKey::AppRestartServerBody
+            })),
             &crate::ui::confirm_answers(
                 t(L10nKey::AppRestart),
                 t(crate::ui::i18n::L10nKey::Cancel),
@@ -1443,7 +1454,20 @@ impl Tty7App {
                 return;
             }
             let restarted = cx
-                .background_spawn(async move { crate::daemon::spawn::restart() })
+                .background_spawn(async move {
+                    // In place if it can be: the panes and everything running
+                    // in them carry straight over. Every way this fails leaves
+                    // the daemon serving exactly as it was, so falling back to
+                    // stopping and starting it loses nothing that was not
+                    // already going to be lost.
+                    match crate::daemon::spawn::hand_off() {
+                        Ok(()) => Ok(()),
+                        Err(e) => {
+                            log::info!("service could not hand over in place ({e}); restarting it");
+                            crate::daemon::spawn::restart()
+                        }
+                    }
+                })
                 .await;
             let _ = this.update_in(cx, |this, window, cx| {
                 match &restarted {

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -2491,6 +2491,14 @@ impl Tty7App {
         self.update_config(cx, |cfg| cfg.restore_session = on);
     }
 
+    /// The daemon reads this from the config file on its own — it is the one
+    /// holding the output — so there is nothing to tell it here. Turning it off
+    /// also removes what was already stored, which the daemon does on its next
+    /// pass rather than leaving the bytes behind.
+    pub(crate) fn set_persist_scrollback(&mut self, on: bool, cx: &mut Context<Self>) {
+        self.update_config(cx, |cfg| cfg.persist_scrollback = on);
+    }
+
     pub(crate) fn set_show_tray_icon(&mut self, on: bool, cx: &mut Context<Self>) {
         self.update_config(cx, |cfg| cfg.show_tray_icon = on);
     }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -2523,6 +2523,12 @@ impl Tty7App {
         self.update_config(cx, |cfg| cfg.persist_scrollback = on);
     }
 
+    /// Takes effect on the next pane: a shell is told where its history lives
+    /// when it starts, and nothing can move it afterwards.
+    pub(crate) fn set_per_pane_history(&mut self, on: bool, cx: &mut Context<Self>) {
+        self.update_config(cx, |cfg| cfg.per_pane_history = on);
+    }
+
     pub(crate) fn set_show_tray_icon(&mut self, on: bool, cx: &mut Context<Self>) {
         self.update_config(cx, |cfg| cfg.show_tray_icon = on);
     }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1455,17 +1455,20 @@ impl Tty7App {
             }
             let restarted = cx
                 .background_spawn(async move {
-                    // In place if it can be: the panes and everything running
-                    // in them carry straight over. Every way this fails leaves
-                    // the daemon serving exactly as it was, so falling back to
-                    // stopping and starting it loses nothing that was not
-                    // already going to be lost.
-                    match crate::daemon::spawn::hand_off() {
-                        Ok(()) => Ok(()),
-                        Err(e) => {
-                            log::info!("service could not hand over in place ({e}); restarting it");
-                            crate::daemon::spawn::restart()
-                        }
+                    // The same test that chose the dialog's copy chooses the
+                    // action, because the copy is a promise. A daemon that
+                    // advertises the handoff was described as replacing itself
+                    // with nothing interrupted — if that fails, the failure is
+                    // shown, not silently traded for the restart that kills
+                    // every pane the user was just told would live. The
+                    // stop-and-start path is only taken where its bloodbath is
+                    // what the dialog actually said.
+                    if crate::daemon::spawn::local_daemon_supports(
+                        crate::daemon::protocol::FEATURE_HANDOFF,
+                    ) {
+                        crate::daemon::spawn::hand_off()
+                    } else {
+                        crate::daemon::spawn::restart()
                     }
                 })
                 .await;

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -1340,6 +1340,17 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         }
         L10nKey::Replace => "Replace",
         L10nKey::SftpErrorInvalidOctalMode => "invalid octal mode",
+        L10nKey::PaneRestoredScreenBanner => {
+            "restored screen — this shell is new, nothing above it is still running"
+        }
+        L10nKey::SettingsPersistScrollback => "Keep pane output on disk",
+        L10nKey::SettingsPersistScrollbackDescription => {
+            "If the background service dies without warning — a crash, or a reboot — panes come \
+             back showing what was on them instead of blank. The processes are gone either way; \
+             this restores the picture. It writes a capped tail of every pane's output to disk, \
+             including anything printed there: tokens, the output of `env`, an agent's \
+             transcript. Off means that output only ever lives in memory."
+        }
         L10nKey::PanelMoreChangedFiles => {
             "… and {count} more changed files — run git diff to see them."
         }

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -1340,6 +1340,18 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         }
         L10nKey::Replace => "Replace",
         L10nKey::SftpErrorInvalidOctalMode => "invalid octal mode",
+        L10nKey::SettingsDaemonStaleDescInPlace => {
+            "tty7 was updated in place, so the app is new but your panes are still served by the \
+             previous build. The server can replace itself with the new one without stopping: \
+             your shells and whatever is running in them carry straight over. Panes on tty7's \
+             built-in SSH client are the exception — those connections close and need reopening."
+        }
+        L10nKey::AppRestartServerBodyInPlace => {
+            "The background server replaces itself with this build without stopping. Your shells \
+             keep running — commands, agents and `ssh` sessions in a pane are not interrupted — \
+             and the window reconnects to them a moment later. Panes on tty7's built-in SSH \
+             client are the exception: those connections close and need reopening."
+        }
         L10nKey::PaneRestoredScreenBanner => {
             "restored screen — this shell is new, nothing above it is still running"
         }

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -1355,6 +1355,13 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         L10nKey::PaneRestoredScreenBanner => {
             "restored screen — this shell is new, nothing above it is still running"
         }
+        L10nKey::SettingsPerPaneHistory => "Give each pane its own shell history",
+        L10nKey::SettingsPerPaneHistoryDescription => {
+            "Up walks through what you ran in this pane, instead of an interleaving of every \
+             pane. A new pane starts from your existing history rather than blank, and what it \
+             adds is written back when it closes, so nothing is lost. Applies to bash and zsh \
+             panes that tty7 can set up; a shell started with your own arguments is left alone."
+        }
         L10nKey::SettingsPersistScrollback => "Keep pane output on disk",
         L10nKey::SettingsPersistScrollbackDescription => {
             "If the background service dies without warning — a crash, or a reboot — panes come \

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -1387,6 +1387,18 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         }
         L10nKey::Replace => "置き換える",
         L10nKey::SftpErrorInvalidOctalMode => "無効な 8 進数モードです",
+        L10nKey::SettingsDaemonStaleDescInPlace => {
+            "tty7 はその場で更新されたため、アプリは新しくても、ペインは前のビルドが提供したままです。\
+             サーバーは停止せずに新しいビルドへ自分自身を置き換えられます。\
+             シェルとその中で動いているものはそのまま引き継がれます。\
+             tty7 内蔵の SSH クライアントを使うペインだけは例外で、その接続は閉じられ、開き直しが必要です"
+        }
+        L10nKey::AppRestartServerBodyInPlace => {
+            "バックグラウンドサーバーは停止せずに、自分自身をこのビルドに置き換えます。\
+             シェルは動いたままで、ペイン内のコマンド・エージェント・`ssh` セッションは中断されません。\
+             ウィンドウはすぐに再接続します。\
+             tty7 内蔵の SSH クライアントを使うペインだけは例外で、その接続は閉じられ、開き直しが必要です"
+        }
         L10nKey::PaneRestoredScreenBanner => {
             "復元された画面 — 以下は新しいシェルで、これより上のものは動いていません"
         }

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -1387,6 +1387,17 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         }
         L10nKey::Replace => "置き換える",
         L10nKey::SftpErrorInvalidOctalMode => "無効な 8 進数モードです",
+        L10nKey::PaneRestoredScreenBanner => {
+            "復元された画面 — 以下は新しいシェルで、これより上のものは動いていません"
+        }
+        L10nKey::SettingsPersistScrollback => "ペインの出力をディスクに残す",
+        L10nKey::SettingsPersistScrollbackDescription => {
+            "バックグラウンドサービスが引き継ぎの間もなく落ちた場合（クラッシュや再起動）、\
+             ペインは空ではなく、そこにあった内容を表示して戻ります。プロセスはいずれにせよ失われ、\
+             ここで戻るのは画面だけです。各ペインの出力の末尾を上限つきでディスクに書き込みます。\
+             そこに表示されたもの（トークン、`env` の出力、エージェントの記録）も含みます。\
+             オフなら、その出力はメモリ上にしか存在しません。"
+        }
         L10nKey::PanelMoreChangedFiles => {
             "… さらに変更されたファイル {count} 個 — 表示するには `git diff` を実行してください"
         }

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -1402,6 +1402,12 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         L10nKey::PaneRestoredScreenBanner => {
             "復元された画面 — 以下は新しいシェルで、これより上のものは動いていません"
         }
+        L10nKey::SettingsPerPaneHistory => "ペインごとに独自のシェル履歴を持たせる",
+        L10nKey::SettingsPerPaneHistoryDescription => {
+            "上キーでたどるのは、すべてのペインが混ざったものではなく、このペインで実行したコマンドです。\
+             新しいペインは空ではなく既存の履歴から始まり、追加された分はペインを閉じるときに書き戻されるので失われません。\
+             tty7 が設定できる bash と zsh のペインが対象で、独自の引数で起動したシェルはそのままです"
+        }
         L10nKey::SettingsPersistScrollback => "ペインの出力をディスクに残す",
         L10nKey::SettingsPersistScrollbackDescription => {
             "バックグラウンドサービスが引き継ぎの間もなく落ちた場合（クラッシュや再起動）、\

--- a/src/ui/i18n/mod.rs
+++ b/src/ui/i18n/mod.rs
@@ -1108,6 +1108,8 @@ l10n_keys! {
     Replace,
     SftpErrorInvalidOctalMode,
     PaneRestoredScreenBanner,
+    AppRestartServerBodyInPlace,
+    SettingsDaemonStaleDescInPlace,
     SettingsPersistScrollback,
     SettingsPersistScrollbackDescription,
 }

--- a/src/ui/i18n/mod.rs
+++ b/src/ui/i18n/mod.rs
@@ -1112,6 +1112,8 @@ l10n_keys! {
     SettingsDaemonStaleDescInPlace,
     SettingsPersistScrollback,
     SettingsPersistScrollbackDescription,
+    SettingsPerPaneHistory,
+    SettingsPerPaneHistoryDescription,
 }
 
 pub fn set_locale(gui_language: &str) {

--- a/src/ui/i18n/mod.rs
+++ b/src/ui/i18n/mod.rs
@@ -1107,6 +1107,9 @@ l10n_keys! {
     SftpReplaceBody,
     Replace,
     SftpErrorInvalidOctalMode,
+    PaneRestoredScreenBanner,
+    SettingsPersistScrollback,
+    SettingsPersistScrollbackDescription,
 }
 
 pub fn set_locale(gui_language: &str) {

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -1273,6 +1273,15 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         L10nKey::SftpReplaceBody => "{names} 在这个文件夹里已经存在，上传会覆盖它们。",
         L10nKey::Replace => "覆盖",
         L10nKey::SftpErrorInvalidOctalMode => "无效的八进制模式",
+        L10nKey::PaneRestoredScreenBanner => {
+            "已恢复的画面 —— 下面是新的 shell，上面的内容都已不在运行"
+        }
+        L10nKey::SettingsPersistScrollback => "把面板输出留在磁盘上",
+        L10nKey::SettingsPersistScrollbackDescription => {
+            "后台服务如果没来得及交接就没了（崩溃、重启机器），面板回来时会显示原先的内容，而不是一片空白。\
+             进程无论如何都救不回来，这里恢复的只是画面。它会把每个面板输出的末尾（有上限）写到磁盘上，\
+             包括那里打印过的一切：token、`env` 的输出、agent 的对话记录。关掉则这些输出只存在于内存里。"
+        }
         L10nKey::PanelMoreChangedFiles => "…还有 {count} 个变更文件——运行 git diff 查看。",
         L10nKey::PanelUntracked => "{count} 个未跟踪文件",
         L10nKey::AppMenuAbout => "关于 tty7",

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -1286,6 +1286,12 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         L10nKey::PaneRestoredScreenBanner => {
             "已恢复的画面 —— 下面是新的 shell，上面的内容都已不在运行"
         }
+        L10nKey::SettingsPerPaneHistory => "每个面板用自己的 shell 历史",
+        L10nKey::SettingsPerPaneHistoryDescription => {
+            "上方向键翻的是这个面板里跑过的命令，而不是所有面板混在一起的结果。\
+             新面板会从你已有的历史开始，而不是一片空白；面板关闭时，它新增的部分会写回原来的历史文件，不会丢。\
+             只对 tty7 能接管的 bash 和 zsh 面板生效；用你自己参数启动的 shell 不受影响。"
+        }
         L10nKey::SettingsPersistScrollback => "把面板输出留在磁盘上",
         L10nKey::SettingsPersistScrollbackDescription => {
             "后台服务如果没来得及交接就没了（崩溃、重启机器），面板回来时会显示原先的内容，而不是一片空白。\

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -1273,6 +1273,16 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         L10nKey::SftpReplaceBody => "{names} 在这个文件夹里已经存在，上传会覆盖它们。",
         L10nKey::Replace => "覆盖",
         L10nKey::SftpErrorInvalidOctalMode => "无效的八进制模式",
+        L10nKey::SettingsDaemonStaleDescInPlace => {
+            "tty7 是原地更新的，所以应用是新的，但你的面板仍由上一个版本在服务。\
+             server 可以在不停止的情况下把自己换成新版本：你的 shell 和里面正在跑的东西会直接延续下来。\
+             用 tty7 内置 SSH 客户端的面板除外——那些连接会断开，需要重新打开。"
+        }
+        L10nKey::AppRestartServerBodyInPlace => {
+            "后台 server 会在不停止的情况下把自己换成当前这个版本。\
+             你的 shell 会继续运行——面板里的命令、agent、`ssh` 会话都不会被打断——窗口稍后会重新连上它们。\
+             用 tty7 内置 SSH 客户端的面板除外：那些连接会断开，需要重新打开。"
+        }
         L10nKey::PaneRestoredScreenBanner => {
             "已恢复的画面 —— 下面是新的 shell，上面的内容都已不在运行"
         }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -5734,6 +5734,15 @@ impl Tty7App {
         });
         let failure = update_status.failure.clone();
         let stale_daemon = crate::daemon::spawn::local_daemon_stale_build();
+        // Whether picking up the new build costs the user their running panes
+        // decides what this offer is, so it decides what it says.
+        let stale_daemon_note = if crate::daemon::spawn::local_daemon_supports(
+            crate::daemon::protocol::FEATURE_HANDOFF,
+        ) {
+            L10nKey::SettingsDaemonStaleDescInPlace
+        } else {
+            L10nKey::SettingsDaemonStaleDesc
+        };
         let check_for_updates = cx.global::<Config>().check_for_updates;
         let auto_download = cx.global::<Config>().auto_download_updates;
         let channel_idx = match cx.global::<Config>().update_channel {
@@ -6072,7 +6081,7 @@ impl Tty7App {
                                     div()
                                         .text_xs()
                                         .text_color(muted_fg)
-                                        .child(t(L10nKey::SettingsDaemonStaleDesc)),
+                                        .child(t(stale_daemon_note)),
                                 )
                                 .child(
                                     h_flex().child(

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -4732,6 +4732,7 @@ impl Tty7App {
             NewTabPosition::End => 1,
         };
         let restore_session = cfg.restore_session;
+        let persist_scrollback = cfg.persist_scrollback;
         let remember_window_size = cfg.remember_window_size;
         let show_tray_icon = cfg.show_tray_icon;
         let tab_bar_idx = match cfg.tab_bar_position {
@@ -4791,6 +4792,10 @@ impl Tty7App {
         let restore_switch = crate::ui::theme::switch("wt-restore-session", cx)
             .checked(restore_session)
             .on_click(cx.listener(|this, on: &bool, _w, cx| this.set_restore_session(*on, cx)))
+            .into_any_element();
+        let persist_scrollback_switch = crate::ui::theme::switch("wt-persist-scrollback", cx)
+            .checked(persist_scrollback)
+            .on_click(cx.listener(|this, on: &bool, _w, cx| this.set_persist_scrollback(*on, cx)))
             .into_any_element();
         let remember_window_switch = crate::ui::theme::switch("wt-remember-window", cx)
             .checked(remember_window_size)
@@ -4883,6 +4888,12 @@ impl Tty7App {
                 t(L10nKey::SettingsRestoreLastLayout),
                 t(L10nKey::SettingsRestoreLastLayoutDesc),
                 restore_switch,
+                cx,
+            ))
+            .child(self.settings_row(
+                t(L10nKey::SettingsPersistScrollback),
+                t(L10nKey::SettingsPersistScrollbackDescription),
+                persist_scrollback_switch,
                 cx,
             ))
             .child(self.settings_row(

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -4438,6 +4438,7 @@ impl Tty7App {
         let option_as_alt = cfg.macos_option_as_alt;
         let tab_completion = cfg.tab_completion;
         let history_search = cfg.history_search;
+        let per_pane_history = cfg.per_pane_history;
         let smart_select = cfg.smart_select;
         let copy_on_select = cfg.copy_on_select;
         let clip_trim = cfg.clipboard_trim_trailing_spaces;
@@ -4449,6 +4450,10 @@ impl Tty7App {
         let history_search_switch = crate::ui::theme::switch("term-history-search", cx)
             .checked(history_search)
             .on_click(cx.listener(|this, on: &bool, _w, cx| this.set_history_search(*on, cx)))
+            .into_any_element();
+        let per_pane_history_switch = crate::ui::theme::switch("term-per-pane-history", cx)
+            .checked(per_pane_history)
+            .on_click(cx.listener(|this, on: &bool, _w, cx| this.set_per_pane_history(*on, cx)))
             .into_any_element();
         let smart_select_switch = crate::ui::theme::switch("term-smart-select", cx)
             .checked(smart_select)
@@ -4493,6 +4498,12 @@ impl Tty7App {
                 t(L10nKey::SettingsHistorySearch),
                 t(L10nKey::SettingsHistorySearchDesc),
                 history_search_switch,
+                cx,
+            ))
+            .child(self.settings_row(
+                t(L10nKey::SettingsPerPaneHistory),
+                t(L10nKey::SettingsPerPaneHistoryDescription),
+                per_pane_history_switch,
                 cx,
             ))
             .child(self.section_rule(cx))


### PR DESCRIPTION
Closes #420.

Three separable pieces of what that issue asks for: the daemon can now upgrade itself without killing anything, panes come back showing what was on them after a death nobody chose, and a pane can keep its own shell history.

## Before / After

| | Before | After |
|---|---|---|
| Settings → Restart Server | Every shell, agent and SSH session on the machine is killed; tabs come back with fresh shells | The server replaces itself with the new build in place. Shells keep running, commands are not interrupted, the window reconnects a moment later (unix) |
| "The background server is still running \<old build\>" | Offers a restart that ends every process in your panes | Offers an in-place upgrade that ends nothing. Copy differs by what the platform can actually do |
| Server crashes / `kill -9` / reboot | Panes come back blank | Panes come back showing their last screen, under a rule saying the shell below is new (opt-in) |
| A pane's screen | Lives only in daemon memory | Optionally a capped tail on disk: 256 KiB per pane, 0600, written only when the ring moved |
| Up-arrow in a pane | Walks every pane's commands interleaved | Optionally walks only this pane's, seeded from your real history and merged back when the pane closes (opt-in, bash/zsh) |
| `flock` interrupted by a signal | Read as "cannot evaluate the lock" → a second daemon starts beside the first | Retried |

Both new settings default to **off**. Persisting pane output writes whatever a pane printed — echoed tokens, `env` output, agent transcripts — to disk, and that is the user's call to make. Per-pane history changes what a terminal has always done, and someone who did not ask for it would experience it as their history forgetting the other window.

## Why

Restarting the daemon kills every pane because the pty master is a descriptor the daemon holds: when the process goes, the slave side raises `SIGHUP`. No amount of state on disk changes that — a stored screen cannot bring back a process. `execve` can: it replaces the image while keeping the process, so the descriptors, the children, the file locks and the signal mask all survive, and the shells never learn that the code on the other end of their pty was swapped.

That splits the problem cleanly. The handoff covers every restart anyone schedules — app updates, protocol bumps, picking up a stale build — and nothing is lost on those paths. Scrollback persistence covers only what a handoff cannot: the deaths where the process runs no code on its way out. Doing it in that order is also what keeps the persistence layer cheap: it is a periodic snapshot rather than a write-through of every pty byte, because the common case never needs it.

## How the handoff works

```mermaid
sequenceDiagram
    participant W as Window
    participant D as daemon (pid 4242)
    participant S as shell (pty)
    W->>D: Handoff { exe }
    D->>D: carry() every pane: fd, child pid, ring, cwd, agent
    D->>D: stage blob in an unlinked file
    D->>D: clear FD_CLOEXEC on masters, blob, seat
    D->>D: execve(exe, --daemon --handoff N --handoff-seat M)
    Note over D,S: same pid, same pty, same shell — no SIGHUP
    D->>D: adopt(N): rebuild panes over the inherited descriptors
    W--xD: old socket died with the image
    W->>D: Attach { pane_id } → replays the ring, finds the pane alive
```

Three things cannot cross, and are handled rather than hidden:

- **Native SSH panes** — their session is cipher state in memory, so they are hung up before the exec and the far end sees a clean close. Said plainly in the dialog copy.
- **Client connections** — the window reconnects and reattaches by pane id, the path it already uses after any restart. This time the attach finds the pane alive.
- **Windows** — no `execve`, and a ConPTY handle cannot be handed to another process. It keeps the stop/start path, keeps the old copy, and relies on the scrollback snapshot instead.

The singleton seat travels on the command line rather than inside the blob: the lock is still held by this process, so the new image must adopt the descriptor instead of asking for the lock again. Asking would be refused by its own lock and it would stand down in favour of itself — losing panes is a bad afternoon, exiting leaves the machine with no daemon at all.

## Per-pane history

The seeding is done by the shell, not the daemon, and that is the only reason it works. `HISTFILE` belongs to the user's rc file and can point anywhere, long after the pane's environment was decided. tty7's integration snippet is appended to the rc it wraps, so it runs after that decision and is the one place the real path is known: it copies the tail, records how much it copied, and repoints. Both bash and zsh load history after their startup files, so the switch lands before the first line is read. The daemon's half is a filename, a rename when a restored pane inherits its predecessor's file, a merge on close, and a sweep for panes a killed daemon never retired.

## Testing

- `cargo test` green across the workspace (1190 + 919 + integration suites); `cargo fmt --check` clean; no clippy warnings in the new files.
- **`crates/tty7-server/tests/handoff.rs`** — sets `tty7_kept=survivor` in a real shell, hands over, reads it back. Nothing but the original process can answer that. Also asserts the pid is unchanged *and* the daemon's instance id changed, so the test cannot pass if the handoff quietly did nothing. Second case: a handoff to a binary that cannot be executed leaves the daemon serving, the pane alive and the pid and instance untouched.
- **`crates/tty7-server/tests/pane_history.rs`** — real bash reading a real `.bashrc`: the pane is seeded from the user's history, its command does *not* reach the shared file while the pane is open, it does after a clean exit, the seed is not duplicated, and two panes cannot see each other's commands.
- Unit tests for the snapshot format (round-trip, truncation, head-trimming), the ring seed and the restore preamble, the handoff blob (per-pane offsets, unreadable blob refused, flags in both spellings, the staged file having no name), history merge-back (only the delta, a shrunk file left alone, a non-absolute origin refused, carry across a restore), and adopting a descriptor that is not a terminal.
