### PR TITLE
fix(settings): keep one restart button for the stale background server

### DIFF
--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -6075,37 +6075,7 @@ impl Tty7App {
                                 .into_any_element(),
                             cx,
                         ),
-                    )
-                    // The other half of an in-place update: the app is new, the
-                    // process serving every pane is not. Shown rather than
-                    // prompted — restarting it ends the user's running work,
-                    // which is not a thing to ask for on tty7's initiative.
-                    .when_some(stale_daemon, |this, build| {
-                        this.child(
-                            v_flex()
-                                .gap_1()
-                                .child(div().text_sm().text_color(foreground).child(t_fmt(
-                                    L10nKey::SettingsDaemonStale,
-                                    &[("build", &build)],
-                                )))
-                                .child(
-                                    div()
-                                        .text_xs()
-                                        .text_color(muted_fg)
-                                        .child(t(stale_daemon_note)),
-                                )
-                                .child(
-                                    h_flex().child(
-                                        Button::new("restart-stale-daemon")
-                                            .label(t(L10nKey::SettingsRestartServer))
-                                            .small()
-                                            .on_click(cx.listener(|this, _, window, cx| {
-                                                this.restart_daemon(window, cx)
-                                            })),
-                                    ),
-                                ),
-                        )
-                    }),
+                    ),
             )
             .child(self.settings_row(
                 t(L10nKey::SettingsAppHttpProxy),
@@ -6118,11 +6088,30 @@ impl Tty7App {
             .child(
                 v_flex()
                     .gap_2()
+                    // The other half of an in-place update: the app is new, the
+                    // process serving every pane is not. Said here rather than
+                    // beside the update controls, so the one button that offers
+                    // to pick the new build up stays the only one on the page.
+                    .when_some(stale_daemon.as_deref(), |this, build| {
+                        this.child(
+                            div()
+                                .text_sm()
+                                .text_color(foreground)
+                                .child(t_fmt(L10nKey::SettingsDaemonStale, &[("build", build)])),
+                        )
+                    })
                     .child(
                         div()
                             .text_sm()
                             .text_color(muted_fg)
-                            .child(t(L10nKey::SettingsServerDesc)),
+                            // A stale server has a more specific thing to say
+                            // than the section's standing description, and it
+                            // ends with the same button.
+                            .child(t(if stale_daemon.is_some() {
+                                stale_daemon_note
+                            } else {
+                                L10nKey::SettingsServerDesc
+                            })),
                     )
                     .child(
                         h_flex().child(


### PR DESCRIPTION
Settings → About showed two identical "Restart server…" buttons whenever the background server was left on the pre-update build. This folds the stale-build notice into the Server section so only one remains.

| | Before | After |
|---|---|---|
| Stale server after an in-place update | Notice + explanation + `Restart server…` inside Updates, and a second `Restart server…` in Server below it | One notice line under the **Server** header, one `Restart server…` button |
| Server section description (stale) | Generic "Restarts the background server that keeps your shells running…" | `stale_daemon_note` — the handoff or the stop-and-start wording, whichever the running server earned |
| Server section description (not stale) | Generic text | Unchanged |
| Buttons wired to `restart_daemon` on the page | 2 | 1 |

Both buttons already called the same `restart_daemon`, and both blocks of copy explained what picking up the new build costs. The information that the server is stale is not redundant — the second button and the duplicated explanation were. Putting the notice where the control lives keeps the one action that touches every running pane to a single place on the page.

Rebased onto #449, so the note the Server section shows is still the one that tells the truth about the running server: the in-place handoff wording where the daemon advertises `FEATURE_HANDOFF`, the stop-and-start wording where it does not.

## Testing

- `cargo build -p tty7`, `cargo fmt --check` clean.
- No l10n changes: the stale button already reused `SettingsRestartServer`, and `SettingsDaemonStale` / `SettingsDaemonStaleDesc` / `SettingsDaemonStaleDescInPlace` are all still used.
