### PR TITLE
fix(windows): give the pane grip and drags in flight a cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shows through the whole workspace, and the settings panel stays opaque.
   macOS and Linux keep the existing blur toggle.
 
+### Fixed
+
+- **Drag cursors on Windows** — the grip on a pane's top edge, and a sidebar
+  group being dragged, now change the pointer on Windows too. Win32 ships no
+  open- or closed-hand cursor and gpui answers both with the plain arrow, so
+  the grip read as ordinary background and a drag in flight gave the pointer
+  nothing to say; both now use the pointing hand there, and hovering the grip
+  no longer hands the cursor back to the arrow the moment the drag it
+  advertised begins.
+
 ## [26.8.2] - 2026-08-09
 
 ### Added

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -5960,10 +5960,18 @@ impl Render for Tty7App {
                 self.drop_pane(from, zone, window, cx);
             }
         }
+        // Windows has no closed-hand cursor and gpui answers `ClosedHand` with
+        // the plain arrow there, which would drop the grip's pointing hand the
+        // instant the drag it advertised began.
+        let held = if cfg!(target_os = "windows") {
+            gpui::CursorStyle::PointingHand
+        } else {
+            gpui::CursorStyle::ClosedHand
+        };
         if (self.reorder.borrow().is_some() || self.pane_drag.borrow().is_some())
-            && cx.active_drag_cursor_style() != Some(gpui::CursorStyle::ClosedHand)
+            && cx.active_drag_cursor_style() != Some(held)
         {
-            cx.set_active_drag_cursor_style(gpui::CursorStyle::ClosedHand, window);
+            cx.set_active_drag_cursor_style(held, window);
         }
         let vertical = matches!(cx.global::<Config>().tab_bar_position, TabBarPosition::Left)
             && !self.tabs.is_empty();

--- a/src/ui/pane_drag.rs
+++ b/src/ui/pane_drag.rs
@@ -32,6 +32,7 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
+use gpui::prelude::FluentBuilder as _;
 use gpui::{
     App, AppContext, Bounds, Context, EntityId, InteractiveElement, IntoElement, ParentElement,
     Pixels, Point, Render, StatefulInteractiveElement, Styled, Window, div, point, px, size,
@@ -140,7 +141,7 @@ pub(crate) fn handle(pane: EntityId, state: &PaneDragState, cx: &App) -> gpui::A
                 .flex()
                 .items_center()
                 .justify_center()
-                .cursor_grab()
+                .map(crate::ui::reorder::cursor_grab)
                 .tooltip(|window, cx| {
                     Tooltip::new(t(L10nKey::PaneDragHandleTooltip)).build(window, cx)
                 })

--- a/src/ui/reorder.rs
+++ b/src/ui/reorder.rs
@@ -1,9 +1,22 @@
-use gpui::{Axis, Bounds, Pixels, Point, px};
+use gpui::{Axis, Bounds, Pixels, Point, Styled, px};
 use std::cell::{Cell, RefCell};
 use std::path::PathBuf;
 use std::rc::Rc;
 
 pub(crate) type ReorderState = Rc<RefCell<Option<Reorder>>>;
+
+/// The cursor for a grip you pick up and drag. Win32 ships no open-hand
+/// cursor, and gpui's Windows backend quietly answers `OpenHand` with the
+/// plain arrow — so a grip there would look like ordinary background. The
+/// pointing hand is the closest thing Windows has that still reads as
+/// "this responds to the mouse".
+pub(crate) fn cursor_grab<E: Styled>(el: E) -> E {
+    if cfg!(target_os = "windows") {
+        el.cursor_pointer()
+    } else {
+        el.cursor_grab()
+    }
+}
 
 pub(crate) struct Preview {
     pub(crate) order: Vec<usize>,

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -797,12 +797,7 @@ impl Tty7App {
                     .text_size(px(11.))
                     .text_color(cx.theme().muted_foreground)
                     .when_some(group_slot, |header, slot| {
-                        let header = if cfg!(target_os = "windows") {
-                            header.cursor_pointer()
-                        } else {
-                            header.cursor_grab()
-                        };
-                        header.on_drag(DragGroup, {
+                        crate::ui::reorder::cursor_grab(header).on_drag(DragGroup, {
                             let state = self.reorder.clone();
                             let slots = group_slots.clone();
                             move |_drag, grab, _window, cx| {


### PR DESCRIPTION
Hovering a pane's drag grip on Windows left the pointer as the plain arrow, so the grip read as ordinary background — nothing said it could be picked up.

## Why

gpui's Win32 backend maps only IBeam / Crosshair / PointingHand / the resize family / OperationNotAllowed to real cursors; everything else falls through to `IDC_ARROW` (`gpui_windows/src/util.rs`). `OpenHand` (`cursor_grab()`) and `ClosedHand` are both in that fall-through.

The sidebar's group header had already hit this and carried a local `cfg!(target_os = "windows")` branch to `cursor_pointer()`. The grip added in #445 didn't, and neither did the drag-in-flight cursor — `set_active_drag_cursor_style(ClosedHand)` degrades to the arrow too, so even where the hover cursor worked the pointer went back to default the instant the drag it advertised began.

## What changed

- `reorder::cursor_grab` — the sidebar's workaround lifted into one shared helper: `cursor_grab()` off Windows, `cursor_pointer()` on it.
- The pane grip (`pane_drag::handle`) and the sidebar group header both call it; the header's inline branch is gone.
- `Tty7App::render` picks the held cursor per platform: `PointingHand` on Windows, `ClosedHand` elsewhere. This covers sidebar group drags as well as pane drags, which share that line.

No behaviour change on macOS or Linux — same two cursor styles as before.

## Testing

`cargo check --bin tty7-app` passes. The cursor itself needs a real pointer over the grip to see; not covered by a test.
