### PR TITLE
feat(splits): draw the pane grip as Ghostty draws its own

### DIFF
--- a/src/ui/pane.rs
+++ b/src/ui/pane.rs
@@ -107,9 +107,9 @@ pub(crate) struct PaneChrome {
     /// Whether a pane can be picked up and put somewhere else. False for a tab
     /// holding one pane: there is nowhere to move it to.
     pub rearrangeable: bool,
-    /// The pane the pointer is over. The leaves write it as the pointer crosses
-    /// them and the same frame's siblings read it, so only the pane under the
-    /// pointer offers its drag handle.
+    /// The pane whose top edge the pointer is near. The leaves write it as the
+    /// pointer crosses their reveal bands and the same frame's siblings read
+    /// it, so at most one grip is ever drawn.
     pub hovered: Rc<Cell<Option<gpui::EntityId>>>,
     /// The pane being dragged, drawn faded where it came from.
     pub lifted: Option<gpui::EntityId>,
@@ -830,41 +830,41 @@ impl Pane<PaneSlot> {
                 let id = v.entity_id();
                 let focused = v.contains_focused(window, cx);
                 let lifted = chrome.lifted == Some(id);
-                let handle = chrome.rearrangeable
-                    && chrome.lifted.is_none()
-                    && chrome.hovered.get() == Some(id);
+                let grip = chrome.rearrangeable && chrome.lifted.is_none();
+                // Whatever fading the pane is under is worn by what it holds,
+                // not by the pane: a grip dimmed along with the pane it belongs
+                // to would be faintest on exactly the panes being reached for.
+                let fade = if lifted {
+                    Some(0.45)
+                } else if chrome.dim_inactive && !focused {
+                    Some(0.55)
+                } else {
+                    None
+                };
+                let content =
+                    div()
+                        .size_full()
+                        .when_some(fade, |d, f| d.opacity(f))
+                        .map(|d| match v {
+                            PaneSlot::Ready(t) => d.child(t.clone()),
+                            PaneSlot::Connecting(p) => d.child(p.clone()),
+                        });
                 div()
-                    // An id only so the pane can hear the pointer arrive and
-                    // leave; it adds no listener of its own, so everything the
-                    // terminal below reacts to still reaches it.
-                    .id(("pane-leaf", id.as_u64() as usize))
                     .size_full()
                     .relative()
                     .overflow_hidden()
-                    .when(chrome.dim_inactive && !focused, |d| d.opacity(0.55))
-                    .when(lifted, |d| d.opacity(0.45))
                     .when(chrome.rearrangeable, |d| {
-                        d.pt(px(crate::ui::pane_drag::HANDLE_STRIP)).on_hover({
-                            let hovered = chrome.hovered.clone();
-                            move |over, window, _cx| {
-                                let next = match (*over, hovered.get() == Some(id)) {
-                                    (true, _) => Some(id),
-                                    (false, true) => None,
-                                    // Left a pane the pointer had already left:
-                                    // the enter of its neighbour got here first.
-                                    (false, false) => return,
-                                };
-                                hovered.set(next);
-                                window.refresh();
-                            }
-                        })
+                        d.pt(px(crate::ui::pane_drag::HANDLE_STRIP))
                     })
-                    .map(|d| match v {
-                        PaneSlot::Ready(t) => d.child(t.clone()),
-                        PaneSlot::Connecting(p) => d.child(p.clone()),
-                    })
-                    .when(handle, |d| {
-                        d.child(crate::ui::pane_drag::handle(id, &chrome.drag, cx))
+                    .child(content)
+                    .when(grip, |d| {
+                        d.child(crate::ui::pane_drag::reveal_band(id, &chrome.hovered))
+                            .child(crate::ui::pane_drag::handle(
+                                id,
+                                chrome.hovered.get() == Some(id),
+                                &chrome.drag,
+                                cx,
+                            ))
                     })
                     .into_any_element()
             }

--- a/src/ui/pane_drag.rs
+++ b/src/ui/pane_drag.rs
@@ -31,11 +31,13 @@
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
+use std::time::Duration;
 
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
-    App, AppContext, Bounds, Context, EntityId, InteractiveElement, IntoElement, ParentElement,
-    Pixels, Point, Render, StatefulInteractiveElement, Styled, Window, div, point, px, size,
+    Animation, AnimationExt as _, App, AppContext, Bounds, Context, EntityId, InteractiveElement,
+    IntoElement, ParentElement, Pixels, Point, Render, StatefulInteractiveElement, Styled, Window,
+    div, point, px, size,
 };
 use gpui_component::ActiveTheme as _;
 use gpui_component::tooltip::Tooltip;
@@ -43,29 +45,58 @@ use gpui_component::tooltip::Tooltip;
 use crate::ui::i18n::{L10nKey, t};
 use crate::ui::pane::{Dir, Pane};
 
-/// The grip a pane is picked up by: a target big enough to aim at, holding a
-/// bar small enough to ignore. The bar grows into the target under the pointer,
-/// so the affordance is quiet until it is the thing being reached for.
-const GRIP_TARGET: (f32, f32) = (56., 10.);
-const GRIP_IDLE: (f32, f32) = (22., 3.);
-const GRIP_LIVE: (f32, f32) = (40., 5.);
+/// The grip a pane is picked up by, cut to the shape Ghostty gives its own: a
+/// target wide enough to aim at without looking, holding three dots small
+/// enough to forget.
+///
+/// The target is there for as long as the pane can be moved — only the dots
+/// come and go. Something the pointer can already grab before it can be seen
+/// is what makes the mark itself free to stay this quiet.
+const GRIP_TARGET: (f32, f32) = (80., 12.);
+const GRIP_DOTS: usize = 3;
+const GRIP_DOT: f32 = 3.;
+const GRIP_DOT_GAP: f32 = 3.;
 
-/// The name the bar watches for the pointer under. One name for every pane:
+/// Where the dots sit in the target: up against its top edge, not centred in
+/// it. The rest of the target is reach, not mark.
+const GRIP_DOT_TOP: f32 = 2.;
+
+/// The dots with the pointer somewhere in the band, and with it on the grip
+/// itself. Nothing but the ink changes between the two: a grip that grew or
+/// moved as the pointer closed in would be aiming at where it used to be.
+const GRIP_IDLE: f32 = 0.3;
+const GRIP_LIVE: f32 = 0.8;
+
+/// Long enough to read as the dots arriving rather than as a flicker, short
+/// enough to be over before a pointer crossing the band has settled.
+const GRIP_FADE_MS: u64 = 150;
+
+/// The name the dots watch for the pointer under. One name for every pane:
 /// a group resolves to the nearest ancestor that carries it, which is always
-/// the grip the bar is inside.
+/// the grip the dots are inside.
 const GRIP_GROUP: &str = "pane-grip";
+
+/// How much of a pane, down from its top edge, asks for the grip.
+///
+/// The pointer only has to be *near* the top of a pane, not on the grip, for
+/// the dots to show — which is the whole reason a mark this quiet is findable.
+/// A share of the pane rather than a fixed strip, so a short pane answers over
+/// most of its top and a tall one over a slice, with a floor under it so the
+/// band can never be thinner than the grip it is meant to reveal.
+const REVEAL_SHARE: f32 = 0.2;
+const REVEAL_MIN: f32 = 24.;
 
 /// The strip a rearrangeable pane keeps clear above its grid for the grip.
 ///
 /// Held open for as long as the tab has panes to rearrange, rather than only
-/// while the grip shows: the grid is measured from this box, so opening the
+/// while the dots show: the grid is measured from this box, so opening the
 /// strip on hover would reflow the terminal every time the pointer crossed a
 /// pane. Better to spend it once, when the tab gains its second pane and is
-/// being reflowed anyway — which is also why it is sized to the *bar* and not
-/// to the target around it. The target's last couple of pixels hang over the
-/// top of the grid, where they cost a sliver of one row's clicks and cover
+/// being reflowed anyway — which is also why it is sized to the *dots* and not
+/// to the target around them. The target's last few pixels hang over the top
+/// of the grid, where they cost a sliver of one row's clicks and cover
 /// nothing, rather than being paid for in blank space above every pane.
-pub(crate) const HANDLE_STRIP: f32 = GRIP_LIVE.1 + 3.;
+pub(crate) const HANDLE_STRIP: f32 = GRIP_DOT_TOP + GRIP_DOT + 2.;
 
 /// How much of a pane, in from a side that is also the tab's own edge, still
 /// means "beside everything else" rather than "split this pane".
@@ -121,10 +152,20 @@ impl Render for DragPane {
     }
 }
 
-/// The grip along a pane's top edge, offered while the pointer is over that
-/// pane. Dragging it picks the pane up.
-pub(crate) fn handle(pane: EntityId, state: &PaneDragState, cx: &App) -> gpui::AnyElement {
+/// The grip along a pane's top edge. Dragging it picks the pane up.
+///
+/// Offered for as long as the pane can be moved; `revealed` says only whether
+/// the dots are drawn. A pointer that goes straight for the top of a pane can
+/// press the grip on the frame it arrives, without waiting to be told the
+/// thing it is already on is there.
+pub(crate) fn handle(
+    pane: EntityId,
+    revealed: bool,
+    state: &PaneDragState,
+    cx: &App,
+) -> gpui::AnyElement {
     let state = state.clone();
+    let ink = cx.theme().foreground;
     div()
         .absolute()
         .top_0()
@@ -139,8 +180,9 @@ pub(crate) fn handle(pane: EntityId, state: &PaneDragState, cx: &App) -> gpui::A
                 .w(px(GRIP_TARGET.0))
                 .h(px(GRIP_TARGET.1))
                 .flex()
-                .items_center()
+                .items_start()
                 .justify_center()
+                .pt(px(GRIP_DOT_TOP))
                 .map(crate::ui::reorder::cursor_grab)
                 .tooltip(|window, cx| {
                     Tooltip::new(t(L10nKey::PaneDragHandleTooltip)).build(window, cx)
@@ -154,25 +196,64 @@ pub(crate) fn handle(pane: EntityId, state: &PaneDragState, cx: &App) -> gpui::A
                     begin(&state, pane);
                     cx.new(|_| DragPane)
                 })
-                .child(
-                    // The id is what lets the bar *grow*, not just recolour:
-                    // gpui settles a group-hover size at layout time, and the
-                    // only record of the group being hovered that survives from
-                    // one frame's paint to the next frame's layout is the
-                    // element state an id buys.
-                    div()
-                        .id(("pane-drag-grip", pane.as_u64() as usize))
-                        .w(px(GRIP_IDLE.0))
-                        .h(px(GRIP_IDLE.1))
-                        .rounded_full()
-                        .bg(cx.theme().border.opacity(0.7))
-                        .group_hover(GRIP_GROUP, |s| {
-                            s.w(px(GRIP_LIVE.0))
-                                .h(px(GRIP_LIVE.1))
-                                .bg(cx.theme().drag_border)
-                        }),
-                ),
+                .when(revealed, |d| d.child(dots(pane, ink))),
         )
+        .into_any_element()
+}
+
+/// The mark itself, fading up as it arrives.
+///
+/// Only the ink answers the pointer, and it can do that from paint: a group
+/// hover that had to settle a *size* would need the element state an id buys,
+/// because the record of the group being hovered has to survive from one
+/// frame's paint into the next frame's layout.
+fn dots(pane: EntityId, ink: gpui::Hsla) -> impl IntoElement {
+    div()
+        .flex()
+        .gap(px(GRIP_DOT_GAP))
+        .children((0..GRIP_DOTS).map(move |_| {
+            div()
+                .size(px(GRIP_DOT))
+                .rounded_full()
+                .bg(ink.opacity(GRIP_IDLE))
+                .group_hover(GRIP_GROUP, move |s| s.bg(ink.opacity(GRIP_LIVE)))
+        }))
+        .with_animation(
+            ("pane-grip-fade", pane.as_u64() as usize),
+            Animation::new(Duration::from_millis(GRIP_FADE_MS)).with_easing(gpui::ease_out_quint()),
+            |dots, delta| dots.opacity(delta),
+        )
+}
+
+/// The band across the top of a pane that reveals its grip.
+///
+/// It draws nothing and takes nothing: an ordinary hitbox does not stand in
+/// front of the ones beneath it, so the terminal under the band still reads
+/// its own presses, its own selection and its own links.
+pub(crate) fn reveal_band(
+    pane: EntityId,
+    hovered: &Rc<Cell<Option<EntityId>>>,
+) -> gpui::AnyElement {
+    let hovered = hovered.clone();
+    div()
+        .id(("pane-grip-band", pane.as_u64() as usize))
+        .absolute()
+        .top_0()
+        .left_0()
+        .right_0()
+        .h(gpui::relative(REVEAL_SHARE))
+        .min_h(px(REVEAL_MIN))
+        .on_hover(move |over, window, _cx| {
+            let next = match (*over, hovered.get() == Some(pane)) {
+                (true, _) => Some(pane),
+                (false, true) => None,
+                // Left a band the pointer had already left: the enter of a
+                // neighbour's got here first.
+                (false, false) => return,
+            };
+            hovered.set(next);
+            window.refresh();
+        })
         .into_any_element()
 }
 


### PR DESCRIPTION
Redraws the grip a split pane is picked up by in the shape Ghostty gives its own grab handle: three quiet dots, a wide target around them, and a band along the pane's top edge that reveals them.

| | Before | After |
|---|---|---|
| The mark | A 22x3 pill that grew to 40x5 under the pointer | Three 3px dots, 80x12 of reach around them, same size in both states |
| Its ink | `border` @0.7, recoloured to `drag_border` on hover | `foreground` @0.3 in the band, @0.8 on the grip |
| When it shows | Pointer anywhere in the pane | Pointer in the pane's top fifth, floored at 24px |
| When it can be grabbed | Only once it had shown | Always, while the pane can be moved — the dots are all that come and go |
| Arrival | Appears in one frame | Fades up over 150ms |
| A pane faded by `dim_inactive_panes` | Grip faded with it | Grip stays at full strength |
| Strip reserved above the grid | 8px | 7px |

## Why

The old grip was loud in the wrong places. It put a mark on top of the terminal wherever the mouse happened to rest, and the one thing it did on approach was move — a target that grows under a pointer already aiming at it is a target aiming at where it used to be. Ghostty's answer is the opposite: an ellipsis that never changes shape, kept near the top edge where the gesture starts, with a hit area that is always live so the affordance is free to stay faint.

The two behavioural notes worth reviewing:

* **The reveal band draws nothing and takes nothing.** It is an ordinary gpui hitbox, and an ordinary hitbox does not stand in front of the ones beneath it (`HitboxBehavior::Normal`), so presses, selection and link hovering in the top of a terminal are untouched. Only `BlockMouse`/`occlude` would have changed that.
* **The pane's fade moved onto its content.** `dim_inactive_panes` and the lifted-pane fade used to sit on the pane element, which took the grip down with it — faintest on exactly the panes being reached for. Ghostty hoists its handle above the unfocused overlay for the same reason.

## Testing

* `cargo build -p tty7`, `cargo fmt --check` clean.
* `cargo test -p tty7 pane_drag` — 9 tests pass. The geometry the tests cover (`zone_at`, `landing`, `leaf_bounds`) is untouched; this PR only changes what is drawn and what reveals it.
* Accepted by hand on a split tab, in an isolated dev instance (`--config-dir`).
