### PR TITLE
fix(search): wash a match in the accent, at a strength the theme can afford

### DIFF
--- a/src/terminal/element.rs
+++ b/src/terminal/element.rs
@@ -232,6 +232,22 @@ fn active_selection_bg(cx: &gpui::App) -> Rgb {
     }
 }
 
+/// What a search match is washed with.
+///
+/// The theme's accent, not the terminal palette's selection colour. A hit and a
+/// selection are different things, and washing both from the same tint left the
+/// only difference between them a few percent of luminance — on a grid that is
+/// already grey on grey, that reads as "slightly dirty background", not as "the
+/// thing you searched for". The accent is the one colour the terminal surface
+/// has nothing else in, and `legible_accent` has already floored it at 3:1
+/// against the background, so the wash always has somewhere to travel.
+fn match_tint(cx: &gpui::App) -> u32 {
+    match cx.try_global::<crate::ui::presets::ActiveAccent>() {
+        Some(a) => a.0,
+        None => pack_rgb(active_selection_bg(cx)),
+    }
+}
+
 struct PaintColors {
     default_fg: Hsla,
     default_bg: Hsla,
@@ -239,7 +255,6 @@ struct PaintColors {
     selection_bg: Hsla,
     match_bg: Hsla,
     current_match_bg: Hsla,
-    current_match_border: Hsla,
     fg_rgb: Rgb,
     bg_rgb: Rgb,
 }
@@ -254,21 +269,25 @@ impl PaintColors {
             c.a = 0.24;
             c
         };
-        // Opaque, and solved for a fixed contrast against the background
-        // rather than a fixed alpha: the selection tint is only 24% away from
-        // the background to begin with, so a 0.32 alpha landed 7% off it in
-        // every theme — on a white one the matches were all but invisible.
-        let bg_packed = pack_rgb(super::palette::hsla_to_rgb(default_bg));
-        let tint = pack_rgb(active_selection_bg(cx));
+        // Opaque, and solved for a contrast against the background rather than
+        // a fixed alpha: the selection tint is only 24% away from the
+        // background to begin with, so a 0.32 alpha landed 7% off it in every
+        // theme — on a white one the matches were all but invisible. How far
+        // the wash may travel is the theme's to say (`match_wash_targets`),
+        // since the glyph on top of it pays for every step.
+        let fg_rgb = super::palette::hsla_to_rgb(default_fg);
+        let bg_rgb = super::palette::hsla_to_rgb(default_bg);
+        let bg_packed = pack_rgb(bg_rgb);
+        let tint = match_tint(cx);
+        let (hit_target, current_target) =
+            crate::ui::presets::match_wash_targets(bg_packed, pack_rgb(fg_rgb));
         let match_bg = to_hsla(unpack_rgb(crate::ui::presets::wash(
-            bg_packed,
-            tint,
-            crate::ui::presets::MATCH_WASH,
+            bg_packed, tint, hit_target,
         )));
         let current_match_bg = to_hsla(unpack_rgb(crate::ui::presets::wash(
             bg_packed,
             tint,
-            crate::ui::presets::CURRENT_MATCH_WASH,
+            current_target,
         )));
         Self {
             default_fg,
@@ -277,9 +296,8 @@ impl PaintColors {
             selection_bg,
             match_bg,
             current_match_bg,
-            current_match_border: caret,
-            fg_rgb: super::palette::hsla_to_rgb(default_fg),
-            bg_rgb: super::palette::hsla_to_rgb(default_bg),
+            fg_rgb,
+            bg_rgb,
         }
     }
 }
@@ -313,7 +331,6 @@ fn paint_cell_runs(
     geom: &CellGeom,
     buf: &[RenderCell],
     color: Hsla,
-    border: Option<Hsla>,
     mut covered: impl FnMut(&RenderCell) -> bool,
 ) {
     for row in 0..geom.rows {
@@ -332,11 +349,7 @@ fn paint_cell_runs(
                     break;
                 }
             }
-            let rect = geom.cell_rect(row, start, col - start);
-            window.paint_quad(fill(rect, color));
-            if let Some(b) = border {
-                window.paint_quad(outline(rect, b, BorderStyle::Solid));
-            }
+            window.paint_quad(fill(geom.cell_rect(row, start, col - start), color));
         }
     }
 }
@@ -1564,24 +1577,22 @@ impl Element for TerminalElement {
         window.with_content_mask(Some(ContentMask { bounds }), |window| {
             paint_backgrounds(window, &geom, &buf);
             if snap.any_selected {
-                paint_cell_runs(window, &geom, &buf, colors.selection_bg, None, |c| {
-                    c.selected
-                });
+                paint_cell_runs(window, &geom, &buf, colors.selection_bg, |c| c.selected);
             }
             if snap.any_match {
-                paint_cell_runs(window, &geom, &buf, colors.match_bg, None, |c| {
+                paint_cell_runs(window, &geom, &buf, colors.match_bg, |c| {
                     c.match_hit && !c.match_current
                 });
             }
             if snap.any_current {
-                paint_cell_runs(
-                    window,
-                    &geom,
-                    &buf,
-                    colors.current_match_bg,
-                    Some(colors.current_match_border),
-                    |c| c.match_current,
-                );
+                // Fill only. The current match used to carry a caret-coloured
+                // outline as well, because a wash it could only be 2.1:1 off the
+                // background had no way to say "this one" on its own. Now that
+                // it is the accent at the top of the theme's budget, the outline
+                // is the same colour saying the same thing a second time.
+                paint_cell_runs(window, &geom, &buf, colors.current_match_bg, |c| {
+                    c.match_current
+                });
             }
             paint_glyphs(
                 window,
@@ -1664,7 +1675,7 @@ impl Element for TerminalElement {
                 };
                 paint_backgrounds(window, &sg, row);
                 if snap.any_selected {
-                    paint_cell_runs(window, &sg, row, colors.selection_bg, None, |c| c.selected);
+                    paint_cell_runs(window, &sg, row, colors.selection_bg, |c| c.selected);
                 }
                 paint_glyphs(
                     window,
@@ -1795,7 +1806,6 @@ mod tests {
             selection_bg: Hsla::default(),
             match_bg: Hsla::default(),
             current_match_bg: Hsla::default(),
-            current_match_border: Hsla::default(),
             fg_rgb: Rgb {
                 r: 17,
                 g: 17,
@@ -2565,7 +2575,6 @@ mod tests {
             selection_bg: wash(0.55),
             match_bg: wash(0.32),
             current_match_bg: wash(0.85),
-            current_match_border: to_hsla(fg),
             fg_rgb: fg,
             bg_rgb: bg,
         }

--- a/src/ui/presets.rs
+++ b/src/ui/presets.rs
@@ -487,13 +487,38 @@ pub(crate) fn is_lighter(a: u32, b: u32) -> bool {
 
 const ACCENT_FLOOR: f32 = 3.0;
 
-/// How far a search match's wash has to stand off the background it sits on,
-/// and how much further the one you are looking at has to stand off the rest.
+/// What the glyph painted on top of a match wash keeps for itself.
 ///
-/// These are non-text ratios: enough to spot a block at a glance without
-/// drowning the glyph on top of it.
-pub(crate) const MATCH_WASH: f32 = 1.45;
-pub(crate) const CURRENT_MATCH_WASH: f32 = 2.1;
+/// WCAG's non-text ratio, not its text one. A match is a state you read
+/// *through* for a moment, not a surface you set body copy on — and holding the
+/// glyph at 4.5:1 is not a choice this can make anyway: three of the builtins
+/// only give their own text 6.6:1, which caps the wash at 1.46:1. That is a
+/// hairline's worth of shift (a hairline is 1.5:1) spread over a whole cell,
+/// and it is what made a match impossible to find by scanning.
+const GLYPH_FLOOR: f32 = 3.0;
+
+/// The two ends of what a wash is allowed to be, whatever the theme.
+///
+/// The floor buys the weakest palettes a match you can actually see, at the
+/// price of a glyph that dips under `GLYPH_FLOOR` on one. The ceiling stops the
+/// strongest from painting what reads as a solid block rather than a highlight.
+const WASH_FLOOR: f32 = 1.9;
+const WASH_CEILING: f32 = 3.2;
+
+/// How far a search match's wash stands off the background it sits on, and how
+/// much further the one you are looking at stands off the rest. Returned as
+/// `(hit, current)` contrast targets.
+///
+/// Derived from the theme rather than fixed, because the budget being spent is
+/// the theme's: a palette with 21:1 between its text and its background can
+/// afford a wash you cannot miss, and one with 6.6:1 cannot. A single constant
+/// has to be safe for the second, which leaves the first with nothing.
+pub(crate) fn match_wash_targets(bg: u32, fg: u32) -> (f32, f32) {
+    let current = (contrast(fg, bg) / GLYPH_FLOOR).clamp(WASH_FLOOR, WASH_CEILING);
+    // The plain hits are the crowd the current one has to read out of, so they
+    // get a little over half the distance it travels.
+    (1.0 + (current - 1.0) * 0.55, current)
+}
 
 /// The opacity at which `tint` over `surface` first reaches `target` contrast,
 /// as a blended colour.
@@ -1856,13 +1881,14 @@ mod tests {
                 faint(bg, fg)
             );
             let tint = mix(bg, fg, 0.24);
-            let w = wash(bg, tint, MATCH_WASH);
+            let (hit, current) = match_wash_targets(bg, fg);
+            let w = wash(bg, tint, hit);
             assert!(
-                contrast(w, bg) >= MATCH_WASH - 0.02,
+                contrast(w, bg) >= hit - 0.02,
                 "{:.2}:1 on {bg:06x}",
                 contrast(w, bg)
             );
-            let cur = wash(bg, tint, CURRENT_MATCH_WASH);
+            let cur = wash(bg, tint, current);
             assert!(
                 contrast(cur, bg) > contrast(w, bg),
                 "the current match has to stand out from the rest"
@@ -1871,10 +1897,64 @@ mod tests {
     }
 
     #[test]
+    fn a_low_contrast_theme_gets_a_gentler_wash_than_a_high_contrast_one() {
+        let (soft_hit, soft_cur) = match_wash_targets(0x282c34, 0xabb2bf);
+        let (hard_hit, hard_cur) = match_wash_targets(0x000000, 0xffffff);
+        assert!(
+            soft_cur < hard_cur && soft_hit < hard_hit,
+            "the wash spends the theme's own contrast budget, so it has to \
+             scale with it: {soft_cur:.2} vs {hard_cur:.2}"
+        );
+        assert!(
+            soft_hit >= 1.45,
+            "even the gentle end has to beat the flat constant it replaced"
+        );
+        assert!(hard_cur <= WASH_CEILING, "a highlight, not a solid block");
+    }
+
+    #[test]
+    fn a_match_wash_leaves_the_glyph_painted_on_top_of_it_readable() {
+        // The wash is opaque and the text is drawn over it, so every step up in
+        // visibility is a step down in the contrast the glyph has left. This is
+        // the ceiling both targets are chosen against — on every builtin, and
+        // in the accent the terminal actually washes with.
+        for t in builtins() {
+            let n = t.neutrals();
+            let (hit_t, cur_t) = match_wash_targets(n.background, n.foreground);
+            let hit = wash(n.background, n.accent, hit_t);
+            let cur = wash(n.background, n.accent, cur_t);
+            for (label, fill) in [("hit", hit), ("current", cur)] {
+                // `wash` bisects to *at least* its target and 8-bit channels do
+                // not divide evenly, so a fill can sit a hair past where the
+                // target asked for it — and the glyph pays that hair.
+                assert!(
+                    contrast(n.foreground, fill) >= GLYPH_FLOOR - 0.05,
+                    "{}: text on a {label} is {:.2}:1",
+                    t.id,
+                    contrast(n.foreground, fill)
+                );
+            }
+            assert!(
+                contrast(hit, n.background) > 1.5,
+                "{}: a hit only shifts {:.2}:1 off the background — a hairline",
+                t.id,
+                contrast(hit, n.background)
+            );
+            assert!(
+                contrast(cur, hit) >= 1.2,
+                "{}: the current match only reads {:.2}:1 apart from the rest",
+                t.id,
+                contrast(cur, hit)
+            );
+        }
+    }
+
+    #[test]
     fn a_wash_whose_tint_cannot_reach_the_target_still_lands_on_something_legible() {
         // A theme whose selection colour is its background: no alpha gets there.
-        let w = wash(0xffffff, 0xfefefe, MATCH_WASH);
-        assert!(contrast(w, 0xffffff) >= MATCH_WASH - 0.02, "{w:06x}");
+        let (hit, _) = match_wash_targets(0xffffff, 0x111111);
+        let w = wash(0xffffff, 0xfefefe, hit);
+        assert!(contrast(w, 0xffffff) >= hit - 0.02, "{w:06x}");
     }
 
     #[test]


### PR DESCRIPTION
A search match was too faint to find by scanning. It is now washed in the theme's accent rather than the terminal palette's selection colour, at a strength derived from the theme instead of a flat constant.

| | Before | After |
|---|---|---|
| Match tint | Terminal palette's **selection** colour — a hit read as a weaker selection | Theme **accent** (`ActiveAccent`, the one behind `ring`/`drag_border`) |
| Wash strength | Fixed `MATCH_WASH = 1.45` / `CURRENT_MATCH_WASH = 2.1` for every theme | `match_wash_targets(bg, fg)`, derived from the theme's own text contrast, clamped 1.9–3.2 |
| Current match | Washed fill **+ caret-coloured outline** | Washed fill only |

What the derivation lands on:

| Theme | Text contrast | Hit (was 1.45) | Current (was 2.1) |
|---|---|---|---|
| `light` | 18.9:1 | 2.21 | 3.2 |
| `dark` | 21.0:1 | 2.21 | 3.2 |
| `catppuccin_latte` | 7.1:1 | 1.74 | 2.35 |
| `one_dark_pro` | 6.6:1 | 1.65 | 2.19 |

## Why

The wash is opaque and the glyph is drawn on top of it, so every step toward visibility is a step the text loses. That is the whole constraint, and a single constant cannot serve both ends of it: `one_dark_pro`, `rose_pine_dawn` and `catppuccin_latte` only give their own body text ~6.6:1, so holding the glyph at 4.5:1 there caps the wash at **1.46:1** — which is under what a hairline is worth (1.5:1), spread over a whole cell. That cap is where 1.45 came from, and it was then charged to every theme, including the ones with 21:1 to spend.

So the budget being spent is the theme's, and the target is derived from it: the glyph keeps `GLYPH_FLOOR` (3:1 — WCAG's non-text ratio, because a match is a state you read *through* for a moment, not a surface you set body copy on), and the wash gets the rest. Both ends are clamped so the weakest palette still shows something and the strongest does not paint a solid block.

The tint change is orthogonal and free: hue costs the glyph no contrast at all, and the accent is the one colour the terminal surface has nothing else in. Note this needs the `ActiveAccent` global, not `cx.theme().accent` — in tty7 the latter is a neutral surface tint, not the brand accent.

The outline on the current match existed to compensate for a fill that could only be 2.1:1 off the background. With the fill now at the top of the theme's budget, and `theme.caret` itself derived from the accent, it was the same colour saying the same thing a second time.

## Testing

- `a_match_wash_leaves_the_glyph_painted_on_top_of_it_readable` (new) — for every builtin theme, in the accent it actually washes with: the glyph clears `GLYPH_FLOOR` on both a hit and the current match, a hit clears a hairline off the background, and the current match reads apart from the rest.
- `a_low_contrast_theme_gets_a_gentler_wash_than_a_high_contrast_one` (new) — guards that the targets scale with the theme's budget and stay inside the clamps.
- `a_match_wash_is_visible_on_a_white_theme_and_a_black_one`, `a_wash_whose_tint_cannot_reach_the_target_still_lands_on_something_legible` — updated to the derived targets.
- Full suite: 1337 passed, `cargo fmt --check` clean.
- Verified by hand in an isolated dev instance (`--config-dir /tmp/t7dev`) with seeded scrollback: ⌘F on a term with several hits, checked the hits stand off the background and the current one stands off the hits.
