### PR TITLE
fix(ui): let the overlay scrollbars fade out again

### DIFF
--- a/src/terminal/element.rs
+++ b/src/terminal/element.rs
@@ -232,6 +232,22 @@ fn active_selection_bg(cx: &gpui::App) -> Rgb {
     }
 }
 
+/// What a search match is washed with.
+///
+/// The theme's accent, not the terminal palette's selection colour. A hit and a
+/// selection are different things, and washing both from the same tint left the
+/// only difference between them a few percent of luminance — on a grid that is
+/// already grey on grey, that reads as "slightly dirty background", not as "the
+/// thing you searched for". The accent is the one colour the terminal surface
+/// has nothing else in, and `legible_accent` has already floored it at 3:1
+/// against the background, so the wash always has somewhere to travel.
+fn match_tint(cx: &gpui::App) -> u32 {
+    match cx.try_global::<crate::ui::presets::ActiveAccent>() {
+        Some(a) => a.0,
+        None => pack_rgb(active_selection_bg(cx)),
+    }
+}
+
 struct PaintColors {
     default_fg: Hsla,
     default_bg: Hsla,
@@ -239,7 +255,6 @@ struct PaintColors {
     selection_bg: Hsla,
     match_bg: Hsla,
     current_match_bg: Hsla,
-    current_match_border: Hsla,
     fg_rgb: Rgb,
     bg_rgb: Rgb,
 }
@@ -254,21 +269,25 @@ impl PaintColors {
             c.a = 0.24;
             c
         };
-        // Opaque, and solved for a fixed contrast against the background
-        // rather than a fixed alpha: the selection tint is only 24% away from
-        // the background to begin with, so a 0.32 alpha landed 7% off it in
-        // every theme — on a white one the matches were all but invisible.
-        let bg_packed = pack_rgb(super::palette::hsla_to_rgb(default_bg));
-        let tint = pack_rgb(active_selection_bg(cx));
+        // Opaque, and solved for a contrast against the background rather than
+        // a fixed alpha: the selection tint is only 24% away from the
+        // background to begin with, so a 0.32 alpha landed 7% off it in every
+        // theme — on a white one the matches were all but invisible. How far
+        // the wash may travel is the theme's to say (`match_wash_targets`),
+        // since the glyph on top of it pays for every step.
+        let fg_rgb = super::palette::hsla_to_rgb(default_fg);
+        let bg_rgb = super::palette::hsla_to_rgb(default_bg);
+        let bg_packed = pack_rgb(bg_rgb);
+        let tint = match_tint(cx);
+        let (hit_target, current_target) =
+            crate::ui::presets::match_wash_targets(bg_packed, pack_rgb(fg_rgb));
         let match_bg = to_hsla(unpack_rgb(crate::ui::presets::wash(
-            bg_packed,
-            tint,
-            crate::ui::presets::MATCH_WASH,
+            bg_packed, tint, hit_target,
         )));
         let current_match_bg = to_hsla(unpack_rgb(crate::ui::presets::wash(
             bg_packed,
             tint,
-            crate::ui::presets::CURRENT_MATCH_WASH,
+            current_target,
         )));
         Self {
             default_fg,
@@ -277,9 +296,8 @@ impl PaintColors {
             selection_bg,
             match_bg,
             current_match_bg,
-            current_match_border: caret,
-            fg_rgb: super::palette::hsla_to_rgb(default_fg),
-            bg_rgb: super::palette::hsla_to_rgb(default_bg),
+            fg_rgb,
+            bg_rgb,
         }
     }
 }
@@ -313,7 +331,6 @@ fn paint_cell_runs(
     geom: &CellGeom,
     buf: &[RenderCell],
     color: Hsla,
-    border: Option<Hsla>,
     mut covered: impl FnMut(&RenderCell) -> bool,
 ) {
     for row in 0..geom.rows {
@@ -332,11 +349,7 @@ fn paint_cell_runs(
                     break;
                 }
             }
-            let rect = geom.cell_rect(row, start, col - start);
-            window.paint_quad(fill(rect, color));
-            if let Some(b) = border {
-                window.paint_quad(outline(rect, b, BorderStyle::Solid));
-            }
+            window.paint_quad(fill(geom.cell_rect(row, start, col - start), color));
         }
     }
 }
@@ -1564,24 +1577,22 @@ impl Element for TerminalElement {
         window.with_content_mask(Some(ContentMask { bounds }), |window| {
             paint_backgrounds(window, &geom, &buf);
             if snap.any_selected {
-                paint_cell_runs(window, &geom, &buf, colors.selection_bg, None, |c| {
-                    c.selected
-                });
+                paint_cell_runs(window, &geom, &buf, colors.selection_bg, |c| c.selected);
             }
             if snap.any_match {
-                paint_cell_runs(window, &geom, &buf, colors.match_bg, None, |c| {
+                paint_cell_runs(window, &geom, &buf, colors.match_bg, |c| {
                     c.match_hit && !c.match_current
                 });
             }
             if snap.any_current {
-                paint_cell_runs(
-                    window,
-                    &geom,
-                    &buf,
-                    colors.current_match_bg,
-                    Some(colors.current_match_border),
-                    |c| c.match_current,
-                );
+                // Fill only. The current match used to carry a caret-coloured
+                // outline as well, because a wash it could only be 2.1:1 off the
+                // background had no way to say "this one" on its own. Now that
+                // it is the accent at the top of the theme's budget, the outline
+                // is the same colour saying the same thing a second time.
+                paint_cell_runs(window, &geom, &buf, colors.current_match_bg, |c| {
+                    c.match_current
+                });
             }
             paint_glyphs(
                 window,
@@ -1664,7 +1675,7 @@ impl Element for TerminalElement {
                 };
                 paint_backgrounds(window, &sg, row);
                 if snap.any_selected {
-                    paint_cell_runs(window, &sg, row, colors.selection_bg, None, |c| c.selected);
+                    paint_cell_runs(window, &sg, row, colors.selection_bg, |c| c.selected);
                 }
                 paint_glyphs(
                     window,
@@ -1795,7 +1806,6 @@ mod tests {
             selection_bg: Hsla::default(),
             match_bg: Hsla::default(),
             current_match_bg: Hsla::default(),
-            current_match_border: Hsla::default(),
             fg_rgb: Rgb {
                 r: 17,
                 g: 17,
@@ -2565,7 +2575,6 @@ mod tests {
             selection_bg: wash(0.55),
             match_bg: wash(0.32),
             current_match_bg: wash(0.85),
-            current_match_border: to_hsla(fg),
             fg_rgb: fg,
             bg_rgb: bg,
         }

--- a/src/ui/presets.rs
+++ b/src/ui/presets.rs
@@ -487,13 +487,38 @@ pub(crate) fn is_lighter(a: u32, b: u32) -> bool {
 
 const ACCENT_FLOOR: f32 = 3.0;
 
-/// How far a search match's wash has to stand off the background it sits on,
-/// and how much further the one you are looking at has to stand off the rest.
+/// What the glyph painted on top of a match wash keeps for itself.
 ///
-/// These are non-text ratios: enough to spot a block at a glance without
-/// drowning the glyph on top of it.
-pub(crate) const MATCH_WASH: f32 = 1.45;
-pub(crate) const CURRENT_MATCH_WASH: f32 = 2.1;
+/// WCAG's non-text ratio, not its text one. A match is a state you read
+/// *through* for a moment, not a surface you set body copy on — and holding the
+/// glyph at 4.5:1 is not a choice this can make anyway: three of the builtins
+/// only give their own text 6.6:1, which caps the wash at 1.46:1. That is a
+/// hairline's worth of shift (a hairline is 1.5:1) spread over a whole cell,
+/// and it is what made a match impossible to find by scanning.
+const GLYPH_FLOOR: f32 = 3.0;
+
+/// The two ends of what a wash is allowed to be, whatever the theme.
+///
+/// The floor buys the weakest palettes a match you can actually see, at the
+/// price of a glyph that dips under `GLYPH_FLOOR` on one. The ceiling stops the
+/// strongest from painting what reads as a solid block rather than a highlight.
+const WASH_FLOOR: f32 = 1.9;
+const WASH_CEILING: f32 = 3.2;
+
+/// How far a search match's wash stands off the background it sits on, and how
+/// much further the one you are looking at stands off the rest. Returned as
+/// `(hit, current)` contrast targets.
+///
+/// Derived from the theme rather than fixed, because the budget being spent is
+/// the theme's: a palette with 21:1 between its text and its background can
+/// afford a wash you cannot miss, and one with 6.6:1 cannot. A single constant
+/// has to be safe for the second, which leaves the first with nothing.
+pub(crate) fn match_wash_targets(bg: u32, fg: u32) -> (f32, f32) {
+    let current = (contrast(fg, bg) / GLYPH_FLOOR).clamp(WASH_FLOOR, WASH_CEILING);
+    // The plain hits are the crowd the current one has to read out of, so they
+    // get a little over half the distance it travels.
+    (1.0 + (current - 1.0) * 0.55, current)
+}
 
 /// The opacity at which `tint` over `surface` first reaches `target` contrast,
 /// as a blended colour.
@@ -1856,13 +1881,14 @@ mod tests {
                 faint(bg, fg)
             );
             let tint = mix(bg, fg, 0.24);
-            let w = wash(bg, tint, MATCH_WASH);
+            let (hit, current) = match_wash_targets(bg, fg);
+            let w = wash(bg, tint, hit);
             assert!(
-                contrast(w, bg) >= MATCH_WASH - 0.02,
+                contrast(w, bg) >= hit - 0.02,
                 "{:.2}:1 on {bg:06x}",
                 contrast(w, bg)
             );
-            let cur = wash(bg, tint, CURRENT_MATCH_WASH);
+            let cur = wash(bg, tint, current);
             assert!(
                 contrast(cur, bg) > contrast(w, bg),
                 "the current match has to stand out from the rest"
@@ -1871,10 +1897,64 @@ mod tests {
     }
 
     #[test]
+    fn a_low_contrast_theme_gets_a_gentler_wash_than_a_high_contrast_one() {
+        let (soft_hit, soft_cur) = match_wash_targets(0x282c34, 0xabb2bf);
+        let (hard_hit, hard_cur) = match_wash_targets(0x000000, 0xffffff);
+        assert!(
+            soft_cur < hard_cur && soft_hit < hard_hit,
+            "the wash spends the theme's own contrast budget, so it has to \
+             scale with it: {soft_cur:.2} vs {hard_cur:.2}"
+        );
+        assert!(
+            soft_hit >= 1.45,
+            "even the gentle end has to beat the flat constant it replaced"
+        );
+        assert!(hard_cur <= WASH_CEILING, "a highlight, not a solid block");
+    }
+
+    #[test]
+    fn a_match_wash_leaves_the_glyph_painted_on_top_of_it_readable() {
+        // The wash is opaque and the text is drawn over it, so every step up in
+        // visibility is a step down in the contrast the glyph has left. This is
+        // the ceiling both targets are chosen against — on every builtin, and
+        // in the accent the terminal actually washes with.
+        for t in builtins() {
+            let n = t.neutrals();
+            let (hit_t, cur_t) = match_wash_targets(n.background, n.foreground);
+            let hit = wash(n.background, n.accent, hit_t);
+            let cur = wash(n.background, n.accent, cur_t);
+            for (label, fill) in [("hit", hit), ("current", cur)] {
+                // `wash` bisects to *at least* its target and 8-bit channels do
+                // not divide evenly, so a fill can sit a hair past where the
+                // target asked for it — and the glyph pays that hair.
+                assert!(
+                    contrast(n.foreground, fill) >= GLYPH_FLOOR - 0.05,
+                    "{}: text on a {label} is {:.2}:1",
+                    t.id,
+                    contrast(n.foreground, fill)
+                );
+            }
+            assert!(
+                contrast(hit, n.background) > 1.5,
+                "{}: a hit only shifts {:.2}:1 off the background — a hairline",
+                t.id,
+                contrast(hit, n.background)
+            );
+            assert!(
+                contrast(cur, hit) >= 1.2,
+                "{}: the current match only reads {:.2}:1 apart from the rest",
+                t.id,
+                contrast(cur, hit)
+            );
+        }
+    }
+
+    #[test]
     fn a_wash_whose_tint_cannot_reach_the_target_still_lands_on_something_legible() {
         // A theme whose selection colour is its background: no alpha gets there.
-        let w = wash(0xffffff, 0xfefefe, MATCH_WASH);
-        assert!(contrast(w, 0xffffff) >= MATCH_WASH - 0.02, "{w:06x}");
+        let (hit, _) = match_wash_targets(0xffffff, 0x111111);
+        let w = wash(0xffffff, 0xfefefe, hit);
+        assert!(contrast(w, 0xffffff) >= hit - 0.02, "{w:06x}");
     }
 
     #[test]

--- a/src/ui/scrollbar.rs
+++ b/src/ui/scrollbar.rs
@@ -33,10 +33,9 @@ pub(crate) fn with_vertical_scrollbar(
                 .right_0()
                 .bottom_0()
                 // No `scrollbar_show` override: it falls back to
-                // `cx.theme().scrollbar_show`, which `apply_theme` derives from
-                // `should_auto_hide_scrollbars()` — the OS "show scroll bars"
-                // preference. Pinning it here would take that choice away from
-                // everyone who asked for always-visible bars.
+                // `cx.theme().scrollbar_show`, which `apply_theme` pins to
+                // `Scrolling` for every list in the app. Overriding it here
+                // would be one list disagreeing with the rest.
                 .child(Scrollbar::vertical(handle).id(id)),
         )
         .into_any_element()

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -578,7 +578,6 @@ pub(crate) fn apply_theme(mut window: Option<&mut Window>, cx: &mut App) {
     let surfaces = theme.surfaces();
     let sem = theme.semantics();
     let active = theme.active_palette(config.theme_legible_palette);
-    let auto_hide_scrollbars = cx.should_auto_hide_scrollbars();
 
     let backdrop = config.window_backdrop;
 
@@ -769,11 +768,14 @@ pub(crate) fn apply_theme(mut window: Option<&mut Window>, cx: &mut App) {
     t.tokens.scrollbar_thumb = scrollbar_thumb.into();
     t.tokens.scrollbar_thumb_hover = scrollbar_thumb_hover.into();
 
-    t.scrollbar_show = if auto_hide_scrollbars {
-        ScrollbarShow::Scrolling
-    } else {
-        ScrollbarShow::Always
-    };
+    // Not `should_auto_hide_scrollbars()`. That preference answers a question
+    // about *legacy* scrollbars — the ones that take a gutter out of the layout
+    // — and macOS says "don't hide them" for anyone with a mouse plugged in.
+    // Ours are overlay bars painted on top of the content, so honouring it
+    // parked an opaque bar over the switcher's tab column for the whole time
+    // the panel was open, with nothing to fade it out. Every list in the app
+    // gets the same bar, so it fades everywhere or nowhere.
+    t.scrollbar_show = ScrollbarShow::Scrolling;
 
     t.radius = px(8.);
 


### PR DESCRIPTION
Overlay scrollbars stopped fading out on machines where macOS reports "don't auto-hide scrollbars", leaving an opaque bar parked over the switcher's columns for as long as the panel was open.

| | Before | After |
|---|---|---|
| Scrollbar in the switcher's workspace / tab columns | Painted from the moment the panel opens and never fades, even untouched | Appears while scrolling, fades out ~2s after it stops |
| Same bar in the sidebar, right panel, settings, diff overlay, SCM panel, file tree, SFTP | Same permanent bar wherever a list overflowed | Same fade-out everywhere |
| Bar width at rest | 8px "active" bar | 6px resting bar, widening to 8px on hover/drag |
| Machines with a trackpad only | Already faded out | Unchanged |

## Why

`apply_theme` derived `scrollbar_show` from `cx.should_auto_hide_scrollbars()`, mapping `false` to `ScrollbarShow::Always`. That platform preference answers a question about *legacy* scrollbars — the kind that take a gutter out of the layout — and macOS returns "don't hide them" for anyone with a mouse plugged in. Ours are overlay bars painted on top of the content, so `Always` doesn't reserve space for them; it just leaves a bar sitting on the content with nothing to fade it out. In the switcher that bar overlapped the tab column's header text.

Every list in the app goes through the same `with_vertical_scrollbar` helper and reads the same theme field, so this was app-wide — the switcher is only where it was most visible, because that panel is a fixed-height card whose columns almost always overflow.

## Testing

- `cargo build`, `cargo fmt --check`, `cargo test -p tty7 --bin tty7-app theme::` — clean.
- Verified by hand in an isolated dev instance (`--config-dir`) seeded with 15 workspaces and a 10-tab workspace so both switcher columns overflow: the bars now appear on scroll and fade out when idle.
