### PR TITLE
fix(tree-sync): pay back a remote window's owed tree pull

### DIFF
--- a/src/ui/remote_workspace.rs
+++ b/src/ui/remote_workspace.rs
@@ -956,6 +956,12 @@ fn pump_tick(cx: &mut gpui::App) -> bool {
                 changed = true;
                 log::info!("link to {target} is attached");
                 crate::ui::machine_mirror::MachineMirrors::refresh(cx, host);
+                // A link this machine's windows never asked for — the switcher
+                // connected it, or `finish_connect` installed it — comes up
+                // without any reconnect attempt finishing, so nothing else
+                // tells the windows on it that their machine can be reached
+                // now. One of them may be sitting empty owing a pull.
+                crate::ui::tree_sync::on_link_up(cx, host);
             }
             continue;
         }

--- a/src/ui/tree_sync.rs
+++ b/src/ui/tree_sync.rs
@@ -716,8 +716,16 @@ struct WsState {
     rehydrate: Option<Adopt>,
     /// How many pulls in a row this window has owed, which paces the retry.
     ///
-    /// Cleared the moment one lands, so a machine that hiccups once is asked
-    /// again promptly and one that is really gone is not asked in a loop.
+    /// Counts consecutive failures, so it is cleared by anything that ends the
+    /// run: a pull that lands (`finish_hydration`), a prime that lands
+    /// (`finish_prime` — the machine answered, which is the whole question),
+    /// and a debt abandoned rather than paid (`take_rehydrate` dropping a
+    /// `Replace` the user has overtaken). A machine that hiccups once is then
+    /// asked again promptly, and one that is really gone is not asked in a
+    /// loop.
+    ///
+    /// Leaving it standing after the run ends is what makes a *first* failure
+    /// wait the cap: the count would still be carrying an outage that is over.
     rehydrate_attempts: u32,
     /// Whether this window has already been told why it opened empty.
     ///
@@ -825,7 +833,14 @@ fn take_rehydrate(cx: &mut App, client_ws: WorkspaceId, window_is_empty: bool) -
         .windows
         .get_mut(&client_ws)?;
     let adopt = state.rehydrate.take()?;
-    (window_is_empty || adopt == Adopt::IfEmpty).then_some(adopt)
+    if !window_is_empty && adopt == Adopt::Replace {
+        // Abandoned, not paid — but the run of failures is over either way, and
+        // a count left standing would make the next window's first failure wait
+        // the cap on an outage that has nothing to do with it.
+        state.rehydrate_attempts = 0;
+        return None;
+    }
+    Some(adopt)
 }
 
 /// Whether a window with no tabs may delete `client_ws` outright — from the
@@ -1076,6 +1091,9 @@ fn finish_prime(cx: &mut App, client_ws: WorkspaceId, epoch: u64, outcome: io::R
     let landed = match outcome {
         Ok(mirror) => {
             state.informed |= mirror.tabs.is_empty();
+            // The machine answered, which is the only thing the retry was
+            // waiting to find out, so the next failure starts its backoff over.
+            state.rehydrate_attempts = 0;
             let landed = (mirror.tabs.clone(), mirror.active);
             state.sync = SyncPhase::Primed(mirror);
             landed
@@ -1258,7 +1276,7 @@ enum Adopt {
 fn hydrate(cx: &mut App, client_ws: WorkspaceId, adopt: Adopt) {
     let host = WorkspaceStore::host_of(cx, client_ws);
     let machine_ws = tree_workspace_id(cx, client_ws);
-    let epoch = {
+    let (epoch, failures) = {
         let state = cx
             .default_global::<TreeSync>()
             .windows
@@ -1272,22 +1290,29 @@ fn hydrate(cx: &mut App, client_ws: WorkspaceId, adopt: Adopt) {
         state.epoch += 1;
         // This attempt takes over the debt; it re-records it if it fails too.
         state.rehydrate = None;
-        state.epoch
+        (state.epoch, state.rehydrate_attempts)
     };
+    // How many times in a row this window has already failed, which is what
+    // decides whether another failure is news or the same news again.
+    let level = hydration_log_level(failures, log::Level::Warn);
     cx.spawn(async move |cx| {
         let deadline = std::time::Instant::now() + HYDRATE_LINK_DEADLINE;
         let client = loop {
             match cx.update(|cx| tree_control_for(cx, host)) {
                 TreeLink::Ready(client) => break Some(client),
                 TreeLink::Unserved => {
-                    log::warn!(
+                    log::log!(
+                        level,
                         "workspace {client_ws}: its machine's server does not serve the \
                          machine tree; opening empty"
                     );
                     break None;
                 }
                 TreeLink::Down if std::time::Instant::now() > deadline => {
-                    log::warn!("workspace {client_ws}: no link to its machine; opening empty");
+                    log::log!(
+                        level,
+                        "workspace {client_ws}: no link to its machine; opening empty"
+                    );
                     break None;
                 }
                 TreeLink::Down => cx.background_executor().timer(HYDRATE_LINK_POLL).await,
@@ -1373,7 +1398,10 @@ fn owe_rehydration(cx: &mut App, client_ws: WorkspaceId, epoch: u64, adopt: Adop
     state.rehydrate = Some(adopt);
     state.rehydrate_attempts = state.rehydrate_attempts.saturating_add(1);
     let attempts = state.rehydrate_attempts;
-    log::info!(
+    log::log!(
+        // Once settled this line says the same thing every thirty seconds until
+        // the window closes, which is a fact about the machine and not an event.
+        hydration_log_level(attempts, log::Level::Info),
         "workspace {client_ws}: will pull its layout again once its machine answers \
          (attempt {attempts})"
     );
@@ -1391,12 +1419,36 @@ fn still_owed(cx: &App, client_ws: WorkspaceId, epoch: u64) -> bool {
         .is_some_and(|s| s.rehydrate.is_some() && s.epoch == epoch)
 }
 
+/// The attempt from which the backoff no longer grows.
+///
+/// Also the point where a window stops being a fresh failure and becomes a
+/// standing one, which is what [`hydration_log_level`] keys off.
+const REHYDRATE_SETTLED: u32 = 5;
+const REHYDRATE_BACKOFF_CAP: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// The first retry is soon enough to look instant to someone watching an empty
 /// window; the backoff is what keeps a machine that is really unreachable from
 /// being asked on a loop for as long as its window stays open.
 fn rehydrate_backoff(attempts: u32) -> std::time::Duration {
-    const CAP: u64 = 30;
-    std::time::Duration::from_secs(2u64.saturating_pow(attempts.min(5)).min(CAP))
+    std::time::Duration::from_secs(2u64.saturating_pow(attempts.min(REHYDRATE_SETTLED)))
+        .min(REHYDRATE_BACKOFF_CAP)
+}
+
+/// Steps `fresh` down to `debug` once this window's failures have stopped being
+/// events and become a standing condition.
+///
+/// The first few are news: something that was working stopped. Once the backoff
+/// has settled at its cap the window is in a steady state — a machine that is
+/// simply not there — and the retry will go on failing every thirty seconds for
+/// as long as the window stays open. Repeating that at full volume buries
+/// whatever else is in the log. The retry stays exactly as persistent either
+/// way; only the volume drops.
+fn hydration_log_level(attempts: u32, fresh: log::Level) -> log::Level {
+    if attempts >= REHYDRATE_SETTLED {
+        log::Level::Debug
+    } else {
+        fresh
+    }
 }
 
 /// Asks `client_ws` to sync once the backoff is up, if it still owes a pull.
@@ -1413,9 +1465,11 @@ fn arm_rehydrate_retry(cx: &mut App, client_ws: WorkspaceId, epoch: u64, attempt
             if !still_owed(cx, client_ws, epoch) {
                 return;
             }
-            // No window left to fill: the debt stays parked for whoever opens
-            // this workspace next, and asking its machine now would be work
-            // for nobody.
+            // No window left to fill, so asking its machine now would be work
+            // for nobody. Closing a window drops its whole `WsState` through
+            // `forget`, debt and all, so `still_owed` above normally answers
+            // first; this covers the window that is on its way out and has
+            // already dropped its app.
             let Some(app) = crate::ui::windows::WindowRegistry::app_for(cx, client_ws)
                 .and_then(|app| app.upgrade())
             else {
@@ -1455,7 +1509,22 @@ fn pull_workspace(
         // on the machine either way, and it may already hold tabs: read the
         // tree again and hydrate from what is really there. Treating this as a
         // failure left the window empty over a workspace that was fine.
-        Err(refused) => layout_of(machine_get(client)?, machine_ws).map_err(|_| refused),
+        //
+        // Any refusal is worth the second look, not just "already exists": what
+        // matters is whether the workspace is there now, and the tree answers
+        // that better than the error text does. If it still is not there, the
+        // create's own refusal is the honest error to report — the reread
+        // happened on its behalf and has nothing of its own to say.
+        Err(refused) => {
+            log::debug!(
+                "workspace {machine_ws} could not be created ({refused}); reading the tree \
+                 again in case something else created it first"
+            );
+            match machine_get(client) {
+                Ok(machine) => layout_of(machine, machine_ws).map_err(|_| refused),
+                Err(_) => Err(refused),
+            }
+        }
     }
 }
 
@@ -1502,7 +1571,15 @@ fn finish_hydration(
     let (machine, mirror, session) = match outcome {
         Ok(pulled) => pulled,
         Err(e) => {
-            log::warn!("could not hydrate workspace {client_ws} from its machine: {e}");
+            let failures = cx
+                .default_global::<TreeSync>()
+                .windows
+                .get(&client_ws)
+                .map_or(0, |s| s.rehydrate_attempts);
+            log::log!(
+                hydration_log_level(failures, log::Level::Warn),
+                "could not hydrate workspace {client_ws} from its machine: {e}"
+            );
             let _ = owe_rehydration(cx, client_ws, epoch, adopt);
             return;
         }
@@ -2294,12 +2371,139 @@ mod tests {
             secs(1) < secs(2) && secs(2) < secs(3),
             "a machine that keeps refusing must be asked less often, not more"
         );
-        assert_eq!(secs(5), 30);
+        assert_eq!(secs(REHYDRATE_SETTLED), 30);
         assert_eq!(
             secs(50),
             30,
             "a window left open on an unreachable machine settles at the cap"
         );
+    }
+
+    /// Once the backoff stops growing the same failure repeats every thirty
+    /// seconds for as long as the window stays open. Reporting each one at full
+    /// volume turns one unreachable machine into a log nobody can read past.
+    #[test]
+    fn a_standing_failure_stops_shouting_once_the_backoff_settles() {
+        assert_eq!(
+            hydration_log_level(1, log::Level::Warn),
+            log::Level::Warn,
+            "the first failures are news and must stay news"
+        );
+        assert_eq!(
+            hydration_log_level(REHYDRATE_SETTLED, log::Level::Warn),
+            log::Level::Debug
+        );
+        assert_eq!(
+            hydration_log_level(REHYDRATE_SETTLED, log::Level::Info),
+            log::Level::Debug,
+            "the step down is to debug from wherever it started, not to warn"
+        );
+    }
+
+    /// The count paces the retry, so it has to mean "failures in a row". Left
+    /// standing after the run ends, it makes the next *first* failure wait the
+    /// cap on an outage that was already over.
+    #[gpui::test]
+    fn the_backoff_count_ends_with_the_run_of_failures(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let _ = tty7_core::core::config::set_config_dir(
+                std::env::temp_dir().join(format!("tty7-backoff-count-{}", std::process::id())),
+            );
+            let view = crate::core::session::WindowView::default();
+            let ws = view.id;
+            WorkspaceStore::install_for_test(
+                cx,
+                crate::core::session::WindowViews {
+                    views: vec![view],
+                    active: Some(ws),
+                },
+            );
+            let unprimed = |cx: &mut App| {
+                cx.default_global::<TreeSync>()
+                    .windows
+                    .entry(ws)
+                    .or_default()
+                    .sync = SyncPhase::Unprimed {
+                    dirty: false,
+                    priming: true,
+                };
+            };
+            let attempts =
+                |cx: &mut App| cx.default_global::<TreeSync>().windows[&ws].rehydrate_attempts;
+
+            unprimed(cx);
+            let epoch = cx.default_global::<TreeSync>().windows[&ws].epoch;
+            for expected in 1..=3 {
+                unprimed(cx);
+                owe_rehydration(cx, ws, epoch, Adopt::IfEmpty);
+                assert_eq!(
+                    attempts(cx),
+                    expected,
+                    "each failure in the run paces the next"
+                );
+            }
+
+            // The machine answered. Whatever it was, it is over.
+            unprimed(cx);
+            finish_prime(cx, ws, epoch, Ok(WsMirror::default()));
+            assert_eq!(
+                attempts(cx),
+                0,
+                "a prime landing is the machine answering, which is the whole question"
+            );
+
+            // Abandoned rather than paid: the user filled the window in
+            // themselves, so the `Replace` is dropped — and the run is over too.
+            {
+                let state = cx
+                    .default_global::<TreeSync>()
+                    .windows
+                    .get_mut(&ws)
+                    .unwrap();
+                state.rehydrate = Some(Adopt::Replace);
+                state.rehydrate_attempts = 4;
+            }
+            assert!(take_rehydrate(cx, ws, false).is_none());
+            assert_eq!(
+                attempts(cx),
+                0,
+                "a debt nobody owes any more cannot go on pacing the next one"
+            );
+        });
+    }
+
+    /// The retry fires on a timer, so the window it was armed for can be gone
+    /// by the time it runs. It has to notice and stand down — and leave the
+    /// debt where it is, because a window that is not there is not one that
+    /// has been paid.
+    #[gpui::test]
+    async fn a_retry_that_finds_no_window_stands_down(cx: &mut gpui::TestAppContext) {
+        let ws = cx.update(|cx| {
+            crate::ui::windows::WindowRegistry::init(cx);
+            let ws = WorkspaceId::new();
+            let epoch = cx
+                .default_global::<TreeSync>()
+                .windows
+                .entry(ws)
+                .or_default()
+                .epoch;
+            owe_rehydration(cx, ws, epoch, Adopt::IfEmpty);
+            ws
+        });
+
+        // Well past the first backoff: the armed retry really runs, rather than
+        // the test ending while it is still asleep.
+        cx.executor().advance_clock(rehydrate_backoff(1) * 2);
+        cx.executor().run_until_parked();
+
+        cx.update(|cx| {
+            assert!(
+                cx.default_global::<TreeSync>().windows[&ws]
+                    .rehydrate
+                    .is_some(),
+                "the debt outlives a retry that found nothing to pay it into"
+            );
+        });
     }
 
     #[gpui::test]

--- a/src/ui/tree_sync.rs
+++ b/src/ui/tree_sync.rs
@@ -714,6 +714,11 @@ struct WsState {
     /// from it until the pull is retried — an empty window diffs into
     /// "close every tab" and would wipe the layout off the machine.
     rehydrate: Option<Adopt>,
+    /// How many pulls in a row this window has owed, which paces the retry.
+    ///
+    /// Cleared the moment one lands, so a machine that hiccups once is asked
+    /// again promptly and one that is really gone is not asked in a loop.
+    rehydrate_attempts: u32,
     /// Whether this window has already been told why it opened empty.
     ///
     /// The retry is as quiet as the failure was, so a window whose machine
@@ -736,6 +741,7 @@ impl Default for WsState {
             informed: false,
             epoch: 0,
             rehydrate: None,
+            rehydrate_attempts: 0,
             said_why_empty: false,
         }
     }
@@ -1334,12 +1340,23 @@ fn say_why_the_window_is_empty(cx: &mut App, client_ws: WorkspaceId) {
     });
 }
 
-/// Records that a hydration failed and still owes `client_ws` its layout.
+/// Records that a hydration failed and still owes `client_ws` its layout, and
+/// arms the retry that pays it back.
 ///
 /// Nothing else recovers on its own: the window stays empty, and without this
 /// the next `sync_window` would push that emptiness to the machine as "close
-/// every tab". Instead the pull is retried the next time the window syncs —
-/// which is what a reconnect does through `on_link_up`.
+/// every tab". The debt is settled by the next sync of this window — a
+/// reconnect drives one through `on_link_up`, an edit in the window drives one
+/// through `save_session`, and [`arm_rehydrate_retry`] drives one when neither
+/// happens.
+///
+/// That last driver is the load-bearing one. A pull can fail with the link
+/// perfectly healthy — a `MachineGet` that overran its ten seconds on a slow
+/// link, or a create that lost its race with `start_prime` — and then no link
+/// ever comes back up to notice, and an empty window has nothing to edit. The
+/// window sat empty until the app was restarted, with every tab and every
+/// shell still on the machine: "tty7 lost my session" for a request that
+/// needed asking twice.
 ///
 /// Returns whether the debt was taken on. A superseded attempt gets `false`:
 /// a newer hydration owns the window now, and this one speaks for nothing.
@@ -1354,43 +1371,116 @@ fn owe_rehydration(cx: &mut App, client_ws: WorkspaceId, epoch: u64, adopt: Adop
         *priming = false;
     }
     state.rehydrate = Some(adopt);
-    log::info!("workspace {client_ws}: will pull its layout again once its machine answers");
+    state.rehydrate_attempts = state.rehydrate_attempts.saturating_add(1);
+    let attempts = state.rehydrate_attempts;
+    log::info!(
+        "workspace {client_ws}: will pull its layout again once its machine answers \
+         (attempt {attempts})"
+    );
+    arm_rehydrate_retry(cx, client_ws, epoch, attempts);
     true
+}
+
+/// Whether the debt this retry was armed for is still the window's own.
+///
+/// A newer epoch means another hydration took the window over while the
+/// backoff ran, and this retry speaks for nothing.
+fn still_owed(cx: &App, client_ws: WorkspaceId, epoch: u64) -> bool {
+    cx.try_global::<TreeSync>()
+        .and_then(|t| t.windows.get(&client_ws))
+        .is_some_and(|s| s.rehydrate.is_some() && s.epoch == epoch)
+}
+
+/// The first retry is soon enough to look instant to someone watching an empty
+/// window; the backoff is what keeps a machine that is really unreachable from
+/// being asked on a loop for as long as its window stays open.
+fn rehydrate_backoff(attempts: u32) -> std::time::Duration {
+    const CAP: u64 = 30;
+    std::time::Duration::from_secs(2u64.saturating_pow(attempts.min(5)).min(CAP))
+}
+
+/// Asks `client_ws` to sync once the backoff is up, if it still owes a pull.
+///
+/// Deliberately routed through `sync_window` rather than straight into
+/// `hydrate`: that is where the rules about *whether* a window may still adopt
+/// the machine's layout live — a preempted workspace stays out of it, and a
+/// `Replace` is dropped once the user has filled the window in themselves.
+fn arm_rehydrate_retry(cx: &mut App, client_ws: WorkspaceId, epoch: u64, attempts: u32) {
+    let delay = rehydrate_backoff(attempts);
+    cx.spawn(async move |cx| {
+        cx.background_executor().timer(delay).await;
+        let _ = cx.update(|cx| {
+            if !still_owed(cx, client_ws, epoch) {
+                return;
+            }
+            // No window left to fill: the debt stays parked for whoever opens
+            // this workspace next, and asking its machine now would be work
+            // for nobody.
+            let Some(app) = crate::ui::windows::WindowRegistry::app_for(cx, client_ws)
+                .and_then(|app| app.upgrade())
+            else {
+                return;
+            };
+            app.update(cx, |app, cx| sync_window(app, cx));
+        });
+    })
+    .detach();
 }
 
 fn pull_workspace(
     client: &ControlClient,
     machine_ws: WorkspaceId,
 ) -> io::Result<(Machine, WsMirror, Session)> {
-    let machine: Machine = match client.call(ControlRequest::MachineGet)? {
-        ReplyOk::MachineTree(m) => *m,
-        other => return Err(io::Error::other(format!("MachineGet answered {other:?}"))),
+    let machine = match layout_of(machine_get(client)?, machine_ws) {
+        Ok(pulled) => return Ok(pulled),
+        Err(machine) => machine,
     };
-    match machine.workspaces.iter().find(|w| w.id == machine_ws) {
-        Some(ws) => {
-            let mirror = WsMirror {
-                tabs: ws.tabs.clone(),
-                active: ws.active_tab,
-            };
-            let session = session_from_tree(ws, &machine.panes);
-            Ok((machine, mirror, session))
-        }
-        None => {
-            // The whole tree is already in hand, so the taken names can be read
-            // straight off it rather than passed down from the main thread.
-            let taken: Vec<&str> = machine
-                .workspaces
-                .iter()
-                .filter_map(|w| w.name.as_deref())
-                .collect();
-            let name = tty7_core::core::codename::unique(|n| taken.contains(&n));
-            client.call(ControlRequest::WorkspaceCreate {
-                name: Some(name),
-                workspace: Some(machine_ws),
-            })?;
-            Ok((machine, WsMirror::default(), Session::default()))
-        }
+    // The whole tree is already in hand, so the taken names can be read
+    // straight off it rather than passed down from the main thread.
+    let taken: Vec<&str> = machine
+        .workspaces
+        .iter()
+        .filter_map(|w| w.name.as_deref())
+        .collect();
+    let name = tty7_core::core::codename::unique(|n| taken.contains(&n));
+    match client.call(ControlRequest::WorkspaceCreate {
+        name: Some(name),
+        workspace: Some(machine_ws),
+    }) {
+        Ok(_) => Ok((machine, WsMirror::default(), Session::default())),
+        // Losing this create is not a failed hydration. Opening a remote
+        // workspace runs two pulls at once — this one and `start_prime`'s —
+        // and both create when the tree they read did not hold it yet, so the
+        // loser is told it already exists. The workspace the create was for is
+        // on the machine either way, and it may already hold tabs: read the
+        // tree again and hydrate from what is really there. Treating this as a
+        // failure left the window empty over a workspace that was fine.
+        Err(refused) => layout_of(machine_get(client)?, machine_ws).map_err(|_| refused),
     }
+}
+
+fn machine_get(client: &ControlClient) -> io::Result<Machine> {
+    match client.call(ControlRequest::MachineGet)? {
+        ReplyOk::MachineTree(m) => Ok(*m),
+        other => Err(io::Error::other(format!("MachineGet answered {other:?}"))),
+    }
+}
+
+/// This workspace's layout as `machine` has it, or the tree handed back
+/// untouched when the machine does not hold the workspace at all.
+fn layout_of(
+    machine: Machine,
+    machine_ws: WorkspaceId,
+) -> Result<(Machine, WsMirror, Session), Machine> {
+    let Some(ws) = machine.workspaces.iter().find(|w| w.id == machine_ws) else {
+        return Err(machine);
+    };
+    let mirror = WsMirror {
+        tabs: ws.tabs.clone(),
+        active: ws.active_tab,
+    };
+    let session = session_from_tree(ws, &machine.panes);
+    Ok((machine, mirror, session))
 }
 
 fn finish_hydration(
@@ -1427,6 +1517,8 @@ fn finish_hydration(
         let dirty = matches!(state.sync, SyncPhase::Unprimed { dirty: true, .. });
         state.informed |= machine_was_empty;
         state.sync = SyncPhase::Primed(mirror);
+        // The machine answered, so the next failure starts its backoff over.
+        state.rehydrate_attempts = 0;
         // The machine answered, so the explanation has been overtaken by events
         // and a later outage deserves its own.
         state.said_why_empty = false;
@@ -2148,6 +2240,66 @@ mod tests {
                     .is_none()
             );
         });
+    }
+
+    /// The debt an owed pull records is worth nothing without something that
+    /// pays it. A pull can fail with the link up and healthy — a `MachineGet`
+    /// past its deadline on a slow link, a create that lost its race — and
+    /// then no reconnect ever happens to notice, and an empty window has no
+    /// edit in it to drive a sync. The window sat there empty, with every tab
+    /// still on the machine, until the app was restarted.
+    #[gpui::test]
+    fn an_owed_pull_is_retried_until_it_is_paid_or_superseded(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let ws = WorkspaceId::new();
+            let epoch = cx
+                .default_global::<TreeSync>()
+                .windows
+                .entry(ws)
+                .or_default()
+                .epoch;
+            owe_rehydration(cx, ws, epoch, Adopt::IfEmpty);
+            assert!(
+                still_owed(cx, ws, epoch),
+                "the retry armed for this debt must still recognise it"
+            );
+
+            // Paid: the pull landed, so the retry that is still in flight has
+            // to stand down rather than replay the machine over the window.
+            cx.default_global::<TreeSync>()
+                .windows
+                .get_mut(&ws)
+                .expect("owed above")
+                .rehydrate = None;
+            assert!(!still_owed(cx, ws, epoch));
+
+            // Superseded: a newer hydration owns the window now.
+            let state = cx
+                .default_global::<TreeSync>()
+                .windows
+                .get_mut(&ws)
+                .expect("owed above");
+            state.rehydrate = Some(Adopt::IfEmpty);
+            state.epoch += 1;
+            assert!(!still_owed(cx, ws, epoch));
+            assert!(still_owed(cx, ws, epoch + 1));
+        });
+    }
+
+    #[test]
+    fn the_retry_backs_off_and_settles_at_a_cap() {
+        let secs = |n| rehydrate_backoff(n).as_secs();
+        assert_eq!(secs(1), 2, "the first retry is prompt: a window is empty");
+        assert!(
+            secs(1) < secs(2) && secs(2) < secs(3),
+            "a machine that keeps refusing must be asked less often, not more"
+        );
+        assert_eq!(secs(5), 30);
+        assert_eq!(
+            secs(50),
+            30,
+            "a window left open on an unreachable machine settles at the cap"
+        );
     }
 
     #[gpui::test]


### PR DESCRIPTION
A window opened onto a remote workspace could come up empty and stay empty, with every tab and every shell still alive on the machine, until the app was restarted. This retries the tree pull that failed instead of parking the debt where nothing pays it.

## What changed

| | Before | After |
|---|---|---|
| A tree pull that fails while the link stays up | Debt recorded, never settled — the window sits on the home page until the app is restarted | Retried on a backoff (2s → 4 → 8 → 16 → 30s cap) until it lands |
| `WorkspaceCreate` losing its race with `start_prime` ("workspace … already exists") | Counted as a failed hydration | Tree is read again and the window hydrates from what is really there |
| A remote link coming up without a reconnect attempt (the switcher connected it) | Nothing tells its windows the machine is reachable | `on_link_up` runs for the host, as its doc comment always claimed |
| A machine that is genuinely unreachable | — | Asked once per 30s at most, and not at all once its window is gone |

## Why

Opening a window onto a remote workspace pulls the machine's tree and rebuilds the tabs from it. Until that lands the window is empty, and it has to be: an empty window diffs into "close every tab", so `sync_window` holds everything back while a pull is owed.

When the pull failed, `owe_rehydration` recorded the debt and returned, on the promise in its own doc comment that the next sync would settle it — *"which is what a reconnect does through `on_link_up`"*. But `on_link_up` was called for `HostId::LOCAL` and nowhere else. On a remote host the debt was only ever settled by a reconnect completing, by an edit in the window, or by a restart.

So one narrow condition made it permanent: **a pull that fails while the link stays healthy.** No reconnect follows, because nothing disconnected; and an empty window has nothing in it to edit. Two routine ways to get there — a `MachineGet` past its ten-second deadline on a slow link, and a `WorkspaceCreate` losing its race with the `start_prime` that runs from the other side of the same window opening. The second fires on every remote workspace opened; it was invisible only because the workspace it usually lands on is empty anyway.

```mermaid
flowchart TD
    A[window opens on a remote workspace] --> B[hydrate: pull the machine tree]
    B -->|lands| C[tabs rebuilt]
    B -->|fails| D[owe_rehydration: debt parked]
    D -.->|before: only these| E[link drops and reconnects]
    D -.->|before: only these| F[user edits the window]
    D -.->|before: only these| G[app restart]
    D ==>|after| H[armed retry, backed off]
    H --> I{still owed<br/>and not superseded?}
    I -->|yes| B
    I -->|no| J[stand down]
```

## Testing

- `an_owed_pull_is_retried_until_it_is_paid_or_superseded` — the retry recognises its own debt, stands down once the pull lands, and stands down when a newer hydration takes the window over.
- `the_retry_backs_off_and_settles_at_a_cap` — prompt first ask, monotonic backoff, 30s cap.
- `cargo test --bin tty7-app`: 1342 passed, 0 failed.
- Reproduced and verified by hand against a pseudo-remote machine (`TTY7_LOCAL_STDIO_SERVER`, its own config/data dir) with a shim that delays the control connection past `MachineGet`'s deadline:
  - **Before:** ⌘-clicking a detached remote workspace with 2 live shells opened a window with no tabs; the log showed `could not hydrate … timed out after 10s` / `will pull its layout again once its machine answers` and then nothing. The window was still empty 45s after the link was healthy again. Restarting the app rebuilt both tabs.
  - **After:** same run logs `attempt 1`, `attempt 2`, then `rebuilding 1 tab(s) … from its machine's tree` — the window fills itself in, no restart.
  - Creating a remote workspace no longer logs an `already exists` hydration failure.

## Review follow-ups (second commit)

| | Was | Now |
|---|---|---|
| The attempt count after a debt is abandoned (`Replace` dropped because the user filled the window in) or after a prime lands | Left standing, so the next *first* failure waited the 30s cap on an outage already over | Cleared wherever the run of failures ends |
| A window left open on a machine that is really gone | A `warn` and an `info` every ~45s, forever | Both step down to `debug` once the backoff settles at its cap — the retry is exactly as persistent, only the volume drops |
| A create refused, then the reread also fails | The reread's error replaced the create's own refusal | The create's refusal is reported; the reread has nothing of its own to say |
| The race recovery (`WorkspaceCreate` refused → reread the tree) | Entirely silent, so the extra round trip was invisible in a log | Says at `debug` that it happened and why |

Also corrects the comment on the window-gone guard in `arm_rehydrate_retry`: closing a window drops its whole `WsState` through `forget`, debt and all, so nothing is parked for whoever opens the workspace next.

New tests:

- `the_backoff_count_ends_with_the_run_of_failures` — the count is cleared at all three sites that end a run.
- `a_standing_failure_stops_shouting_once_the_backoff_settles` — the step down is to `debug` from wherever the line started, and it shares its threshold with the backoff cap.
- `a_retry_that_finds_no_window_stands_down` — drives the armed retry through a real timer (`advance_clock`) into the window-gone guard. This is the first coverage of the retry *firing*, rather than of the predicate it consults; verified non-vacuous by probing a panic into the retry body and watching the test fail.