### PR TITLE
ci(macos): give the DMG somewhere to go on a runner that ran out of disk

### DIFF
--- a/.github/scripts/bundle-macos.sh
+++ b/.github/scripts/bundle-macos.sh
@@ -210,12 +210,33 @@ if [[ "$PACKAGE_UPDATE_ZIP" != "0" ]]; then
 fi
 
 # Package the (now stapled) bundle as a drag-to-Applications DMG.
+#
+# `hdiutil` needs room for the whole image beside the staged bundle, and the
+# hosted Intel runners stopped having it — three nightlies in a row died right
+# here on 2026-08-10 with "hdiutil: create failed - No space left on device",
+# across two different commits. The arm64 runners have never hit it. So the two
+# steps below give the image somewhere to go rather than assuming there is room.
 DMG="dist/tty7-${VERSION}-macos-${ARCH}.dmg"
 STAGE="dist/dmg-stage"
 rm -rf "$STAGE"
 mkdir "$STAGE"
-cp -R "$APP" "$STAGE/"
+# `mv`, not `cp -R`: this is the peak, and a second full copy of the bundle is
+# the most expensive thing on the volume that nobody needs. Nothing reads
+# dist/tty7.app after this point — the zip above is what the updater ships and
+# what nightly.yml verifies (it extracts that, not this), and release.yml only
+# knows about tty7.app as an intermediate to keep out of the upload globs.
+mv "$APP" "$STAGE/"
 ln -s /Applications "$STAGE/Applications"
+# The build tree is dead weight from here on: every binary it produced is
+# already inside the bundle, and no later step in either workflow reads it.
+# The cost is that rust-cache finds little left to save, so the next macOS
+# build recompiles the dependency graph. That is a slower nightly; the
+# alternative is no nightly at all. `df` first so the next person to look at
+# this has the number that made it necessary.
+df -h . || true
+rm -rf "target/${TARGET}/release/deps" \
+       "target/${TARGET}/release/build" \
+       "target/${TARGET}/release/incremental"
 hdiutil create -volname "tty7" -srcfolder "$STAGE" -ov -format UDZO "$DMG"
 rm -rf "$STAGE"
 if [[ -n "$SIGN_ID" && -n "${APPLE_CERTIFICATE:-}" ]]; then


### PR DESCRIPTION
Three nightlies in a row died in `bundle-macos.sh` with `hdiutil: create failed - No space left on device` — always on `macos-15-intel`, never on arm64, and across two different commits, so this is the hosted runner tightening rather than anything in the tree.

| nightly run | commit | Intel |
|---|---|---|
| 06:32 | — | pass |
| 09:24 | `fafcaa0` | **fail** |
| 10:42 | `0f5e637` | **fail** |
| rerun | `0f5e637` | **fail** |

The build, the Developer ID signing and the notarization all succeed; the log reaches `signed + notarized + stapled` every time and then cannot write the image. `publish` needs all four platforms, so each of those nights shipped nothing and users stayed on the previous nightly — which is the workflow behaving as designed, but it means the channel has been frozen since 06:32.

## What is on the volume

At `hdiutil create` the runner is holding five things at once:

1. the whole release `target/` tree
2. the signed `dist/tty7.app`
3. the compressed update zip
4. a second full copy of the bundle under `dist/dmg-stage`
5. the disk image being written

Two of those are avoidable.

**Stage with `mv`, not `cp -R`.** Nothing reads `dist/tty7.app` after this point: the updater ships the zip, `nightly.yml` verifies that zip by extracting it into `$RUNNER_TEMP`, and `release.yml` knows `tty7.app` only as an intermediate to keep out of the upload globs.

**Drop the build tree before the image is written.** Every binary it produced is already inside the bundle, and no later step in either workflow reads `target/`.

## Cost

`rust-cache` finds little left to save, so the next macOS build recompiles the dependency graph. That is a slower nightly, against no nightly at all. `df -h` runs just before the delete so the next person to look at this has the number that made it necessary — if the headroom turns out to be comfortable, the delete can be narrowed to the Intel runner or dropped.

## Testing

- `bash -n .github/scripts/bundle-macos.sh` — clean.
- Verified by reading both workflows that no step after `bundle-macos.sh` reads `dist/tty7.app` or `target/`: the macOS branch goes straight to `upload-artifact`, whose globs are `*.dmg`, `*.tar.gz`, `*.zip`, `*-setup.exe`, `*.AppImage`.
- The real check is a nightly that gets past `hdiutil` on `macos-15-intel`; that runs once this lands.