### PR TITLE
feat(agent-hooks): report the opencode session id

### DIFF
--- a/crates/tty7-core/src/core/agent_hooks.rs
+++ b/crates/tty7-core/src/core/agent_hooks.rs
@@ -924,6 +924,12 @@ export const Tty7Presence = async ({{ $ }}) => {{
   const cmd = {prefix}
   let sessionId = ""
   let announced = ""
+  // A subagent runs in a child session on the *same* event stream, and its
+  // status events are indistinguishable from the pane's own — only
+  // `session.created`/`session.updated` name a parent. Remember the children,
+  // so a task tool cannot hand the pane the wrong session to resume, nor call
+  // the pane done when only the subagent is.
+  const children = new Set()
   const emit = (event) => {{
     // Every event carries the session id (`properties.sessionID`), so a pane
     // that restarts can resume the same session with `opencode --session`.
@@ -935,7 +941,7 @@ export const Tty7Presence = async ({{ $ }}) => {{
   // `session.created` event); the session-start report rides on the first
   // event that names one, so a restored pane can reattach to it.
   const capture = async (id) => {{
-    if (id) sessionId = id
+    if (id && !children.has(id)) sessionId = id
     if (sessionId && sessionId !== announced) {{
       announced = sessionId
       await emit("session-start")
@@ -956,12 +962,15 @@ export const Tty7Presence = async ({{ $ }}) => {{
       await capture(input?.sessionID)
       await emit("prompt-submit")
     }},
-    "permission.ask": async () => {{
-      await capture()
+    "permission.ask": async (input) => {{
+      await capture(input?.sessionID)
       await emit("permission-request")
     }},
     event: async ({{ event }}) => {{
       const properties = event.properties ?? {{}}
+      const info = properties.info
+      if (info?.id && info.parentID) children.add(info.id)
+      if (properties.sessionID && children.has(properties.sessionID)) return
       await capture(properties.sessionID)
       const key = event.type === "session.status" ? `session.status.${{properties.status?.type}}` : event.type
       const action = ACTION[key]
@@ -1425,6 +1434,14 @@ mod tests {
             (
                 "session.idle",
                 "opencode still maps the session.idle event to stop",
+            ),
+            (
+                "info.parentID",
+                "opencode tells a subagent's child session apart from the pane's own",
+            ),
+            (
+                "children.has(properties.sessionID)",
+                "opencode lets a child session's events pass without touching the pane",
             ),
         ] {
             assert!(opencode.contains(needle), "{message}");

--- a/crates/tty7-core/src/core/agent_hooks.rs
+++ b/crates/tty7-core/src/core/agent_hooks.rs
@@ -922,27 +922,50 @@ fn opencode_plugin_js(target: &HookTarget) -> Option<String> {
 export const Tty7Presence = async ({{ $ }}) => {{
   if (!process.env["TTY7"]) return {{}}
   const cmd = {prefix}
-  const emit = (event) => $`sh -c ${{cmd + event}}`.quiet().nothrow()
-
-  // Plugin load = the agent is running in this pane.
-  await emit("session-start")
+  let sessionId = ""
+  let announced = ""
+  const emit = (event) => {{
+    // Every event carries the session id (`properties.sessionID`), so a pane
+    // that restarts can resume the same session with `opencode --session`.
+    const payload = sessionId ? new Response(JSON.stringify({{ session_id: sessionId }})) : undefined
+    const proc = payload ? $`sh -c ${{cmd + event}} < ${{payload}}` : $`sh -c ${{cmd + event}}`
+    return proc.quiet().nothrow()
+  }}
+  // The session id is only known once opencode creates the session (the
+  // `session.created` event); the session-start report rides on the first
+  // event that names one, so a restored pane can reattach to it.
+  const capture = async (id) => {{
+    if (id) sessionId = id
+    if (sessionId && sessionId !== announced) {{
+      announced = sessionId
+      await emit("session-start")
+    }}
+  }}
+  const ACTION = {{
+    "session.status.busy": "prompt-submit",
+    "session.status.idle": "stop",
+    "session.idle": "stop",
+    "permission.replied": "prompt-submit",
+  }}
 
   return {{
     dispose: async () => {{
       await emit("session-end")
     }},
-    "tool.execute.before": async () => {{
+    "tool.execute.before": async (input) => {{
+      await capture(input?.sessionID)
       await emit("prompt-submit")
     }},
     "permission.ask": async () => {{
+      await capture()
       await emit("permission-request")
     }},
     event: async ({{ event }}) => {{
-      if (event.type === "session.idle") {{
-        await emit("stop")
-      }} else if (event.type === "permission.replied") {{
-        await emit("prompt-submit")
-      }}
+      const properties = event.properties ?? {{}}
+      await capture(properties.sessionID)
+      const key = event.type === "session.status" ? `session.status.${{properties.status?.type}}` : event.type
+      const action = ACTION[key]
+      if (action) await emit(action)
     }},
   }}
 }}
@@ -1386,6 +1409,26 @@ mod tests {
         assert!(opencode.contains("agent-hook opencode"));
         assert!(opencode.contains(hook_exe));
         assert!(opencode.contains(r#"process.env["TTY7"]"#));
+        for (needle, message) in [
+            (
+                "properties.sessionID",
+                "opencode captures the session id from event properties",
+            ),
+            (
+                r#"session_id: sessionId"#,
+                "opencode forwards the session id to the emitter",
+            ),
+            (
+                "session.status",
+                "opencode maps session.status busy/idle to prompt-submit/stop",
+            ),
+            (
+                "session.idle",
+                "opencode still maps the session.idle event to stop",
+            ),
+        ] {
+            assert!(opencode.contains(needle), "{message}");
+        }
 
         for (agent, slug, package) in [
             (HookAgent::Pi, "pi", "@mariozechner/pi-coding-agent"),


### PR DESCRIPTION
## Summary

The opencode plugin now captures `properties.sessionID` from events and forwards it to `agent-hook opencode <event>` on stdin as JSON. It also maps `session.status` (busy/idle) events.

## Motivation

Let tty7 recognize the opencode session running in a pane so it can resume it with `opencode --session <id>` after a restart.

## Changes

- `emit()` sends the session id on stdin as a JSON payload (Bun Shell `< ${Response}` redirect)
- `session-start` is emitted on the first event that names a session id (`announced` prevents re-announcing the same id)
- Added `session.status.busy → prompt-submit` / `session.status.idle → stop` so completion detection works even on opencode versions without `session.idle`
- Fallback capture from `input.sessionID` in `tool.execute.before`

## Verification

- `cargo test -p tty7-core` (961 passed, aside from a known flake)
- `cargo test -p tty7-server -p tty7-cli` all pass
- `cargo clippy -p tty7-core --tests` no new warnings
- Ran the generated plugin against a stub emitter; every event carried `{"session_id":"..."}` on stdin
