### PR TITLE
fix(ui): stop washing out the workspace discs in the switcher

### DIFF
--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -1812,11 +1812,7 @@ impl Tty7App {
             .anchor_scroll(self.switcher_anchor(Column::Left, picked))
             .hover(move |r| r.bg(hover))
             .child(crate::ui::tab_strip::workspace_avatar(
-                &row.name,
-                row.live,
-                row.current,
-                ROW_AVATAR,
-                cx,
+                &row.name, row.live, ROW_AVATAR, cx,
             ))
             .child(
                 v_flex()

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -535,7 +535,6 @@ pub(crate) const UNKNOWN_DOT: u32 = 0x9AA0A6;
 pub(crate) fn workspace_avatar(
     name: &str,
     live: crate::terminal::pane_liveness::Liveness,
-    current: bool,
     size: f32,
     cx: &App,
 ) -> impl IntoElement + use<> {
@@ -550,6 +549,10 @@ pub(crate) fn workspace_avatar(
         .next()
         .map(|c| c.to_uppercase().to_string())
         .unwrap_or_else(|| "~".to_string());
+    // The disc reads the same on every row, current one included: the rows that
+    // are the current workspace already say so with a badge, a heavier name and
+    // a selected background, and dimming the disc on top of that only pushed the
+    // monogram under the liveness dot beside it, which is never dimmed.
     div()
         .relative()
         .flex_shrink_0()
@@ -565,8 +568,7 @@ pub(crate) fn workspace_avatar(
                 .text_size(px((size * 0.46).round()))
                 .font_weight(FontWeight::MEDIUM)
                 .text_color(cx.theme().foreground.opacity(0.65))
-                .child(initial)
-                .when(!current, |disc| disc.opacity(0.55)),
+                .child(initial),
         )
         .children(dot.map(|rgb| Tty7App::status_dot(rgb, 0, size, cx.theme().popover, false)))
 }


### PR DESCRIPTION
The monogram disc beside every workspace row in the switcher was drawn at
opacity 0.55 unless that row was the current workspace, and the initial inside
it is already the foreground at 0.65 — so the letter landed at about 0.36 and
went illegible on exactly the rows the panel exists to let you pick between.
Only one row in the list is ever the current workspace; the other
however-many all got the dimmed treatment.

The liveness dot is painted on the wrapper rather than inside the disc, so it
never dimmed with it: a washed-out grey blob with a full-strength green dot
stuck to its corner, which is what made the column look dirty rather than
quiet.

This drops the dimming. Nothing is lost by it — the current workspace already
carries a "this window" badge, a medium-weight name and the selected
background, so the disc was saying a fourth time what three louder things had
said. `current` was the only reason `workspace_avatar` took that argument, so
it goes too; the switcher is its only caller.
