### PR TITLE
feat(cli): wait on commands, press keys, and reap orphan panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A pane's shell is recorded alongside, so a git bash pane no longer comes
   back as PowerShell.
 
+- **`tty7 wait` can wait for a command, not just an agent** — a new `free`
+  state ends the wait when the pane's foreground command has exited and the
+  pane is back to its bare shell, which is what a `cargo test` running in a
+  pane has instead of an agent status. With `--changed` it means "something ran
+  and then finished", the shape you want on the line after a `send`. It costs a
+  second request per poll and so is only checked when you name it.
+
+- **`tty7 send --key` presses keys instead of typing characters** — `C-c` to
+  stop a runaway build, `escape` to close a TUI, `up`/`down`/`enter` to answer
+  a permission prompt that takes no text. Repeatable for a sequence, composable
+  with `TEXT`, and delivered as separate events 200 ms apart so a raw-mode TUI
+  reads a sequence as a sequence rather than as a paste. An unknown key name is
+  a usage error raised before anything is written.
+
+- **`tty7 pane close` takes several panes, and `--orphans` clears the lot** —
+  `pane ls --all` has been able to *show* the panes an interrupted `run` leaves
+  behind; there was no way to act on that except by reading ids off the table
+  one at a time. A pane that cannot be closed no longer abandons the rest of
+  the batch.
+
+- **`tty7 doctor` reports where the agent status hooks stand** — it has claimed
+  to check hooks in its own `--help` for a while without doing so. Missing or
+  outdated hooks are why an agent can look frozen in `tty7 agents` and why
+  `tty7 wait` on it only ever times out, so the check belongs in the verb
+  people run when something is not working.
+
+### Changed
+
+- **`tty7 pane close --json` now reports `{"closed": [ids]}`** rather than a
+  single `{"closed": id}`, because the verb takes more than one pane.
+
 ### Fixed
+
+- **`tty7 wait` no longer calls a busy shell `idle`** — a pane with nothing
+  reporting agent status was reported as `idle`, so `tty7 wait %3 --until idle`
+  returned success immediately, `matched: true`, about a pane that was midway
+  through a build. Those panes now report `no-agent`, which is both true and
+  the signal to use `--until free` instead; a wait that times out there says so.
 
 - **An SFTP upload no longer sits in the browser under its temporary name** —
   an upload is written as `<name>.tty7-upload-<hex>` and renamed into place at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pane is back to its bare shell, which is what a `cargo test` running in a
   pane has instead of an agent status. With `--changed` it means "something ran
   and then finished", the shape you want on the line after a `send`. It costs a
-  second request per poll and so is only checked when you name it.
+  second request per poll and so is only checked when you name it — and only
+  when none of the agent states you named answered first, so `waiting,done,free`
+  on a pane of unknown kind cannot lose you a `waiting`.
 
 - **`tty7 send --key` presses keys instead of typing characters** — `C-c` to
   stop a runaway build, `escape` to close a TUI, `up`/`down`/`enter` to answer
@@ -92,7 +94,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **`tty7 pane close --json` now reports `{"closed": [ids]}`** rather than a
-  single `{"closed": id}`, because the verb takes more than one pane.
+  single `{"closed": id}`, because the verb takes more than one pane. A batch
+  that could not close everything exits 1 with `{"closed": […], "failed": […]}`
+  and the complaint on stderr, so a retry knows what is left.
 
 ### Fixed
 

--- a/crates/tty7-cli/src/backend.rs
+++ b/crates/tty7-cli/src/backend.rs
@@ -90,6 +90,10 @@ pub mod mock {
         pub capture_segments: Vec<CaptureSegment>,
         pub procs_calls: Vec<u64>,
         pub procs_reply: PaneProcs,
+        /// Consumed one per call before falling back to `procs_reply`, so a
+        /// test can script a pane going busy and then quiet again — which is
+        /// the whole of what `wait --until free` watches for.
+        pub procs_replies: VecDeque<PaneProcs>,
         pub agent_hooks_states: Vec<(HookAgent, HooksState)>,
         pub registry: Vec<PaneInfo>,
         pub killed: Vec<u64>,
@@ -112,6 +116,7 @@ pub mod mock {
                 capture_segments: Vec::new(),
                 procs_calls: Vec::new(),
                 procs_reply: PaneProcs::default(),
+                procs_replies: VecDeque::new(),
                 agent_hooks_states: Vec::new(),
                 registry: Vec::new(),
                 killed: Vec::new(),
@@ -173,7 +178,10 @@ pub mod mock {
 
         fn procs(&mut self, pane: u64) -> Result<PaneProcs> {
             self.procs_calls.push(pane);
-            Ok(self.procs_reply.clone())
+            Ok(self
+                .procs_replies
+                .pop_front()
+                .unwrap_or_else(|| self.procs_reply.clone()))
         }
 
         fn agent_hooks_state(&mut self, agent: HookAgent) -> Option<HooksState> {

--- a/crates/tty7-cli/src/cli.rs
+++ b/crates/tty7-cli/src/cli.rs
@@ -68,16 +68,12 @@ pub enum Command {
     #[command(about = "Split a pane (= tty7 pane split)")]
     Split(SplitArgs),
 
+    // The key list is built from the table it is a list *of*, rather than
+    // written out here: a hand-copied vocabulary drifts the first time a key
+    // is added, and this is the text a caller reaches for to learn the names.
     #[command(
         about = "Type text into a pane, or send it keystrokes with --key",
-        long_about = "Types TEXT into the pane exactly as a keyboard would.\n\n\
-                      --key sends a keystroke rather than characters, which is what a pane \
-                      wants once something is already running in it: answering a prompt that \
-                      only takes arrow keys, closing a TUI with escape, stopping a build with \
-                      C-c. Repeat it for a sequence.\n\n\
-                      Keys: enter, escape, tab, backtab, space, backspace, delete, up, down, \
-                      right, left, home, end, pageup, pagedown, C-<char> (Ctrl), M-<char> \
-                      (Alt). Aliases: return, cr, esc, del, bs, shift-tab, pgup, pgdn."
+        long_about = crate::keys::send_long_help()
     )]
     Send(SendArgs),
 

--- a/crates/tty7-cli/src/cli.rs
+++ b/crates/tty7-cli/src/cli.rs
@@ -68,7 +68,17 @@ pub enum Command {
     #[command(about = "Split a pane (= tty7 pane split)")]
     Split(SplitArgs),
 
-    #[command(about = "Type text into a pane")]
+    #[command(
+        about = "Type text into a pane, or send it keystrokes with --key",
+        long_about = "Types TEXT into the pane exactly as a keyboard would.\n\n\
+                      --key sends a keystroke rather than characters, which is what a pane \
+                      wants once something is already running in it: answering a prompt that \
+                      only takes arrow keys, closing a TUI with escape, stopping a build with \
+                      C-c. Repeat it for a sequence.\n\n\
+                      Keys: enter, escape, tab, backtab, space, backspace, delete, up, down, \
+                      right, left, home, end, pageup, pagedown, C-<char> (Ctrl), M-<char> \
+                      (Alt). Aliases: return, cr, esc, del, bs, shift-tab, pgup, pgdn."
+    )]
     Send(SendArgs),
 
     #[command(
@@ -100,7 +110,8 @@ pub enum Command {
     Status,
 
     #[command(
-        about = "Check this install: socket, dialect, config, versions, hooks, links, context"
+        about = "Check this install: socket, dialect, config, versions, agent hooks, links, \
+                 context"
     )]
     Doctor,
 
@@ -190,24 +201,51 @@ pub struct SplitArgs {
 #[derive(Debug, Args)]
 pub struct SendArgs {
     #[arg(value_name = "%PANE|TEXT")]
-    pub first: String,
+    pub first: Option<String>,
 
     #[arg(value_name = "TEXT")]
     pub second: Option<String>,
 
     #[arg(long, help = "Press Enter after the text")]
     pub enter: bool,
+
+    // Text covers "type this command"; it cannot express the keystrokes a pane
+    // asks for once something is already running — the arrow keys a permission
+    // prompt is answered with, the Escape that closes a TUI, the Ctrl-C that
+    // stops a runaway build. Repeatable, and delivered in the order given.
+    #[arg(
+        long = "key",
+        value_name = "KEY",
+        value_parser = crate::keys::parse,
+        help = "Send a keystroke instead of text; repeat for a sequence \
+                (C-c, escape, up, enter, …). See `tty7 send --help`"
+    )]
+    pub keys: Vec<crate::keys::Key>,
 }
 
-/// One resting place a `wait` can end on. `Exit` is pane-level (the child
-/// died or the pane is gone), the rest are the agent-status ladder the
-/// server maintains from hook events.
+/// One resting place a `wait` can end on. Three ontologies meet here, which is
+/// why the list is longer than the agent ladder: `Idle`/`Working`/`Waiting`/
+/// `Done` are the agent status the server keeps from hook events, `NoAgent`
+/// and `Free` describe the pane itself, and `Exit` is the pane being gone.
+///
+/// `NoAgent` exists because the alternative was worse: a pane with nothing
+/// reporting used to read as `idle`, so `--until idle` answered "yes, done"
+/// about a shell that was midway through a build. Saying "no agent is
+/// reporting here" is both true and the thing a caller needs in order to
+/// switch to `Free`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum WaitState {
     Idle,
     Working,
     Waiting,
     Done,
+    /// Nothing is reporting agent status in this pane — a plain shell, or an
+    /// agent whose hooks are not installed. Watch `Free` for those.
+    #[value(name = "no-agent")]
+    NoAgent,
+    /// The pane is back to its bare shell: the foreground command has exited.
+    /// Costs one extra request per poll, so it is only checked when asked for.
+    Free,
     Exit,
 }
 
@@ -221,6 +259,8 @@ impl WaitState {
             WaitState::Working => "working",
             WaitState::Waiting => "waiting",
             WaitState::Done => "done",
+            WaitState::NoAgent => "no-agent",
+            WaitState::Free => "free",
             WaitState::Exit => "exit",
         }
     }
@@ -236,12 +276,14 @@ pub struct WaitArgs {
 
     // The default is the two states worth waking for plus the one nobody can
     // wait past: "my peer needs input", "my peer finished", "my peer died".
+    // `free` is deliberately not in it — it is the answer for a pane running a
+    // command rather than an agent, and it costs a second request per poll.
     #[arg(
         long,
         value_name = "STATE,…",
         value_delimiter = ',',
         default_values = ["waiting", "done", "exit"],
-        help = "States that end the wait"
+        help = "States that end the wait; `free` waits for a plain command to finish"
     )]
     pub until: Vec<WaitState>,
 
@@ -259,10 +301,17 @@ pub struct WaitArgs {
     // before the agent has even read the input. `--changed` refuses the state
     // the pane was already in, which is what a delegation loop wants on every
     // round after the first.
+    //
+    // `free` is level-triggered the same way and needs the same guard, but a
+    // shell that goes free → busy → free returns to the state it started in,
+    // so comparing against a baseline would miss it. There the rule is instead
+    // "we watched something run": `free` only counts once the pane has been
+    // seen busy, which is exactly "the command I just sent has finished".
     #[arg(
         long,
         help = "Ignore the state the pane was already in — only wake on a state it \
-                moved into after the wait began (use this after `send`)"
+                moved into after the wait began; with `free`, wait until something \
+                has actually run (use this after `send`)"
     )]
     pub changed: bool,
 
@@ -412,10 +461,22 @@ pub enum PaneCmd {
     #[command(about = "Split a pane in two")]
     Split(SplitArgs),
 
-    #[command(about = "Close a pane; its shell is hung up")]
+    #[command(about = "Close panes; their shells are hung up")]
     Close {
-        #[arg(value_name = "%PANE")]
-        target: Option<String>,
+        #[arg(value_name = "%PANE", help = "Panes to close; defaults to $TTY7_PANE")]
+        targets: Vec<String>,
+
+        // `pane ls --all` has been able to *show* the panes an interrupted
+        // `run` leaves behind for a while, and the only way to act on that was
+        // to read ids off the table and close them one at a time. The CLI
+        // creates these; it should be able to clear them.
+        #[arg(
+            long,
+            conflicts_with = "targets",
+            help = "Close every pane no workspace holds — what an interrupted `run` \
+                    leaves behind. Lists them; pass --json for the ids"
+        )]
+        orphans: bool,
     },
 }
 
@@ -593,7 +654,7 @@ mod tests {
         let Some(Command::Send(args)) = cli.command else {
             panic!("send did not parse");
         };
-        assert_eq!(args.first, "%42");
+        assert_eq!(args.first.as_deref(), Some("%42"));
         assert_eq!(args.second.as_deref(), Some("make -j8"));
         assert!(args.enter);
 
@@ -601,8 +662,37 @@ mod tests {
         let Some(Command::Send(args)) = cli.command else {
             panic!("send did not parse");
         };
-        assert_eq!(args.first, "make -j8");
+        assert_eq!(args.first.as_deref(), Some("make -j8"));
         assert!(args.second.is_none());
+    }
+
+    /// `--key` is the reason TEXT became optional: `send %42 --key C-c` has an
+    /// address and no text, which every other shape would read as a mistake.
+    #[test]
+    fn send_accepts_keys_with_or_without_text() {
+        let cli = parse(&["tty7", "send", "%42", "--key", "C-c"]);
+        let Some(Command::Send(args)) = cli.command else {
+            panic!("send did not parse");
+        };
+        assert_eq!(args.first.as_deref(), Some("%42"));
+        assert!(args.second.is_none());
+        assert_eq!(args.keys.len(), 1);
+        assert_eq!(args.keys[0].bytes, vec![0x03]);
+
+        // A sequence keeps the order it was written in — that is the whole
+        // point for a menu that has to be walked down and then confirmed.
+        let cli = parse(&["tty7", "send", "--key", "down", "--key", "enter"]);
+        let Some(Command::Send(args)) = cli.command else {
+            panic!("send did not parse");
+        };
+        assert!(args.first.is_none(), "the pane comes from $TTY7_PANE");
+        let names: Vec<&str> = args.keys.iter().map(|k| k.name.as_str()).collect();
+        assert_eq!(names, vec!["down", "enter"]);
+
+        // An unknown key is a usage error, caught before anything is sent —
+        // half a key sequence in a live pane is worse than none.
+        let err = Cli::try_parse_from(["tty7", "send", "--key", "f7"]).unwrap_err();
+        assert_eq!(err.exit_code(), 2);
     }
 
     #[test]
@@ -676,8 +766,22 @@ mod tests {
         ));
         assert!(matches!(
             parse(&["tty7", "pane", "close", "%9"]).command,
-            Some(Command::Pane(PaneCmd::Close { target: Some(t) })) if t == "%9"
+            Some(Command::Pane(PaneCmd::Close { targets, orphans: false })) if targets == ["%9"]
         ));
+        // Several at once, because a cleanup usually has more than one thing
+        // to clean up — and the whole registry with `--orphans`.
+        assert!(matches!(
+            parse(&["tty7", "pane", "close", "%9", "%10"]).command,
+            Some(Command::Pane(PaneCmd::Close { targets, .. })) if targets == ["%9", "%10"]
+        ));
+        assert!(matches!(
+            parse(&["tty7", "pane", "close", "--orphans"]).command,
+            Some(Command::Pane(PaneCmd::Close { targets, orphans: true })) if targets.is_empty()
+        ));
+        // Naming panes *and* asking for every orphan is a contradiction: which
+        // set did the caller mean? Refuse rather than pick one.
+        let err = Cli::try_parse_from(["tty7", "pane", "close", "%9", "--orphans"]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/crates/tty7-cli/src/commands.rs
+++ b/crates/tty7-cli/src/commands.rs
@@ -826,12 +826,24 @@ fn pane_close(
     }
 
     if !failures.is_empty() {
-        bail!(
-            "closed {} pane(s); {} could not be closed — {}",
+        // Structured even here, for the reason `wait` is: the caller was
+        // cleaning up, and what they need next is which panes are still theirs
+        // to deal with — an anyhow error would leave `--json` holding prose.
+        // The complaint goes to stderr all the same, so `-q` still reports it
+        // and the exit code is not the only thing that says so.
+        eprintln!(
+            "tty7: closed {} pane(s); {} could not be closed — {}",
             closed.len(),
             failures.len(),
             failures.join("; ")
         );
+        return Ok(Outcome::Exit(
+            1,
+            Report {
+                human: String::new(),
+                json: json!({ "closed": closed, "failed": failures }),
+            },
+        ));
     }
     let human = match closed.as_slice() {
         // The single-pane case is the overwhelming one and has always been
@@ -973,10 +985,12 @@ fn wait(args: WaitArgs, ctx: &Context, backend: &mut dyn Backend) -> Result<Outc
         let mut changed = cursor != baseline;
 
         // `free` is a fact about the process tree, not the agent ladder, so it
-        // is asked separately and only when requested. It outranks the ladder
-        // when true: a pane whose foreground command has exited is free
-        // whatever a hook last said about it.
-        if watch_free && current != WaitState::Exit {
+        // is asked separately, only when requested, and only once the ladder
+        // has failed to answer. A state the caller listed is their answer:
+        // overwriting a real `waiting` with a process-tree fact would strand a
+        // pane whose depth-0 process *is* the agent (see `pane_is_free`), where
+        // the tree reads free for the whole turn.
+        if watch_free && current != WaitState::Exit && !args.until.contains(&current) {
             if pane_is_free(backend, pane)? {
                 current = WaitState::Free;
                 changed = seen_busy;
@@ -1055,6 +1069,17 @@ fn wait(args: WaitArgs, ctx: &Context, backend: &mut dyn Backend) -> Result<Outc
                      status hook",
                 );
             }
+            // `--changed` needs to have *seen* the pane busy, and a command
+            // that starts and finishes inside one interval never is. That
+            // looks exactly like "the command never ran", so say both, rather
+            // than let a finished command read as a timeout.
+            if current == WaitState::Free && !seen_busy {
+                human.push_str(
+                    "\nnothing was ever seen running here — either the command never started, \
+                     or it finished inside one --interval. Poll faster (--interval 100) or drop \
+                     --changed",
+                );
+            }
             return Ok(Outcome::Exit(
                 124,
                 Report {
@@ -1078,8 +1103,18 @@ fn wait(args: WaitArgs, ctx: &Context, backend: &mut dyn Backend) -> Result<Outc
 /// Depth, not count: the pane's own shell sits at depth 0 and everything it
 /// launched hangs below, so "nothing deeper than the shell" holds however many
 /// shells the pane ended up with, and does not have to guess at process names.
+/// It is also the portable question — Windows has no foreground process group
+/// to ask about, so `ProcEntry::foreground` is never true there.
+///
+/// What it cannot see, both by construction: a pane whose depth-0 process *is*
+/// the command — which is what `tty7 run` spawns — reads free for as long as it
+/// runs, and a backgrounded job keeps a pane busy after the foreground command
+/// is long gone. An empty tree is "we could not see in" rather than "free":
+/// answering free there would be the same false success `no-agent` exists to
+/// remove.
 fn pane_is_free(backend: &mut dyn Backend, pane: u64) -> Result<bool> {
-    Ok(backend.procs(pane)?.procs.iter().all(|p| p.depth == 0))
+    let procs = backend.procs(pane)?.procs;
+    Ok(!procs.is_empty() && procs.iter().all(|p| p.depth == 0))
 }
 
 /// Whether the daemon still has a live pane behind this id. Absent from the
@@ -2020,6 +2055,10 @@ mod tests {
     /// A batch keeps going after a failure. Stopping at the first one would
     /// leave the rest of the leak exactly where it was — while still reporting
     /// the failure, because a half-done cleanup that claims success is worse.
+    ///
+    /// Reported as an exit code carrying a report, not as an error: the caller
+    /// was cleaning up, and the useful answer is which panes are still theirs
+    /// to deal with. An anyhow error would leave `--json` with prose.
     #[test]
     fn pane_close_reports_failures_without_abandoning_the_batch() {
         let mut backend = mock();
@@ -2030,13 +2069,30 @@ mod tests {
         ];
         backend.kill_failures = vec![78];
 
-        let err = execute(
+        let out = execute(
             cli(&["tty7", "pane", "close", "--orphans"]),
             &Context::default(),
             &mut backend,
         )
-        .expect_err("a pane that could not be closed has to be reported");
-        assert!(err.to_string().contains("%78"), "{err}");
+        .expect("a partial cleanup is an exit code, not an error");
+        let Outcome::Exit(1, r) = out else {
+            panic!("a pane that could not be closed has to be reported");
+        };
+        assert_eq!(
+            r.json["closed"],
+            serde_json::json!([77, 79]),
+            "the survivors of the batch are what a retry needs: {}",
+            r.json
+        );
+        assert!(
+            r.json["failed"]
+                .as_array()
+                .expect("the failures are a list")
+                .iter()
+                .any(|f| f.as_str().is_some_and(|f| f.contains("%78"))),
+            "{}",
+            r.json
+        );
         assert_eq!(
             backend.killed,
             vec![77, 78, 79],
@@ -2864,6 +2920,94 @@ mod tests {
         assert_eq!(json["status"], "free");
         assert_eq!(json["matched"], true);
         assert_eq!(json["stale"], false);
+    }
+
+    /// A command that starts and finishes between two polls is never *seen*
+    /// busy, which is indistinguishable from one that never ran — so the
+    /// timeout has to name both doors instead of letting a finished command
+    /// read as "still going".
+    #[test]
+    fn wait_changed_free_says_why_it_saw_nothing_run() {
+        let mut backend = mock();
+        for _ in 0..2 {
+            backend.replies.push_back(ReplyOk::AgentStates(Vec::new()));
+        }
+        backend.procs_reply = idle_procs();
+
+        let out = execute(
+            cli(&[
+                "tty7",
+                "wait",
+                "%3",
+                "--until",
+                "free",
+                "--changed",
+                "--timeout",
+                "0",
+            ]),
+            &Context::default(),
+            &mut backend,
+        )
+        .expect("a timeout is an exit code, not an error");
+        let Outcome::Exit(124, r) = out else {
+            panic!("a pane that was free all along has not run anything");
+        };
+        assert!(
+            r.human.contains("--interval") && r.human.contains("--changed"),
+            "the timeout should name the two ways out: {}",
+            r.human
+        );
+    }
+
+    /// `free` answers for a pane the agent ladder cannot, so it must not answer
+    /// *over* it. A pane whose depth-0 process is the agent itself reads free
+    /// for its whole turn; letting that outrank a `waiting` the caller asked
+    /// for would strand exactly the delegation loop the verb exists for.
+    #[test]
+    fn wait_free_does_not_overrule_a_state_the_caller_asked_for() {
+        use tty7_core::core::cli_agent::AgentStatus;
+        let mut backend = mock();
+        backend
+            .replies
+            .push_back(ReplyOk::AgentStates(vec![agent_state(
+                3,
+                AgentStatus::Waiting,
+            )]));
+        // The agent is the pane's only process, so the tree reads "free".
+        backend.procs_reply = idle_procs();
+
+        let json = json_of(run_cli(
+            &["tty7", "wait", "%3", "--until", "waiting,free"],
+            &Context::default(),
+            &mut backend,
+        ));
+        assert_eq!(json["status"], "waiting", "the ladder answered first");
+        assert_eq!(json["matched"], true);
+        assert!(
+            backend.procs_calls.is_empty(),
+            "and the process tree was never asked"
+        );
+    }
+
+    /// An unreadable process tree is not an idle one. Answering `free` on an
+    /// empty reply would be the same false success `no-agent` was added to
+    /// remove, one layer down.
+    #[test]
+    fn wait_free_does_not_read_an_empty_process_tree_as_finished() {
+        let mut backend = mock();
+        backend.replies.push_back(ReplyOk::AgentStates(Vec::new()));
+        backend.procs_reply = tty7_core::daemon::protocol::PaneProcs::default();
+
+        let out = execute(
+            cli(&["tty7", "wait", "%3", "--until", "free", "--timeout", "0"]),
+            &Context::default(),
+            &mut backend,
+        )
+        .expect("a timeout is an exit code, not an error");
+        assert!(
+            matches!(out, Outcome::Exit(124, _)),
+            "nothing was seen, so nothing can be claimed"
+        );
     }
 
     /// Watching `free` must not cost anything for callers who did not ask:

--- a/crates/tty7-cli/src/commands.rs
+++ b/crates/tty7-cli/src/commands.rs
@@ -86,8 +86,8 @@ pub fn execute(cli: Cli, ctx: &Context, backend: &mut dyn Backend) -> Result<Out
         Some(Command::Tab(TabCmd::Rename { tab, name })) => tab_rename(&tab, name, backend),
         Some(Command::Tab(TabCmd::Move { tab, index })) => tab_move(&tab, index, backend),
         Some(Command::Pane(PaneCmd::Ls { ws, all })) => pane_ls(ws.as_deref(), all, backend),
-        Some(Command::Pane(PaneCmd::Close { target })) => {
-            pane_close(target.as_deref(), ctx, backend)
+        Some(Command::Pane(PaneCmd::Close { targets, orphans })) => {
+            pane_close(&targets, orphans, ctx, backend)
         }
         Some(Command::Events) => events(json_mode, backend),
         Some(Command::Agents) => agents(backend),
@@ -482,29 +482,64 @@ fn pane_split(args: SplitArgs, ctx: &Context, backend: &mut dyn Backend) -> Resu
 }
 
 fn send(args: SendArgs, ctx: &Context, backend: &mut dyn Backend) -> Result<Outcome> {
-    const ENTER_GAP: Duration = Duration::from_millis(200);
+    const KEY_GAP: Duration = Duration::from_millis(200);
 
-    let (target, text) = match &args.second {
-        Some(text) => (Some(args.first.as_str()), text.as_str()),
-        None => {
-            if args.first.starts_with('%') && address::parse_pane(&args.first).is_ok() {
-                bail!("send needs TEXT after the pane address");
+    // Three shapes reach here, and only the address is ever ambiguous:
+    // `send %3 "text"`, `send "text"` (this pane), and — new with --key —
+    // `send %3 --key C-c`, where there is no text at all and the lone
+    // positional is therefore an address rather than the missing-text error it
+    // has to stay in every other case.
+    let (target, text) = match (&args.first, &args.second) {
+        (Some(first), Some(text)) => (Some(first.as_str()), Some(text.as_str())),
+        (Some(first), None) if first.starts_with('%') && address::parse_pane(first).is_ok() => {
+            if args.keys.is_empty() {
+                bail!("send needs TEXT after the pane address, or a --key to press");
             }
-            (None, args.first.as_str())
+            (Some(first.as_str()), None)
+        }
+        (Some(first), None) => (None, Some(first.as_str())),
+        (None, _) => {
+            if args.keys.is_empty() {
+                bail!("send needs TEXT to type or a --key to press");
+            }
+            (None, None)
         }
     };
+
     let pane = address::pane_or_context(target, ctx)?;
-    backend.send_input(pane, text.as_bytes().to_vec())?;
+    let mut already_wrote = false;
+    if let Some(text) = text {
+        backend.send_input(pane, text.as_bytes().to_vec())?;
+        already_wrote = true;
+    }
+    // `--enter` is the same thing as `--key enter`, and predates it. Keeping it
+    // as sugar rather than deprecating it: it reads better for the overwhelming
+    // case, which is typing one command and running it. Going through the same
+    // parser leaves one definition of what Enter puts on the wire.
+    let mut pressed = args.keys.clone();
     if args.enter {
+        pressed.push(crate::keys::parse("enter").expect("enter is in the vocabulary"));
+    }
+    for key in &pressed {
         // Raw-mode TUIs detect a fast stream as pasted input and intentionally
-        // absorb Enter as a newline. Keep the public one-shot command, but let
-        // the text leave that burst window before delivering the key itself.
-        std::thread::sleep(ENTER_GAP);
-        backend.send_input(pane, vec![b'\r'])?;
+        // absorb Enter as a newline — and a menu being driven by arrow keys has
+        // the same problem. Let each keystroke leave the burst window on its
+        // own, which is what makes a sequence land as a sequence. Nothing
+        // precedes the first write, though, so an interrupt stays immediate.
+        if already_wrote {
+            std::thread::sleep(KEY_GAP);
+        }
+        backend.send_input(pane, key.bytes.clone())?;
+        already_wrote = true;
     }
     report(
         "",
-        json!({ "pane": pane, "sent": text, "enter": args.enter }),
+        json!({
+            "pane": pane,
+            "sent": text.unwrap_or_default(),
+            "enter": args.enter,
+            "keys": pressed.iter().map(|k| k.name.as_str()).collect::<Vec<_>>(),
+        }),
     )
 }
 
@@ -734,27 +769,100 @@ fn pane_ls_all(backend: &mut dyn Backend) -> Result<Outcome> {
     let mut human = output::registry_table(&running, &|pane| holder(pane).map(|ws| ws.to_string()));
     if orphans > 0 {
         human.push_str(&format!(
-            "\n{orphans} pane(s) held by no workspace — `tty7 pane close %<id>` stops one\n"
+            "\n{orphans} pane(s) held by no workspace — `tty7 pane close %<id>` stops one, \
+             `tty7 pane close --orphans` stops all of them\n"
         ));
     }
     report(human, json!({ "panes": panes, "orphans": orphans }))
 }
 
-fn pane_close(target: Option<&str>, ctx: &Context, backend: &mut dyn Backend) -> Result<Outcome> {
-    let pane = address::pane_or_context(target, ctx)?;
+fn pane_close(
+    targets: &[String],
+    orphans: bool,
+    ctx: &Context,
+    backend: &mut dyn Backend,
+) -> Result<Outcome> {
+    // One tree read for the whole batch: it resolves the orphan set and then
+    // every pane's owning workspace.
     let machine = fetch_machine(backend)?;
-    match resolve::workspace_of_pane(&machine, pane) {
-        Ok(ws) => {
-            let workspace = ws.id;
-            let reply = backend.control(ControlRequest::PaneClose { workspace, pane })?;
-            hang_up_removed_panes("PaneClose", reply, backend)?;
+    let panes = if orphans {
+        let found = orphan_panes(&machine, backend)?;
+        if found.is_empty() {
+            return report("no orphan panes\n", json!({ "closed": [] }));
         }
-        // No workspace holds it, so PaneClose has nothing to route through.
-        // Hang it up directly instead of refusing — this is exactly the orphan
-        // `pane ls --all` just pointed the user at.
-        Err(_) => backend.kill_pane(pane)?,
+        found
+    } else if targets.is_empty() {
+        vec![address::pane_or_context(None, ctx)?]
+    } else {
+        targets
+            .iter()
+            .map(|t| address::pane_or_context(Some(t), ctx))
+            .collect::<Result<Vec<_>>>()?
+    };
+
+    // Every pane is attempted even if an earlier one fails — a reaper that
+    // stops at the first error leaves the rest of the leak in place, which is
+    // the state the caller was trying to fix.
+    let mut closed = Vec::new();
+    let mut failures = Vec::new();
+    for pane in panes {
+        let outcome = match resolve::workspace_of_pane(&machine, pane) {
+            Ok(ws) => {
+                let workspace = ws.id;
+                match backend.control(ControlRequest::PaneClose { workspace, pane }) {
+                    Ok(reply) => hang_up_removed_panes("PaneClose", reply, backend),
+                    Err(e) => Err(e),
+                }
+            }
+            // No workspace holds it, so PaneClose has nothing to route through.
+            // Hang it up directly instead of refusing — this is exactly the
+            // orphan `pane ls --all` points the user at.
+            Err(_) => backend.kill_pane(pane),
+        };
+        match outcome {
+            Ok(()) => closed.push(pane),
+            Err(e) => failures.push(format!("%{pane}: {e:#}")),
+        }
     }
-    report("", json!({ "closed": pane }))
+
+    if !failures.is_empty() {
+        bail!(
+            "closed {} pane(s); {} could not be closed — {}",
+            closed.len(),
+            failures.len(),
+            failures.join("; ")
+        );
+    }
+    let human = match closed.as_slice() {
+        // The single-pane case is the overwhelming one and has always been
+        // silent on success; only a batch is worth narrating.
+        [_] => String::new(),
+        many => format!(
+            "closed {} panes: {}\n",
+            many.len(),
+            many.iter()
+                .map(|p| format!("%{p}"))
+                .collect::<Vec<_>>()
+                .join(" ")
+        ),
+    };
+    report(human, json!({ "closed": closed }))
+}
+
+/// The panes the daemon is running that no workspace's tab tree references.
+fn orphan_panes(machine: &Machine, backend: &mut dyn Backend) -> Result<Vec<u64>> {
+    let held: Vec<u64> = machine
+        .workspaces
+        .iter()
+        .flat_map(|ws| ws.tabs.iter())
+        .flat_map(|tab| tab.root.pane_ids())
+        .collect();
+    Ok(backend
+        .list_panes()?
+        .iter()
+        .map(|info| info.pane_id)
+        .filter(|pane| !held.contains(pane))
+        .collect())
 }
 
 fn events(json_mode: bool, backend: &mut dyn Backend) -> Result<Outcome> {
@@ -789,15 +897,23 @@ fn event_line(event: &ControlEvent) -> String {
     }
 }
 
-/// The one verb that *blocks*: poll until the watched pane's agent reaches a
-/// requested state, then report it. This is what turns the CLI into an
-/// orchestration tool — "wake me when my peer agent needs input, or finishes
-/// its turn" — without the screen-scraping a tmux-based agent team resorts to.
+/// The one verb that *blocks*: poll until the watched pane reaches a requested
+/// state, then report it. This is what turns the CLI into an orchestration tool
+/// — "wake me when my peer agent needs input, or finishes its turn" — without
+/// the screen-scraping a tmux-based agent team resorts to.
 ///
-/// A poll of `AgentStates` rather than an `events` subscription on purpose: a
-/// one-shot, stateless question composes into scripts (`tty7 wait %3 &&
-/// tty7 capture %3 --plain`), survives a server restart mid-wait, and needs no
-/// cursor management. At the default 500ms interval the cost is one aggregate
+/// Two kinds of pane can be waited on, and they are watched differently. An
+/// agent pane has a status the server keeps from hook events; a pane merely
+/// running a command has none, and for it the question is whether the
+/// foreground command has exited — `free`, read off the process tree. Keeping
+/// both here rather than in two verbs means a caller that does not know which
+/// kind it has can ask for `waiting,done,free,exit` and get an answer either
+/// way.
+///
+/// A poll rather than an `events` subscription on purpose: a one-shot,
+/// stateless question composes into scripts (`tty7 wait %3 && tty7 capture %3
+/// --plain`), survives a server restart mid-wait, and needs no cursor
+/// management. At the default 500ms interval an agent wait costs one aggregate
 /// control request per tick — the same request `tty7 agents` makes once.
 fn wait(args: WaitArgs, ctx: &Context, backend: &mut dyn Backend) -> Result<Outcome> {
     use std::time::{Duration, Instant};
@@ -821,7 +937,11 @@ fn wait(args: WaitArgs, ctx: &Context, backend: &mut dyn Backend) -> Result<Outc
         .timeout
         .and_then(|t| Instant::now().checked_add(Duration::from_secs(t)));
     let interval = Duration::from_millis(args.interval);
+    let watch_free = args.until.contains(&WaitState::Free);
     let mut baseline: Option<Cursor> = None;
+    // Sticky: has the pane been seen running something since the wait began?
+    // This is `--changed`'s edge for `free` — see the flag's own comment.
+    let mut seen_busy = false;
     let mut polls: u32 = 0;
     loop {
         let states = match backend.control(ControlRequest::AgentStates)? {
@@ -836,11 +956,13 @@ fn wait(args: WaitArgs, ctx: &Context, backend: &mut dyn Backend) -> Result<Outc
                 AgentStatus::Waiting => WaitState::Waiting,
                 AgentStatus::Done => WaitState::Done,
             },
-            // No agent state for the pane: an agentless-but-live pane reads
-            // as idle; a dead or vanished one as exit. The machine tree is
-            // only fetched on this branch — while an agent is reporting, its
-            // state alone answers the question.
-            None if pane_is_live(backend, pane)? => WaitState::Idle,
+            // No agent state for the pane: a live one is agentless — a plain
+            // shell, or an agent whose hooks never got installed — and a dead
+            // or vanished one has exited. Reporting `idle` here (as this once
+            // did) made `--until idle` answer "finished" about a pane that was
+            // midway through a build. The machine tree is only fetched on this
+            // branch — while an agent is reporting, its state alone answers.
+            None if pane_is_live(backend, pane)? => WaitState::NoAgent,
             None => WaitState::Exit,
         };
 
@@ -848,7 +970,20 @@ fn wait(args: WaitArgs, ctx: &Context, backend: &mut dyn Backend) -> Result<Outc
         // position we arrived at is last turn's answer until the agent moves.
         let cursor: Cursor = entry.as_ref().map(|e| (e.state.status, e.state.activity));
         let baseline = *baseline.get_or_insert(cursor);
-        let changed = cursor != baseline;
+        let mut changed = cursor != baseline;
+
+        // `free` is a fact about the process tree, not the agent ladder, so it
+        // is asked separately and only when requested. It outranks the ladder
+        // when true: a pane whose foreground command has exited is free
+        // whatever a hook last said about it.
+        if watch_free && current != WaitState::Exit {
+            if pane_is_free(backend, pane)? {
+                current = WaitState::Free;
+                changed = seen_busy;
+            } else {
+                seen_busy = true;
+            }
+        }
 
         let mut matched = args.until.contains(&current) && (changed || !args.changed);
         polls += 1;
@@ -898,17 +1033,32 @@ fn wait(args: WaitArgs, ctx: &Context, backend: &mut dyn Backend) -> Result<Outc
                 human.push_str(&format!(" — {msg}"));
             }
             if !changed {
-                human.push_str(" (unchanged since the wait began)");
+                human.push_str(match current {
+                    WaitState::Free => " (already free — nothing ran while we watched)",
+                    _ => " (unchanged since the wait began)",
+                });
             }
             return report(human, json);
         }
         if deadline.is_some_and(|d| Instant::now() >= d) {
             // 124 = the `timeout(1)` convention: "gave up", distinct from
             // both success and error, so orchestration scripts can branch.
+            let mut human = format!("pane %{pane}: still {} — timed out", current.name());
+            // A wait for agent states that never move is the shape of both
+            // "there is no agent here" and "the agent's hooks are missing",
+            // and neither is visible from a timeout alone. Say which door to
+            // try rather than leaving the caller to poll harder.
+            if current == WaitState::NoAgent {
+                human.push_str(
+                    "\nnothing is reporting agent status in this pane — for a plain command \
+                     wait `--until free`, and for an agent check `tty7 agents` for a missing \
+                     status hook",
+                );
+            }
             return Ok(Outcome::Exit(
                 124,
                 Report {
-                    human: format!("pane %{pane}: still {} — timed out", current.name()),
+                    human,
                     json: json!({ "pane": pane, "status": current.name(), "timed_out": true }),
                 },
             ));
@@ -921,6 +1071,15 @@ fn wait(args: WaitArgs, ctx: &Context, backend: &mut dyn Backend) -> Result<Outc
         };
         std::thread::sleep(nap);
     }
+}
+
+/// Whether the pane is back to its bare shell — nothing running in front of it.
+///
+/// Depth, not count: the pane's own shell sits at depth 0 and everything it
+/// launched hangs below, so "nothing deeper than the shell" holds however many
+/// shells the pane ended up with, and does not have to guess at process names.
+fn pane_is_free(backend: &mut dyn Backend, pane: u64) -> Result<bool> {
+    Ok(backend.procs(pane)?.procs.iter().all(|p| p.depth == 0))
 }
 
 /// Whether the daemon still has a live pane behind this id. Absent from the
@@ -1089,6 +1248,7 @@ fn doctor(ctx: &Context, backend: &mut dyn Backend) -> Result<Outcome> {
         vec![address::ENV_PANE.to_string(), mark(&ctx.pane)],
     ];
     let mut server = json!({ "reachable": false });
+    let mut hooks: Vec<(HookAgent, HooksState)> = Vec::new();
     match backend.hello() {
         Ok(hello) => {
             let dialect_ok = hello.control_version == CONTROL_VERSION
@@ -1127,6 +1287,13 @@ fn doctor(ctx: &Context, backend: &mut dyn Backend) -> Result<Outcome> {
                 "machine links".to_string(),
                 format!("{} known, {connected} connected", routes.len()),
             ]);
+            // Without hooks an agent reports no status, which means `tty7
+            // agents` shows it standing still and `tty7 wait` never wakes. That
+            // failure looks like a hang rather than a missing install, so the
+            // check that explains it belongs in the verb people run when
+            // something is not working.
+            hooks = hook_survey(backend);
+            rows.push(vec!["agent hooks".to_string(), hooks_summary(&hooks)]);
             server = json!({
                 "reachable": true,
                 "dialect_ok": dialect_ok,
@@ -1154,8 +1321,74 @@ fn doctor(ctx: &Context, backend: &mut dyn Backend) -> Result<Outcome> {
                 "pane": ctx.pane.is_some(),
             },
             "server": server,
+            "hooks": hooks_json(&hooks),
         }),
     )
+}
+
+/// Where every installable status hook stands on this machine.
+///
+/// Agents whose state cannot be read at all are left out rather than guessed
+/// at: the backend answers `None` both for a `-m` run (hooks are a local
+/// install, and this is a local check) and when the app itself cannot be found,
+/// and neither is the same as "not installed".
+fn hook_survey(backend: &mut dyn Backend) -> Vec<(HookAgent, HooksState)> {
+    HookAgent::ALL
+        .into_iter()
+        .filter_map(|agent| Some((agent, backend.agent_hooks_state(agent)?)))
+        .collect()
+}
+
+fn hooks_summary(hooks: &[(HookAgent, HooksState)]) -> String {
+    if hooks.is_empty() {
+        return "unknown — hooks are a local install, and this check could not read them".into();
+    }
+    let named = |want: HooksState| -> Vec<&'static str> {
+        hooks
+            .iter()
+            .filter(|(_, state)| *state == want)
+            .map(|(agent, _)| agent.display_name())
+            .collect()
+    };
+    let installed = named(HooksState::Installed);
+    let outdated = named(HooksState::Outdated);
+
+    // The current ones are named because that is the answer to "can I delegate
+    // to this agent"; the missing ones are a count, since listing every agent
+    // tty7 knows about would bury it. "Up to date" rather than "installed":
+    // an outdated hook *is* installed, and saying "none installed" next to six
+    // outdated ones reads as a contradiction.
+    let mut summary = if installed.is_empty() {
+        "none up to date".to_string()
+    } else {
+        format!("{} up to date", installed.join(", "))
+    };
+    if !outdated.is_empty() {
+        summary.push_str(&format!("; {} OUTDATED", outdated.join(", ")));
+    }
+    let missing = hooks.len() - installed.len() - outdated.len();
+    if missing > 0 {
+        summary.push_str(&format!("; {missing} not installed"));
+    }
+    if installed.is_empty() || !outdated.is_empty() {
+        summary.push_str(" (Settings → Agents)");
+    }
+    summary
+}
+
+fn hooks_json(hooks: &[(HookAgent, HooksState)]) -> Value {
+    let slugs = |want: HooksState| -> Vec<&'static str> {
+        hooks
+            .iter()
+            .filter(|(_, state)| *state == want)
+            .map(|(agent, _)| agent.slug())
+            .collect()
+    };
+    json!({
+        "installed": slugs(HooksState::Installed),
+        "outdated": slugs(HooksState::Outdated),
+        "not_installed": slugs(HooksState::NotInstalled),
+    })
 }
 
 #[cfg(test)]
@@ -1740,6 +1973,77 @@ mod tests {
         );
     }
 
+    /// The CLI is what creates orphans, so it should be able to clear them.
+    /// `--orphans` closes exactly the panes the registry holds and the tab
+    /// trees do not — panes that *are* held must survive it untouched.
+    #[test]
+    fn pane_close_orphans_reaps_only_what_no_workspace_holds() {
+        let mut backend = mock();
+        // %1 and %3 live in the tree (see two_workspace_machine); %77 and %78
+        // are what interrupted `run`s left behind.
+        backend.registry = vec![
+            pane_info(1, None),
+            pane_info(3, None),
+            pane_info(77, Some("tty7-cli")),
+            pane_info(78, Some("tty7-cli")),
+        ];
+
+        let json = json_of(run_cli(
+            &["tty7", "pane", "close", "--orphans"],
+            &Context::default(),
+            &mut backend,
+        ));
+        assert_eq!(json["closed"], serde_json::json!([77, 78]));
+        assert_eq!(backend.killed, vec![77, 78]);
+        assert!(
+            !backend
+                .control_calls
+                .iter()
+                .any(|c| matches!(c, ControlRequest::PaneClose { .. })),
+            "orphans have no workspace to route a PaneClose through"
+        );
+
+        // Nothing to reap is a success with an empty list, not an error: a
+        // cleanup step that fails when the machine is already clean is one a
+        // script has to guard, and every script would then guard it the same way.
+        let mut backend = mock();
+        backend.registry = vec![pane_info(1, None), pane_info(3, None)];
+        let json = json_of(run_cli(
+            &["tty7", "pane", "close", "--orphans"],
+            &Context::default(),
+            &mut backend,
+        ));
+        assert_eq!(json["closed"], serde_json::json!([]));
+        assert!(backend.killed.is_empty());
+    }
+
+    /// A batch keeps going after a failure. Stopping at the first one would
+    /// leave the rest of the leak exactly where it was — while still reporting
+    /// the failure, because a half-done cleanup that claims success is worse.
+    #[test]
+    fn pane_close_reports_failures_without_abandoning_the_batch() {
+        let mut backend = mock();
+        backend.registry = vec![
+            pane_info(77, None),
+            pane_info(78, None),
+            pane_info(79, None),
+        ];
+        backend.kill_failures = vec![78];
+
+        let err = execute(
+            cli(&["tty7", "pane", "close", "--orphans"]),
+            &Context::default(),
+            &mut backend,
+        )
+        .expect_err("a pane that could not be closed has to be reported");
+        assert!(err.to_string().contains("%78"), "{err}");
+        assert_eq!(
+            backend.killed,
+            vec![77, 78, 79],
+            "the panes after the failure still had to be attempted"
+        );
+    }
+
     #[test]
     fn send_reaches_the_pane_socket_seam_not_the_control_socket() {
         let mut backend = mock();
@@ -1761,6 +2065,66 @@ mod tests {
         backend.sent.clear();
         run_cli(&["tty7", "send", "echo hi"], &ctx, &mut backend);
         assert_eq!(backend.sent, vec![(3, b"echo hi".to_vec())]);
+    }
+
+    /// The keystrokes text cannot express. Each goes out as its own write, in
+    /// the order given, because a pane reads them as separate key events —
+    /// which is what walking a menu and then confirming it requires.
+    #[test]
+    fn send_key_presses_keys_in_order() {
+        let mut backend = mock();
+        run_cli(
+            &["tty7", "send", "%1", "--key", "down", "--key", "enter"],
+            &Context::default(),
+            &mut backend,
+        );
+        assert_eq!(
+            backend.sent,
+            vec![(1, b"\x1b[B".to_vec()), (1, b"\r".to_vec())]
+        );
+
+        // Text and keys compose: type the answer, then press the key that
+        // submits it in whatever the pane is showing.
+        let mut backend = mock();
+        run_cli(
+            &["tty7", "send", "%1", "y", "--key", "enter"],
+            &Context::default(),
+            &mut backend,
+        );
+        assert_eq!(backend.sent, vec![(1, b"y".to_vec()), (1, b"\r".to_vec())]);
+
+        // Interrupting takes no text at all — the case that made TEXT optional.
+        let mut backend = mock();
+        let json = json_of(run_cli(
+            &["tty7", "send", "%1", "--key", "C-c"],
+            &Context::default(),
+            &mut backend,
+        ));
+        assert_eq!(backend.sent, vec![(1, vec![0x03])]);
+        assert_eq!(json["keys"], serde_json::json!(["c-c"]));
+        assert_eq!(json["sent"], "", "nothing was typed");
+    }
+
+    /// A lone address still has to be the missing-text error it always was —
+    /// otherwise `tty7 send %42` would silently do nothing at all.
+    #[test]
+    fn send_still_refuses_a_bare_address_when_there_is_nothing_to_press() {
+        let mut backend = mock();
+        let err = execute(
+            cli(&["tty7", "send", "%1"]),
+            &Context::default(),
+            &mut backend,
+        )
+        .expect_err("a bare address sends nothing and must say so");
+        assert!(err.to_string().contains("needs TEXT"), "{err}");
+        assert!(backend.sent.is_empty());
+
+        // And outside a tty7 shell, with neither text nor keys, the complaint
+        // is about the missing input rather than the missing pane.
+        let mut backend = mock();
+        let err = execute(cli(&["tty7", "send"]), &Context::default(), &mut backend)
+            .expect_err("send with no arguments has nothing to do");
+        assert!(err.to_string().contains("--key"), "{err}");
     }
 
     #[test]
@@ -2143,6 +2507,39 @@ mod tests {
         agent_state_at(pane_id, status, 0)
     }
 
+    /// A pane sitting at its prompt: the shell, and nothing in front of it.
+    fn idle_procs() -> tty7_core::daemon::protocol::PaneProcs {
+        tty7_core::daemon::protocol::PaneProcs {
+            procs: vec![proc_entry(100, "zsh", 0, true)],
+            ports: Vec::new(),
+        }
+    }
+
+    /// The same pane with a command running in it.
+    fn busy_procs() -> tty7_core::daemon::protocol::PaneProcs {
+        tty7_core::daemon::protocol::PaneProcs {
+            procs: vec![
+                proc_entry(100, "zsh", 0, false),
+                proc_entry(101, "cargo", 1, true),
+            ],
+            ports: Vec::new(),
+        }
+    }
+
+    fn proc_entry(
+        pid: u32,
+        name: &str,
+        depth: u8,
+        foreground: bool,
+    ) -> tty7_core::daemon::protocol::ProcEntry {
+        tty7_core::daemon::protocol::ProcEntry {
+            pid,
+            name: name.into(),
+            depth,
+            foreground,
+        }
+    }
+
     fn agent_state_at(
         pane_id: u64,
         status: tty7_core::core::cli_agent::AgentStatus,
@@ -2312,18 +2709,18 @@ mod tests {
     }
 
     /// Panes without an agent state fall back to the machine tree: live means
-    /// idle, dead-or-gone means exit — which ends every wait, but only counts
-    /// as *matched* when the caller listed it.
+    /// `no-agent`, dead-or-gone means exit — which ends every wait, but only
+    /// counts as *matched* when the caller listed it.
     #[test]
     fn wait_reads_agentless_panes_from_the_tree() {
         let mut backend = mock();
         backend.replies.push_back(ReplyOk::AgentStates(Vec::new()));
         let out = run_cli(
-            &["tty7", "wait", "%3", "--until", "idle"],
+            &["tty7", "wait", "%3", "--until", "no-agent"],
             &Context::default(),
             &mut backend,
         );
-        assert_eq!(json_of(out)["status"], "idle");
+        assert_eq!(json_of(out)["status"], "no-agent");
 
         // Pane 9 exists nowhere: "exit", matched by the default until-set.
         let mut backend = mock();
@@ -2351,6 +2748,142 @@ mod tests {
         assert_eq!(r.json["status"], "exit");
         assert_eq!(r.json["matched"], false);
         assert!(r.human.contains("exited"), "{}", r.human);
+    }
+
+    /// The trap this state exists to close. A pane with nothing reporting used
+    /// to answer `idle`, so `--until idle` returned success — instantly, with
+    /// `matched: true` — about a shell that was midway through a build. The
+    /// caller then read a half-finished screen and believed it.
+    #[test]
+    fn wait_does_not_call_a_busy_shell_idle() {
+        let mut backend = mock();
+        backend.replies.push_back(ReplyOk::AgentStates(Vec::new()));
+        backend.procs_reply = busy_procs();
+
+        let out = execute(
+            cli(&["tty7", "wait", "%3", "--until", "idle", "--timeout", "0"]),
+            &Context::default(),
+            &mut backend,
+        )
+        .expect("a timeout is an exit code, not an error");
+        let Outcome::Exit(124, r) = out else {
+            panic!("a pane with no agent must not satisfy --until idle");
+        };
+        assert_eq!(r.json["status"], "no-agent");
+        assert!(
+            r.human.contains("--until free"),
+            "the timeout should point at the flag that answers this question: {}",
+            r.human
+        );
+    }
+
+    /// `free` is the missing half of the verb: an agent pane has a status to
+    /// wait on, a pane merely running a command has only its process tree.
+    /// Nothing below the depth-0 shell means the foreground command exited.
+    #[test]
+    fn wait_free_ends_when_the_foreground_command_exits() {
+        let mut backend = mock();
+        for _ in 0..3 {
+            backend.replies.push_back(ReplyOk::AgentStates(Vec::new()));
+        }
+        // Busy, busy, then back to the bare shell.
+        backend.procs_replies.push_back(busy_procs());
+        backend.procs_replies.push_back(busy_procs());
+        backend.procs_replies.push_back(idle_procs());
+
+        let json = json_of(run_cli(
+            &["tty7", "wait", "%3", "--until", "free", "--interval", "50"],
+            &Context::default(),
+            &mut backend,
+        ));
+        assert_eq!(json["status"], "free");
+        assert_eq!(json["matched"], true);
+        assert_eq!(json["stale"], false, "we watched the command finish");
+        assert_eq!(
+            backend.procs_calls.len(),
+            3,
+            "one process-tree read per poll, and only because `free` was asked for"
+        );
+    }
+
+    /// The process tree is level-triggered like the agent ladder, but a shell
+    /// that goes free → busy → free lands back where it started, so a baseline
+    /// comparison would miss it. `--changed` therefore means "something ran
+    /// while I watched" here — which is what a caller wants right after `send`.
+    #[test]
+    fn wait_changed_free_waits_for_something_to_actually_run() {
+        // Already free and it stays that way: the command has not started yet,
+        // so answering "free" would report the shell we sent the work *to*.
+        let mut backend = mock();
+        for _ in 0..2 {
+            backend.replies.push_back(ReplyOk::AgentStates(Vec::new()));
+        }
+        backend.procs_reply = idle_procs();
+        let out = execute(
+            cli(&[
+                "tty7",
+                "wait",
+                "%3",
+                "--until",
+                "free",
+                "--changed",
+                "--timeout",
+                "0",
+            ]),
+            &Context::default(),
+            &mut backend,
+        )
+        .expect("a timeout is an exit code, not an error");
+        assert!(
+            matches!(out, Outcome::Exit(124, _)),
+            "a pane that was free all along has not run anything"
+        );
+
+        // Free → busy → free is the real shape, and it must wake.
+        let mut backend = mock();
+        for _ in 0..3 {
+            backend.replies.push_back(ReplyOk::AgentStates(Vec::new()));
+        }
+        backend.procs_replies.push_back(idle_procs());
+        backend.procs_replies.push_back(busy_procs());
+        backend.procs_replies.push_back(idle_procs());
+        let json = json_of(run_cli(
+            &[
+                "tty7",
+                "wait",
+                "%3",
+                "--until",
+                "free",
+                "--changed",
+                "--interval",
+                "50",
+            ],
+            &Context::default(),
+            &mut backend,
+        ));
+        assert_eq!(json["status"], "free");
+        assert_eq!(json["matched"], true);
+        assert_eq!(json["stale"], false);
+    }
+
+    /// Watching `free` must not cost anything for callers who did not ask:
+    /// the process tree is a second round trip per poll on top of the agent
+    /// snapshot, and the default wait is for agents.
+    #[test]
+    fn wait_only_reads_the_process_tree_when_free_is_asked_for() {
+        use tty7_core::core::cli_agent::AgentStatus;
+        let mut backend = mock();
+        backend
+            .replies
+            .push_back(ReplyOk::AgentStates(vec![agent_state(
+                3,
+                AgentStatus::Waiting,
+            )]));
+        run_cli(&["tty7", "wait", "%3"], &Context::default(), &mut backend);
+        assert!(
+            backend.procs_calls.is_empty(),
+            "the default until-set names no pane-level state"
+        );
     }
 
     /// A `--timeout` that runs out exits 124 — the `timeout(1)` convention —
@@ -2566,5 +3099,61 @@ mod tests {
         };
         let out = human(run_cli(&["tty7", "doctor"], &ctx, &mut doctor_backend()));
         assert!(out.contains("set (/cfg/tty7)"), "{out}");
+    }
+
+    /// Missing hooks are the reason a perfectly healthy-looking agent never
+    /// reports and `tty7 wait` sits there until it times out. `doctor` is the
+    /// verb people run when something is not working, so it is where that has
+    /// to be visible — and it long claimed to check hooks without doing so.
+    #[test]
+    fn doctor_reports_where_the_agent_status_hooks_stand() {
+        use tty7_core::core::agent_hooks::HookAgent;
+
+        let mut backend = doctor_backend();
+        // The real backend answers for every agent it knows how to install
+        // hooks for, so the mock does too — the interesting part is that the
+        // three states are told apart, not that a lookup can come back empty.
+        backend.agent_hooks_states = HookAgent::ALL
+            .into_iter()
+            .map(|agent| match agent {
+                HookAgent::Claude => (agent, HooksState::Installed),
+                HookAgent::Codex => (agent, HooksState::Outdated),
+                other => (other, HooksState::NotInstalled),
+            })
+            .collect();
+        let out = run_cli(&["tty7", "doctor"], &Context::default(), &mut backend);
+        let Outcome::Report(r) = out else {
+            panic!("doctor reports");
+        };
+        assert!(r.human.contains("agent hooks"), "{}", r.human);
+        assert!(
+            r.human.contains("OUTDATED"),
+            "an outdated hook is the quiet failure worth shouting about: {}",
+            r.human
+        );
+        assert!(
+            r.human.contains("Settings → Agents"),
+            "say where the fix is: {}",
+            r.human
+        );
+        assert_eq!(r.json["hooks"]["installed"], serde_json::json!(["claude"]));
+        assert_eq!(r.json["hooks"]["outdated"], serde_json::json!(["codex"]));
+        assert_eq!(
+            r.json["hooks"]["not_installed"]
+                .as_array()
+                .expect("the rest are reported as a list, not omitted")
+                .len(),
+            HookAgent::ALL.len() - 2
+        );
+
+        // A backend that cannot read hook state at all — a `-m` run, where the
+        // hooks live on the other machine — says so rather than reporting a
+        // machine-wide gap that is not there.
+        let out = human(run_cli(
+            &["tty7", "doctor"],
+            &Context::default(),
+            &mut doctor_backend(),
+        ));
+        assert!(out.contains("unknown"), "{out}");
     }
 }

--- a/crates/tty7-cli/src/keys.rs
+++ b/crates/tty7-cli/src/keys.rs
@@ -1,0 +1,226 @@
+//! Key names for `tty7 send --key`.
+//!
+//! `send` types text, and text is enough right up until the pane is showing
+//! something that text cannot answer: a permission prompt whose options are
+//! chosen with the arrow keys, a TUI to be dismissed with Escape, a build to be
+//! interrupted with Ctrl-C. Those are keystrokes, not characters — the caller
+//! would otherwise have to know that Ctrl-C is byte 0x03 and that Up is
+//! `ESC [ A`, and write them into a shell string without a typo.
+//!
+//! The vocabulary is deliberately the orchestration subset rather than every
+//! key a terminal can encode: the modifier-plus-function-key combinations live
+//! in a much larger table (and a mode-dependent one), and nothing here needs
+//! them. What is missing can still be sent as literal text.
+
+use std::fmt;
+
+/// A parsed key: the bytes to write, plus the spelling the caller used so
+/// errors and `--json` can name it back to them.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Key {
+    pub name: String,
+    pub bytes: Vec<u8>,
+}
+
+impl fmt::Display for Key {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.name)
+    }
+}
+
+/// The named keys, in the order `--help` should list them.
+///
+/// Cursor keys are written in their CSI ("normal") form rather than the SS3
+/// form a terminal in application-cursor mode sends. Both are widely accepted
+/// by readline and by TUI toolkits, and CSI is what a pane emits until an
+/// application asks for the other — so it is the form that is right when we
+/// cannot know which mode the pane is in.
+const NAMED: &[(&str, &[u8])] = &[
+    ("enter", b"\r"),
+    ("escape", b"\x1b"),
+    ("tab", b"\t"),
+    ("backtab", b"\x1b[Z"),
+    ("space", b" "),
+    ("backspace", b"\x7f"),
+    ("delete", b"\x1b[3~"),
+    ("up", b"\x1b[A"),
+    ("down", b"\x1b[B"),
+    ("right", b"\x1b[C"),
+    ("left", b"\x1b[D"),
+    ("home", b"\x1b[H"),
+    ("end", b"\x1b[F"),
+    ("pageup", b"\x1b[5~"),
+    ("pagedown", b"\x1b[6~"),
+];
+
+/// Spellings that mean one of the above. Keeping these as aliases rather than
+/// entries of their own keeps the `--help` list short while accepting the name
+/// whichever terminal's documentation the caller learned it from.
+const ALIASES: &[(&str, &str)] = &[
+    ("return", "enter"),
+    ("cr", "enter"),
+    ("esc", "escape"),
+    ("del", "delete"),
+    ("bs", "backspace"),
+    ("shift-tab", "backtab"),
+    ("pgup", "pageup"),
+    ("pgdn", "pagedown"),
+    ("pgdown", "pagedown"),
+];
+
+/// What `--help` prints, and what an unknown name is answered with.
+pub fn vocabulary() -> String {
+    let named: Vec<&str> = NAMED.iter().map(|(name, _)| *name).collect();
+    format!("{}, C-<char> (Ctrl), M-<char> (Alt)", named.join(", "))
+}
+
+/// clap's `value_parser` for `--key`, so an unknown name is a usage error
+/// caught before a single byte reaches the pane — sending half a key sequence
+/// and then failing would leave the pane in a state nobody asked for.
+pub fn parse(spelling: &str) -> Result<Key, String> {
+    let folded = spelling.trim().to_ascii_lowercase();
+    let canonical = ALIASES
+        .iter()
+        .find_map(|(from, to)| (*from == folded).then_some(*to))
+        .unwrap_or(folded.as_str());
+
+    if let Some((_, bytes)) = NAMED.iter().find(|(name, _)| *name == canonical) {
+        return Ok(Key {
+            name: canonical.to_string(),
+            bytes: bytes.to_vec(),
+        });
+    }
+    if let Some(rest) = strip_modifier(canonical, &["c-", "ctrl-", "control-"]) {
+        return control(rest).map(|byte| Key {
+            name: format!("c-{rest}"),
+            bytes: vec![byte],
+        });
+    }
+    // Alt is a prefixed ESC — the encoding every Unix terminal has used for it
+    // since long before there was a modifier-reporting protocol to do better.
+    if let Some(rest) = strip_modifier(canonical, &["m-", "alt-", "meta-"]) {
+        let mut chars = rest.chars();
+        return match (chars.next(), chars.next()) {
+            (Some(ch), None) => {
+                let mut bytes = vec![0x1b];
+                let mut buf = [0u8; 4];
+                bytes.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+                Ok(Key {
+                    name: format!("m-{rest}"),
+                    bytes,
+                })
+            }
+            _ => Err(format!(
+                "'{spelling}' is not a key — Alt takes a single character, as in M-x"
+            )),
+        };
+    }
+    Err(format!(
+        "'{spelling}' is not a key. Known keys: {}. Anything else can be sent as text.",
+        vocabulary()
+    ))
+}
+
+fn strip_modifier<'a>(name: &'a str, prefixes: &[&str]) -> Option<&'a str> {
+    prefixes
+        .iter()
+        .find_map(|prefix| name.strip_prefix(prefix))
+        .filter(|rest| !rest.is_empty())
+}
+
+/// The C0 control byte a Ctrl-chord produces. This is the ASCII table's own
+/// rule — clear the top three bits — which is why the range runs past the
+/// letters and into `[ \ ] ^ _`, and why Ctrl-? is the odd one out at 0x7f.
+fn control(rest: &str) -> Result<u8, String> {
+    let mut chars = rest.chars();
+    let (Some(ch), None) = (chars.next(), chars.next()) else {
+        return Err(format!(
+            "'{rest}' is not a Ctrl chord — it takes a single character, as in C-c"
+        ));
+    };
+    match ch {
+        'a'..='z' => Ok(ch as u8 - b'a' + 1),
+        '@' => Ok(0),
+        '[' => Ok(0x1b),
+        '\\' => Ok(0x1c),
+        ']' => Ok(0x1d),
+        '^' => Ok(0x1e),
+        '_' => Ok(0x1f),
+        '?' => Ok(0x7f),
+        _ => Err(format!(
+            "Ctrl-{ch} is not a control character — Ctrl takes a-z or one of @ [ \\ ] ^ _ ?"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bytes(spelling: &str) -> Vec<u8> {
+        parse(spelling)
+            .unwrap_or_else(|e| panic!("{spelling} should parse: {e}"))
+            .bytes
+    }
+
+    #[test]
+    fn the_keys_an_orchestrator_actually_reaches_for() {
+        // Interrupting a runaway command, and answering a prompt that only
+        // takes keystrokes: the two things text alone cannot do.
+        assert_eq!(bytes("C-c"), vec![0x03]);
+        assert_eq!(bytes("escape"), vec![0x1b]);
+        assert_eq!(bytes("up"), b"\x1b[A".to_vec());
+        assert_eq!(bytes("down"), b"\x1b[B".to_vec());
+        assert_eq!(bytes("enter"), b"\r".to_vec());
+        assert_eq!(bytes("tab"), b"\t".to_vec());
+    }
+
+    #[test]
+    fn spelling_is_forgiving_but_the_bytes_are_not() {
+        // Case and the common aliases all land on the same key, because the
+        // caller learned the name from whichever terminal they came from.
+        for spelling in ["enter", "Enter", "ENTER", "return", "CR"] {
+            assert_eq!(bytes(spelling), b"\r".to_vec(), "{spelling}");
+        }
+        for spelling in ["C-c", "c-c", "ctrl-c", "Control-C"] {
+            assert_eq!(bytes(spelling), vec![0x03], "{spelling}");
+        }
+        assert_eq!(bytes("shift-tab"), b"\x1b[Z".to_vec());
+        assert_eq!(bytes("pgdn"), b"\x1b[6~".to_vec());
+    }
+
+    #[test]
+    fn the_control_range_follows_the_ascii_rule_not_a_lookup_table() {
+        assert_eq!(bytes("C-a"), vec![0x01]);
+        assert_eq!(bytes("C-d"), vec![0x04], "end of input");
+        assert_eq!(bytes("C-l"), vec![0x0c], "clear");
+        assert_eq!(bytes("C-z"), vec![0x1a], "suspend");
+        assert_eq!(bytes("C-["), vec![0x1b], "the same byte as Escape");
+        assert_eq!(bytes("C-?"), vec![0x7f], "the one that is not 0x00..0x1f");
+    }
+
+    #[test]
+    fn alt_is_a_prefixed_escape() {
+        assert_eq!(bytes("M-x"), vec![0x1b, b'x']);
+        assert_eq!(bytes("alt-b"), vec![0x1b, b'b']);
+    }
+
+    /// An unknown name has to fail before anything is written: a key sequence
+    /// half-delivered into a live pane is worse than one not delivered at all.
+    /// So the error names the vocabulary rather than just refusing.
+    #[test]
+    fn an_unknown_key_is_refused_with_the_list() {
+        let err = parse("f7").expect_err("f7 is outside the vocabulary");
+        assert!(err.contains("not a key"), "{err}");
+        assert!(
+            err.contains("escape"),
+            "the error should list what is known: {err}"
+        );
+
+        let err = parse("C-cc").expect_err("a Ctrl chord takes one character");
+        assert!(err.contains("single character"), "{err}");
+
+        let err = parse("C-1").expect_err("Ctrl-1 is not a control character");
+        assert!(err.contains("a-z"), "{err}");
+    }
+}

--- a/crates/tty7-cli/src/keys.rs
+++ b/crates/tty7-cli/src/keys.rs
@@ -68,17 +68,36 @@ const ALIASES: &[(&str, &str)] = &[
     ("pgdown", "pagedown"),
 ];
 
-/// What `--help` prints, and what an unknown name is answered with.
+/// Every spelling `--key` accepts, in one line: what an unknown name is
+/// answered with, and half of what `tty7 send --help` prints.
 pub fn vocabulary() -> String {
     let named: Vec<&str> = NAMED.iter().map(|(name, _)| *name).collect();
     format!("{}, C-<char> (Ctrl), M-<char> (Alt)", named.join(", "))
+}
+
+/// `tty7 send --help`. Assembled from the tables above so that adding a key or
+/// an alias cannot leave the help text describing the vocabulary of an older
+/// build — the drift nobody notices until a caller is told a key exists and it
+/// does not, or the reverse.
+pub fn send_long_help() -> String {
+    let aliases: Vec<&str> = ALIASES.iter().map(|(from, _)| *from).collect();
+    format!(
+        "Types TEXT into the pane exactly as a keyboard would.\n\n\
+         --key sends a keystroke rather than characters, which is what a pane wants once \
+         something is already running in it: answering a prompt that only takes arrow keys, \
+         closing a TUI with escape, stopping a build with C-c. Repeat it for a sequence.\n\n\
+         Keys: {}. Aliases: {}.",
+        vocabulary(),
+        aliases.join(", ")
+    )
 }
 
 /// clap's `value_parser` for `--key`, so an unknown name is a usage error
 /// caught before a single byte reaches the pane — sending half a key sequence
 /// and then failing would leave the pane in a state nobody asked for.
 pub fn parse(spelling: &str) -> Result<Key, String> {
-    let folded = spelling.trim().to_ascii_lowercase();
+    let trimmed = spelling.trim();
+    let folded = trimmed.to_ascii_lowercase();
     let canonical = ALIASES
         .iter()
         .find_map(|(from, to)| (*from == folded).then_some(*to))
@@ -90,6 +109,8 @@ pub fn parse(spelling: &str) -> Result<Key, String> {
             bytes: bytes.to_vec(),
         });
     }
+    // Ctrl reads the folded spelling: the C0 rule clears the top three bits, so
+    // C-c and C-C are the same byte and always were.
     if let Some(rest) = strip_modifier(canonical, &["c-", "ctrl-", "control-"]) {
         return control(rest).map(|byte| Key {
             name: format!("c-{rest}"),
@@ -98,7 +119,14 @@ pub fn parse(spelling: &str) -> Result<Key, String> {
     }
     // Alt is a prefixed ESC — the encoding every Unix terminal has used for it
     // since long before there was a modifier-reporting protocol to do better.
-    if let Some(rest) = strip_modifier(canonical, &["m-", "alt-", "meta-"]) {
+    // Which means the character rides through as itself, so unlike Ctrl this
+    // one has to read the spelling as written: M-X is not M-x.
+    // Stripped from `folded` rather than `canonical`: only that one is the
+    // caller's own spelling with the case knocked out of it, which is what
+    // makes the tail recoverable from `trimmed` by length.
+    if let Some(rest) =
+        strip_modifier(&folded, &["m-", "alt-", "meta-"]).map(|rest| as_written(trimmed, rest))
+    {
         let mut chars = rest.chars();
         return match (chars.next(), chars.next()) {
             (Some(ch), None) => {
@@ -126,6 +154,15 @@ fn strip_modifier<'a>(name: &'a str, prefixes: &[&str]) -> Option<&'a str> {
         .iter()
         .find_map(|prefix| name.strip_prefix(prefix))
         .filter(|rest| !rest.is_empty())
+}
+
+/// The same tail of the spelling the caller wrote, before it was folded.
+///
+/// Safe to index by length: `to_ascii_lowercase` is byte-for-byte, and every
+/// modifier prefix is ASCII, so a suffix of the folded form is a suffix of the
+/// original at the same offset and on the same char boundary.
+fn as_written<'a>(original: &'a str, folded_rest: &str) -> &'a str {
+    &original[original.len() - folded_rest.len()..]
 }
 
 /// The C0 control byte a Ctrl-chord produces. This is the ASCII table's own
@@ -203,6 +240,38 @@ mod tests {
     fn alt_is_a_prefixed_escape() {
         assert_eq!(bytes("M-x"), vec![0x1b, b'x']);
         assert_eq!(bytes("alt-b"), vec![0x1b, b'b']);
+    }
+
+    /// Ctrl can be folded and Alt cannot: the ASCII rule throws the case away
+    /// either way for a control byte, while Alt carries the character through
+    /// as itself, so `M-X` and `M-x` are two different keys and must stay so.
+    #[test]
+    fn alt_keeps_the_case_the_caller_wrote() {
+        assert_eq!(bytes("M-X"), vec![0x1b, b'X']);
+        assert_eq!(bytes("Meta-X"), vec![0x1b, b'X']);
+        assert_eq!(bytes("M-x"), vec![0x1b, b'x']);
+        assert_eq!(parse("M-X").unwrap().name, "m-X");
+        // Non-ASCII rides through as its own UTF-8, and the prefix arithmetic
+        // must not land mid-character doing it.
+        assert_eq!(bytes("M-ä"), vec![0x1b, 0xc3, 0xa4]);
+    }
+
+    /// The help text is generated from the tables, so it cannot describe a
+    /// vocabulary the parser does not have. This is the assertion that the
+    /// generating is real rather than a second copy that happens to agree.
+    #[test]
+    fn the_help_text_lists_every_key_the_parser_takes() {
+        let help = send_long_help();
+        for (name, _) in NAMED {
+            assert!(help.contains(name), "`{name}` is missing from --help");
+        }
+        for (alias, _) in ALIASES {
+            assert!(help.contains(alias), "`{alias}` is missing from --help");
+        }
+        assert!(
+            help.contains("C-<char>") && help.contains("M-<char>"),
+            "{help}"
+        );
     }
 
     /// An unknown name has to fail before anything is written: a key sequence

--- a/crates/tty7-cli/src/main.rs
+++ b/crates/tty7-cli/src/main.rs
@@ -3,6 +3,7 @@ mod backend;
 mod cli;
 mod commands;
 mod gui;
+mod keys;
 mod output;
 mod resolve;
 mod screen;

--- a/docs/agents/orchestration.mdx
+++ b/docs/agents/orchestration.mdx
@@ -34,11 +34,11 @@ That is the whole shape. The interesting step is the third.
 tty7 wait [%PANE] [--until STATE,…] [--changed] [--timeout SECS] [--interval MS]
 ```
 
-Blocks until the pane's agent reaches one of the states you named.
+Blocks until the pane reaches one of the states you named.
 
 | Flag | Default | |
 |---|---|---|
-| `--until` | `waiting,done,exit` | Which states end the wait: `idle`, `working`, `waiting`, `done`, `exit` |
+| `--until` | `waiting,done,exit` | Which states end the wait — see below |
 | `--changed` | off | Ignore the state the pane was *already* in — only wake on one it moved into after the wait began |
 | `--timeout` | none | Give up after this many seconds, exiting 124 |
 | `--interval` | 500 ms | How often to poll |
@@ -54,6 +54,38 @@ Exit codes are made for scripts:
 The reply carries the agent's own message and its native session id, so a
 wake-up is directly actionable.
 
+### The states
+
+Four of them are the agent's own [status](/agents/status). The other three are
+about the pane, because not everything worth waiting on is an agent:
+
+| State | Means |
+|---|---|
+| `idle` `working` `waiting` `done` | What the agent's hooks last reported |
+| `no-agent` | Nothing reports status in this pane — a plain shell, or an agent whose hooks are missing |
+| `free` | The foreground command has exited; the pane is back to its bare shell |
+| `exit` | The pane is gone. Ends every wait, whether you asked for it or not |
+
+### Waiting on a command instead of an agent
+
+An agent says when it is done. A `cargo test` does not — so for a plain pane the
+question is whether anything is still running in front of the shell, which is
+what `free` answers:
+
+```bash
+tty7 send "$PANE" 'cargo test > /tmp/t.log 2>&1; echo $? > /tmp/t.rc' --enter
+tty7 wait "$PANE" --until free --changed --timeout 900
+cat /tmp/t.rc /tmp/t.log
+```
+
+`free` costs one extra request per poll, so it is only checked when you name it.
+
+<Note>
+  A pane with no agent reports `no-agent`, **not** `idle`. That distinction is
+  why `--until idle` cannot be used to mean "the command finished" — `idle` is a
+  thing an agent says about itself, and a busy shell never says it.
+</Note>
+
 ### Why `--changed` matters
 
 The status the server keeps is a **level, not an event**. `done` stands until
@@ -63,6 +95,37 @@ So a `wait` issued immediately after a `send` can answer with the *previous*
 turn's state, before the worker has even read the input. `--changed` refuses the
 state the pane was already in, which is what every round after the first needs.
 Without it, the JSON's `stale` flag tells you whether that happened.
+
+`free` has the same problem and a different fix: a shell that goes free → busy →
+free ends up where it started, so there is no new state to compare against.
+There `--changed` means "something ran while I was watching", which is exactly
+what you want in the line after a `send`.
+
+## Answering a prompt
+
+A worker that stops at `waiting` is usually showing something that keystrokes,
+not text, are the answer to — a permission prompt driven by the arrow keys, a
+menu, a TUI to be dismissed. `send --key` presses keys:
+
+```bash
+tty7 wait "$PANE" --until waiting --changed   # it needs something
+tty7 capture "$PANE" --plain | tail -20       # see what it is asking
+tty7 send "$PANE" --key down --key enter      # answer it
+tty7 send "$PANE" --key C-c                   # or stop it altogether
+```
+
+Keys are delivered as separate events 200 ms apart, so a raw-mode TUI reads a
+sequence as a sequence rather than as a paste. The
+[full vocabulary](/cli/reference#tty7-send-pane-text-enter-key-key) is in the
+reference.
+
+## When an agent never moves
+
+If `tty7 wait` times out and `tty7 agents` shows a status that never changes,
+the likely cause is that the agent's status hooks are not installed or are out
+of date — the agent is working fine, it just has no way to say so. `tty7 doctor`
+reports where every agent's hooks stand, and `tty7 agents` names the specific
+one when it can see the gap.
 
 ## Watching everything at once
 
@@ -103,5 +166,9 @@ never touches another pane pays nothing for it.
 - **Never `server stop` or `server restart`.** Every pane on the machine dies
   with it.
 - **Clean up what you did create** — `tty7 pane close %83` when you are done.
+  An interrupted `run` leaves its pane behind; `tty7 pane ls --all` shows those,
+  and `tty7 pane close --orphans` clears them. That last one is a human's
+  broom, not an agent's: it closes every orphan on the machine, including ones
+  somebody else abandoned mid-command.
 
 The full agent-facing contract is in [the skill](/cli/agent-skill).

--- a/docs/agents/orchestration.mdx
+++ b/docs/agents/orchestration.mdx
@@ -78,7 +78,17 @@ tty7 wait "$PANE" --until free --changed --timeout 900
 cat /tmp/t.rc /tmp/t.log
 ```
 
-`free` costs one extra request per poll, so it is only checked when you name it.
+`free` costs one extra request per poll, so it is only checked when you name it —
+and only once the agent ladder has not already answered, so pairing it with
+`waiting,done` never costs you a state you asked for.
+
+<Warning>
+  `free` is read off the process tree, which has two blind spots. A pane whose
+  own root process *is* the command — what `tty7 run` spawns — looks free the
+  whole time it runs; wait on `tty7 run` itself instead, it already blocks. And
+  a backgrounded job (`… &`) keeps the pane busy after the foreground command
+  has finished.
+</Warning>
 
 <Note>
   A pane with no agent reports `no-agent`, **not** `idle`. That distinction is
@@ -100,6 +110,12 @@ Without it, the JSON's `stale` flag tells you whether that happened.
 free ends up where it started, so there is no new state to compare against.
 There `--changed` means "something ran while I was watching", which is exactly
 what you want in the line after a `send`.
+
+That does mean a command which starts *and* finishes between two polls is never
+seen running, and the wait sits there until it times out. If the thing you are
+waiting on can be that quick, poll faster (`--interval 100`) or drop `--changed`
+and let a sentinel file carry the answer. The timeout says as much when it
+happens.
 
 ## Answering a prompt
 

--- a/docs/agents/status.mdx
+++ b/docs/agents/status.mdx
@@ -43,8 +43,9 @@ Every tab chip and sidebar row carries a dot:
   <img src="/images/placeholder.svg" alt="Agent status dots" />
 </Frame>
 
-The same three states are what `tty7 agents` reports as `running` / `waiting` /
-`idle`, and what [`tty7 wait`](/agents/orchestration) blocks on.
+The same three states are what `tty7 agents` reports as `working` / `waiting` /
+`done`, and what [`tty7 wait`](/agents/orchestration) blocks on. A fourth state,
+`idle`, carries no dot — it is an agent that has not started a turn.
 
 ## Notifications
 

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -81,12 +81,30 @@ in the same cwd. Exactly one axis is required — `--v`/`--vertical` puts the ne
 pane below, `--h`/`--horizontal` to the right. `--ratio` (default `0.5`) is the
 share kept by the *existing* pane. Prints `%NN`. JSON: `{"pane"}`.
 
-### `tty7 send [%PANE] TEXT [--enter]`
+### `tty7 send [%PANE] [TEXT] [--enter] [--key KEY]…`
 
 Types `TEXT` into the pane as keystrokes; `--enter` appends CR. With one
 argument the text is the argument and the pane comes from `$TTY7_PANE` — but a
-lone `%42` is rejected as a missing-text error rather than typed.
-JSON: `{"pane","sent","enter"}`.
+lone `%42` is rejected as a missing-text error rather than typed, unless a
+`--key` gives it something to do.
+
+`--key` presses a key instead of typing characters, which is what a pane wants
+once something is already running in it: answering a prompt that only takes
+arrow keys, closing a TUI with `escape`, stopping a build with `C-c`. Repeat it
+for a sequence, and it composes with `TEXT` — the text goes first.
+
+| | |
+|---|---|
+| Named | `enter` `escape` `tab` `backtab` `space` `backspace` `delete` `up` `down` `right` `left` `home` `end` `pageup` `pagedown` |
+| Chords | `C-<char>` (Ctrl, e.g. `C-c`), `M-<char>` (Alt) |
+| Aliases | `return` `cr` `esc` `del` `bs` `shift-tab` `pgup` `pgdn` |
+
+Names are case-insensitive, and an unknown one is a usage error (exit `2`)
+raised before anything is sent — half a key sequence in a live pane is worse
+than none. Each keystroke is delivered as its own event, 200 ms apart, so a
+raw-mode TUI reads a sequence as a sequence rather than as a paste.
+
+JSON: `{"pane","sent","enter","keys"}`.
 
 ### `tty7 capture [%PANE] [--plain] [--scrollback]`
 
@@ -115,19 +133,36 @@ JSON: `{"procs":[{"pid","name","depth","foreground"}],"ports":[{"port","pid","na
 ### `tty7 agents`
 
 Every pane running a recognised coding agent. Table:
-`PANE AGENT STATUS MESSAGE`, status one of `running` / `waiting` / `idle`.
-JSON: `{"agents":[...]}`.
+`PANE AGENT STATUS MESSAGE`, status one of `idle` / `working` / `waiting` /
+`done`. JSON: `{"agents":[...]}`, plus a `"diagnostics"` array when an agent's
+status hook is missing or out of date — that is why an agent can be listed with
+a status that never moves.
 
 ### `tty7 wait [%PANE] [--until STATE,…] [--changed] [--timeout SECS] [--interval MS]`
 
-Blocks until the pane's agent reaches one of the named states.
+Blocks until the pane reaches one of the named states.
 
 | Flag | Default | |
 |---|---|---|
-| `--until` | `waiting,done,exit` | `idle`, `working`, `waiting`, `done`, `exit` |
+| `--until` | `waiting,done,exit` | See the state table below |
 | `--changed` | off | Only wake on a state the pane moved into *after* the wait began |
 | `--timeout` | none | Give up after N seconds, exiting `124` |
 | `--interval` | `500` | Poll interval in ms (50–3,600,000) |
+
+The states come from two places. Four are the agent's own status, as reported
+by its [hooks](/agents/status); the last three are facts about the pane:
+
+| State | Means |
+|---|---|
+| `idle` `working` `waiting` `done` | The agent's status |
+| `no-agent` | Nothing is reporting status here — a plain shell, or an agent whose hooks are not installed |
+| `free` | The foreground command has exited; the pane is back to its bare shell |
+| `exit` | The pane itself is gone. Ends every wait whether it was asked for or not |
+
+`free` is how you wait for a **command** rather than an agent, and it is the
+one state that costs a second request per poll — so it is only checked when you
+name it. With `--changed` it means "something ran and then finished", which is
+what you want directly after a `send`.
 
 The reply carries the agent's message and native session id. The JSON's `stale`
 flag says whether the answer might belong to the previous turn.
@@ -149,11 +184,18 @@ socket path. JSON is the `ServerStatus` object itself (`pid`, `uptime_secs`,
 
 The install check: the three environment variables, whether the server answers,
 whether its control and protocol versions match this binary, pid/uptime/panes,
-and how many machine links exist. Adds a note when you are not inside a tty7
-shell.
+how many machine links exist, and where each agent's
+[status hooks](/agents/status) stand. Adds a note when you are not inside a
+tty7 shell.
 
-JSON: `{"context":{"config_dir","workspace","pane"},"server":{"reachable","dialect_ok","build","status","routes"}}`
-— the context fields are booleans, not values.
+The hooks row is the one that explains a mystery: without them an agent reports
+nothing, so `tty7 agents` shows it standing still and `tty7 wait` sits there
+until it times out. Outdated hooks fail the same quiet way. Hooks are a local
+install, so under `-m` the row reads `unknown`.
+
+JSON: `{"context":{"config_dir","workspace","pane"},"server":{"reachable","dialect_ok","build","status","routes"},"hooks":{"installed","outdated","not_installed"}}`
+— the context fields are booleans, not values, and each `hooks` field is a list
+of agent slugs.
 
 ## `ws` — workspaces
 
@@ -214,12 +256,25 @@ a stand-in.
 | `pane ls [WORKSPACE]` | Panes with their workspace, tab, cwd, live flag | `{"panes":[…]}` |
 | `pane ls --all` | The server's whole pane registry, including orphans | `{"panes":[…],"orphans":N}` |
 | `pane split …` | Identical to top-level `split` | `{"pane"}` |
-| `pane close [%PANE]` | Close the pane; its shell is hung up | `{"closed"}` |
+| `pane close [%PANE…]` | Close panes; their shells are hung up | `{"closed":[…]}` |
+| `pane close --orphans` | Close every pane no workspace holds | `{"closed":[…]}` |
 
 `--all` is the one that shows leaks. Each entry is
 `{"pane","workspace","orphan","owner","title","cwd","live"}`: `owner` is
 `tty7-cli` for panes this CLI spawned, and `orphan: true` means no workspace
 holds it. An interrupted `run` and a removed workspace both leave orphans here.
+
+`--orphans` is the reaper for exactly those. It closes what `pane ls --all`
+lists as orphaned and nothing else — panes a workspace holds are untouched —
+and reports an empty list rather than an error when there is nothing to clean
+up, so a script does not have to guard it. A pane that cannot be closed does
+not abandon the rest of the batch; the failure is reported at the end.
+
+<Warning>
+  `--orphans` closes every orphan on the machine, and an orphan can still be
+  doing real work — an interrupted `run` leaves the command running. Look at
+  `pane ls --all` first.
+</Warning>
 
 `title` is usually the running command — `claude`, `nvim`, `cargo` — which makes
 `pane ls --all --json` a quick way to find "the pane running X".

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -161,8 +161,10 @@ by its [hooks](/agents/status); the last three are facts about the pane:
 
 `free` is how you wait for a **command** rather than an agent, and it is the
 one state that costs a second request per poll — so it is only checked when you
-name it. With `--changed` it means "something ran and then finished", which is
-what you want directly after a `send`.
+name it, and only when none of the agent states you asked for already matched.
+With `--changed` it means "something ran and then finished", which is what you
+want directly after a `send`; a command quick enough to finish inside one
+`--interval` is never seen running, and the timeout says so.
 
 The reply carries the agent's message and native session id. The JSON's `stale`
 flag says whether the answer might belong to the previous turn.
@@ -268,7 +270,9 @@ holds it. An interrupted `run` and a removed workspace both leave orphans here.
 lists as orphaned and nothing else — panes a workspace holds are untouched —
 and reports an empty list rather than an error when there is nothing to clean
 up, so a script does not have to guard it. A pane that cannot be closed does
-not abandon the rest of the batch; the failure is reported at the end.
+not abandon the rest of the batch: the rest are still attempted, the complaint
+goes to stderr, and the verb exits 1 with `{"closed":[…],"failed":[…]}` — the
+list a retry needs.
 
 <Warning>
   `--orphans` closes every orphan on the machine, and an orphan can still be

--- a/skills/tty7/SKILL.md
+++ b/skills/tty7/SKILL.md
@@ -186,6 +186,11 @@ Exit codes are built for this: `0` means a state you asked for was reached,
 `124` means the timeout ran out (the `timeout(1)` convention, so "not yet" is
 distinguishable from "broken"), `1` means the pane died first.
 
+One trap in `--changed`: a command that finishes inside a single poll (500ms by
+default) is never *seen* running, so the wait keeps going until it times out.
+For something that quick, `--interval 100`, or drop `--changed` and read the
+`.rc` file. The timeout message says so when it happens.
+
 If you want the process tree itself — "what is running in there", "which port is
 this pane serving" — that is `tty7 procs %83`: indented by depth, `*` on the
 foreground process, then the ports those processes are listening on.
@@ -225,6 +230,10 @@ understanding.
 "your turn again". Note that `idle` is something an agent says about *itself* —
 a pane running a build is `no-agent`, never `idle`, so `--until idle` is never
 the way to ask "is the command finished". That is `free`.
+
+Mixing the two is safe: `--until waiting,done,free` covers a pane whose kind you
+don't know, because `free` is only consulted when none of the agent states you
+named matched first.
 
 ### `--changed` is not optional in a loop
 

--- a/skills/tty7/SKILL.md
+++ b/skills/tty7/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tty7
 description: >-
-  Drive the tty7 terminal workbench from the shell with the `tty7` binary — list workspaces/tabs/panes, split a pane, send keystrokes into one, capture what is on a pane's screen, run a command in a real PTY and pass its exit code through, see which coding agents are running and which ports a pane is listening on. Use this whenever tty7, panes, workspaces, or `%42`/`@7`/"the other pane"/"the other agent" come up; whenever you need to start something long-running or interactive (dev server, REPL, ssh session, `tail -f`, a TUI) that should not sit blocking your Bash tool; whenever a program needs a real terminal to behave the way the user sees it; and whenever you need to look at or report on what is running in some *other* terminal on this machine. Cheap to check: if `$TTY7_PANE` is set you are already inside tty7 and every command here works with no setup.
+  Drive the tty7 terminal workbench from the shell with the `tty7` binary — list workspaces/tabs/panes, split a pane, send text or keystrokes into one, capture what is on a pane's screen, run a command in a real PTY and pass its exit code through, block until a pane finishes or needs input, see which coding agents are running and which ports a pane is listening on. Use this whenever tty7, panes, workspaces, or `%42`/`@7`/"the other pane"/"the other agent" come up; whenever you want to hand work to another agent and collect the result ("get Claude/Codex to do X", "派个活", "let another agent handle this", running several agents in parallel); whenever you need to start something long-running or interactive (dev server, REPL, ssh session, `tail -f`, a TUI) that should not sit blocking your Bash tool; whenever a program needs a real terminal to behave the way the user sees it; and whenever you need to look at or report on what is running in some *other* terminal on this machine. Cheap to check: if `$TTY7_PANE` is set you are already inside tty7 and every command here works with no setup.
 ---
 
 # Driving tty7 from the command line
@@ -17,14 +17,18 @@ tty7 doctor
 ```
 
 One table, and it answers everything you need before doing anything else:
-whether a server is reachable, whether the dialect matches, and whether
-`TTY7_CONFIG_DIR` / `TTY7_WS` / `TTY7_PANE` are set — i.e. whether you are
-running *inside* a tty7 pane.
+whether a server is reachable, whether the dialect matches, whether each agent's
+status hooks are installed, and whether `TTY7_CONFIG_DIR` / `TTY7_WS` /
+`TTY7_PANE` are set — i.e. whether you are running *inside* a tty7 pane.
 
 Being inside a pane matters for two reasons: the address-taking verbs
-(`split`, `send`, `capture`, `procs`) default to `$TTY7_PANE`, and `run --keep`
-files its pane into `$TTY7_WS`. Outside a tty7 shell you must name a target
-explicitly, and the error will say so rather than guessing.
+(`split`, `send`, `capture`, `procs`, `wait`, `pane close`) default to
+`$TTY7_PANE`, and `run --keep` files its pane into `$TTY7_WS`. Outside a tty7
+shell you must name a target explicitly, and the error will say so rather than
+guessing.
+
+The hooks row matters if you intend to delegate to another agent: without them
+an agent reports no status, so `tty7 wait` on it will only ever time out.
 
 If `tty7 doctor` says the server is unreachable, stop and tell the user — do
 not run `tty7 server start` on your own initiative. Starting a server they
@@ -48,6 +52,9 @@ Reach for tty7 when one of these is true:
 - **You're being asked about something you didn't start.** "What's running in
   that pane?", "why is port 3000 taken?", "what are my agents doing?" — you can
   answer those from here without touching anything.
+- **Someone else should do the work.** Another coding agent can run in a pane,
+  and you can wait on it and read its answer. See [Handing work to another
+  agent](#handing-work-to-another-agent).
 
 ## Addresses
 
@@ -77,10 +84,11 @@ The command's output streams to your stdout as it happens, and `tty7` exits
 with the command's own exit code. This is the closest thing to a Bash call —
 the difference is the PTY and the fact that the user can see it.
 
-Two things to know. `--keep` needs a workspace, so it only works inside a tty7
-shell or with `--ws <workspace>`. And with `--json`, the streamed output comes
-first and the JSON object last — the combined stream is *not* parseable as
-JSON, so read the last line.
+Three things to know. `--keep` needs a workspace, so it only works inside a tty7
+shell or with `--ws <workspace>`. With `--json`, the streamed output comes first
+and the JSON object last — the combined stream is *not* parseable as JSON, so
+read the last line. And the pane is 120 columns wide with no way to change it,
+so output that assumes a wider terminal wraps.
 
 ### Non-blocking: a pane you talk to over time
 
@@ -111,7 +119,11 @@ read -r WS PANE < <(tty7 new --json /path/to/repo \
 
 `send` types text into the pane exactly as a keyboard would; `--enter` appends
 the carriage return. It does not wait and it does not tell you what happened —
-reading is a separate step.
+reading is a separate step, and waiting is `tty7 wait`.
+
+For keystrokes rather than characters — Ctrl-C, Escape, the arrow keys — use
+`--key` (see [Answering a prompt](#answering-a-prompt)). Typing `^C` as text
+does nothing; it arrives as two characters.
 
 ## Reading a pane
 
@@ -150,32 +162,125 @@ Complete output, a real exit code, no terminal in the middle.
 
 ### Knowing when a command has finished
 
+Don't poll the screen and don't write your own loop — block on it:
+
 ```bash
-tty7 procs %83
+tty7 wait "$PANE" --until free --changed --timeout 900
 ```
 
-lists the process tree inside the pane, indented, with `*` on the foreground
-process — plus any ports those processes are listening on. When the only entry
-left is the depth-0 shell, the command is done. That is a far more reliable
-"finished?" signal than grepping the screen, where your sentinel string can get
-line-wrapped or echoed twice.
-
-Poll it on an interval rather than in a tight loop — a few seconds between
-checks. In Claude Code, use the Monitor tool with an until-condition instead of
-a bare foreground `sleep`.
+`free` means the foreground command has exited and the pane is back to its bare
+shell. `--changed` adds "and something actually ran while I watched", which is
+what you want on the line right after a `send`: without it, a command that has
+not started yet leaves the pane looking finished.
 
 The whole shape, end to end:
 
 ```bash
 tty7 send "$PANE" 'cargo test > /tmp/t.log 2>&1; echo $? > /tmp/t.rc' --enter
-# poll until only the shell is left
-until [ "$(tty7 procs "$PANE" --json | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["procs"]))')" = 1 ]; do sleep 3; done
+tty7 wait "$PANE" --until free --changed --timeout 900
 cat /tmp/t.rc /tmp/t.log
 tty7 pane close "$PANE"
 ```
 
-The ports half also stands alone: `tty7 procs %62` answers "what is this pane
-serving, and on which port" without any guessing.
+Exit codes are built for this: `0` means a state you asked for was reached,
+`124` means the timeout ran out (the `timeout(1)` convention, so "not yet" is
+distinguishable from "broken"), `1` means the pane died first.
+
+If you want the process tree itself — "what is running in there", "which port is
+this pane serving" — that is `tty7 procs %83`: indented by depth, `*` on the
+foreground process, then the ports those processes are listening on.
+
+## Handing work to another agent
+
+Everything above also works when the thing in the pane is a coding agent, and
+that is where this stops being a terminal wrapper and starts being useful. An
+agent reports its own status, so you can wait on *it* rather than on its
+process tree:
+
+```bash
+PANE=$(tty7 split --v)
+tty7 send "$PANE" 'claude -p "add tests for the parser"' --enter
+tty7 wait "$PANE" --until waiting,done --changed --timeout 900
+tty7 capture "$PANE" --plain | tail -40
+tty7 pane close "$PANE"
+```
+
+Five steps: give it a pane, hand it the task, sleep until it needs you or
+finishes, read what happened, clean up. The third is the one worth
+understanding.
+
+### What the states mean
+
+| State | The pane is |
+|---|---|
+| `working` | mid-turn |
+| `waiting` | **stopped, needing you** — a permission prompt, a question |
+| `done` | finished its turn |
+| `idle` | an agent that has not started a turn |
+| `free` | no agent: the foreground command exited (see above) |
+| `no-agent` | nothing reports status here — a plain shell, or hooks not installed |
+| `exit` | the pane is gone; ends every wait whether you asked for it or not |
+
+`--until waiting,done,exit` is the default because those are the three that mean
+"your turn again". Note that `idle` is something an agent says about *itself* —
+a pane running a build is `no-agent`, never `idle`, so `--until idle` is never
+the way to ask "is the command finished". That is `free`.
+
+### `--changed` is not optional in a loop
+
+The status is a **level, not an event**: `done` stands until the next turn
+begins. So a `wait` issued right after a `send` will happily answer with *last*
+turn's `done` before the worker has even read the input, and you will read a
+stale screen and think it failed. `--changed` refuses the state the pane was
+already in. Every round after the first needs it; the JSON's `stale` flag tells
+you when it mattered.
+
+### Answering a prompt
+
+A worker that stops at `waiting` is usually showing something that text cannot
+answer — a permission prompt driven by arrow keys, a menu, a TUI. Look first,
+then press keys:
+
+```bash
+tty7 capture "$PANE" --plain | tail -20   # what is it asking?
+tty7 send "$PANE" --key down --key enter  # answer it
+tty7 send "$PANE" --key C-c               # or stop it
+```
+
+`--key` takes `enter escape tab backtab space backspace delete up down right
+left home end pageup pagedown`, plus `C-<char>` for Ctrl and `M-<char>` for
+Alt. Repeat it for a sequence; text and keys compose, text first. This is also
+how you interrupt a runaway command in a pane you own — `--key C-c` — which
+plain `send` cannot express.
+
+### Running several at once
+
+Panes are independent, so fan out and then collect:
+
+```bash
+for task in parser lexer codegen; do
+  P=$(tty7 split --v)
+  tty7 send "$P" "claude -p 'add tests for the $task'" --enter
+  echo "$P" >> /tmp/workers
+done
+while read -r P; do
+  tty7 wait "$P" --until done,exit --changed --timeout 1800 || echo "$P did not finish"
+  tty7 capture "$P" --plain | tail -40
+  tty7 pane close "$P"
+done < /tmp/workers
+```
+
+Splitting repeatedly makes the user's window very busy; `tty7 new` gives each
+worker its own workspace instead if you would rather not.
+
+### When a worker never moves
+
+A `wait` that times out while `tty7 agents` shows a status that never changes
+almost always means the agent's status hooks are missing or out of date — the
+worker is fine, it just has no way to say so. `tty7 agents` names the agent when
+it can see the gap, and `tty7 doctor` reports where every agent's hooks stand.
+Hooks are installed from the GUI's **Settings → Agents**; tell the user rather
+than trying to install them yourself.
 
 ## Looking around
 
@@ -191,8 +296,11 @@ tty7 events                # stream server events, one per line, until interrupt
 ```
 
 `tty7 agents` is worth knowing about: it reports each pane running a recognised
-coding agent as `running` / `waiting` / `idle`. If you are one of them, you are
-in that list too.
+coding agent as `idle` / `working` / `waiting` / `done`, with the agent's own
+message beside it. If you are one of them, you are in that list too. It also
+prints a diagnostic — `diagnostics` in the JSON — when it can see an agent
+running whose status hooks are missing or outdated, which is the explanation for
+any agent that appears frozen.
 
 Add `--json` to any of these to parse instead of eyeball. `-q` suppresses
 output on success but never suppresses errors.
@@ -204,15 +312,20 @@ coding agents mid-task. Treat anything you did not create as read-only:
 
 - **Never `send` into a pane you didn't open.** Keystrokes into another agent's
   pane, or into a shell the user is typing in, land in the middle of whatever
-  is happening there. Check `tty7 agents` before you touch a pane.
+  is happening there. Check `tty7 agents` before you touch a pane. This goes
+  double for `--key`: a stray `C-c` kills somebody's work.
 - **Never `pane close` / `tab close` / `ws rm` something you didn't create.**
+- **Never `pane close --orphans`.** It closes every abandoned pane on the
+  machine, and an abandoned pane can still be running a real command. It is the
+  user's broom; point them at it, don't swing it.
 - **Never `server stop` or `server restart`.** Every pane on the machine dies
   with the server, including yours. If the server genuinely seems wedged, say
   so and let the user decide.
 - **Clean up what you did create.** `tty7 pane close %83` when you're done with
-  a scratch pane. Note that `ws rm` does *not* kill the panes inside it — they
-  survive as orphans, visible under `tty7 pane ls --all` with no workspace, and
-  you have to close them individually.
+  a scratch pane; it takes several ids at once. `ws rm` hangs up the panes the
+  workspace held, so removing a scratch workspace is enough on its own. What
+  does leak is an interrupted `tty7 run` — that pane keeps running with nothing
+  referencing it, and shows up under `tty7 pane ls --all`.
 
 ## Remote machines
 
@@ -230,9 +343,8 @@ from the GUI.
 
 ## Not wired up yet
 
-`ws stop`, `machine connect`, `machine disconnect`, and bare `tty7 <path>` (GUI
-launch) all exit with a message saying they're not implemented. Don't build a
-plan around them.
+`ws stop`, `machine connect` and `machine disconnect` exit with a message saying
+they're not implemented. Don't build a plan around them.
 
 ## Full command reference
 

--- a/skills/tty7/references/commands.md
+++ b/skills/tty7/references/commands.md
@@ -30,7 +30,7 @@ Set inside every tty7 pane, inherited by anything you launch from one.
 
 | Variable | Meaning |
 |---|---|
-| `TTY7_PANE` | This pane's id, e.g. `71` or `%71` (both forms are accepted). The default target of `split`, `send`, `capture`, `procs`, `pane close`. |
+| `TTY7_PANE` | This pane's id, e.g. `71` or `%71` (both forms are accepted). The default target of `split`, `send`, `capture`, `procs`, `wait`, `pane close`. |
 | `TTY7_WS` | This pane's workspace id. The default for `run --keep`, `tab new`, `ws tree`. |
 | `TTY7_CONFIG_DIR` | The server's config dir. How the CLI finds the right server's sockets — you never pass a socket path. |
 
@@ -44,20 +44,24 @@ Outside a tty7 shell the address-taking verbs fail with
 | 0 | success |
 | 1 | the command failed; the reason is one line on stderr, prefixed `tty7:` |
 | 2 | usage error (clap) — unknown verb, missing argument, bad type |
+| 124 | `tty7 wait` gave up — the `timeout(1)` convention, so "not yet" is distinguishable from "broken" |
 | 141 | Unix only: the reader hung up (`| head -1`) and SIGPIPE ended it, exactly as it ends `cat`. Not a failure. Windows reports 0 for the same thing, having no signal to imitate. |
 | *other* | only from `tty7 run`, which passes the child's exit code through |
-
-Builds before this was fixed panic instead of exiting on a hung-up reader:
-`tty7 capture %71 | head -1` prints a Rust `failed printing to stdout: Broken
-pipe` note and a backtrace hint to stderr. Harmless, and the data you asked for
-still arrived — don't read it as the command having failed. On such a build,
-redirect to a file and slice the file instead of piping into `head`.
 
 If `run` cannot learn the child's code it prints a note to stderr and exits 1
 with `"exit_code_known": false` in the JSON — that is how you tell a real 1
 from a stand-in.
 
 ## Top-level verbs
+
+### `tty7 [PATH]`
+No subcommand means the GUI. A running window is asked to come forward and open
+a tab at `PATH`; if none is registered, the app is launched instead. Without
+`PATH` it just activates the app. `-m` is refused — this verb drives the GUI on
+*this* machine. JSON: `{"path","delivered","launched"}`.
+
+A word in this position that does not name a path is treated as a mistyped verb
+and refused, rather than silently opening a window.
 
 ### `tty7 ls`
 Same as `ws ls`. Table: `WORKSPACE NAME TABS PANES ATTACHED`.
@@ -95,11 +99,28 @@ in the same cwd. Exactly one axis is required — `--v`/`--vertical` puts the ne
 pane below, `--h`/`--horizontal` to the right. `--ratio` (default 0.5) is the
 share kept by the *existing* pane. Prints `%NN`. JSON: `{"pane"}`.
 
-### `tty7 send [%PANE] TEXT [--enter]`
+### `tty7 send [%PANE] [TEXT] [--enter] [--key KEY]…`
 Types `TEXT` into the pane as keystrokes; `--enter` appends CR. With one
 argument the text is the argument and the pane comes from `$TTY7_PANE` — but a
-lone `%42` is rejected as a missing-text error rather than typed.
-JSON: `{"pane","sent","enter"}`.
+lone `%42` is rejected as a missing-text error rather than typed, unless a
+`--key` gives it something to do.
+JSON: `{"pane","sent","enter","keys"}`.
+
+`--key` presses a key instead of typing characters — the arrow keys a
+permission prompt wants, the `escape` that closes a TUI, the `C-c` that stops a
+build. Repeatable, delivered in order, and composable with `TEXT` (text first).
+
+| | |
+|---|---|
+| Named | `enter` `escape` `tab` `backtab` `space` `backspace` `delete` `up` `down` `right` `left` `home` `end` `pageup` `pagedown` |
+| Chords | `C-<char>` (Ctrl: `C-c`, `C-d`, `C-z`, also `C-@ C-[ C-\ C-] C-^ C-_ C-?`), `M-<char>` (Alt = prefixed ESC) |
+| Aliases | `return` `cr` `esc` `del` `bs` `shift-tab` `pgup` `pgdn` |
+
+Case-insensitive. An unknown name is a usage error (exit 2) raised before
+anything is written, so a bad key never lands half a sequence in a live pane.
+Each keystroke goes out as its own event 200 ms after the last, which is what
+keeps a raw-mode TUI from reading the sequence as a paste; the first write is
+not delayed, so an interrupt is immediate.
 
 ### `tty7 capture [%PANE] [--plain] [--scrollback]`
 The pane's replay. Two independent choices: **how much** — the newest scrollback
@@ -139,13 +160,53 @@ Prints `nothing running in this pane` when both are empty.
 
 JSON: `{"procs":[{"pid","name","depth","foreground"}],"ports":[{"port","pid","name"}]}`.
 
-The reliable "is it done?" check: when the only entry is the depth-0 shell, the
-foreground command has exited.
+Nothing below the depth-0 shell means the foreground command has exited — but
+you rarely need to check that by hand, because that is exactly what
+`tty7 wait --until free` blocks on.
 
 ### `tty7 agents`
 Every pane running a recognised coding agent. Table: `PANE AGENT STATUS
-MESSAGE`, status one of `running` / `waiting` / `idle`.
-JSON: `{"agents":[...]}`.
+MESSAGE`, status one of `idle` / `working` / `waiting` / `done`.
+JSON: `{"agents":[...]}`, plus `"diagnostics"` when an agent is running whose
+status hooks are missing or outdated — the reason an agent can sit in one status
+forever. Each diagnostic is
+`{"kind":"agent_status_hooks_unavailable","agent","hooks_state","action"}`.
+
+### `tty7 wait [%PANE] [--until STATE,…] [--changed] [--timeout SECS] [--interval MS]`
+Blocks until the pane reaches one of the named states. The orchestration
+primitive: `tty7 wait %3 && tty7 capture %3 --plain`.
+
+| Flag | Default | |
+|---|---|---|
+| `--until` | `waiting,done,exit` | Comma-separated; see the states below |
+| `--changed` | off | Only wake on a state the pane moved into *after* the wait began |
+| `--timeout` | none | Give up after N seconds, exiting 124 |
+| `--interval` | 500 | Poll interval in ms (50–3,600,000) |
+
+| State | Means |
+|---|---|
+| `idle` `working` `waiting` `done` | The agent's own status, from its hooks |
+| `no-agent` | Nothing reports status here — a plain shell, or hooks not installed |
+| `free` | The foreground command has exited; the pane is back to its bare shell |
+| `exit` | The pane is gone. Ends every wait whether asked for or not |
+
+JSON: `{"pane","status","matched","stale","activity","message","session_id"}`.
+`stale: true` means the pane was already in that state when the wait began, so
+the answer may belong to a previous turn — which is what `--changed` refuses.
+
+Exit 0 = a requested state was reached; 124 = timed out; 1 = the pane exited
+without reaching it (the JSON still comes, with `"matched": false`).
+
+Notes that decide whether a loop works:
+
+- **`idle` is not "the command finished".** It is something an *agent* says
+  about itself. A pane running a build has no agent and reports `no-agent`.
+  Use `free` for commands.
+- **`free` costs a second request per poll**, so it is only checked when named.
+- **`--changed` means something different for `free`**: a shell goes free →
+  busy → free and ends where it started, so there is no new state to compare
+  against. There it means "something ran while I watched" — exactly what you
+  want on the line after a `send`.
 
 ### `tty7 events`
 Streams server events until interrupted, one per line — pane exits, agent
@@ -159,10 +220,17 @@ socket path. JSON is the `ServerStatus` object itself (`pid`, `uptime_secs`,
 
 ### `tty7 doctor`
 The install check: the three env vars, whether the server answers, whether its
-control/protocol versions match this binary, pid/uptime/panes, and how many
-machine links exist. Adds a note when you are not inside a tty7 shell.
-JSON: `{"context":{"config_dir","workspace","pane"},"server":{"reachable","dialect_ok","build","status","routes"}}`
-— the context fields are booleans, not values.
+control/protocol versions match this binary, pid/uptime/panes, how many machine
+links exist, and where each agent's status hooks stand. Adds a note when you are
+not inside a tty7 shell.
+JSON: `{"context":{"config_dir","workspace","pane"},"server":{"reachable","dialect_ok","build","status","routes"},"hooks":{"installed","outdated","not_installed"}}`
+— the context fields are booleans, not values; each `hooks` field is a list of
+agent slugs.
+
+The hooks row is what explains an agent that never moves: without hooks it
+reports no status, so `tty7 agents` shows it frozen and `tty7 wait` only ever
+times out. Hooks are a local install, so under `-m` the row reads `unknown`
+rather than claiming a gap it cannot see.
 
 ## `ws` — workspaces
 
@@ -181,8 +249,9 @@ lists the candidates.
 | `ws attach WORKSPACE` | become its controlling client | `{"attached","took_over_from"}` |
 | `ws detach WORKSPACE` | let go without interrupting anything | `{"detached"}` |
 
-`ws rm` does not kill the panes it held — they keep running as orphans with no
-workspace. Find them with `pane ls --all` and close them one by one.
+`ws rm` hangs up the panes the workspace held, so removing a scratch workspace
+is enough on its own. What does leak is an interrupted `tty7 run`: that pane
+keeps running with nothing referencing it. `pane ls --all` finds those.
 
 Prefer `tty7 new <path>` over `ws new` when you want something usable: `ws new`
 leaves you with an empty workspace you then have to populate, while
@@ -225,13 +294,23 @@ still tell a real name from a stand-in.
 | `pane ls [WORKSPACE]` | panes with their workspace, tab, cwd, live flag | `{"panes":[...]}` |
 | `pane ls --all` | the server's whole pane registry, including orphans no workspace holds | `{"panes":[...],"orphans":N}` |
 | `pane split ...` | identical to top-level `split` | `{"pane"}` |
-| `pane close [%PANE]` | close the pane; its shell is hung up | `{"closed"}` |
+| `pane close [%PANE…]` | close panes; their shells are hung up | `{"closed":[...]}` |
+| `pane close --orphans` | close every pane no workspace holds | `{"closed":[...]}` |
 
 `--all` is the one that shows leaks. Each entry is
 `{"pane","workspace","orphan","owner","title","cwd","live"}`: `owner` is
 `tty7-cli` for panes this CLI spawned (a workspace id otherwise), and
-`orphan: true` means no workspace holds it. An interrupted `tty7 run` and a
-removed workspace both leave orphans here.
+`orphan: true` means no workspace holds it. An interrupted `tty7 run` is what
+leaves them.
+
+`close` takes several ids at once and keeps going after a failure, reporting
+what could not be closed at the end rather than abandoning the rest. `--orphans`
+closes exactly what `pane ls --all` marks orphaned, and reports an empty list
+instead of an error when there is nothing to do.
+
+**`--orphans` is the user's broom, not yours.** It closes every abandoned pane
+on the machine, and an abandoned pane may still be running someone's command.
+Point the user at it; don't run it on your own initiative.
 
 `title` is the pane's current title — usually the running command, so it reads
 `claude`, `nvim`, `cargo` — which makes `pane ls --all --json` a quick way to
@@ -264,4 +343,3 @@ These parse and then exit 1 with an explanation:
 
 - `ws stop` — the control dialect has no workspace-stop request yet
 - `machine connect` / `machine disconnect` — use the GUI
-- bare `tty7 <path>` (launch or focus the GUI) — not wired up

--- a/skills/tty7/references/commands.md
+++ b/skills/tty7/references/commands.md
@@ -202,11 +202,18 @@ Notes that decide whether a loop works:
 - **`idle` is not "the command finished".** It is something an *agent* says
   about itself. A pane running a build has no agent and reports `no-agent`.
   Use `free` for commands.
-- **`free` costs a second request per poll**, so it is only checked when named.
+- **`free` costs a second request per poll**, so it is only checked when named,
+  and only if none of the agent states you asked for matched first — pairing
+  `waiting,done,free` never loses you a `waiting`.
 - **`--changed` means something different for `free`**: a shell goes free →
   busy → free and ends where it started, so there is no new state to compare
   against. There it means "something ran while I watched" — exactly what you
-  want on the line after a `send`.
+  want on the line after a `send`. A command fast enough to finish inside one
+  `--interval` is never seen running, so it times out instead; use
+  `--interval 100` for those, or drop `--changed` and read a sentinel file.
+- **`free` reads the process tree**, so a pane whose root process is the command
+  itself (a `tty7 run` pane) looks free while it runs, and a backgrounded job
+  keeps a pane busy after the foreground command is gone.
 
 ### `tty7 events`
 Streams server events until interrupted, one per line — pane exits, agent
@@ -303,10 +310,11 @@ still tell a real name from a stand-in.
 `orphan: true` means no workspace holds it. An interrupted `tty7 run` is what
 leaves them.
 
-`close` takes several ids at once and keeps going after a failure, reporting
-what could not be closed at the end rather than abandoning the rest. `--orphans`
-closes exactly what `pane ls --all` marks orphaned, and reports an empty list
-instead of an error when there is nothing to do.
+`close` takes several ids at once and keeps going after a failure: the rest are
+still attempted, and it exits 1 with `{"closed":[...],"failed":[...]}` so you
+know what is left. `--orphans` closes exactly what `pane ls --all` marks
+orphaned, and reports an empty list instead of an error when there is nothing
+to do.
 
 **`--orphans` is the user's broom, not yours.** It closes every abandoned pane
 on the machine, and an abandoned pane may still be running someone's command.


### PR DESCRIPTION
Closes the gaps that made `tty7 wait` an agents-only primitive, gives `send` a key vocabulary, adds an orphan reaper, makes `doctor` perform the hooks check it already advertised — and brings the bundled skill up to date with all of it.

## Before / After

| | Before | After |
|---|---|---|
| `wait` on a pane running a build | Reports `idle`; `--until idle` returns `0` with `matched: true` **while the build is still running** | Reports `no-agent`; `--until free` blocks until the foreground command exits |
| Waiting for a plain command to finish | No state means this. Hand-rolled `until` loop polling `procs --json` | `tty7 wait "$P" --until free --changed` |
| `--changed` on a non-agent pane | Never fires — the agent cursor never moves | Means "something ran while I watched", the shape wanted right after a `send` |
| A `wait` that times out on a silent pane | `still idle — timed out` | Names the two causes: use `--until free` for a command, check `tty7 agents` for a missing status hook |
| Sending Ctrl-C, Escape, arrow keys | Not expressible — hand-craft `$'\x03'` / `$'\e[A'` as text | `send %3 --key C-c`, `--key up --key enter`; repeatable, composes with `TEXT` |
| An unknown key name | — | Usage error (exit `2`) before a single byte is written |
| `pane close` | One pane per invocation | `pane close %9 %10`, and `pane close --orphans` for everything no workspace holds |
| `pane close` mid-batch failure | — | Attempts every pane, reports what failed at the end |
| `doctor` | `--help` promised "hooks"; no hooks row existed | Reports installed / outdated / not-installed per agent; `unknown` under `-m` |
| `agents` status names in docs & skill | `running` / `waiting` / `idle` | `idle` / `working` / `waiting` / `done` (what the code actually emits) |

## Why

`tty7 wait --help` calls itself "the orchestration primitive", but it could only answer questions about agents. The `idle` conflation was the sharp edge: a pane with no agent reporting looked exactly like an agent sitting idle, so the obvious way to ask "is my command done" returned `0` immediately and the caller read a half-finished screen and believed it. Verified against a live server before and after:

```
$ tty7 procs %414
44724  zsh
45020    sleep  *          # still running

$ tty7 wait %414 --until idle --json     # before
{"status":"idle","matched":true,...}     # 0.04s, exit 0

$ tty7 wait %414 --until idle            # after
pane %414: still no-agent — timed out    # exit 124
nothing is reporting agent status in this pane — for a plain command wait
`--until free`, and for an agent check `tty7 agents` for a missing status hook
```

`free` reads the process tree `procs` already exposes, and costs a second request per poll — so it is only checked when named, leaving the default agent wait at one request per tick.

The bundled skill (`skills/tty7/`) predated `wait` entirely: its last content change was one day after `wait` landed and only touched frontmatter. It taught a hand-rolled `python3`-in-a-shell-loop for "is it done", had no concept of delegating to another agent, and carried three claims the code had outgrown — the status names above, "`ws rm` does not kill the panes inside it" (it does; `ws_rm` calls `hang_up_removed_panes`), and bare `tty7 <path>` listed as not implemented (it is).

## Wait states

```mermaid
flowchart LR
    P{pane} -->|agent reporting| A[idle / working / waiting / done]
    P -->|no agent, live| N["no-agent"]
    P -->|no agent, foreground command exited| F["free"]
    P -->|pane gone| X["exit"]
    A -.->|default --until| W["waiting, done, exit"]
    F -.->|"--until free"| C["command finished"]
```

`free` is polled only when requested, and only once none of the requested agent states have answered; `exit` ends every wait whether asked for or not.

## Review round

A second pass over the first commit found five things, fixed in `420431d`:

| | Was | Now |
|---|---|---|
| `--until free --changed` on a fast command | Never *sees* the pane busy, so it waits out the full `--timeout` and reports a finished command as a timeout | Same blind spot (it is inherent to polling), but the timeout names both causes and the two ways out |
| `free` vs. the agent ladder | Outranked it — a pane whose depth-0 process *is* the agent reads free for its whole turn, so a requested `waiting` could be overwritten and then withheld by `--changed` | Consulted only when no requested agent state matched; also one fewer request on agent panes |
| An unreadable process tree | Empty `procs` → `free` | Empty means "could not see in", not "finished" |
| `--key M-X` | Sent `ESC x` — the whole spelling was folded to lowercase, which is free for Ctrl and wrong for Alt | Alt keeps the case as written |
| `send --help` | Key vocabulary hand-copied beside the table it lists; already drifted by one alias (`pgdown`) | Generated from the table, with a test that says so |
| `pane close` partial failure | `bail!` — `--json` got prose exactly when a cleanup script needed the list | Exits 1 with `{"closed": […], "failed": […]}`, complaint still on stderr so `-q` reports it |

## Breaking

`tty7 pane close --json` now reports `{"closed": [ids]}` instead of `{"closed": id}`, since the verb takes more than one pane. A batch that could not close everything exits 1 with `{"closed": […], "failed": […]}`.

## Testing

- 14 new unit tests: the `idle` regression guard, `free` end-to-end, `--changed`+`free` (free → busy → free), "no procs call unless `free` was asked for", key parsing (control-range ASCII rule, aliases, unknown-key refusal), `send --key` ordering and the bare-address error, `--orphans` selectivity, batch-failure handling, and the `doctor` hooks row — plus, from the review round, Alt case fidelity, the generated help covering every key, `free` not overruling a requested state, an empty process tree not reading as finished, and the timeout that explains a `--changed` miss.
- `MockBackend` gained `procs_replies` so a test can script a pane going busy and quiet again.
- Full `tty7-cli` suite green (120 unit + 13 e2e), `cargo fmt --check` clean, no new clippy warnings.
- Verified live against a running server: `--until free` blocked 6.4s for a `sleep 6` and returned `stale: false`; `--until idle` on a busy pane now exits 124; `send --key C-c` killed a `sleep 60` (process tree back to the bare shell); `doctor` surfaced 6 outdated hooks on the dev machine. Scratch workspace created for the test was removed afterwards.

## Note for the reviewer

`docs/agents/status.mdx` and `docs/cli/reference.mdx` are being edited concurrently in another working tree. The status-name paragraph in `status.mdx` here is byte-identical to the fix in flight so it merges cleanly; `reference.mdx` may need a small merge in the `agents` and `wait` sections.

Unrelated flake spotted while running the suite: `tty7-core`'s `daemon::singleton::tests::the_second_claim_is_refused_while_the_first_is_held` fails roughly one run in three under the full parallel suite and passes in isolation, on unchanged code. Not touched here.

CI on this branch also went red twice on tests this PR does not touch, both re-run green: `tty7-server`'s `send_input_to_a_dead_pane_answers_an_error` (asserts the refusal says `not running`, but a reaped pane answers `no such pane` — whichever wins is a race), and `ui::scm::panel`'s `render_idle_gpui_tests`, where `draws_while_idle()` returns 1 instead of 0. The latter is failing on `main` as well, on a different test of the same module and a different platform. Both want a separate fix.