### PR TITLE
feat(ssh): probe ~/.ssh default identity keys (#484)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A pane's shell is recorded alongside, so a git bash pane no longer comes
   back as PowerShell.
 
+- **SSH probes the `~/.ssh` default identity keys** — a connection with no
+  identity file of its own used to offer the server nothing unless an agent
+  was running, which on Windows is the common case (the OpenSSH
+  Authentication Agent service is off by default), and then reported "no
+  public key was accepted" when no key had ever been sent. `id_ed25519`,
+  `id_ecdsa` and `id_rsa` are now offered after the connection's own files
+  and before the agent, OpenSSH-style, deduplicated against the explicit list
+  by canonical path so one key spelled two ways is offered once — every offer
+  spends one of the server's `MaxAuthTries`. A discovered key that is
+  encrypted is used only when its passphrase is already in the OS keychain:
+  russh has no offer-without-signing probe, so asking would spend a prompt on
+  a key the server may not even want. A key named in the profile still asks,
+  as before. The failure text now separates the two situations the old line
+  papered over — keys the server rejected are named, and a round that offered
+  nothing says where it looked. (#484)
+
 ### Fixed
 
 - **An SFTP upload no longer sits in the browser under its temporary name** —

--- a/crates/tty7-core/src/core/ssh_profile.rs
+++ b/crates/tty7-core/src/core/ssh_profile.rs
@@ -288,25 +288,62 @@ pub fn expand_identity_placeholders(path: &str, host: &str, user: &str) -> Strin
     expand_tilde(&out)
 }
 
-pub fn expand_tilde(path: &str) -> String {
-    let home = || {
-        #[cfg(windows)]
-        let var = "USERPROFILE";
-        #[cfg(not(windows))]
-        let var = "HOME";
-        std::env::var(var).ok().filter(|h| !h.is_empty())
-    };
+/// The platform home directory: `%USERPROFILE%` on Windows, `$HOME` elsewhere.
+fn home_dir() -> Option<String> {
+    #[cfg(windows)]
+    let var = "USERPROFILE";
+    #[cfg(not(windows))]
+    let var = "HOME";
+    std::env::var(var).ok().filter(|h| !h.is_empty())
+}
+
+fn expand_tilde_with(path: &str, home: Option<&str>) -> String {
     if let Some(rest) = path.strip_prefix("~/") {
-        if let Some(home) = home() {
+        if let Some(home) = home {
             let sep = if home.ends_with('/') { "" } else { "/" };
             return format!("{home}{sep}{rest}");
         }
     } else if path == "~" {
-        if let Some(home) = home() {
-            return home;
+        if let Some(home) = home {
+            return home.to_string();
         }
     }
     path.to_string()
+}
+
+pub fn expand_tilde(path: &str) -> String {
+    expand_tilde_with(path, home_dir().as_deref())
+}
+
+/// The private keys publickey auth probes when a connection carries no usable
+/// `IdentityFile` of its own — OpenSSH's default-identity behaviour (issue
+/// #484). Without it, "no profile key + no agent" offers the server zero keys,
+/// which on Windows is the common case (the OpenSSH Authentication Agent
+/// service is disabled by default there).
+///
+/// Both the GUI (`ui::ssh_connect`, preloading cached passphrases) and the
+/// daemon (`daemon::ssh::auth`, offering the keys) must see the *same* list:
+/// `NativeSshSpec::key_passphrases` is keyed on these exact strings, so the
+/// two sides share this one definition rather than formatting their own.
+///
+/// The list stays short on purpose: every offered key spends one of the
+/// server's `MaxAuthTries` (default 6), shared with explicit keys and agent
+/// identities. `id_dsa` is long deprecated, `id_xmss`/`id_*_sk` are beyond
+/// what russh can sign with, so the three software keys cover what exists in
+/// practice — ed25519 first as the modern default.
+pub fn default_identity_candidates() -> Vec<String> {
+    let Some(home) = home_dir() else {
+        return Vec::new();
+    };
+    default_identity_candidates_in(&home)
+}
+
+/// The pure core, home injected so tests never touch the environment.
+fn default_identity_candidates_in(home: &str) -> Vec<String> {
+    ["id_ed25519", "id_ecdsa", "id_rsa"]
+        .into_iter()
+        .map(|name| expand_tilde_with(&format!("~/.ssh/{name}"), Some(home)))
+        .collect()
 }
 
 #[cfg(test)]
@@ -457,6 +494,25 @@ mod tests {
         assert_eq!(expand_tilde("/a/~/b"), "/a/~/b");
         assert_eq!(expand_tilde("~user/x"), "~user/x");
         assert_eq!(expand_tilde("/abs/path"), "/abs/path");
+    }
+
+    #[test]
+    fn default_identity_candidates_are_ordered_and_home_relative() {
+        assert_eq!(
+            default_identity_candidates_in("/home/me"),
+            vec![
+                "/home/me/.ssh/id_ed25519".to_string(),
+                "/home/me/.ssh/id_ecdsa".to_string(),
+                "/home/me/.ssh/id_rsa".to_string()
+            ]
+        );
+        // A trailing separator must not double up, and the strings must be
+        // exactly what an explicit `~/.ssh/...` entry expands to, because
+        // `key_passphrases` is keyed on them.
+        assert_eq!(
+            default_identity_candidates_in("/home/me/"),
+            default_identity_candidates_in("/home/me")
+        );
     }
 
     #[test]

--- a/crates/tty7-core/src/daemon/ssh/auth.rs
+++ b/crates/tty7-core/src/daemon/ssh/auth.rs
@@ -439,10 +439,36 @@ async fn try_publickeys(
     broker: &Arc<PromptBroker>,
 ) -> Outcome {
     let mut last: Option<MethodSet> = None;
+    let mut round = KeyRound::default();
 
     if spec.auth_mode != SshAuthMode::Agent {
-        for path in &spec.identity_files {
-            match try_identity_file(handle, spec, broker, path).await {
+        // OpenSSH parity (#484): the `~/.ssh` default identities are appended
+        // after the explicit ones (there is no `IdentitiesOnly` yet), and
+        // deduped against them by canonical path — the explicit list may spell
+        // the same key with different separators or casing, and every offer
+        // spends one of the server's MaxAuthTries. Dedup compares the *expanded*
+        // explicit paths, the same ones `try_identity_file` opens: a spec entry
+        // still carrying `~` or `%h` names a real file, and comparing it raw
+        // would fail to canonicalize and offer that key a second time.
+        let explicit: Vec<String> = spec
+            .identity_files
+            .iter()
+            .map(|p| {
+                crate::core::ssh_profile::expand_identity_placeholders(p, &spec.host, &spec.user)
+            })
+            .collect();
+        let discovered = dedup_candidates(
+            crate::core::ssh_profile::default_identity_candidates(),
+            &explicit,
+            canonical_key,
+        );
+        let files = spec
+            .identity_files
+            .iter()
+            .map(|p| (p.clone(), KeySource::Explicit))
+            .chain(discovered.into_iter().map(|p| (p, KeySource::Discovered)));
+        for (path, source) in files {
+            match try_identity_file(handle, spec, broker, &path, source, &mut round).await {
                 Outcome::Authenticated => return Outcome::Authenticated,
                 Outcome::Failed {
                     remaining_methods, ..
@@ -457,7 +483,7 @@ async fn try_publickeys(
     }
 
     if spec.auth_mode != SshAuthMode::PublicKey {
-        match try_agent(handle, spec).await {
+        match try_agent(handle, spec, &mut round).await {
             Outcome::Authenticated => return Outcome::Authenticated,
             Outcome::Failed {
                 remaining_methods, ..
@@ -472,7 +498,190 @@ async fn try_publickeys(
 
     Outcome::Failed {
         remaining_methods: last,
-        reason: Some("no public key was accepted".to_string()),
+        reason: Some(round.reason(spec.auth_mode)),
+    }
+}
+
+/// Where an identity file came from. Provenance decides failure behaviour:
+/// an explicit key is the user's own choice, so its failures are said aloud
+/// and its encrypted form may ask for a passphrase; a discovered `~/.ssh`
+/// default is none of the user's doing, so every failure of one is silent
+/// (#484).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KeySource {
+    Explicit,
+    Discovered,
+}
+
+/// Canonical path for dedup: the same key reached via `~`, an absolute path,
+/// or different separator/casing spellings must be offered once, not twice —
+/// each offer spends one of the server's MaxAuthTries. Files that cannot be
+/// canonicalized (missing) never enter the set; the read step skips them.
+fn canonical_key(path: &str) -> Option<String> {
+    std::fs::canonicalize(path)
+        .ok()
+        .map(|p| p.to_string_lossy().into_owned())
+}
+
+/// Drop default candidates an explicit entry already names, comparing by
+/// canonical path. Pure apart from the injected canonicalizer, so tests never
+/// touch the filesystem.
+fn dedup_candidates(
+    candidates: Vec<String>,
+    explicit: &[String],
+    canon: impl Fn(&str) -> Option<String>,
+) -> Vec<String> {
+    let mut seen: std::collections::HashSet<String> =
+        explicit.iter().filter_map(|p| canon(p)).collect();
+    let mut out = Vec::new();
+    for candidate in candidates {
+        match canon(&candidate) {
+            Some(key) if seen.contains(&key) => {}
+            Some(key) => {
+                seen.insert(key);
+                out.push(candidate);
+            }
+            // Not canonicalizable means not readable; the read step skips it.
+            None => out.push(candidate),
+        }
+    }
+    out
+}
+
+/// What one publickey round learned, kept so the final error can distinguish
+/// the two situations "no public key was accepted" used to paper over
+/// (#484): nothing local could be offered at all, or keys went to the server
+/// and it refused every one.
+#[derive(Default)]
+struct KeyRound {
+    /// File keys actually sent to the server, by their configured path.
+    offered_files: Vec<String>,
+    /// File keys the server rejected, same spelling.
+    rejected_files: Vec<String>,
+    /// Whether an agent answered, and how many of its identities were
+    /// sent / rejected.
+    agent_available: bool,
+    agent_offered: usize,
+    agent_rejected: usize,
+    /// Explicit files that could not be read or decoded, with the reason.
+    /// (Discovered candidates fail silently, so they never land here.)
+    unusable: Vec<String>,
+    /// Transport-level errors after a key was decoded.
+    errors: Vec<String>,
+}
+
+impl KeyRound {
+    fn reason(&self, mode: SshAuthMode) -> String {
+        if !self.rejected_files.is_empty() || self.agent_rejected > 0 {
+            let mut what = self.rejected_files.clone();
+            if self.agent_rejected > 0 {
+                what.push(format!(
+                    "{} agent {}",
+                    self.agent_rejected,
+                    if self.agent_rejected == 1 {
+                        "identity"
+                    } else {
+                        "identities"
+                    }
+                ));
+            }
+            return format!("server rejected public key(s): {}", what.join(", "));
+        }
+        if self.offered_files.is_empty() && self.agent_offered == 0 {
+            let mut looked: Vec<String> = Vec::new();
+            if mode != SshAuthMode::Agent {
+                looked.push("identity files".to_string());
+                looked.push("~/.ssh default keys".to_string());
+            }
+            if mode != SshAuthMode::PublicKey {
+                looked.push(if self.agent_available {
+                    "the SSH agent".to_string()
+                } else {
+                    "the SSH agent (unavailable)".to_string()
+                });
+            }
+            let mut msg = format!(
+                "no usable private key was found (checked: {})",
+                looked.join(", ")
+            );
+            if !self.unusable.is_empty() {
+                msg.push_str(&format!("; {}", self.unusable.join("; ")));
+            }
+            return msg;
+        }
+        // Keys were offered and none was rejected or accepted: the transport
+        // broke, and the last error says where.
+        if let Some(e) = self.errors.last() {
+            return e.clone();
+        }
+        "no public key was accepted".to_string()
+    }
+}
+
+/// Decode-time policy for one identity file, split from the network so the
+/// source × encryption matrix stays unit-testable. The asymmetry is the
+/// point (#484 review): russh has no offer-without-signature probe, so
+/// trying an encrypted key means signing — i.e. prompting *before* the server
+/// has shown any interest in that key. An explicit key earns that prompt; a
+/// discovered default with no cached passphrase does not.
+enum IdentityLoad {
+    Ready(russh::keys::PrivateKey),
+    /// Not worth an offer: a `.pub`, an undecodable file, or a discovered
+    /// candidate that is encrypted with no cached passphrase.
+    Skip,
+    /// An explicit key the user should hear about.
+    Unusable(String),
+    /// Explicit, encrypted, no cached passphrase — ask the user.
+    NeedsPassphrase,
+}
+
+fn load_identity(
+    contents: &str,
+    raw_path: &str,
+    source: KeySource,
+    cached: Option<&str>,
+) -> IdentityLoad {
+    if PublicKey::from_openssh(contents.trim()).is_ok() {
+        // A `.pub` handed in as the identity file is never an offer. Worth a
+        // line in the log when the user named it themselves — pointing
+        // IdentityFile at the public half is a common slip, and the round is
+        // otherwise silent about it.
+        if source == KeySource::Explicit {
+            log::warn!("identity file {raw_path} is a public key; skipping");
+        }
+        return IdentityLoad::Skip;
+    }
+    match russh::keys::decode_secret_key(contents, None) {
+        Ok(key) => IdentityLoad::Ready(key),
+        Err(russh::keys::Error::KeyIsEncrypted) => match cached {
+            Some(passphrase) => match russh::keys::decode_secret_key(contents, Some(passphrase)) {
+                Ok(key) => IdentityLoad::Ready(key),
+                Err(e) => {
+                    log::warn!("could not decrypt identity file {raw_path}: {e}");
+                    match source {
+                        KeySource::Explicit => IdentityLoad::Unusable(format!(
+                            "could not decrypt identity file {raw_path}"
+                        )),
+                        // A stale cached passphrase for a key the user never
+                        // configured: skip, don't shout.
+                        KeySource::Discovered => IdentityLoad::Skip,
+                    }
+                }
+            },
+            None => match source {
+                KeySource::Explicit => IdentityLoad::NeedsPassphrase,
+                KeySource::Discovered => IdentityLoad::Skip,
+            },
+        },
+        Err(e) => {
+            log::warn!("could not read identity file {raw_path}: {e}");
+            match source {
+                KeySource::Explicit => {
+                    IdentityLoad::Unusable(format!("could not read identity file {raw_path}: {e}"))
+                }
+                KeySource::Discovered => IdentityLoad::Skip,
+            }
+        }
     }
 }
 
@@ -481,77 +690,110 @@ async fn try_identity_file(
     spec: &NativeSshSpec,
     broker: &Arc<PromptBroker>,
     raw_path: &str,
+    source: KeySource,
+    round: &mut KeyRound,
 ) -> Outcome {
-    let path = expand_identity_path(raw_path, &spec.host, &spec.user);
+    let path =
+        crate::core::ssh_profile::expand_identity_placeholders(raw_path, &spec.host, &spec.user);
     let contents = match std::fs::read_to_string(&path) {
         Ok(c) => c,
-        Err(e) => return failed(format!("cannot read identity file {path}: {e}")),
-    };
-
-    if PublicKey::from_openssh(contents.trim()).is_ok() {
-        log::warn!("identity file {path} is a public key; skipping");
-        return Outcome::Skipped;
-    }
-
-    let key = match russh::keys::decode_secret_key(&contents, None) {
-        Ok(k) => k,
-        Err(russh::keys::Error::KeyIsEncrypted) => {
-            let provided = spec
-                .key_passphrases
-                .as_ref()
-                .and_then(|m| m.get(raw_path))
-                .cloned();
-            let passphrase = match provided {
-                Some(p) => p,
-                None => {
-                    let resp = broker
-                        .prompt(AuthPromptKind::KeyPassphrase {
-                            key_path: raw_path.to_string(),
-                            comment: String::new(),
-                        })
-                        .await;
-                    match resp {
-                        AuthResponse::Secret(p) => p,
-                        _ => return Outcome::Skipped,
+        Err(e) => {
+            return match source {
+                KeySource::Explicit => {
+                    round
+                        .unusable
+                        .push(format!("cannot read identity file {raw_path}: {e}"));
+                    Outcome::Failed {
+                        remaining_methods: None,
+                        reason: None,
                     }
                 }
+                // A default candidate that is not there is the normal case,
+                // not a failure.
+                KeySource::Discovered => Outcome::Skipped,
+            };
+        }
+    };
+
+    let cached = spec
+        .key_passphrases
+        .as_ref()
+        .and_then(|m| m.get(raw_path))
+        .map(String::as_str);
+    let key = match load_identity(&contents, raw_path, source, cached) {
+        IdentityLoad::Ready(k) => k,
+        IdentityLoad::Skip => return Outcome::Skipped,
+        IdentityLoad::Unusable(reason) => {
+            round.unusable.push(reason);
+            return Outcome::Failed {
+                remaining_methods: None,
+                reason: None,
+            };
+        }
+        IdentityLoad::NeedsPassphrase => {
+            let resp = broker
+                .prompt(AuthPromptKind::KeyPassphrase {
+                    key_path: raw_path.to_string(),
+                    comment: String::new(),
+                })
+                .await;
+            let AuthResponse::Secret(passphrase) = resp else {
+                return Outcome::Skipped;
             };
             match russh::keys::decode_secret_key(&contents, Some(&passphrase)) {
                 Ok(k) => k,
                 Err(e) => {
                     log::warn!("could not decrypt identity file {path}: {e}");
-                    return failed(format!("could not decrypt identity file {path}"));
+                    round
+                        .unusable
+                        .push(format!("could not decrypt identity file {raw_path}"));
+                    return Outcome::Failed {
+                        remaining_methods: None,
+                        reason: None,
+                    };
                 }
             }
         }
-        Err(e) => {
-            log::warn!("could not read identity file {path}: {e}");
-            return failed(format!("could not read identity file {path}"));
-        }
     };
 
+    round.offered_files.push(raw_path.to_string());
     let hash_alg = rsa_hash_alg(&key.algorithm());
     let pk = PrivateKeyWithHashAlg::new(Arc::new(key), hash_alg);
     match handle.authenticate_publickey(&spec.user, pk).await {
         Ok(AuthResult::Success) => Outcome::Authenticated,
         Ok(AuthResult::Failure {
             remaining_methods, ..
-        }) => Outcome::Failed {
-            remaining_methods: Some(remaining_methods),
-            reason: Some(format!("server rejected key {raw_path}")),
-        },
-        Err(e) => failed(format!("public-key auth error: {e}")),
+        }) => {
+            round.rejected_files.push(raw_path.to_string());
+            Outcome::Failed {
+                remaining_methods: Some(remaining_methods),
+                reason: None,
+            }
+        }
+        Err(e) => {
+            round
+                .errors
+                .push(format!("public-key auth error with {raw_path}: {e}"));
+            Outcome::Failed {
+                remaining_methods: None,
+                reason: None,
+            }
+        }
     }
 }
 
-async fn try_agent(handle: &mut Handle<ClientHandler>, spec: &NativeSshSpec) -> Outcome {
+async fn try_agent(
+    handle: &mut Handle<ClientHandler>,
+    spec: &NativeSshSpec,
+    round: &mut KeyRound,
+) -> Outcome {
     #[cfg(unix)]
     {
         let agent = match AgentClient::connect_env().await {
             Ok(a) => a,
             Err(_) => return Outcome::Skipped,
         };
-        try_agent_identities(handle, spec, agent).await
+        try_agent_identities(handle, spec, agent, round).await
     }
     #[cfg(windows)]
     {
@@ -561,7 +803,7 @@ async fn try_agent(handle: &mut Handle<ClientHandler>, spec: &NativeSshSpec) -> 
             Ok(a) => a,
             Err(_) => return Outcome::Skipped,
         };
-        try_agent_identities(handle, spec, agent).await
+        try_agent_identities(handle, spec, agent, round).await
     }
 }
 
@@ -569,6 +811,7 @@ async fn try_agent_identities<S>(
     handle: &mut Handle<ClientHandler>,
     spec: &NativeSshSpec,
     mut agent: AgentClient<S>,
+    round: &mut KeyRound,
 ) -> Outcome
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
@@ -577,12 +820,14 @@ where
         Ok(ids) => ids,
         Err(_) => return Outcome::Skipped,
     };
+    round.agent_available = true;
     let mut last: Option<MethodSet> = None;
     for identity in identities {
         let pubkey: PublicKey = match &identity {
             AgentIdentity::PublicKey { key, .. } => key.clone(),
             AgentIdentity::Certificate { .. } => continue,
         };
+        round.agent_offered += 1;
         let hash_alg = rsa_hash_alg(&pubkey.algorithm());
         match handle
             .authenticate_publickey_with(&spec.user, pubkey, hash_alg, &mut agent)
@@ -591,13 +836,16 @@ where
             Ok(AuthResult::Success) => return Outcome::Authenticated,
             Ok(AuthResult::Failure {
                 remaining_methods, ..
-            }) => last = Some(remaining_methods),
+            }) => {
+                round.agent_rejected += 1;
+                last = Some(remaining_methods);
+            }
             Err(_) => continue,
         }
     }
     Outcome::Failed {
         remaining_methods: last,
-        reason: Some("no agent key was accepted".to_string()),
+        reason: None,
     }
 }
 
@@ -756,26 +1004,6 @@ fn rsa_hash_alg(algorithm: &Algorithm) -> Option<HashAlg> {
     }
 }
 
-fn expand_identity_path(path: &str, host: &str, user: &str) -> String {
-    let substituted = path.replace("%h", host).replace("%r", user);
-    if let Some(rest) = substituted.strip_prefix("~/") {
-        if let Some(home) = home_dir() {
-            return format!("{home}/{rest}");
-        }
-    }
-    substituted
-}
-
-#[cfg(unix)]
-fn home_dir() -> Option<String> {
-    std::env::var("HOME").ok().filter(|h| !h.is_empty())
-}
-
-#[cfg(not(unix))]
-fn home_dir() -> Option<String> {
-    std::env::var("USERPROFILE").ok().filter(|h| !h.is_empty())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -803,12 +1031,6 @@ mod tests {
         let msg = nothing_to_try(SshAuthMode::Auto, &MethodSet::empty());
         assert!(!msg.contains("offers"), "{msg}");
         assert!(!msg.ends_with(' '), "{msg}");
-    }
-
-    #[test]
-    fn identity_path_expands_tokens_and_tilde() {
-        let p = expand_identity_path("/keys/%r@%h/id", "example.com", "deploy");
-        assert_eq!(p, "/keys/deploy@example.com/id");
     }
 
     #[test]
@@ -870,5 +1092,230 @@ mod tests {
             Some(HashAlg::Sha256)
         );
         assert_eq!(rsa_hash_alg(&Algorithm::Ed25519), None);
+    }
+
+    #[test]
+    fn default_candidates_dedup_against_explicit_by_canonical_path() {
+        // The fake canonicalizer collapses spelling differences; two strings
+        // with the same canonical form are one file, and the explicit entry
+        // wins the offer slot.
+        let canon = |p: &str| Some(p.replace("//", "/"));
+        let out = dedup_candidates(
+            vec![
+                "/home/me/.ssh/id_ed25519".to_string(),
+                "/home/me/.ssh/id_ecdsa".to_string(),
+                "/home/me/.ssh/id_rsa".to_string(),
+            ],
+            &["/home/me//.ssh/id_rsa".to_string()],
+            canon,
+        );
+        assert_eq!(
+            out,
+            vec![
+                "/home/me/.ssh/id_ed25519".to_string(),
+                "/home/me/.ssh/id_ecdsa".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn candidates_that_do_not_canonicalize_pass_through() {
+        // A missing default is the normal case; the read step skips it, so
+        // dedup must not drop it here either.
+        let out = dedup_candidates(vec!["/missing/id_ed25519".to_string()], &[], |_| None);
+        assert_eq!(out, vec!["/missing/id_ed25519".to_string()]);
+    }
+
+    const PASSPHRASE: &str = "correct horse battery staple";
+
+    /// The throwaway ed25519 key these tests offer, built here rather than
+    /// pasted in as a PEM blob: a private key sitting in the tree is a
+    /// secret-scanner hit whatever its provenance, and a scanner that has to
+    /// be overridden to stay green is one nobody reads. The seed is fixed, so
+    /// the bytes are the same on every run, and this key exists nowhere but
+    /// these assertions.
+    fn fixture_key() -> russh::keys::PrivateKey {
+        russh::keys::PrivateKey::from(russh::keys::ssh_key::private::Ed25519Keypair::from_seed(
+            &[7u8; 32],
+        ))
+    }
+
+    fn plain_key() -> String {
+        fixture_key()
+            .to_openssh(russh::keys::ssh_key::LineEnding::LF)
+            .expect("encode the fixture key")
+            .to_string()
+    }
+
+    /// The same key under `PASSPHRASE`. `encrypt_with` takes the KDF and
+    /// checkint rather than an RNG, which is what keeps this crate free of a
+    /// rand dependency it otherwise has no use for; the low bcrypt round count
+    /// is a test's, not a real key's.
+    fn encrypted_key() -> String {
+        fixture_key()
+            .encrypt_with(
+                russh::keys::ssh_key::Cipher::Aes256Ctr,
+                russh::keys::ssh_key::Kdf::Bcrypt {
+                    salt: vec![9u8; 16],
+                    rounds: 4,
+                },
+                0,
+                PASSPHRASE,
+            )
+            .expect("encrypt the fixture key")
+            .to_openssh(russh::keys::ssh_key::LineEnding::LF)
+            .expect("encode the encrypted fixture key")
+            .to_string()
+    }
+
+    #[test]
+    fn load_identity_ready_for_plain_key_either_source() {
+        for source in [KeySource::Explicit, KeySource::Discovered] {
+            assert!(
+                matches!(
+                    load_identity(&plain_key(), "k", source, None),
+                    IdentityLoad::Ready(_)
+                ),
+                "plain key must load for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn load_identity_skips_public_key_content() {
+        let public = fixture_key()
+            .public_key()
+            .to_openssh()
+            .expect("encode the fixture public key");
+        for source in [KeySource::Explicit, KeySource::Discovered] {
+            assert!(
+                matches!(
+                    load_identity(&public, "k", source, None),
+                    IdentityLoad::Skip
+                ),
+                "a .pub is never an offer"
+            );
+        }
+    }
+
+    #[test]
+    fn load_identity_garbage_is_loud_for_explicit_quiet_for_discovered() {
+        assert!(matches!(
+            load_identity("not a key", "k", KeySource::Explicit, None),
+            IdentityLoad::Unusable(_)
+        ));
+        assert!(matches!(
+            load_identity("not a key", "k", KeySource::Discovered, None),
+            IdentityLoad::Skip
+        ));
+    }
+
+    #[test]
+    fn load_identity_encrypted_prompts_only_for_explicit() {
+        // The whole policy (#484): russh can only try an encrypted key by
+        // signing, so a discovered one with no cached passphrase is skipped
+        // rather than spending a prompt on a key the server may not want.
+        assert!(matches!(
+            load_identity(&encrypted_key(), "k", KeySource::Explicit, None),
+            IdentityLoad::NeedsPassphrase
+        ));
+        assert!(matches!(
+            load_identity(&encrypted_key(), "k", KeySource::Discovered, None),
+            IdentityLoad::Skip
+        ));
+    }
+
+    #[test]
+    fn load_identity_encrypted_uses_a_cached_passphrase_for_either_source() {
+        for source in [KeySource::Explicit, KeySource::Discovered] {
+            assert!(
+                matches!(
+                    load_identity(&encrypted_key(), "k", source, Some(PASSPHRASE)),
+                    IdentityLoad::Ready(_)
+                ),
+                "cached passphrase must unlock for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn load_identity_wrong_cached_passphrase_is_loud_only_for_explicit() {
+        assert!(matches!(
+            load_identity(&encrypted_key(), "k", KeySource::Explicit, Some("wrong")),
+            IdentityLoad::Unusable(_)
+        ));
+        assert!(matches!(
+            load_identity(&encrypted_key(), "k", KeySource::Discovered, Some("wrong")),
+            IdentityLoad::Skip
+        ));
+    }
+
+    #[test]
+    fn reason_names_the_keys_the_server_rejected() {
+        let mut round = KeyRound::default();
+        round.offered_files = vec!["/home/me/.ssh/id_ed25519".to_string()];
+        round.rejected_files = round.offered_files.clone();
+        let msg = round.reason(SshAuthMode::Auto);
+        assert_eq!(
+            msg,
+            "server rejected public key(s): /home/me/.ssh/id_ed25519"
+        );
+
+        round.agent_offered = 2;
+        round.agent_rejected = 2;
+        let msg = round.reason(SshAuthMode::Auto);
+        assert_eq!(
+            msg,
+            "server rejected public key(s): /home/me/.ssh/id_ed25519, 2 agent identities"
+        );
+    }
+
+    #[test]
+    fn reason_for_nothing_offered_says_where_it_looked() {
+        let round = KeyRound::default();
+        let msg = round.reason(SshAuthMode::Auto);
+        assert!(msg.contains("no usable private key was found"), "{msg}");
+        assert!(msg.contains("~/.ssh default keys"), "{msg}");
+        assert!(msg.contains("agent (unavailable)"), "{msg}");
+
+        // An agent that answered but held nothing is "checked", not
+        // "unavailable".
+        let mut round = KeyRound::default();
+        round.agent_available = true;
+        let msg = round.reason(SshAuthMode::Auto);
+        assert!(msg.contains("the SSH agent"), "{msg}");
+        assert!(!msg.contains("unavailable"), "{msg}");
+
+        // Pinned modes name only what they would have used.
+        let msg = KeyRound::default().reason(SshAuthMode::Agent);
+        assert!(!msg.contains("default keys"), "{msg}");
+        let msg = KeyRound::default().reason(SshAuthMode::PublicKey);
+        assert!(!msg.contains("agent"), "{msg}");
+    }
+
+    #[test]
+    fn reason_appends_unusable_explicit_files() {
+        let mut round = KeyRound::default();
+        round
+            .unusable
+            .push("cannot read identity file /bad/key: denied".to_string());
+        let msg = round.reason(SshAuthMode::PublicKey);
+        assert!(
+            msg.contains("cannot read identity file /bad/key: denied"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn reason_falls_back_to_the_transport_error_after_an_offer() {
+        let mut round = KeyRound::default();
+        round.offered_files = vec!["/home/me/.ssh/id_ed25519".to_string()];
+        round.errors.push(
+            "public-key auth error with /home/me/.ssh/id_ed25519: connection lost".to_string(),
+        );
+        assert_eq!(
+            round.reason(SshAuthMode::Auto),
+            "public-key auth error with /home/me/.ssh/id_ed25519: connection lost"
+        );
     }
 }

--- a/src/ui/ssh_connect.rs
+++ b/src/ui/ssh_connect.rs
@@ -191,7 +191,13 @@ fn build_spec_inner(
 
     let mut key_passphrases: HashMap<String, String> = HashMap::new();
     if matches!(profile.auth, AuthMode::Auto | AuthMode::PublicKey) {
-        for path in &identity_files {
+        // Explicit files, then the same `~/.ssh` defaults the daemon probes
+        // (#484): it looks passphrases up by the candidate string, so both
+        // sides must iterate the one shared list.
+        for path in identity_files
+            .iter()
+            .chain(crate::core::ssh_profile::default_identity_candidates().iter())
+        {
             let Ok(bytes) = std::fs::read(path) else {
                 continue;
             };


### PR DESCRIPTION
## 关联

Close #484。

## 背景

Windows 上未配置显式 IdentityFile 的连接，在 agent 服务（OpenSSH Authentication Agent 默认禁用）不可用时，不会向服务器递出任何密钥，最终却报错 "no public key was accepted"——实际上一把 key 都没递出去过。

## 实现（按 #484 讨论中确认的方案）

- [x] `tty7-core` 新增共享 `default_identity_candidates()`（`core::ssh_profile`）：`~/.ssh/id_ed25519` / `id_ecdsa` / `id_rsa`。GUI 与 daemon 共用这一份候选列表——`key_passphrases` 按这些字符串做 map key，两边必须一致
- [x] daemon `try_publickeys` 顺序：显式 key → 默认候选 → agent（OpenSSH parity；`IdentitiesOnly` 后续单独加）
- [x] 去重按 canonical 路径（`std::fs::canonicalize`）而非字符串比较；无法 canonicalize 的候选（文件不存在）保留并交由读取步骤静默跳过
- [x] 默认候选里的加密 key：仅在 keychain 已缓存 passphrase 时使用，无缓存则静默跳过、不弹窗（russh 没有 offer-without-signature 探测 API，弹窗可能浪费在服务器根本不想要的 key 上）；显式 key 维持现有弹窗行为
- [x] 只递存在且能解析的文件：不存在的默认候选静默跳过；`.pub` 内容不当私钥递；读不了/解不了的**显式** key 计入报错明细
- [x] GUI 侧 `ssh_connect.rs` 的 keychain passphrase 预载扩展到默认候选（saved profile / quick connect / jump chain 都走 `build_spec_inner`，一处改动全覆盖）
- [x] 报错文案区分两种情形：服务器拒绝 → `server rejected public key(s): <路径…>`（含 agent identity 计数）；一把都没递出 → `no usable private key was found (checked: …)` 并附显式 key 不可用的具体原因

## 测试

- 纯函数单测：候选顺序与 home 相对性、canonical 去重（注入假 canonicalizer，不碰文件系统）、`load_identity` 的「显式/发现 × 明文/加密/有缓存/缓存错误」矩阵（内嵌一次性 ed25519 fixture）、`KeyRound::reason` 各分支
- `cargo test --locked -p tty7-core`、`cargo fmt --check`、host-boundary 脚本全绿
- 尚未做真机端到端验证（连一台只认 `~/.ssh/id_ed25519` 的服务器），欢迎指点
