### PR TITLE
Run the test suite under cargo-nextest for per-test timeouts and isolation

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -14,8 +14,9 @@
 # Excluding it here rather than teaching it the libtest protocol is the right
 # trade: converting it would mean giving up the shared daemon and the self-exec,
 # which is the whole design of the file. CI keeps running it, under plain
-# `cargo test`, in its own step — see the `CLI end-to-end` step in ci.yml. Keep
-# the two in sync: dropping the step would silently retire thirteen tests.
+# `cargo test`, in its own step — see the `CLI end-to-end` step in ci.yml, and
+# note the comment there about why that step must not name the package. Keep the
+# two in sync: dropping the step would silently retire thirteen tests.
 #
 # This lives on `default` rather than on `ci` so a local `cargo nextest run`
 # behaves the same way instead of erroring out.

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,104 @@
+# cargo-nextest's configuration. `.github/workflows/ci.yml` selects `--profile
+# ci`; a bare `cargo nextest run` locally uses `default` and inherits everything
+# not overridden below.
+
+[profile.default]
+# `tty7-cli`'s cli_e2e is `harness = false` (see crates/tty7-cli/Cargo.toml), and
+# deliberately so: the test binary *is* `fn main()`, and it re-execs itself as
+# the daemon under test (`TTY7_CLI_E2E_DAEMON=1`) and as a raw-mode TUI fixture
+# (`--tty7-e2e-paste-aware-fixture`), then runs its cases in order against the
+# one daemon it started. nextest can only drive a libtest harness — it enumerates
+# tests with `--list`, which that `main` ignores, so leaving it in fails the run
+# before a single test executes.
+#
+# Excluding it here rather than teaching it the libtest protocol is the right
+# trade: converting it would mean giving up the shared daemon and the self-exec,
+# which is the whole design of the file. CI keeps running it, under plain
+# `cargo test`, in its own step — see the `CLI end-to-end` step in ci.yml. Keep
+# the two in sync: dropping the step would silently retire thirteen tests.
+#
+# This lives on `default` rather than on `ci` so a local `cargo nextest run`
+# behaves the same way instead of erroring out.
+default-filter = "not binary_id(tty7-cli::cli_e2e)"
+
+[profile.ci]
+# One failure must not hide the rest. On CI the value of a run is the complete
+# list of what broke, and re-running to discover the second failure costs another
+# six minutes of runner time.
+fail-fast = false
+
+# This is as much the reason for using nextest as the speed is.
+#
+# The suite intermittently hangs — roughly one run in ten, on any branch, while
+# the same commit passes on a re-run (seen on Windows three times and on Linux
+# once). Under `cargo test` the only backstop was the *step* timeout, and that
+# kills the whole process tree: the job fails having said nothing about which
+# test was stuck, because GitHub tears the step down before the log can be read.
+# See the `Test` step's comment in ci.yml for the full history.
+#
+# nextest runs each test in its own process, so it can time out the individual
+# test instead of the run: `SLOW` is reported at 60s while everything else keeps
+# going, and a test still running at three minutes is terminated and named in the
+# summary as TIMEOUT. The step timeout stays as the outer backstop, but it should
+# now never be the thing that trips.
+slow-timeout = { period = "60s", terminate-after = 3 }
+
+# Keep the slow tests in the summary even on a fully green run. That list is the
+# targeting data for the next round of "why does tty7-core take 44s on Windows
+# and 10s on Linux".
+final-status-level = "slow"
+
+# ---------------------------------------------------------------------------
+# Serialization
+#
+# The suite carries nine `static Mutex` guards that exist purely to keep tests
+# out of each other's way under libtest, where every test shares one process:
+# `serial()` in ui::scm::panel, ui::scm::graph and ui::file_tree;
+# `lock_config_file`, `lock_session_file`, `responder_lock`, `pin_dir`,
+# `claim_mailbox`, and windows_env's `SCRATCH`.
+#
+# nextest gives each test its own process, so most of those become no-ops — and
+# for seven of the nine that is strictly *better* than the lock they replace,
+# because what they were protecting is process-global state that is now simply
+# not shared:
+#
+#   - lock_config_file / lock_session_file / pin_dir all guard `set_config_dir`,
+#     which is process-wide, over a scratch dir already keyed by `process::id()`.
+#     Separate processes get separate dirs and separate globals.
+#   - responder_lock guards `AUTH_RESPONDER`, a `static OnceLock`.
+#   - claim_mailbox guards `AUTH_MAILBOX`, a `static Mutex<Vec<_>>`.
+#
+# The two that are not covered by process isolation get a group below. Leave the
+# mutexes in place regardless: they are what makes `cargo test` correct, and CI
+# still runs one target that way (tty7-cli's cli_e2e).
+
+[test-groups]
+# Frame-accounting tests: they drive a gpui window to quiescence and then assert
+# that an idle panel draws *zero* further frames. That is a claim about a quiet
+# machine, not about mutual exclusion — an unrelated test hogging a core is
+# enough to make a stray frame land and the count come back 1. Under libtest the
+# three `serial()` mutexes gave them a calm-enough process; `max-threads = 1`
+# across all of them is the equivalent, and stricter, since the three locks were
+# independent of each other and these tests never needed to overlap.
+render-idle = { max-threads = 1 }
+
+# windows_env's live-registry tests write one shared value name
+# (`TTY7_ISSUE333_PROBE`) into `HKCU\Environment`. HKCU belongs to the *user*,
+# not the process, so this is the one lock here that process isolation does not
+# subsume: without a group, one test's cleanup deletes the value another is
+# still reading, exactly as the `SCRATCH` mutex's own comment describes.
+#
+# Unverifiable from a macOS dev machine — these are `#[cfg(windows)]`, so
+# `nextest show-config test-groups` reports "no matches" here and the Windows CI
+# job is the filter's first real exercise. A filter that matches nothing is not
+# an error, so the pattern below is deliberately loose about what sits between
+# the module and the mod name rather than pinning the exact nesting.
+windows-registry = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'test(/render_idle_gpui_tests::/) or test(/drop_gpui_tests::/)'
+test-group = 'render-idle'
+
+[[profile.default.overrides]]
+filter = 'test(/windows_env::.*live_registry::/)'
+test-group = 'windows-registry'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,9 +175,18 @@ jobs:
       #
       # Deleting this step would not fail anything — it would silently retire
       # thirteen end-to-end tests.
+      #
+      # No `-p tty7-cli`, and that is load-bearing rather than shorthand.
+      # Naming the package resolves features for *its* dependency graph alone,
+      # while every step above builds the default members together — and the root
+      # package turns on tty7-core's `gssapi` and `remote-install`. The two
+      # feature sets are two different builds of tty7-core, so `-p` rebuilds it
+      # and everything above it from scratch: 91 crates, measured at 1m03s on
+      # Linux and 2m12s on Windows. Without `-p`, cargo selects the same default
+      # members as the rest of the job and compiles nothing.
       - name: CLI end-to-end
         timeout-minutes: 15
-        run: cargo test --locked -p tty7-cli --test cli_e2e --target ${{ matrix.target }}
+        run: cargo test --locked --test cli_e2e --target ${{ matrix.target }}
 
       # nextest does not run doctests, so on its own the switch above would let a
       # doctest be added and silently never run. There are none in the tree today

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,17 @@ jobs:
     # hung test runs to GitHub's six-hour job limit, which is how a 90-second
     # step turned into a six-hour one three times in a day.
     timeout-minutes: 60
+    env:
+      # Two thirds of this job is compiling, and a measurable slice of that is
+      # emitting debug info nothing here consumes: no debugger ever attaches on a
+      # runner, and the one thing CI needs from a panic is the `file:line` in the
+      # backtrace, which `line-tables-only` keeps. `[profile.dev]` in Cargo.toml
+      # stays at `debug = "limited"` for local development — this narrows it for
+      # CI only.
+      #
+      # Note for whoever changes this next: Swatinem/rust-cache hashes `CARGO_*`
+      # into its cache key, so editing this line makes exactly one run cold.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
     steps:
       - name: Checkout tty7
         uses: actions/checkout@v4
@@ -110,44 +121,80 @@ jobs:
         timeout-minutes: 30
         run: cargo build --locked --target ${{ matrix.target }}
 
-      # `cargo test` has no timeout of its own, so one hung test is
-      # indistinguishable from a slow suite until the job hits GitHub's six-hour
-      # limit. The suite intermittently hangs here — roughly one run in ten, on
-      # any branch, while the same commit passes on a re-run — and every time it
-      # did, the job held a runner slot for hours and reported nothing.
+      # nextest rather than `cargo test`, for two reasons.
       #
-      # Seen on Windows three times and on Linux once, so it is not a
-      # platform-specific test: `Build` succeeds, `Test` starts, and nothing
-      # further is ever written.
+      # Speed: `cargo test` runs the sixteen test binaries strictly one after
+      # another, and paying each one's process startup separately is most of the
+      # cost on Windows — the per-binary times reported there added up to 59s
+      # against 98s of wall clock (run 31499772887). nextest schedules every
+      # test from every binary through one pool, so that gap closes.
       #
-      # The step's honest budget is small: ~75s warm and ~3.5 min when this step
-      # also has to compile the test targets, on every platform. 20 minutes is
-      # pure headroom, so a trip means a hang, not a slow runner.
+      # Diagnosis, which matters more: `cargo test` has no timeout of its own, so
+      # one hung test was indistinguishable from a slow suite until the job hit
+      # GitHub's six-hour limit. The suite intermittently hangs — roughly one run
+      # in ten, on any branch, while the same commit passes on a re-run, seen on
+      # Windows three times and on Linux once — and every time it did, the job
+      # held a runner slot for hours and reported nothing: `Build` succeeded,
+      # `Test` started, and nothing further was ever written.
+      #
+      # An earlier attempt at that problem was a post-mortem step that dumped the
+      # process table on failure. It cannot work, and that is worth recording:
+      # GitHub kills the step's whole process tree when `timeout-minutes` trips,
+      # *before* the next step runs, so on the one failure that matters the dump
+      # comes back empty — verified on run 30526538997, where it printed two
+      # headers and nothing between them.
+      #
+      # nextest fixes it at the right level instead: each test is its own
+      # process, so the *test* times out and gets named in the summary while the
+      # rest of the suite finishes normally (see `.config/nextest.toml`). The
+      # 20-minute step timeout below stays as the outer backstop, but it should
+      # now never be the thing that trips — if it does, the hang is in the
+      # harness rather than in a test.
+      #
+      # The step's honest budget is small: ~75s warm and ~3.5 min when it also
+      # has to compile the test targets. 20 minutes is pure headroom.
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
       - name: Test
         timeout-minutes: 20
-        run: cargo test --locked --target ${{ matrix.target }}
+        run: cargo nextest run --locked --profile ci --target ${{ matrix.target }}
 
       - name: Test desktop updater
         if: runner.os == 'macOS' || runner.os == 'Windows'
         timeout-minutes: 10
-        run: cargo test --locked --features updater --bin tty7-updater --target ${{ matrix.target }}
+        run: cargo nextest run --locked --profile ci --features updater --bin tty7-updater --target ${{ matrix.target }}
 
-      # There is deliberately no post-mortem step here, and that is worth
-      # recording, because an earlier version of this file had one: on failure it
-      # dumped the process table to find the surviving test binary.
+      # tty7-cli's cli_e2e is `harness = false` — the test binary is its own
+      # `fn main()`, re-execs itself as the daemon under test and as a raw-mode
+      # TUI fixture, and runs its cases in order against the single daemon it
+      # started. nextest drives libtest harnesses only, so `.config/nextest.toml`
+      # filters this binary out of the run above and it stays on `cargo test`.
       #
-      # It does not work, and cannot. GitHub kills the step's whole process tree
-      # when `timeout-minutes` trips, *before* the next step runs, so on the one
-      # failure that matters the dump comes back empty — verified on run
-      # 30526538997, where it printed two headers and nothing between them.
+      # Deleting this step would not fail anything — it would silently retire
+      # thirteen end-to-end tests.
+      - name: CLI end-to-end
+        timeout-minutes: 15
+        run: cargo test --locked -p tty7-cli --test cli_e2e --target ${{ matrix.target }}
+
+      # nextest does not run doctests, so on its own the switch above would let a
+      # doctest be added and silently never run. There are none in the tree today
+      # — the only fenced block in a doc comment is a `text` lane diagram in
+      # tty7-core's git log code — so this is a guard, not a workload.
       #
-      # Nor is it needed. libtest already prints "<test> has been running for
-      # over 60 seconds" for a test that has not returned, and that line was
-      # sitting in every hung run all along. The obstacle was never the
-      # diagnostic: a job's log cannot be fetched while the job is in progress
-      # (the API 404s), and nobody cancels a six-hour run to read one. The `Test`
-      # timeout above is what fixes that — the step *fails*, so the log lands,
-      # with the name in it.
+      # Linux only, deliberately: doctests are platform-independent, and the
+      # Linux job finishes in under half the Windows job's time, so putting the
+      # rustdoc pass there keeps it off the critical path entirely.
+      - name: Doc tests
+        if: runner.os == 'Linux'
+        timeout-minutes: 10
+        run: cargo test --locked --doc --target ${{ matrix.target }}
+
+      # There is still deliberately no post-mortem step here — see the `Test`
+      # step's comment for why one cannot work, and why naming the hung test is
+      # nextest's job rather than a later step's.
 
   # Static musl builds of the headless server binary that remote workspaces push
   # onto the far machine (decision D10).

--- a/src/terminal/remote.rs
+++ b/src/terminal/remote.rs
@@ -2460,6 +2460,7 @@ mod tests {
 
     #[test]
     fn kitty_keyboard_negotiation_reports_the_requested_mode() {
+        crate::core::config::pin_test_config_dir();
         let config = terminal_config_from_user(&crate::core::config::Config::default());
         assert!(config.kitty_keyboard);
 
@@ -2495,6 +2496,7 @@ mod tests {
 
     #[test]
     fn deep_keyboard_mode_pushes_leave_the_reader_alive() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
 
@@ -2525,6 +2527,7 @@ mod tests {
 
     #[test]
     fn emoji_presentation_sequences_reserve_two_columns() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
 
@@ -2671,6 +2674,7 @@ mod tests {
 
     #[test]
     fn reader_feeds_local_grid() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
 
         let size = TermSize::new(80, 24);
@@ -2725,6 +2729,7 @@ mod tests {
 
     #[test]
     fn cursor_style_sequence_overrides_and_resets_to_user_default() {
+        crate::core::config::pin_test_config_dir();
         use alacritty_terminal::vte::ansi::CursorShape;
 
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
@@ -2765,6 +2770,7 @@ mod tests {
 
     #[test]
     fn reader_surfaces_auth_prompt_and_status() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
 
@@ -2801,6 +2807,7 @@ mod tests {
 
     #[test]
     fn child_exit_is_distinguished_from_daemon_disconnect() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
         DaemonMsg::Exited { code: Some(0) }
@@ -2857,6 +2864,7 @@ mod tests {
 
     #[test]
     fn prompt_report_scrubs_stale_tui_modes() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
 
@@ -2900,6 +2908,7 @@ mod tests {
 
     #[test]
     fn snapshot_replay_suppresses_query_replies_and_side_effects() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
 
@@ -2955,6 +2964,7 @@ mod tests {
 
     #[test]
     fn decrqm_probe_reports_sync_update_supported() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
 
@@ -2993,6 +3003,7 @@ mod tests {
 
     #[test]
     fn write_sends_input_frames() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
 
@@ -3007,6 +3018,7 @@ mod tests {
 
     #[test]
     fn attach_replay_runs_at_the_daemon_reported_size() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
 
@@ -3052,6 +3064,7 @@ mod tests {
 
     #[test]
     fn first_resize_always_syncs_then_dedups() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let mut term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
 
@@ -3071,6 +3084,7 @@ mod tests {
 
     #[test]
     fn sync_update_without_esu_flushes_after_the_deadline() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
 
@@ -3103,6 +3117,7 @@ mod tests {
 
     #[test]
     fn snapshot_replay_flushes_a_dangling_sync_frame_suppressed() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
 
@@ -3276,6 +3291,7 @@ mod tests {
 
     #[test]
     fn layout_resize_reasserts_geometry_after_a_late_size_frame() {
+        crate::core::config::pin_test_config_dir();
         use alacritty_terminal::grid::Dimensions as _;
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let mut term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
@@ -3317,6 +3333,7 @@ mod tests {
 
     #[test]
     fn resize_updates_size_and_notifies_daemon() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let mut term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
 
@@ -3332,6 +3349,7 @@ mod tests {
 
     #[test]
     fn echoed_resize_defers_the_grid_reflow_to_the_daemons_size_frame() {
+        crate::core::config::pin_test_config_dir();
         use alacritty_terminal::grid::Dimensions as _;
         use alacritty_terminal::index::{Column, Line};
 
@@ -3394,6 +3412,7 @@ mod tests {
 
     #[test]
     fn at_prompt_stays_false_while_shell_integration_is_inactive() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
         assert!(!term.shell_active(), "no report yet → integration inactive");
@@ -3428,6 +3447,7 @@ mod tests {
 
     #[test]
     fn at_prompt_follows_daemon_prompt_reports() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
 
@@ -3455,6 +3475,7 @@ mod tests {
 
     #[test]
     fn foreground_agent_follows_daemon_agent_reports() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
 
@@ -3483,6 +3504,7 @@ mod tests {
 
     #[test]
     fn agent_session_follows_daemon_status_reports() {
+        crate::core::config::pin_test_config_dir();
         use crate::core::cli_agent::{AgentSessionState, AgentStatus};
 
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
@@ -3586,6 +3608,7 @@ mod tests {
 
     #[test]
     fn zle_reading_follows_live_prompt_end_marks() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
         let poll = |want: bool| {
@@ -3688,6 +3711,7 @@ mod tests {
 
     #[test]
     fn shell_vi_mode_follows_live_prompt_mode_marks_without_disarming_zle() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
         let poll = |vi: bool, zle: bool| {
@@ -3736,6 +3760,7 @@ mod tests {
 
     #[test]
     fn shell_vi_mode_is_restored_from_snapshot_replay() {
+        crate::core::config::pin_test_config_dir();
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
         let poll = |vi: bool| {
@@ -3796,6 +3821,7 @@ mod tests {
 
     #[test]
     fn segmented_ring_replay_reproduces_live_rendering() {
+        crate::core::config::pin_test_config_dir();
         const MARK: &str = "DUPMARK";
         let frame_lines = |f: usize| -> Vec<String> {
             (0..10)

--- a/src/ui/scm/detail.rs
+++ b/src/ui/scm/detail.rs
@@ -1223,12 +1223,29 @@ mod detail_gpui_tests {
         // What the graph hands over: a row it already holds. The subject is
         // deliberately not the real one, so a `git show` behind our back would
         // overwrite it and show up here.
-        let mut seed = tty7_core::core::git::log::load_commit(
-            &*tty7_core::host::local::LocalHost::new(),
-            &root,
-            &head,
-        )
-        .expect("the scratch repo answers");
+        //
+        // Loaded on a worker thread because `load_commit` is a Host call and
+        // `host::guard_off_ui` rejects those on the UI thread — which is exactly
+        // where a `#[gpui::test]` body runs. The real caller reaches it off the
+        // UI thread too, so this is also the honest shape for the seed.
+        //
+        // That assert was inert here until the suite gained process isolation:
+        // `UI_THREAD` is a process-wide `OnceLock`, so whichever gpui test
+        // registered first owned it and every later test's thread compared
+        // unequal, which made the guard silently pass for all of them.
+        let mut seed = {
+            let (root, head) = (root.clone(), head.clone());
+            std::thread::spawn(move || {
+                tty7_core::core::git::log::load_commit(
+                    &*tty7_core::host::local::LocalHost::new(),
+                    &root,
+                    &head,
+                )
+                .expect("the scratch repo answers")
+            })
+            .join()
+            .expect("the seed load thread")
+        };
         seed.summary = "what the graph already knew".into();
         app.update_in(&mut vcx, |app, _, cx| {
             app.open_commit_detail(repo.clone(), head.clone(), Some(seed), cx)

--- a/src/ui/sftp.rs
+++ b/src/ui/sftp.rs
@@ -2182,6 +2182,7 @@ mod gpui_tests {
 
     #[gpui::test]
     fn toggle_sftp_opens_files_then_closes_the_panel(cx: &mut TestAppContext) {
+        crate::core::config::pin_test_config_dir();
         let (app, mut vcx) = harness(cx);
 
         app.update_in(&mut vcx, |app, window, cx| {
@@ -2199,6 +2200,7 @@ mod gpui_tests {
 
     #[gpui::test]
     fn toggle_sftp_switches_tabs_before_it_closes(cx: &mut TestAppContext) {
+        crate::core::config::pin_test_config_dir();
         let (app, mut vcx) = harness(cx);
         app.update_in(&mut vcx, |app, window, cx| {
             app.set_right_panel_tab(RightPanelTab::Info, cx);


### PR DESCRIPTION
Runs the test suite under `cargo-nextest`, so a hung test can be timed out and *named* instead of taking the job down silently, and fixes the 29 tests that only passed because they shared a process with a sibling that had done their setup.

**This is not a speedup.** It was opened as one; the measurement says otherwise, and the numbers below are what the branch actually does.

## What changes

| | Before | After |
|---|---|---|
| Test runner | `cargo test` — 16 binaries strictly sequential | `cargo nextest run --profile ci` — one pool across all binaries |
| A hung test | Step timeout kills the process tree at 20 min, log says nothing | The individual test is terminated at 3 min and named `TIMEOUT`; the rest of the suite finishes |
| A failing test | `fail-fast` stops the run | `fail-fast = false` — the complete list of what broke, in one run |
| Test isolation | One process, shared globals | One process per test |
| Tests runnable alone | 29 of them are not | All of them are |
| `tty7-cli::cli_e2e` | Inside the same `cargo test` | Its own `CLI end-to-end` step, still `cargo test` |
| Doctests | Ran (there are none) | Own Linux-only step, so a future doctest can't be silently retired |

Job names are untouched, so `rustfmt` and the three `build & test (<target>)` required checks still resolve.

## Measured cost

Warm-cache run [31551827957](https://github.com/l0ng-ai/tty7/actions/runs/31551827957) against warm-cache baseline [31499772887](https://github.com/l0ng-ai/tty7/actions/runs/31499772887):

| | Test execution before | after | Job total before | after |
|---|---|---|---|---|
| Windows | 57s | **48s** | 390s | **382s** |
| macOS | 35s | **52s** | 207s | **231s** |
| Linux | 29s | **33s** | 162s | **185s** |

nextest wins on Windows, where process startup was expensive, and loses on macOS and Linux, where spawning 2700 processes costs more than the sequential-binary startup it replaces. **Total CI wall clock is unchanged** — Windows is still the critical path at ~6m20s, and the two jobs that got slower are nowhere near it.

The original premise was wrong and is worth recording so nobody re-derives it: on Windows the per-binary times `cargo test` reported added up to 59s against 98s of wall clock, and that 39s gap looked like process-startup overhead. It is not — it is `cli_e2e`, which is `harness = false` and therefore prints no `test result:` line to be counted.

`CARGO_PROFILE_DEV_DEBUG=line-tables-only` is kept but did not pay off either: Windows test-target compile went 86s → 77s, within noise, and the Linux and macOS `Build` steps did not move at all.

## What this is actually worth

The suite hangs about one run in ten, on any branch. `cargo test` has no per-test timeout, so the job died at the step's 20-minute mark having reported nothing about which test was stuck — one such run held a runner slot for six hours. An earlier post-mortem step could not fix it: GitHub tears the step's process tree down before the next step runs. nextest terminates the individual test and names it.

And process isolation exposed 29 tests that were only passing by accident:

- **28** reached `Config::load`/`save` without pinning a scratch config dir, living off another test's `pin_test_config_dir()`. Each fails on `main` today under `cargo test -- --exact <name>`.
- **`a_seeded_detail_only_asks_for_the_files`** made a Host call on the UI thread. `host::guard_off_ui` is a `debug_assert` behind a process-wide `OnceLock<ThreadId>`, so it only ever judged whichever gpui test registered first, and passed vacuously for every later one. The seed load moves to a worker thread — where the real caller reaches it anyway.

## Serialization

Nine `static Mutex` test guards go quiet under process isolation. Seven guard process-global state that separate processes no longer share, so isolation is strictly stronger than the lock:

| Guard | Protects | Needs a group? |
|---|---|---|
| `lock_config_file`, `lock_session_file`, `pin_dir` | `set_config_dir`, over a scratch dir already keyed by pid | No |
| `responder_lock` | `AUTH_RESPONDER`, a `static OnceLock` | No |
| `claim_mailbox` | `AUTH_MAILBOX`, a `static Mutex<Vec<_>>` | No |
| `serial()` ×3 (scm::panel, scm::graph, file_tree) | Render-idle frame accounting | **Yes** — needs a quiet machine, not mutual exclusion |
| windows_env `SCRATCH` | One value name under `HKCU\Environment` | **Yes** — HKCU belongs to the user, not the process |

The mutexes all stay: they are what keeps `cargo test` correct, and one target still runs that way.

`tty7-cli::cli_e2e` is excluded from nextest and keeps its own step — it is `harness = false` by design, re-execing itself as the daemon under test and as a raw-mode TUI fixture, and nextest can only enumerate a libtest harness. That step must not name the package: `-p tty7-cli` resolves features for its graph alone while the rest of the job builds the default members together, and the two feature sets are two builds of `tty7-core`. Naming it rebuilt 91 crates — 1m03s on Linux, 2m12s on Windows — which the second commit fixes.

## Testing

- Full suite under nextest locally, three consecutive runs: `2732 tests run: 2732 passed, 5 skipped`, ~10.1s each, no flakes.
- CI green on all three targets, cold and warm.
- Same tests still pass under plain `cargo test` — the pins are additive, nothing left the default runner except cli_e2e.
- Verified the config-dir failures are pre-existing: `cargo test --bin tty7-app -- --exact terminal::remote::tests::write_sends_input_frames` fails on `main`.
- `nextest show-config test-groups` confirms the `render-idle` filter catches exactly the 20 tests that took the three `serial()` locks.
- The `-p` fix measured against a clean target directory: 91 crates compiled with it, zero without, same 13 tests either way.

**Not verified:** the `windows-registry` group matches nothing on macOS (those tests are `#[cfg(windows)]`) and a filter matching nothing is not an error, so the Windows job is its first real exercise.
