### PR TITLE
fix(wsl): stop handing bash an rcfile the distro cannot read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A WSL distro that cannot reach `/mnt` keeps its own `.bashrc`** — the
+  bootstrap handed bash a `--rcfile` living on the Windows side without
+  checking the distro could read it. bash ignores an unreadable `--rcfile`
+  without a word, and tty7 starts it non-login precisely so that `--rcfile` is
+  honoured at all — so a distro with automount off, or a root moved by
+  `wsl.conf`, opened a shell that had read no startup file the user wrote: not
+  tty7's, and not their `.bashrc` or `.bash_profile` either. The arm now checks
+  first and falls back to a plain login shell, which reads the same startup
+  files a pane without shell integration reads and only gives up the
+  integration.
+
 - **An idle window stops re-reading the repository on Linux** — with a
   repository open, tty7 ran `git status -uall` about two and a half times a
   second, forever, with nothing on screen changing and nobody touching the

--- a/crates/tty7-core/src/daemon/shell_integration.rs
+++ b/crates/tty7-core/src/daemon/shell_integration.rs
@@ -899,15 +899,17 @@ fn shell_quote(s: &str) -> String {
 /// `remote::bootstrap_command` does over SSH, and anything else falls back to a
 /// plain login shell.
 ///
-/// The zsh arm asks whether the redirectors are really there before trusting
-/// them. They live on the Windows side and reach the distro over `/mnt`, which
-/// is not a given: automount can be off, `/etc/wsl.conf` can move the root, and
-/// a distro can have no drvfs at all. An unguarded `ZDOTDIR` pointing at a
-/// directory that is not there starts zsh with no startup files whatsoever —
-/// the user's entire configuration gone, without a word. Guarded, that distro
-/// gets the plain login shell it had before any of this. The `*/bash)` arm
-/// above has no such guard; that is a real hole of its own, and changing
-/// released behaviour belongs in its own commit rather than riding along here.
+/// Both file-backed arms ask whether what they were handed is really there
+/// before trusting it. The files live on the Windows side and reach the distro
+/// over `/mnt`, which is not a given: automount can be off, `/etc/wsl.conf` can
+/// move the root, and a distro can have no drvfs at all. Unguarded, bash is
+/// handed a `--rcfile` it cannot read — which it ignores in silence, taking the
+/// user's own `.bashrc` down with it, because tty7 starts it non-login so that
+/// `--rcfile` is honoured at all — and zsh is pointed at a `ZDOTDIR` that does
+/// not exist, which takes every startup file the user wrote with it. Guarded,
+/// such a distro gets the plain login shell it had before any of this: no
+/// integration, but the startup files a bare `wsl.exe` pane reads, which is the
+/// failure worth having.
 ///
 /// `sh` parses this script, so the fish body is POSIX-quoted here — unlike the
 /// SSH path, where the far end's own login shell parses the bootstrap and
@@ -917,7 +919,8 @@ fn wsl_exec_script() -> String {
     format!(
         concat!(
             r#"case "${{SHELL:-}}" in "#,
-            r#"*/bash) exec "$SHELL" --rcfile "$TTY7_RC" -i ;; "#,
+            r#"*/bash) [ -r "${{TTY7_RC:-}}" ] && exec "$SHELL" --rcfile "$TTY7_RC" -i; "#,
+            r#"exec "$SHELL" -l ;; "#,
             r#"*/zsh) [ -n "${{TTY7_ZDOTDIR:-}}" ] && [ -r "$TTY7_ZDOTDIR/.zshrc" ] "#,
             r#"&& export ZDOTDIR="$TTY7_ZDOTDIR"; exec "$SHELL" -l ;; "#,
             r#"*/fish) exec "$SHELL" -C {} -l ;; "#,
@@ -1571,7 +1574,9 @@ mod tests {
     fn the_wsl_bootstrap_carries_integration_for_fish_not_just_bash() {
         let script = wsl_exec_script();
 
-        assert!(script.contains(r#"*/bash) exec "$SHELL" --rcfile "$TTY7_RC" -i ;;"#));
+        assert!(script.contains(
+            r#"*/bash) [ -r "${TTY7_RC:-}" ] && exec "$SHELL" --rcfile "$TTY7_RC" -i; exec "$SHELL" -l ;;"#
+        ));
         assert!(script.contains(&format!(
             r#"*/fish) exec "$SHELL" -C {} -l ;;"#,
             shell_quote(FISH_INTEGRATION)
@@ -1650,13 +1655,16 @@ mod tests {
         std::fs::create_dir_all(&zdotdir).unwrap();
         std::fs::write(zdotdir.join(".zshrc"), "").unwrap();
 
-        let run = |shell: &str, zdot: &str| {
+        let rcfile = dir.join("bashrc");
+        std::fs::write(&rcfile, "").unwrap();
+
+        let run = |shell: &str, rc: &str, zdot: &str| {
             let out = Command::new("sh")
                 .arg("-c")
                 .arg(wsl_exec_script())
                 .env_clear()
                 .env("SHELL", dir.join(shell).to_string_lossy().into_owned())
-                .env("TTY7_RC", dir.join("bashrc").to_string_lossy().into_owned())
+                .env("TTY7_RC", rc)
                 .env("TTY7_ZDOTDIR", zdot)
                 .output()
                 .expect("run the bootstrap");
@@ -1664,20 +1672,30 @@ mod tests {
             String::from_utf8_lossy(&out.stdout).into_owned()
         };
 
+        let rc = rcfile.to_string_lossy().into_owned();
         let zdot = zdotdir.to_string_lossy().into_owned();
-        assert!(run("bash", &zdot).contains("bash --rcfile"));
-        assert!(run("fish", &zdot).starts_with("fish -C"));
+        assert!(run("bash", &rc, &zdot).contains("bash --rcfile"));
+        assert!(run("fish", &rc, &zdot).starts_with("fish -C"));
 
-        let zsh = run("zsh", &zdot);
+        let zsh = run("zsh", &rc, &zdot);
         assert!(zsh.contains("zsh -l"), "{zsh}");
         assert!(zsh.contains(&format!("ZDOTDIR={zdot}")), "{zsh}");
 
-        // The distro that cannot see /mnt. It must still get its shell, and it
-        // must not get a ZDOTDIR pointing at nothing.
+        // The distro that cannot see /mnt. Every arm that was handed a path has
+        // to notice, and fall back to the login shell that reads the user's own
+        // files rather than to one holding a path that is not there.
         let missing = dir.join("not-there").to_string_lossy().into_owned();
-        let blind = run("zsh", &missing);
-        assert!(blind.contains("zsh -l"), "{blind}");
-        assert!(blind.contains("ZDOTDIR=unset"), "{blind}");
+
+        let blind_zsh = run("zsh", &rc, &missing);
+        assert!(blind_zsh.contains("zsh -l"), "{blind_zsh}");
+        assert!(blind_zsh.contains("ZDOTDIR=unset"), "{blind_zsh}");
+
+        let blind_bash = run("bash", &missing, &zdot);
+        assert!(
+            !blind_bash.contains("--rcfile"),
+            "bash was handed an rcfile it cannot read: {blind_bash}"
+        );
+        assert!(blind_bash.contains("bash -l"), "{blind_bash}");
 
         let _ = std::fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
> **Stacked on #533.** Its commit shows in this diff until that one merges; the fix here is the second commit, `a9e48c7`. Happy to rebase whenever #533 lands, or to fold this into it if you would rather have one.

Follow-up to the hole I named in #533 rather than fix there, since this one changes released behaviour.

## The bug

The WSL bootstrap writes the rcfile on the Windows side and names it to the distro over `/mnt`. That path is not a given — automount off, a root moved by `wsl.conf`, a distro with no drvfs at all — and the bash arm passed it straight to `--rcfile`:

```sh
*/bash) exec "$SHELL" --rcfile "$TTY7_RC" -i ;;
```

**bash ignores an unreadable `--rcfile` in silence.** And tty7 starts it non-login on purpose, so that `--rcfile` is honoured at all (the comment at `bash_rcfile()` says so), which means there is no `.bash_profile` pass to fall back on either. A pane on such a distro opened a shell that had read **no startup file of any kind** — not tty7's integration, which was the optional part, but the user's own `.bashrc`. Every alias, function and prompt they wrote, quietly absent, in a pane that otherwise looks fine.

## The fix

```sh
*/bash) [ -r "${TTY7_RC:-}" ] && exec "$SHELL" --rcfile "$TTY7_RC" -i; exec "$SHELL" -l ;;
```

Readable → unchanged. Not readable → a plain login shell, which reads everything the user wrote and gives up only the integration. Same shape as the zsh arm in #533, and the better of the two failures.

Demonstrated against a stub `bash` on `$SHELL`, with `TTY7_RC` naming a file that is not there:

```
before:  bash --rcfile /tmp/nope -i
after:   bash -l
```

## Tests

`cargo test -p tty7-core` — 1094 passing. The dispatch test (real `sh`, stub shells) grows a case asserting that an unreadable `TTY7_RC` execs `bash -l` and never mentions `--rcfile`; the arm's pinned text is updated alongside.

Unverified on a real distro with automount off — no Windows machine here. The behaviour is proven at the `sh` level, which is where the decision is made.
