### PR TITLE
fix(switcher): drop the stray guide rail under a remote machine

### DIFF
--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -46,8 +46,6 @@ const ICON: f32 = 16.0;
 
 const KID_INDENT: f32 = 16.0;
 
-const RAIL_X: f32 = ROW_PAD + GUTTER / 2.;
-
 const ROW_PAD: f32 = 8.0;
 
 const TAB_PATH_W: f32 = 160.0;
@@ -1590,7 +1588,7 @@ impl Tty7App {
                 let at = layout.nav.iter().position(|n| *n == item);
                 kids = kids.child(self.render_row(group, &group.rows[*r], picked, at, cx));
             }
-            block = block.child(self.indent(group, kids, cx));
+            block = block.child(div().pl(px(KID_INDENT)).child(kids));
         }
         block.into_any_element()
     }
@@ -1726,25 +1724,6 @@ impl Tty7App {
                             .bg(accent),
                     ),
             )
-    }
-
-    fn indent(&self, group: &Group, kids: impl IntoElement, cx: &mut Context<Self>) -> AnyElement {
-        let rail = cx.theme().border;
-        div()
-            .relative()
-            .child(div().pl(px(KID_INDENT)).child(kids))
-            .when(group.target.is_some(), |wrap| {
-                wrap.child(
-                    div()
-                        .absolute()
-                        .left(px(RAIL_X))
-                        .top(px(0.))
-                        .bottom(px(ROW_H / 2.))
-                        .w(px(1.))
-                        .bg(rail),
-                )
-            })
-            .into_any_element()
     }
 
     fn render_group_header(


### PR DESCRIPTION
Removes the vertical guide rail the workspace switcher drew under an expanded remote machine.

| | Before | After |
|---|---|---|
| Expanded remote machine (e.g. `java`) | A 1px vertical line runs down the left of its workspace rows, ending half a row short of the last one | No line; rows are simply indented |
| Expanded local machine (`This Computer`) | No line | Unchanged |
| Row indentation | `16px`, via a `relative`/`absolute` wrapper | `16px`, plain padding — same as the SSH-host rows below |

## Why

The rail landed in 6868364 as an indent guide "tying a remote machine's rows to it", but only remote groups (`group.target.is_some()`) ever drew one. Against `This Computer` right above it, the line reads as a stray artifact rather than structure — and because it sits at `ROW_PAD + GUTTER / 2` it falls just left of the workspace avatars, which already carry the alignment, while its `bottom(ROW_H / 2)` cutoff leaves a dangling stub next to the last row.

## Testing

- `cargo build -p tty7` — clean, no new warnings (`RAIL_X` and the `indent()` helper are gone; `GUTTER` / `ROW_H` are still used elsewhere).
- No tests covered the rail — it was pure geometry with no observable state.
- Not verified in the running app: this repo's conventions require the maintainer to drive the GUI. Open the switcher with a remote machine expanded to confirm.
