### PR TITLE
fix(switcher): name another workspace's tabs from their terminal titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Switching workspaces no longer wipes the tab titles of the one you left** —
+  in the switcher, the workspace the window was showing had properly named tabs
+  while every other one read "Claude Code", over and over, for as many tabs as
+  it had. The two columns come from two sources: a window names its own tabs
+  from its live terminals' OSC titles, and every workspace it does not own it
+  reads out of the machine tree — which recorded each pane's foreground
+  *process* name and never the terminal's title, so the naming fell through to
+  the next best thing it had, the agent. Switching a workspace happens in place
+  and drops the terminals the window was reading, so the workspace you just
+  left went from named tabs to a column of identical rows. The daemon now
+  records the title a pane sets (OSC 0 and 2, capped at 256 characters) in the
+  tree beside its cwd, and the switcher shows it, put through the same
+  abbreviation the tab strip uses so a shell's `user@host:~/dir` reads `…/dir`
+  in both places. In a split, the pane running an agent names the tab rather
+  than whichever shell happens to be first. `tty7 tab ls` and workspaces listed
+  on a remote machine were reading the same missing field, and are named the
+  same way now.
+
 - **A WSL distro that cannot reach `/mnt` keeps its own `.bashrc`** — the
   bootstrap handed bash a `--rcfile` living on the Windows side without
   checking the distro could read it. bash ignores an unreadable `--rcfile`

--- a/crates/tty7-cli/src/commands.rs
+++ b/crates/tty7-cli/src/commands.rs
@@ -1480,6 +1480,7 @@ mod tests {
             pane_id,
             cwd: None,
             title: "sh".into(),
+            osc_title: None,
             alive: true,
             owner: owner.map(str::to_string),
         }

--- a/crates/tty7-cli/src/output.rs
+++ b/crates/tty7-cli/src/output.rs
@@ -2,25 +2,45 @@ use unicode_width::UnicodeWidthStr;
 
 use tty7_core::core::machine::{Machine, PaneNode, Workspace};
 use tty7_core::core::session::WorkspaceId;
-use tty7_core::core::tab_view::{TabLabel, TabView, tab_views_of};
+use tty7_core::core::tab_view::{TabLabel, TabView, strip_host_prefix, tab_views_of};
 use tty7_core::daemon::control::{PaneAgentState, RouteInfo, ServerStatus};
 use tty7_core::daemon::protocol::{PaneInfo, PaneProcs};
 
 use crate::resolve;
 
-/// What to call a tab in a table or a tree. Almost no tab carries a name —
-/// the GUI's strip reads OSC titles the machine tree never sees — so a column
-/// printing `tab.name` alone comes out empty for a window full of work. The
-/// evidence ranking is shared with the GUI; only the rendering is ours.
+/// What to call a tab in a table or a tree. Almost no tab carries a name — the
+/// GUI's strip shows the terminal's OSC title instead — so a column printing
+/// `tab.name` alone comes out empty for a window full of work. The evidence
+/// ranking is shared with the GUI; only the rendering is ours.
 pub fn tab_label(view: &TabView) -> String {
     match view.label() {
         TabLabel::Named(name) => name.to_string(),
+        TabLabel::Osc(title) => {
+            let title = strip_host_prefix(title);
+            // A title that is only a path is what a shell integration writes,
+            // and it gets cut down to its leaf like a cwd — the tree prints the
+            // whole path underneath anyway. Prose is an agent saying what it is
+            // doing: that is the name, and it stays whole, clamped only so one
+            // talkative tab cannot widen every column in the table.
+            match title.starts_with(['/', '~']) {
+                true => path_leaf(title).to_string(),
+                false => clamp(title, 40),
+            }
+        }
         TabLabel::Agent(agent) => agent.display_name().to_string(),
         // The tree prints every pane's full cwd right underneath, and a table
         // has no room for one anyway: the leaf is what tells tabs apart.
         TabLabel::Cwd(cwd) => path_leaf(cwd).to_string(),
         TabLabel::Process(title) => title.to_string(),
         TabLabel::Unknown => "-".to_string(),
+    }
+}
+
+/// `max` characters at most, with an ellipsis in place of what was dropped.
+fn clamp(s: &str, max: usize) -> String {
+    match s.chars().count() > max {
+        true => s.chars().take(max - 1).chain(['…']).collect(),
+        false => s.to_string(),
     }
 }
 
@@ -328,6 +348,7 @@ mod tests {
             pane_id: id,
             cwd: None,
             title: "zsh".into(),
+            osc_title: None,
             alive: true,
             owner: owner.map(str::to_string),
         };
@@ -447,12 +468,13 @@ mod tests {
     }
 
     #[test]
-    fn an_unnamed_tab_borrows_an_agent_then_a_place_then_its_process() {
+    fn an_unnamed_tab_borrows_its_title_then_an_agent_then_a_place_then_its_process() {
         let view = |f: &dyn Fn(&mut TabView)| {
             let mut v = TabView {
                 id: tty7_core::core::machine::TabId::new(),
                 name: None,
                 title: String::new(),
+                osc_title: None,
                 cwd: None,
                 agent: None,
                 status: None,
@@ -472,6 +494,26 @@ mod tests {
             )),
             "Claude Code"
         );
+        // What the pane's own terminal says it is doing beats naming the agent
+        // running it — every tab of a workspace would otherwise read alike.
+        assert_eq!(
+            tab_label(&view(&|v| {
+                v.osc_title = Some("✳ fixing the switcher".into());
+                v.agent = Some(tty7_core::core::cli_agent::CLIAgent::Claude);
+            })),
+            "✳ fixing the switcher"
+        );
+        assert_eq!(
+            tab_label(&view(
+                &|v| v.osc_title = Some("user@host:~/repo/tty7".into())
+            )),
+            "tty7",
+            "a shell's title is a path and is cut down like one"
+        );
+        let long = "wondering ".repeat(8);
+        let clamped = tab_label(&view(&|v| v.osc_title = Some(long.clone())));
+        assert_eq!(clamped.chars().count(), 40);
+        assert!(clamped.ends_with('…'));
         assert_eq!(
             tab_label(&view(&|v| v.cwd = Some("/Users/me/repo/tty7".into()))),
             "tty7"

--- a/crates/tty7-cli/src/testbed.rs
+++ b/crates/tty7-cli/src/testbed.rs
@@ -45,6 +45,7 @@ pub fn two_workspace_machine() -> Machine {
         id,
         cwd: Some(cwd.to_string()),
         title: String::new(),
+        osc_title: None,
         ssh_spec: None,
         agent: None,
         shell: None,

--- a/crates/tty7-core/src/core/machine.rs
+++ b/crates/tty7-core/src/core/machine.rs
@@ -272,6 +272,18 @@ pub struct PaneRecord {
     pub cwd: Option<String>,
     #[serde(default)]
     pub title: String,
+    /// The title the terminal itself reports (OSC 0/2): a shell writes
+    /// `user@host:~/dir` from its integration, an agent overwrites it with what
+    /// it is working on. Distinct from `title` above, which is the foreground
+    /// process name.
+    ///
+    /// This is the name the window that owns the pane puts on its tab, so it is
+    /// also what anyone else has to read to agree with that window — the
+    /// switcher listing a workspace it does not own, `tty7 tab ls` across a
+    /// socket. `None` until the pane emits one; a pane that resets its title
+    /// clears it back.
+    #[serde(default)]
+    pub osc_title: Option<String>,
     #[serde(default)]
     pub ssh_spec: Option<Box<NativeSshSpec>>,
     #[serde(default)]
@@ -295,6 +307,7 @@ impl PaneRecord {
             id,
             cwd: None,
             title: String::new(),
+            osc_title: None,
             ssh_spec: None,
             agent: None,
             shell: None,
@@ -346,6 +359,7 @@ impl PaneSeed {
             id: self.pane,
             cwd: self.cwd,
             title: String::new(),
+            osc_title: None,
             ssh_spec: self.ssh_spec.map(|s| Box::new(s.without_secrets())),
             agent: self.agent,
             shell: self.shell,

--- a/crates/tty7-core/src/core/tab_view.rs
+++ b/crates/tty7-core/src/core/tab_view.rs
@@ -16,9 +16,12 @@ use crate::core::machine::{PaneRecord, TabId, Workspace};
 pub struct TabView {
     pub id: TabId,
     pub name: Option<String>,
-    /// The foreground process of the tab's leading pane — "zsh", "vim". Not
-    /// the OSC title: the tree never sees one.
+    /// The foreground process of the tab's leading pane — "zsh", "vim".
     pub title: String,
+    /// The title the tab's terminal reported over OSC 0/2, which is the name the
+    /// window that owns it puts on its tab. See
+    /// [`PaneRecord::osc_title`](crate::core::machine::PaneRecord::osc_title).
+    pub osc_title: Option<String>,
     pub cwd: Option<String>,
     pub agent: Option<CLIAgent>,
     pub status: Option<AgentStatus>,
@@ -34,8 +37,17 @@ pub struct TabView {
 pub enum TabLabel<'a> {
     /// Someone named this tab, so nothing else gets a say.
     Named(&'a str),
-    /// No name, but an agent is running in it — which is what anyone
-    /// scanning a list of tabs is looking for.
+    /// The terminal's own title. Second only to a given name because it is what
+    /// the window owning the tab is showing: a shell writes where it is, an
+    /// agent writes what it is doing, and either way disagreeing with the tab
+    /// strip would be worse than any ranking of our own.
+    ///
+    /// It may well be a path (`user@host:~/dir` is what the shell integration
+    /// sets), so a caller that abbreviates [`Cwd`](Self::Cwd) has to abbreviate
+    /// this too.
+    Osc(&'a str),
+    /// No name and no title, but an agent is running in it — which is what
+    /// anyone scanning a list of tabs is looking for.
     Agent(CLIAgent),
     /// The working directory of the tab's leading pane.
     Cwd(&'a str),
@@ -43,6 +55,21 @@ pub enum TabLabel<'a> {
     Process(&'a str),
     /// A tab holding a pane the tree knows nothing about.
     Unknown,
+}
+
+/// Cuts the `user@host:` head that a shell integration writes into its title,
+/// leaving the path (or command) it actually names. A title with no such head —
+/// an agent's, which is prose — comes back untouched, and so does a bare
+/// `host:`: that is a drive letter on Windows.
+///
+/// Here rather than in either renderer because both of them need it and they
+/// have to agree: the GUI abbreviates the path that comes out, the CLI takes its
+/// last segment, and neither can start by guessing where the path begins.
+pub fn strip_host_prefix(raw: &str) -> &str {
+    match raw.split_once(':') {
+        Some((head, tail)) if head.contains('@') => tail,
+        _ => raw,
+    }
 }
 
 impl TabView {
@@ -54,6 +81,14 @@ impl TabView {
             .filter(|n| !n.is_empty())
         {
             return TabLabel::Named(name);
+        }
+        if let Some(title) = self
+            .osc_title
+            .as_deref()
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+        {
+            return TabLabel::Osc(title);
         }
         if let Some(agent) = self.agent {
             return TabLabel::Agent(agent);
@@ -82,10 +117,17 @@ pub fn tab_views_of(ws: &Workspace, panes: &[PaneRecord]) -> Vec<TabView> {
             // is what someone scanning the list is looking for.
             let head = records.first();
             let facts = records.iter().find_map(|p| p.agent.as_ref());
+            // The title follows the agent for the same reason the facts do: an
+            // agent's pane titles itself with what it is working on, while a
+            // plain shell's says where it is — which `cwd` carries anyway. A
+            // split with a shell in front would otherwise name the tab after a
+            // directory and bury the agent.
+            let titled = records.iter().find(|p| p.agent.is_some()).or(head);
             TabView {
                 id: tab.id,
                 name: tab.name.clone(),
                 title: head.map(|p| p.title.clone()).unwrap_or_default(),
+                osc_title: titled.and_then(|p| p.osc_title.clone()),
                 cwd: head.and_then(|p| p.cwd.clone()),
                 agent: facts.map(|f| f.agent),
                 status: facts.and_then(|f| f.status),
@@ -106,6 +148,7 @@ mod tests {
             id: TabId::new(),
             name: None,
             title: String::new(),
+            osc_title: None,
             cwd: None,
             agent: None,
             status: None,
@@ -115,14 +158,33 @@ mod tests {
     }
 
     #[test]
-    fn a_label_prefers_the_name_then_the_agent_then_the_place() {
+    fn a_label_prefers_the_name_then_the_title_then_the_agent_then_the_place() {
         let named = TabView {
             name: Some("  deploy  ".into()),
+            osc_title: Some("✳ fixing the switcher".into()),
             agent: Some(CLIAgent::Claude),
             cwd: Some("/work".into()),
             ..view()
         };
         assert_eq!(named.label(), TabLabel::Named("deploy"));
+
+        // The window owning this tab shows the title its agent set, so the
+        // switcher listing the same tab has to show it too — naming it after
+        // the agent is what made every tab of a workspace read "Claude Code".
+        let titled = TabView {
+            osc_title: Some("  ✳ fixing the switcher  ".into()),
+            agent: Some(CLIAgent::Claude),
+            cwd: Some("/work".into()),
+            ..view()
+        };
+        assert_eq!(titled.label(), TabLabel::Osc("✳ fixing the switcher"));
+
+        let blank_title = TabView {
+            osc_title: Some("   ".into()),
+            agent: Some(CLIAgent::Claude),
+            ..view()
+        };
+        assert_eq!(blank_title.label(), TabLabel::Agent(CLIAgent::Claude));
 
         let working = TabView {
             agent: Some(CLIAgent::Claude),
@@ -166,10 +228,12 @@ mod tests {
             PaneRecord {
                 cwd: Some("/work".into()),
                 title: "zsh".into(),
+                osc_title: Some("user@host:~/work".into()),
                 live: true,
                 ..PaneRecord::new(1)
             },
             PaneRecord {
+                osc_title: Some("✳ fixing the switcher".into()),
                 agent: Some(AgentFacts {
                     agent: CLIAgent::Claude,
                     session_id: None,
@@ -186,5 +250,10 @@ mod tests {
         assert_eq!(views[0].agent, Some(CLIAgent::Claude));
         assert_eq!(views[0].panes, 2);
         assert!(views[0].live, "one live pane makes the tab live");
+        assert_eq!(
+            views[0].osc_title.as_deref(),
+            Some("✳ fixing the switcher"),
+            "the agent's pane names the tab, not the shell in front of it"
+        );
     }
 }

--- a/crates/tty7-core/src/daemon/handoff.rs
+++ b/crates/tty7-core/src/daemon/handoff.rs
@@ -84,6 +84,8 @@ struct PaneRecord {
     size: WinSize,
     cwd: Option<PathBuf>,
     #[serde(default)]
+    osc_title: Option<String>,
+    #[serde(default)]
     shell: Option<crate::daemon::protocol::ShellSpec>,
     shell_active: bool,
     at_prompt: bool,
@@ -229,6 +231,7 @@ fn stage(panes: &[Carried], next_pane_id: u64) -> std::io::Result<std::fs::File>
             integration_dir: pane.integration_dir.clone(),
             size: pane.size,
             cwd: pane.cwd.clone(),
+            osc_title: pane.osc_title.clone(),
             shell: pane.shell_spec.clone(),
             shell_active: pane.shell_active,
             at_prompt: pane.at_prompt,
@@ -361,6 +364,7 @@ pub fn adopt(fd: RawFd) -> Option<Adopted> {
             size: record.size,
             ring,
             cwd: record.cwd,
+            osc_title: record.osc_title,
             shell_spec: record.shell,
             shell_active: record.shell_active,
             at_prompt: record.at_prompt,
@@ -404,6 +408,7 @@ mod tests {
                 bytes: output.to_vec(),
             }],
             cwd: Some(PathBuf::from("/work")),
+            osc_title: Some("user@host:~/work".into()),
             shell_spec: None,
             shell_active: true,
             at_prompt: true,

--- a/crates/tty7-core/src/daemon/pane.rs
+++ b/crates/tty7-core/src/daemon/pane.rs
@@ -642,6 +642,9 @@ struct PaneState {
     observers: Vec<Observer>,
     observer_seq: u64,
     cwd: Option<PathBuf>,
+    /// The last title the pane reported over OSC 0/2, for the machine tree to
+    /// record. See [`crate::core::machine::PaneRecord::osc_title`].
+    osc_title: Option<String>,
     shell: ShellState,
     /// What this pane is running, for the machine tree to record. Distinct from
     /// `shell` above, which is the shell-integration state.
@@ -970,6 +973,7 @@ pub struct Carried {
     pub size: WinSize,
     pub ring: Vec<crate::daemon::scrollback::Segment>,
     pub cwd: Option<PathBuf>,
+    pub osc_title: Option<String>,
     /// What the pane is running. Nothing on the other side of the exec can work
     /// it out again — the command line belongs to a child this image never
     /// spawned — so a handoff that dropped it would leave the tree naming no
@@ -1288,6 +1292,7 @@ impl DaemonPane {
                 observers: Vec::new(),
                 observer_seq: 0,
                 cwd: spawn.initial_cwd,
+                osc_title: None,
                 shell: ShellState::default(),
                 shell_spec: spawn.shell.clone(),
                 remote: spawn.remote.clone(),
@@ -1437,6 +1442,7 @@ impl DaemonPane {
             size: st.ring.tail_size(),
             ring: st.ring.snapshot(),
             cwd: st.cwd.clone(),
+            osc_title: st.osc_title.clone(),
             shell_spec: st.shell_spec.clone(),
             shell_active: st.shell.active,
             at_prompt: st.shell.at_prompt,
@@ -1500,6 +1506,7 @@ impl DaemonPane {
                 observers: Vec::new(),
                 observer_seq: 0,
                 cwd: carried.cwd,
+                osc_title: carried.osc_title,
                 shell_spec: carried.shell_spec,
                 shell: ShellState {
                     active: carried.shell_active,
@@ -1554,6 +1561,7 @@ impl DaemonPane {
             // it is, `ssh_spec` already says.
             shell_spec: None,
             cwd: None,
+            osc_title: None,
             shell: ShellState::default(),
             remote: Some(remote),
             agent: None,
@@ -1807,6 +1815,7 @@ impl DaemonPane {
 
                             let tr1 = trace.then(std::time::Instant::now);
                             let may_change_facts = signals.cwd.is_some()
+                                || signals.title.is_some()
                                 || !signals.agent_events.is_empty()
                                 || signals.notification.is_some()
                                 || !signals.shell.is_empty()
@@ -1841,14 +1850,16 @@ impl DaemonPane {
                                 && let (Some(before), Some(after)) = (facts_before, facts_after)
                                 && facts_changed(&before, &after)
                             {
-                                let (cwd, agent, shell) = after;
                                 crate::core::machine::observe_pane(pane, |p| {
-                                    if cwd.is_some() {
-                                        p.cwd = cwd;
+                                    if after.cwd.is_some() {
+                                        p.cwd = after.cwd;
                                     }
-                                    p.agent = agent;
-                                    if shell.is_some() {
-                                        p.shell = shell;
+                                    // Unlike the others this one is also cleared
+                                    // by a reset, so it is assigned either way.
+                                    p.osc_title = after.osc_title;
+                                    p.agent = after.agent;
+                                    if after.shell.is_some() {
+                                        p.shell = after.shell;
                                     }
                                     if alive {
                                         p.live = true;
@@ -1950,14 +1961,15 @@ impl DaemonPane {
     }
 
     pub fn info(&self) -> PaneInfo {
-        let (cwd, alive) = {
+        let (cwd, osc_title, alive) = {
             let st = self.state.lock().unwrap();
-            (st.cwd.clone(), st.alive)
+            (st.cwd.clone(), st.osc_title.clone(), st.alive)
         };
         PaneInfo {
             pane_id: self.id,
             cwd: cwd.or_else(|| self.foreground_cwd()),
             title: self.foreground_title(),
+            osc_title,
             alive,
             owner: self.owner.clone(),
         }
@@ -2403,11 +2415,16 @@ fn agent_state_snapshot(st: &PaneState) -> Option<crate::daemon::control::PaneAg
         })
 }
 
-type ObservedFacts = (
-    Option<String>,
-    Option<crate::core::machine::AgentFacts>,
-    Option<ShellSpec>,
-);
+/// What the daemon has learned about a pane that the machine tree wants to
+/// hold. Compared before and after each read, and written out only when it
+/// moved — every field here costs a `PaneFacts` delta to every attached client.
+#[derive(Debug, PartialEq)]
+struct ObservedFacts {
+    cwd: Option<String>,
+    osc_title: Option<String>,
+    agent: Option<crate::core::machine::AgentFacts>,
+    shell: Option<ShellSpec>,
+}
 
 fn observed_facts(st: &PaneState) -> ObservedFacts {
     let cwd = st.cwd.as_ref().map(|p| p.to_string_lossy().into_owned());
@@ -2421,13 +2438,19 @@ fn observed_facts(st: &PaneState) -> ObservedFacts {
             .or_else(|| st.agent_argv.clone()),
         status: st.agent_session.as_ref().map(|s| s.status),
     });
-    (cwd, agent, st.shell_spec.clone())
+    ObservedFacts {
+        cwd,
+        osc_title: st.osc_title.clone(),
+        agent,
+        shell: st.shell_spec.clone(),
+    }
 }
 
 fn facts_changed(before: &ObservedFacts, after: &ObservedFacts) -> bool {
-    before.0 != after.0
-        || agent_facts_changed(before.1.as_ref(), after.1.as_ref())
-        || before.2 != after.2
+    before.cwd != after.cwd
+        || before.osc_title != after.osc_title
+        || agent_facts_changed(before.agent.as_ref(), after.agent.as_ref())
+        || before.shell != after.shell
 }
 
 fn agent_facts_changed(
@@ -2452,6 +2475,11 @@ fn apply_signals(st: &mut PaneState, signals: SniffSignals) {
             notify(st, DaemonMsg::Cwd(cwd.clone()));
             st.cwd = Some(cwd);
         }
+    }
+    if let Some(title) = signals.title {
+        // No `notify`: a window renders its own tabs from its own terminal,
+        // which parsed the same sequence. This is only for the tree.
+        st.osc_title = (!title.is_empty()).then_some(title);
     }
     for shell in signals.shell {
         #[cfg(windows)]
@@ -2753,6 +2781,10 @@ struct ShellState {
 #[derive(Default)]
 struct SniffSignals {
     cwd: Option<PathBuf>,
+    /// The last title the pane set in this read, already capped. `Some("")` is
+    /// a reset — an empty OSC 0/2 clears the title rather than setting a blank
+    /// one, the same way the GUI's terminal treats it.
+    title: Option<String>,
     shell: Vec<ShellState>,
     agent_events: Vec<crate::core::cli_agent::AgentEvent>,
     notification: Option<String>,
@@ -2766,7 +2798,7 @@ struct OscSniffer {
 impl OscSniffer {
     fn new() -> Self {
         Self {
-            tok: OscTokenizer::new(&[b"7", b"133", b"9", b"777"]),
+            tok: OscTokenizer::new(&[b"0", b"2", b"7", b"133", b"9", b"777"]),
             shell: ShellState::default(),
         }
     }
@@ -2777,6 +2809,8 @@ impl OscSniffer {
         self.tok.feed(bytes, |payload| {
             if let Some(path) = parse_osc7(payload) {
                 signals.cwd = Some(path);
+            } else if let Some(title) = parse_osc_title(payload) {
+                signals.title = Some(title);
             } else if let Some(rest) = payload.strip_prefix(b"133;") {
                 if handle_osc133(shell, rest) {
                     match signals.shell.last_mut() {
@@ -2859,6 +2893,31 @@ pub(crate) fn parse_osc7(payload: &[u8]) -> Option<PathBuf> {
         return None;
     }
     Some(path_from_bytes(&decoded))
+}
+
+/// Longest title the tree will keep. The window that owns the pane shows about
+/// forty columns of it; the rest is only ever paid for — in `machine.json`, and
+/// in a `PaneFacts` delta to every attached client — so it is cut here rather
+/// than at each place that renders one.
+const MAX_OSC_TITLE: usize = 256;
+
+/// The title from an OSC 0 (icon *and* window) or OSC 2 (window) payload,
+/// capped. An empty payload comes back as `Some("")`: that is a reset, which
+/// the caller has to tell apart from "no title in this read".
+///
+/// OSC 1 is deliberately not read. It sets the icon name alone, which the GUI's
+/// terminal ignores — and the point of recording a title at all is to agree
+/// with what the GUI shows.
+pub(crate) fn parse_osc_title(payload: &[u8]) -> Option<String> {
+    let rest = payload
+        .strip_prefix(b"0;")
+        .or_else(|| payload.strip_prefix(b"2;"))?;
+    let title = String::from_utf8_lossy(rest);
+    let title = title.trim();
+    Some(match title.chars().count() > MAX_OSC_TITLE {
+        true => title.chars().take(MAX_OSC_TITLE).collect(),
+        false => title.to_string(),
+    })
 }
 
 fn percent_decode(input: &[u8]) -> Vec<u8> {
@@ -3604,6 +3663,81 @@ mod tests {
         assert_eq!(sig.cwd, Some(PathBuf::from("/Users/me/dev")));
     }
 
+    /// The tree's only source of the name a window actually shows on a tab. A
+    /// tokenizer that does not list 0 and 2 sniffs nothing here, and the
+    /// switcher goes back to calling every agent tab "Claude Code".
+    #[test]
+    fn sniff_osc_title() {
+        let mut s = OscSniffer::new();
+        assert_eq!(
+            s.feed(b"\x1b]0;user@host:~/dev\x07").title.as_deref(),
+            Some("user@host:~/dev")
+        );
+        assert_eq!(
+            s.feed(b"\x1b]2;\xe2\x9c\xb3 fixing the switcher\x1b\\")
+                .title
+                .as_deref(),
+            Some("✳ fixing the switcher")
+        );
+        // The last one in a read is the one that stuck.
+        assert_eq!(
+            s.feed(b"\x1b]0;first\x07\x1b]0;second\x07")
+                .title
+                .as_deref(),
+            Some("second")
+        );
+        // An empty title is a reset, and has to be told apart from a read with
+        // no title in it at all.
+        assert_eq!(s.feed(b"\x1b]2;\x07").title.as_deref(), Some(""));
+        assert_eq!(s.feed(b"plain output\r\n").title, None);
+        // OSC 1 names the icon, which the window ignores; so do we.
+        assert_eq!(s.feed(b"\x1b]1;icon\x07").title, None);
+
+        let long = format!("\x1b]0;{}\x07", "t".repeat(MAX_OSC_TITLE + 10));
+        assert_eq!(
+            s.feed(long.as_bytes()).title.map(|t| t.chars().count()),
+            Some(MAX_OSC_TITLE)
+        );
+    }
+
+    /// Titles arrive interleaved with everything else in the same read, and the
+    /// tokenizer has one identifier filter for the lot: sniffing a title must
+    /// not cost a cwd or a prompt mark.
+    #[test]
+    fn a_title_does_not_swallow_the_other_marks_in_the_same_read() {
+        let mut s = OscSniffer::new();
+        let sig = s.feed(b"\x1b]0;user@host:~/dev\x07\x1b]7;file://host/dev\x07\x1b]133;A\x07");
+        assert_eq!(sig.title.as_deref(), Some("user@host:~/dev"));
+        assert_eq!(sig.cwd, Some(PathBuf::from("/dev")));
+        assert!(sig.shell.last().unwrap().at_prompt);
+    }
+
+    #[test]
+    fn a_title_is_kept_until_it_changes_and_a_reset_clears_it() {
+        let mut st = test_state(true);
+        apply_signals(
+            &mut st,
+            SniffSignals {
+                title: Some("✳ fixing the switcher".into()),
+                ..SniffSignals::default()
+            },
+        );
+        assert_eq!(st.osc_title.as_deref(), Some("✳ fixing the switcher"));
+
+        // A read with no title in it leaves the stored one alone.
+        apply_signals(&mut st, SniffSignals::default());
+        assert_eq!(st.osc_title.as_deref(), Some("✳ fixing the switcher"));
+
+        apply_signals(
+            &mut st,
+            SniffSignals {
+                title: Some(String::new()),
+                ..SniffSignals::default()
+            },
+        );
+        assert_eq!(st.osc_title, None, "an empty title clears, not blanks");
+    }
+
     #[test]
     fn sniff_osc133_prompt() {
         let mut s = OscSniffer::new();
@@ -3960,6 +4094,7 @@ mod tests {
             observer_seq: 0,
             shell_spec: None,
             cwd: None,
+            osc_title: None,
             shell: ShellState::default(),
             remote: None,
             agent: None,
@@ -3975,7 +4110,15 @@ mod tests {
         use crate::core::cli_agent::{AgentSessionState, AgentStatus, CLIAgent};
 
         let mut st = test_state(true);
-        assert_eq!(observed_facts(&st), (None, None, None));
+        assert_eq!(
+            observed_facts(&st),
+            ObservedFacts {
+                cwd: None,
+                osc_title: None,
+                agent: None,
+                shell: None,
+            }
+        );
 
         st.cwd = Some(PathBuf::from("/work/api"));
         st.agent = Some(CLIAgent::Claude);
@@ -3987,9 +4130,9 @@ mod tests {
             ..Default::default()
         });
 
-        let (cwd, agent, _shell) = observed_facts(&st);
-        assert_eq!(cwd.as_deref(), Some("/work/api"));
-        let agent = agent.expect("an agent in the foreground is a fact");
+        let facts = observed_facts(&st);
+        assert_eq!(facts.cwd.as_deref(), Some("/work/api"));
+        let agent = facts.agent.expect("an agent in the foreground is a fact");
         assert_eq!(agent.agent, CLIAgent::Claude);
         assert_eq!(agent.session_id.as_deref(), Some("sess-1"));
         assert_eq!(
@@ -4000,9 +4143,9 @@ mod tests {
         assert_eq!(agent.status, Some(AgentStatus::Working));
 
         st.agent_session = None;
-        let (_, agent, _) = observed_facts(&st);
+        let facts = observed_facts(&st);
         assert_eq!(
-            agent.unwrap().launch_argv.as_deref(),
+            facts.agent.unwrap().launch_argv.as_deref(),
             Some(&["claude".to_string()][..])
         );
     }
@@ -4080,6 +4223,64 @@ mod tests {
         assert!(
             store.pane(PANE).unwrap().agent.is_none(),
             "an agent that left a pane still in use is a fact, and clears"
+        );
+
+        withdraw_observations();
+    }
+
+    /// The whole path a title takes into the tree: sniffed out of the pane's
+    /// own output, kept on its state, and written to the record every other
+    /// viewer reads. Nothing else can name the tabs of a workspace this process
+    /// does not own — without this the switcher fell back to the agent, and
+    /// every tab of a workspace running one read "Claude Code".
+    #[test]
+    fn a_pane_title_reaches_the_machine_tree() {
+        use crate::core::machine::{
+            MACHINE_FILE, MachineStore, OBSERVE_SLOT, PaneSeed, publish_observations,
+            withdraw_observations,
+        };
+
+        const PANE: u64 = 78;
+        let _slot = OBSERVE_SLOT.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = MachineStore::open(dir.path().join(MACHINE_FILE));
+        let ws = store.workspace_create(None, None, None).unwrap();
+        store
+            .tab_create(ws.id, None, PaneSeed::bare(PANE), None, None)
+            .unwrap();
+        publish_observations(&store);
+
+        let run = |had: Option<&str>, output: &[u8]| {
+            let mut state = test_state(true);
+            state.id = PANE;
+            state.osc_title = had.map(str::to_string);
+            DaemonPane::spawn_reader(
+                Arc::new(Mutex::new(state)),
+                Arc::new(AtomicBool::new(false)),
+                Arc::new(OutputGate::new()),
+                Box::new(std::io::Cursor::new(output.to_vec())),
+                null_writer(),
+                || false,
+                ForegroundProbes {
+                    remote: Box::new(|| None),
+                    agent: Box::new(|| Some(None)),
+                    cwd: Box::new(|| None),
+                },
+                Arc::new(DeathReporter::new(|| {})),
+            )
+            .join()
+            .unwrap();
+            store.pane(PANE).expect("the record was seeded").osc_title
+        };
+
+        assert_eq!(
+            run(None, b"\x1b]0;\xe2\x9c\xb3 fixing the switcher\x07").as_deref(),
+            Some("✳ fixing the switcher")
+        );
+        assert_eq!(
+            run(Some("✳ fixing the switcher"), b"\x1b]2;\x07"),
+            None,
+            "a pane that resets its title clears the one on record"
         );
 
         withdraw_observations();

--- a/crates/tty7-core/src/daemon/protocol.rs
+++ b/crates/tty7-core/src/daemon/protocol.rs
@@ -119,6 +119,10 @@ pub struct PaneInfo {
     pub cwd: Option<PathBuf>,
     #[serde(default)]
     pub title: String,
+    /// See [`crate::core::machine::PaneRecord::osc_title`] — the terminal's own
+    /// title, not the foreground process name `title` carries.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub osc_title: Option<String>,
     pub alive: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub owner: Option<String>,
@@ -1590,6 +1594,7 @@ mod tests {
                     pane_id: 3,
                     cwd: Some(PathBuf::from("/x")),
                     title: "zsh".into(),
+                    osc_title: Some("user@host:~/x".into()),
                     alive: true,
                     owner: None,
                 },
@@ -1597,6 +1602,7 @@ mod tests {
                     pane_id: 4,
                     cwd: None,
                     title: String::new(),
+                    osc_title: None,
                     alive: true,
                     owner: Some("ffe038d0-9ad6-40c0-815d-1fcc43c17ec0".into()),
                 },

--- a/crates/tty7-core/src/host/server.rs
+++ b/crates/tty7-core/src/host/server.rs
@@ -547,6 +547,7 @@ fn machine_with_live_panes(conn: &Conn) -> io::Result<machine::Machine> {
         };
         record.cwd = info.cwd.map(|p| p.to_string_lossy().into_owned());
         record.title = info.title;
+        record.osc_title = info.osc_title;
         record.live = info.alive;
     }
     Ok(machine)
@@ -1731,6 +1732,7 @@ mod aggregate_tests {
                     pane_id: 7,
                     cwd: Some(PathBuf::from("/repo/tty7")),
                     title: "nvim".into(),
+                    osc_title: Some("nvim ~/repo/tty7".into()),
                     alive: true,
                     owner: None,
                 }],
@@ -1742,6 +1744,7 @@ mod aggregate_tests {
         };
         let pane = machine.panes.iter().find(|p| p.id == 7).unwrap();
         assert_eq!(pane.title, "nvim");
+        assert_eq!(pane.osc_title.as_deref(), Some("nvim ~/repo/tty7"));
         assert!(pane.live);
     }
 

--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -2442,10 +2442,11 @@ impl TabRow {
 /// `Tty7App::tab_label` shows for local ones.
 ///
 /// The two read different sources and have to be talked into agreeing. A local
-/// tab is named by its terminal's OSC title, which shells set to the working
-/// directory and agents overwrite with their own name. The machine tree has
-/// neither: `PaneRecord::title` is the *foreground process name* ("zsh"), so
-/// the cwd and the agent stand in for it here.
+/// tab is named by its live terminal's OSC title, which shells set to the
+/// working directory and agents overwrite with what they are doing. The tree
+/// carries a copy of that title (`PaneRecord::osc_title`), which is what makes
+/// the two columns agree; `PaneRecord::title` is the *foreground process name*
+/// ("zsh") and only stands in when there is no title at all.
 fn tab_view_label(view: &crate::ui::machine_mirror::TabView, index: usize) -> String {
     let unnamed = || {
         t_fmt(
@@ -2453,20 +2454,24 @@ fn tab_view_label(view: &crate::ui::machine_mirror::TabView, index: usize) -> St
             &[("n", &((index + 1).to_string()))],
         )
     };
+    // A path can shorten away to nothing (a bare "user@host:"), and the process
+    // name is still worth more than a number.
+    let shortened = |raw: &str| match crate::ui::tab_strip::short_title(raw) {
+        shortened if !shortened.trim().is_empty() => shortened,
+        _ => match view.title.trim() {
+            "" => unnamed(),
+            title => title.to_string(),
+        },
+    };
     match view.label() {
         crate::ui::machine_mirror::TabLabel::Named(name) => name.to_string(),
+        // Through `short_title` because the local strip puts its own titles
+        // through it too: the shell integration writes `user@host:~/dir`, and a
+        // tab that spelled that out in full where the strip says "…/dir" would
+        // be the same disagreement in a new place.
+        crate::ui::machine_mirror::TabLabel::Osc(title) => shortened(title),
         crate::ui::machine_mirror::TabLabel::Agent(agent) => agent.display_name().to_string(),
-        // A cwd can shorten away to nothing (a bare "user@host:"), and the
-        // process name is still worth more than a number.
-        crate::ui::machine_mirror::TabLabel::Cwd(cwd) => {
-            match crate::ui::tab_strip::short_title(cwd) {
-                shortened if !shortened.trim().is_empty() => shortened,
-                _ => match view.title.trim() {
-                    "" => unnamed(),
-                    title => title.to_string(),
-                },
-            }
-        }
+        crate::ui::machine_mirror::TabLabel::Cwd(cwd) => shortened(cwd),
         crate::ui::machine_mirror::TabLabel::Process(title) => title.to_string(),
         crate::ui::machine_mirror::TabLabel::Unknown => unnamed(),
     }
@@ -2975,6 +2980,7 @@ mod tests {
             id: TabId::new(),
             name: Some("  build  ".to_string()),
             title: "zsh".to_string(),
+            osc_title: Some("✳ 修复 workspace switcher".to_string()),
             cwd: Some("/Users/x/repo/tty7".to_string()),
             agent: Some(crate::core::cli_agent::CLIAgent::Claude),
             status: None,
@@ -2986,8 +2992,29 @@ mod tests {
         view.name = None;
         assert_eq!(
             tab_view_label(&view, 0),
+            "✳ 修复 workspace switcher",
+            "then the title the local strip would be showing, verbatim"
+        );
+
+        view.osc_title = Some("user@host:~/repo/025/tty7".to_string());
+        assert_eq!(
+            tab_view_label(&view, 0),
+            crate::ui::tab_strip::short_title("user@host:~/repo/025/tty7"),
+            "a shell's title goes through the shortener the strip uses"
+        );
+
+        view.osc_title = Some("user@host:".to_string());
+        assert_eq!(
+            tab_view_label(&view, 0),
+            "zsh",
+            "a title that shortens away to nothing falls through"
+        );
+
+        view.osc_title = None;
+        assert_eq!(
+            tab_view_label(&view, 0),
             "Claude Code",
-            "an agent names its own tab, as its OSC title would locally"
+            "an agent names a tab that has told us nothing else"
         );
 
         view.agent = None;

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -47,15 +47,10 @@ fn shell_spec(shell: &DetectedShell) -> ShellSpec {
     }
 }
 
-/// Strips a `user@host:` prefix a shell put in front of its title, leaving
-/// the path (or command) it actually names. A bare `host:` with no user is
-/// left alone — that is a drive letter on Windows.
-pub(crate) fn strip_host_prefix(raw: &str) -> &str {
-    match raw.split_once(':') {
-        Some((head, tail)) if head.contains('@') => tail,
-        _ => raw,
-    }
-}
+/// Shared with the switcher's tab column and the CLI, which name tabs of
+/// workspaces this process does not own and have to cut the same head off the
+/// same titles.
+pub(crate) use tty7_core::core::tab_view::strip_host_prefix;
 
 pub(crate) fn abbreviate_home(path: &str) -> std::borrow::Cow<'_, str> {
     use std::borrow::Cow;


### PR DESCRIPTION
Records the title a pane sets over OSC 0/2 in the machine tree, so a window listing a workspace it does not own names that workspace's tabs the same way the window showing it does.

In the switcher, the workspace the window was showing had properly named tabs while every other one read "Claude Code", once per tab. The two columns come from two sources: a window names its own tabs from its live terminals' OSC titles, and every workspace it does not own it reads out of the machine tree — which recorded each pane's foreground *process* name (`zsh`, `nvim`) and never the terminal's title. With no title to go on the naming fell through to the next best evidence, the agent. Switching a workspace happens in place and drops the terminals the window was reading, so the workspace you had just left went from named tabs to a column of identical rows.

## Before / After

| | Before | After |
|---|---|---|
| Switcher, tab column of a workspace this window does not own | The agent's name, once per tab — "Claude Code" ×7 | The title each tab's terminal reported, the same string the tab strip was showing |
| Same column, plain shell tab | The pane's cwd | The terminal's title (`user@host:~/dir`), abbreviated to `…/dir` — the same shortener the strip uses |
| Same column, tab that has never reported a title | The agent, then the cwd, then the process name | Unchanged |
| Split with an agent behind a shell | Named after the shell's cwd | Named by the agent's pane, matching how the tab's agent facts are already read |
| `tty7 tab ls` NAME column | The agent or the cwd leaf | The title: a path cut to its leaf, prose kept whole and clamped to 40 columns |
| Machine tree (`PaneRecord`) | `title` = foreground process name only | `osc_title` beside it, cleared when a pane resets its title |
| A daemon handoff (in-place upgrade) | — | Carries the title across the exec, like the cwd |

The GUI's `strip_host_prefix` moved into `core::tab_view` so the switcher and the CLI cut the same head off the same titles.

## Flow

```mermaid
flowchart LR
    PTY[pane output] --> S[OscSniffer<br/>0 2 7 133 9 777]
    S -->|"OSC 0/2"| ST[PaneState.osc_title]
    ST --> OF[ObservedFacts]
    OF -->|changed| T[(machine tree<br/>PaneRecord.osc_title)]
    T --> TV["TabView::label()"]
    TV --> SW[switcher tab column]
    TV --> CLI[tty7 tab ls]
    T -.->|PaneFacts delta| M[client machine mirror]
    RS[remote: PaneInfo.osc_title] --> T
```

`TabLabel` now ranks `Named` → `Osc` → `Agent` → `Cwd` → `Process`. The title sits second because the point is to agree with the window that owns the tab, not to rank the evidence independently.

## Notes

- Titles are capped at 256 characters where they are sniffed: the window shows about forty columns of one, and the rest is paid for in `machine.json` and in a `PaneFacts` delta to every attached client.
- OSC 1 (icon name) is deliberately not read — the GUI's terminal ignores it, and the tree has to agree with the GUI.
- An empty OSC 0/2 is a reset, so `osc_title` is the one observed fact assigned unconditionally rather than only when present.
- Remote workspaces need the far side rebuilt (`machine_with_live_panes` overlays `PaneInfo.osc_title`); until then they keep showing process names. Panes already live when the daemon is upgraded pick up a title on their next prompt or redraw.

## Testing

- `cargo test --workspace` — 15 test binaries, all green; `cargo fmt --check` clean.
- New: `a_pane_title_reaches_the_machine_tree` — end to end, feeds OSC bytes through `spawn_reader` and asserts the title lands on the record in a real `MachineStore`, including a reset clearing it. Fails if the tokenizer stops listing `0`/`2`.
- New: `sniff_osc_title` (forms, last-one-wins, reset, OSC 1 ignored, cap), `a_title_does_not_swallow_the_other_marks_in_the_same_read` (a title must not cost the cwd or a prompt mark in the same read), `a_title_is_kept_until_it_changes_and_a_reset_clears_it`.
- Updated: `TabLabel` ranking, `tab_views_of` (the agent's pane names the tab), the switcher's `tab_view_label` across all five sources, and the CLI's rendering.
- Manually accepted in an isolated dev instance (own config dir, own daemon).
