### PR TITLE
fix(search): keep highlights on their text while a pane is printing

### DIFF
--- a/src/terminal/search.rs
+++ b/src/terminal/search.rs
@@ -23,6 +23,16 @@ const MAX_MATCHES: usize = 10_000;
 /// pause rather than one per frame.
 pub(super) const SCAN_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(120);
 
+/// How many debounce windows a pane that never stops printing may push the
+/// rescan out before it gets one anyway.
+///
+/// A debounce alone waits for a pause, and a coding agent streaming a reply
+/// does not give one for a minute at a time — the count would sit frozen for
+/// the whole flood and the highlights would sit on text that has since been
+/// rewritten under them. Rebasing keeps a highlight under text that *scrolled*;
+/// only a scan catches up with text that changed in place.
+pub(super) const SCAN_LAG_LIMIT: u32 = 4;
+
 /// The search bar floats over the top of the grid rather than pushing it down,
 /// so these two decide how many rows it hides. Keep them next to the `.top()`
 /// and `.h()` that use them — a match parked under the bar is on screen and
@@ -51,9 +61,12 @@ pub struct SearchState {
     pub input: Entity<InputState>,
     pub matches: Vec<Match>,
     pub current_index: Option<usize>,
-    /// Scrollback depth when `matches` was read off the grid. Match points are
-    /// viewport-relative, so this is what turns one back into the absolute row
-    /// it named — see [`TerminalView::refresh_matches_after_output`].
+    /// Scrollback depth the `matches` lines are counted against. Match points
+    /// are grid-relative, so this is what turns one back into the absolute row
+    /// it named — see [`TerminalView::refresh_matches_after_output`]. It is the
+    /// depth at the last scan until output scrolls the grid, which moves the
+    /// lines and this together (see
+    /// [`TerminalView::rebase_matches_after_scroll`]) so the anchors hold.
     scanned_history: usize,
     _subs: Vec<Subscription>,
 }
@@ -177,10 +190,10 @@ impl TerminalView {
     /// Every match of the current query in the whole grid, and whether the
     /// pattern failed to compile.
     ///
-    /// Match points are lines *relative to the viewport*, so they are only
-    /// meaningful against the grid they were read from: the moment output
-    /// scrolls the grid, every one of them names a different line. Nothing here
-    /// caches, and the two callers below both re-read the grid.
+    /// A match point is a line *of the grid it was read from*, and output
+    /// scrolling the grid makes every one of them name a different line —
+    /// which is what [`TerminalView::rebase_matches_after_scroll`] undoes
+    /// between scans. Nothing here caches, and both callers re-read the grid.
     fn scan_matches(&self, query: &str) -> Scan {
         let mut matches: Vec<Match> = Vec::new();
         if query.is_empty() {
@@ -240,28 +253,38 @@ impl TerminalView {
 
     /// Note that output changed the grid an open search bar is describing.
     ///
-    /// The rescan is debounced rather than run per wakeup: it reads the whole
-    /// grid, which is up to `MAX_SCROLLBACK` lines, and a pane mid-flood is
-    /// repainting far faster than anyone can read a match count off it. One
-    /// task waits for the printing to pause and then rescans once; further
-    /// output while it waits only pushes the deadline out.
+    /// Two things happen here, because output breaks a scan in two ways.
+    ///
+    /// The cheap one runs every wakeup: text that scrolled took the highlights
+    /// off their rows, and [`Self::rebase_matches_after_scroll`] puts them back
+    /// without reading the grid.
+    ///
+    /// The rescan behind it is debounced rather than run per wakeup: it reads
+    /// the whole grid, which is up to `MAX_SCROLLBACK` lines, and a pane
+    /// mid-flood is repainting far faster than anyone can read a match count
+    /// off it. One task waits for the printing to pause and then rescans once;
+    /// further output while it waits pushes the deadline out, up to
+    /// [`SCAN_LAG_LIMIT`] windows — a pane that never pauses still gets scanned.
     pub(super) fn note_output_under_search(&mut self, cx: &mut Context<Self>) {
         if self.search.is_none() {
             return;
         }
+        self.rebase_matches_after_scroll(cx);
         self.search_scan_epoch = self.search_scan_epoch.wrapping_add(1);
         if self.search_scan_armed {
             return;
         }
         self.search_scan_armed = true;
         cx.spawn(async move |this, cx| {
+            let mut waited = 0;
             loop {
                 let Ok(epoch) = this.update(cx, |view, _| view.search_scan_epoch) else {
                     break;
                 };
                 cx.background_executor().timer(SCAN_DEBOUNCE).await;
+                waited += 1;
                 let settled = this.update(cx, |view, cx| {
-                    if view.search_scan_epoch != epoch {
+                    if view.search_scan_epoch != epoch && waited < SCAN_LAG_LIMIT {
                         return false;
                     }
                     view.search_scan_armed = false;
@@ -275,6 +298,52 @@ impl TerminalView {
             }
         })
         .detach();
+    }
+
+    /// Slide the stored match points along with the text they name.
+    ///
+    /// A match point is a grid line, and output moves the text under it: every
+    /// line that scrolls off the top of the screen shifts the whole grid up
+    /// one. Between two scans that leaves each highlight washing the row its
+    /// text has just left — one row off per line scrolled, for as long as the
+    /// printing keeps the debounced rescan from firing, which is exactly when
+    /// someone is watching the highlight. Absolute rows (see [`anchor_row`]) do
+    /// not move, so re-deriving each line from its anchor puts the highlight
+    /// back under its text. Nothing here re-reads the grid, so it is cheap
+    /// enough for every wakeup.
+    ///
+    /// Matches carried off the top of the scrollback are dropped. A grid that
+    /// *shrank* — a cleared scrollback, a swap to the alt screen — moved every
+    /// anchor by an amount this cannot see, so that case rescans instead.
+    fn rebase_matches_after_scroll(&mut self, cx: &mut Context<Self>) {
+        let history = self.terminal.term.lock().grid().history_size();
+        let Some(s) = self.search.as_mut() else {
+            return;
+        };
+        let drift = history as i64 - s.scanned_history as i64;
+        if drift == 0 {
+            return;
+        }
+        if drift < 0 {
+            self.refresh_matches_after_output(cx);
+            return;
+        }
+
+        let drift = drift as i32;
+        let topmost = -(history as i32);
+        let moved = |p: &Point| Point::new(Line(p.line.0 - drift), p.column);
+        // The matches are in grid order, so the ones that fell off the top are
+        // a prefix — and a match whose start survived kept its end too.
+        let gone = s
+            .matches
+            .partition_point(|m| m.start().line.0 - drift < topmost);
+        s.matches.drain(..gone);
+        for m in &mut s.matches {
+            let (start, end) = (moved(m.start()), moved(m.end()));
+            *m = start..=end;
+        }
+        s.current_index = s.current_index.and_then(|i| i.checked_sub(gone));
+        s.scanned_history = history;
     }
 
     /// Re-run the query against the grid as it now stands, keeping the count
@@ -293,12 +362,12 @@ impl TerminalView {
             return;
         };
         let scan = self.scan_matches(&query);
-        // Stay on the match the user stepped to if it survived. Its start point
-        // is viewport-relative, so output that scrolled the grid has already
-        // made it name a different line — compare where it *was*, by absolute
-        // row, or the selection silently latches onto whichever occurrence has
-        // taken over that screen position. When it is gone, fall back to where
-        // a fresh query would land rather than to a stale ordinal.
+        // Stay on the match the user stepped to if it survived. Compare where
+        // it was by absolute row, not by line: a line is only meaningful with
+        // the scrollback depth it was counted against, and matching on the raw
+        // number would latch the selection onto whichever occurrence has taken
+        // that grid row over. When it is gone, fall back to where a fresh query
+        // would land rather than to a stale ordinal.
         let previous = self
             .search
             .as_ref()

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -10432,6 +10432,146 @@ mod gpui_tests {
         });
     }
 
+    /// Print lines into the grid and post the wakeup the reader thread would
+    /// have posted behind them.
+    ///
+    /// Going through the parser directly rather than the socket keeps the two
+    /// tests below off both real time and the clock: the pane has printed by
+    /// the time this returns, and no timer has had a chance to fire.
+    fn print(cx: &mut TestAppContext, view: &Entity<TerminalView>, lines: Vec<String>) {
+        cx.update(|cx| {
+            view.update(cx, |v, cx| {
+                {
+                    use alacritty_terminal::vte::ansi::Handler as _;
+                    let mut term = v.terminal.term.lock();
+                    for line in lines {
+                        for c in line.chars() {
+                            term.input(c);
+                        }
+                        term.carriage_return();
+                        term.linefeed();
+                    }
+                }
+                v.handle_event(AlacEvent::Wakeup, cx);
+            })
+        });
+    }
+
+    /// Filler that scrolls the grid without ever matching the query.
+    fn filler(lines: usize) -> Vec<String> {
+        (0..lines).map(|i| format!("filler {i}")).collect()
+    }
+
+    /// What the grid holds where the current match says its word starts, so a
+    /// test can ask the question the eye asks: is the highlight still on it?
+    fn word_at_the_match(
+        cx: &mut TestAppContext,
+        view: &Entity<TerminalView>,
+        len: usize,
+    ) -> String {
+        cx.update(|cx| {
+            let v = view.read(cx);
+            let start = *v
+                .search
+                .as_ref()
+                .and_then(|s| s.current())
+                .expect("a match to stand on")
+                .start();
+            let term = v.terminal.term.lock();
+            let grid = term.grid();
+            (0..len)
+                .map(|i| grid[start.line][Column(start.column.0 + i)].c)
+                .collect()
+        })
+    }
+
+    /// Print the searched-for word and bury it in the scrollback, then open the
+    /// bar on it. Returns with exactly one match, sitting in history.
+    fn search_a_buried_word(
+        window: &gpui::WindowHandle<gpui_component::Root>,
+        cx: &mut TestAppContext,
+        view: &Entity<TerminalView>,
+    ) {
+        let rows = cx.update(|cx| view.read(cx).terminal.term.lock().grid().screen_lines());
+        print(cx, view, vec!["world 1".to_string()]);
+        print(cx, view, filler(rows + 8));
+        cx.update(|cx| {
+            assert!(
+                view.read(cx).terminal.term.lock().grid().history_size() > 0,
+                "the word has to be in the scrollback for the grid to scroll under it"
+            );
+        });
+
+        window
+            .update(cx, |_, window, cx| {
+                view.update(cx, |v, cx| {
+                    v.open_search(window, cx);
+                    let input = v.search.as_ref().unwrap().input.clone();
+                    input.update(cx, |s, cx| s.set_value("world", window, cx));
+                    v.recompute_matches(cx);
+                    assert_eq!(v.search.as_ref().unwrap().matches.len(), 1);
+                });
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
+    fn a_highlight_follows_its_text_as_output_scrolls_under_it(cx: &mut TestAppContext) {
+        let (window, view, _daemon) = rooted_harness(cx);
+        search_a_buried_word(&window, cx, &view);
+        assert_eq!(
+            word_at_the_match(cx, &view, 5),
+            "world",
+            "the scan has to name its own word"
+        );
+
+        // Output arrives and the clock never moves, so nothing rescans: the
+        // stored point is all the highlight has to go on. Every line printed
+        // here slid the grid up under it, and it has to have come along.
+        print(cx, &view, filler(7));
+        cx.update(|cx| {
+            assert!(
+                view.read(cx).search_scan_armed,
+                "the rescan is still waiting for the pane to go quiet"
+            );
+        });
+        assert_eq!(
+            word_at_the_match(cx, &view, 5),
+            "world",
+            "a match point has to name the row its text scrolled to, \
+             not the row it was read from"
+        );
+    }
+
+    #[gpui::test]
+    fn a_pane_that_never_pauses_is_rescanned_anyway(cx: &mut TestAppContext) {
+        let (window, view, _daemon) = rooted_harness(cx);
+        search_a_buried_word(&window, cx, &view);
+
+        // A pane mid-flood: something new lands every half debounce window, so
+        // the pause the rescan is waiting for never comes.
+        for i in 0..(super::super::search::SCAN_LAG_LIMIT * 2 + 2) {
+            print(cx, &view, vec![format!("world {}", i + 2)]);
+            cx.executor()
+                .advance_clock(super::super::search::SCAN_DEBOUNCE / 2);
+            cx.run_until_parked();
+        }
+
+        cx.update(|cx| {
+            let search = view
+                .read(cx)
+                .search
+                .as_ref()
+                .expect("the bar is still open");
+            assert!(
+                search.matches.len() > 1,
+                "printing without a pause must not hold the scan off forever, \
+                 got {} matches",
+                search.matches.len()
+            );
+        });
+    }
+
     #[gpui::test]
     fn child_exit_marks_the_view_exited(cx: &mut TestAppContext) {
         let (window, _daemon) = harness(cx);


### PR DESCRIPTION
Keeps an open find bar honest while the pane under it is still printing: highlights stay on the text they matched, and the count no longer freezes for the whole of a streaming reply.

| | Before | After |
|---|---|---|
| Highlight while output scrolls the grid | Stays on the row the text just left — one row off per line scrolled, snapping back only once the pane goes quiet | Slides with its text, every wakeup |
| `Enter` / `Shift+Enter` mid-flood | Steps from a stale point, so it can land on whichever occurrence took that row over | Steps from the match the user is actually standing on |
| A pane that never pauses (an agent streaming a reply) | Never rescanned: count frozen at whatever it was when the bar opened, highlights left on text rewritten in place | Rescanned at least every four debounce windows (~0.5s) |
| A pane that pauses | Rescanned 120ms after the pause | Unchanged |

## Why

A `Match` point is a line of the grid it was read from, and output moves the text under it: every line that scrolls off the top shifts the whole grid up one. Between two scans that leaves the highlight painted where its text *was*. The rescan that would fix it was debounced on the pane going quiet for 120ms — which a coding agent streaming a reply does not do for a minute at a time, so during exactly the flood that causes the drift, nothing ever corrected it.

The fix splits the two problems by cost. Text that *scrolled* needs no scan at all: absolute rows (`history_size + line`, the same anchor a command mark or a placed image uses) do not move, so re-deriving each line from its anchor is an `O(matches)` walk with no grid read, cheap enough for every wakeup. Text that changed *in place* can only be caught by a real scan, so the debounce now has a ceiling.

```mermaid
flowchart LR
    W[Wakeup: output landed] --> R[rebase_matches_after_scroll<br/>no grid read, O matches]
    R --> D{scrollback grew?}
    D -->|yes| S[shift every point by the drift,<br/>drop what fell off the top]
    D -->|shrank: cleared / alt screen| F[full rescan — anchors are meaningless]
    R --> E[bump epoch, arm the debounce]
    E --> T{quiet for 120ms?}
    T -->|yes| F2[full rescan]
    T -->|no, still printing| C{pushed out 4 windows?}
    C -->|no| T
    C -->|yes| F2
```

## Known limit

Once the scrollback is full, the number of discarded lines stops being observable (`history_size` saturates), so the drift cannot be measured and the one-row jitter returns. Image placements and command marks carry the same caveat for the same reason; closing it properly wants a monotonic scroll counter in the alacritty fork, which is not worth the patch surface.

## Testing

- `a_highlight_follows_its_text_as_output_scrolls_under_it` — buries the query in the scrollback, scrolls the grid under it without letting any timer fire, and reads the grid back at the stored match point: it must still spell the word. Fails without the rebase.
- `a_pane_that_never_pauses_is_rescanned_anyway` — prints something new every half debounce window so the pause never comes; the count must still grow. Fails without the lag limit.
- Both tests drive the parser directly instead of the socket, so they depend on neither real time nor the clock.
- Full suite: 1421 passed, `cargo fmt --check` clean.
- Manual: isolated dev instance (`--config-dir /tmp/t7dev`) seeded with matches buried in scrollback plus a command that streams a line every 60ms, with the find bar open on it.
