### PR TITLE
fix(switcher): give a machine name its own line above the address

### DIFF
--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -48,8 +48,6 @@ const KID_INDENT: f32 = 16.0;
 
 const ROW_PAD: f32 = 8.0;
 
-const TAB_PATH_W: f32 = 160.0;
-
 const PROGRESS_H: f32 = 3.0;
 
 /// `Failed` stays a unit variant so `Link` can be `Copy` and travel by value in
@@ -1796,6 +1794,10 @@ impl Tty7App {
             _ => muted,
         };
 
+        // Two lines rather than one, like the workspace rows below: the name
+        // is the main line, and the endpoint — with the link status — is the
+        // line under it, so a long address can never crowd the name out and
+        // the address itself no longer has to fight for the same row.
         let head = h_flex()
             .id(gpui::SharedString::from(format!(
                 "switcher-host:{}",
@@ -1803,7 +1805,8 @@ impl Tty7App {
             )))
             .items_center()
             .gap(px(8.))
-            .h(px(HOST_H))
+            .min_h(px(HOST_H))
+            .py(px(4.))
             .px(px(ROW_PAD))
             .rounded(px(6.))
             .overflow_hidden()
@@ -1819,35 +1822,47 @@ impl Tty7App {
                     .text_color(if group.link == Link::Local { muted } else { fg }),
             ))
             .child(
-                div()
+                v_flex()
                     .flex_1()
                     .min_w_0()
-                    .truncate()
-                    .text_sm()
-                    .font_weight(gpui::FontWeight::MEDIUM)
-                    .text_color(fg)
-                    .child(group.label.clone()),
+                    .gap(px(1.))
+                    .child(
+                        div()
+                            .truncate()
+                            .text_sm()
+                            .font_weight(gpui::FontWeight::MEDIUM)
+                            .text_color(fg)
+                            .child(group.label.clone()),
+                    )
+                    .when(
+                        !group.endpoint.is_empty() || dot.is_some() || word.is_some(),
+                        |col| {
+                            col.child(
+                                h_flex()
+                                    .items_center()
+                                    .gap(px(5.))
+                                    .child(
+                                        div()
+                                            .min_w_0()
+                                            .truncate()
+                                            .text_xs()
+                                            .text_color(dim)
+                                            .child(group.endpoint.clone()),
+                                    )
+                                    .children(dot.map(|c| {
+                                        div().flex_shrink_0().size(px(6.)).rounded_full().bg(c)
+                                    }))
+                                    .children(word.map(|w| {
+                                        div()
+                                            .flex_shrink_0()
+                                            .text_xs()
+                                            .text_color(word_color)
+                                            .child(w)
+                                    })),
+                            )
+                        },
+                    ),
             )
-            .when(!group.endpoint.is_empty(), |head| {
-                head.child(
-                    div()
-                        .flex_shrink_0()
-                        .max_w(px(TAB_PATH_W))
-                        .truncate()
-                        .text_xs()
-                        .text_color(dim)
-                        .child(group.endpoint.clone()),
-                )
-            })
-            .children(dot.map(|c| div().flex_shrink_0().size(px(6.)).rounded_full().bg(c)))
-            .children(word.map(|w| {
-                div()
-                    .flex_shrink_0()
-                    .ml(px(-2.))
-                    .text_xs()
-                    .text_color(word_color)
-                    .child(w)
-            }))
             .when(!group.rows.is_empty(), |head| {
                 head.child(
                     div()
@@ -2152,7 +2167,8 @@ impl Tty7App {
                         .id(("switcher-other", i))
                         .items_center()
                         .gap(px(8.))
-                        .h(px(ROW_H))
+                        .min_h(px(ROW_H))
+                        .py(px(4.))
                         .px(px(ROW_PAD))
                         .rounded(px(6.))
                         .overflow_hidden()
@@ -2167,23 +2183,27 @@ impl Tty7App {
                                 .size(px(ICON))
                                 .text_color(dim),
                         ))
+                        // Same two-line shape as the machine headers: the name
+                        // on top, the address on the line under it.
                         .child(
-                            div()
+                            v_flex()
                                 .flex_1()
                                 .min_w_0()
-                                .truncate()
-                                .text_sm()
-                                .text_color(muted)
-                                .child(host.label.clone()),
-                        )
-                        .child(
-                            div()
-                                .flex_shrink_0()
-                                .max_w(px(TAB_PATH_W))
-                                .truncate()
-                                .text_xs()
-                                .text_color(dim)
-                                .child(host.detail.clone()),
+                                .gap(px(1.))
+                                .child(
+                                    div()
+                                        .truncate()
+                                        .text_sm()
+                                        .text_color(muted)
+                                        .child(host.label.clone()),
+                                )
+                                .child(
+                                    div()
+                                        .truncate()
+                                        .text_xs()
+                                        .text_color(dim)
+                                        .child(host.detail.clone()),
+                                ),
                         )
                         .on_click(cx.listener(move |this, _, _window, cx| {
                             this.connect_to_host(choice.clone(), cx)

--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -1795,9 +1795,10 @@ impl Tty7App {
         };
 
         // Two lines rather than one, like the workspace rows below: the name
-        // is the main line, and the endpoint — with the link status — is the
-        // line under it, so a long address can never crowd the name out and
-        // the address itself no longer has to fight for the same row.
+        // is the main line, and the endpoint is the line under it. The
+        // endpoint keeps its natural width and the link status word — the
+        // trailing piece — truncates into whatever room is left, so neither
+        // the name nor the address can be crowded off the row.
         let head = h_flex()
             .id(gpui::SharedString::from(format!(
                 "switcher-host:{}",
@@ -1843,7 +1844,8 @@ impl Tty7App {
                                     .gap(px(5.))
                                     .child(
                                         div()
-                                            .min_w_0()
+                                            .flex_shrink_0()
+                                            .max_w(gpui::relative(1.0))
                                             .truncate()
                                             .text_xs()
                                             .text_color(dim)
@@ -1854,7 +1856,9 @@ impl Tty7App {
                                     }))
                                     .children(word.map(|w| {
                                         div()
-                                            .flex_shrink_0()
+                                            .flex_shrink_1()
+                                            .min_w_0()
+                                            .truncate()
                                             .text_xs()
                                             .text_color(word_color)
                                             .child(w)


### PR DESCRIPTION
In the workspace switcher, a machine group header drew the machine name and its endpoint (`user@host:port`) on one line. The endpoint was a fixed-width flex item (up to 160px, never shrinking), so it took its space first and the name — `flex_1` with basis 0 — collapsed into the leftover. A machine whose name runs long read as a stub:

```
y...  root@host.example.com:58107   1  ⋮  >
GAEM...  root@192.0.2.1   1  ⋮  >
```

The "other machines" rows paired label + address the same way and squeezed the same way.

## Fix

The headers now use the same two-line shape as the workspace rows under them:

```
host.example.com                  1  ⋮  >
root@host.example.com:58107 ●
archlinux                         1  ⋮  >
WSL · this computer  · not connected
```

- **Main line** — the machine name, backed by the full row width; truncated only when the name alone cannot fit.
- **Second line** — the endpoint with the link status dot and word (not connected / connecting / failed / taken over), in the dimmer secondary style.
- Rows with no endpoint or status (the local group) stay single-line; header height now grows with content like the workspace rows (`min_h` + padding) instead of a fixed 34px.

Changes in `src/ui/switcher.rs`:

- `render_group_header` — two-line name / endpoint+status layout
- `render_other_hosts` — same two-line layout for the machine rows
- dropped the now-unused `TAB_PATH_W` constant