### PR TITLE
fix(daemon): rebuild the window from the tree when a restart handoff fails (#554)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`scrollback_limit: 5000` highlighted "10,000", and clicking that cell
   silently overwrote it) — it shows a "Custom (5,000)" cell that names the
   real value and is not a button (#550).
+- **A refused in-place daemon restart no longer strands every pane it
+  promised to keep** — Restart Server clears the window before attempting the
+  handoff, and when the handoff failed the window simply stayed empty with an
+  error on the home page. The daemon was still running and serving those
+  panes, but every restore path is driven by the machine tree, and the next
+  sync of the emptied window diffed into "close every tab" against it —
+  deleting the pane records under shells that were still alive, or the whole
+  workspace at once if the user just closed the window, right after the
+  dialog had promised nothing would be interrupted. A failed restart now
+  drops the dead link and pulls the layout back from the tree, reattaching
+  the living panes; where the failure really did take the daemon away, the
+  missed pull leaves a rehydration debt instead, which is what stops the
+  empty window from being pushed up as the layout. (#554)
 
 ## [26.8.3] - 2026-08-12
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1554,14 +1554,34 @@ impl Tty7App {
                         crate::ui::tree_sync::resync_after_local_daemon_change(cx);
                     }
                     Err(e) => {
-                        // The user asked for this and lands on an empty home
-                        // page; without a reason there it looks like the
-                        // restart worked and took everything with it.
-                        log::error!("restart background service failed, staying on home page: {e}");
-                        this.startup_error = Some(gpui::SharedString::from(t_fmt(
+                        // A refused handoff leaves the daemon exactly as it was,
+                        // still serving the panes this window just dropped. Leaving
+                        // it at the error here strands them: every restore path is
+                        // tree-driven, and the next sync of this emptied window
+                        // would diff into "close every tab" against the mirror —
+                        // deleting the pane records under the still-running shells,
+                        // or the whole workspace if the user simply closes the
+                        // window first (#554). Pull the layout back instead; where
+                        // the failure really did take the daemon away (an exec that
+                        // never re-listened), the pull misses and the rehydration
+                        // debt keeps the empty window from being pushed up.
+                        //
+                        // The invalidating helper, not the one the reconnect uses:
+                        // nothing here handshaked a link. Half of `hand_off`'s
+                        // failures happen *after* the exec — a daemon that never
+                        // started listening again is gone, and the client we still
+                        // hold points at its socket, which `is_connected` keeps
+                        // calling good until its reader sees the EOF.
+                        log::error!(
+                            "restart background service failed, resyncing from the tree: {e}"
+                        );
+                        let text = t_fmt(
                             L10nKey::AppRestartServerFailed,
                             &[("error", &e.to_string())],
-                        )));
+                        );
+                        this.startup_error = Some(gpui::SharedString::from(text.clone()));
+                        window.push_notification(text, cx);
+                        crate::ui::tree_sync::resync_after_local_daemon_change(cx);
                     }
                 }
                 this.focus_active(window, cx);

--- a/src/ui/tree_sync.rs
+++ b/src/ui/tree_sync.rs
@@ -2480,6 +2480,74 @@ mod tests {
         });
     }
 
+    /// #554: Restart Server empties the window *before* it tries the handoff,
+    /// and a refused handoff leaves the daemon exactly as it was, still serving
+    /// every pane the window just dropped.
+    ///
+    /// What makes that recoverable is the window giving up its claim to speak
+    /// for the machine the moment the failure lands. An emptied window that is
+    /// still `informed` over a `Primed` mirror is the dangerous shape: the next
+    /// sync diffs it into "close every tab", and closing the window authorizes
+    /// a `WorkspaceRemove` outright — the shells stay alive, but their records
+    /// go, and nothing tree-driven can ever reach them again.
+    ///
+    /// Tested on `resync_window_from_tree`, which is the per-window step both
+    /// [`resync_after_local_daemon_change`] and [`resync_local_windows_from_tree`]
+    /// do their work through — the pair above it only decides whether the link
+    /// is dropped first and which windows are walked, neither of which is what
+    /// keeps the emptied window quiet.
+    #[gpui::test]
+    fn a_failed_daemon_change_stops_the_emptied_window_speaking_for_the_machine(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| {
+            let ws = WorkspaceId::new();
+            let tab = TabId::new();
+            {
+                let state = cx
+                    .default_global::<TreeSync>()
+                    .windows
+                    .entry(ws)
+                    .or_default();
+                state.informed = true;
+                // The mirror the emptied window would have been diffed against,
+                // already drained the way `save_session` drains it on the way
+                // out of a window that has no tabs left.
+                state.sync = SyncPhase::Primed(WsMirror {
+                    tabs: vec![],
+                    active: None,
+                });
+                state
+                    .queue
+                    .push_back(ControlRequest::TabClose { workspace: ws, tab });
+            }
+            assert!(
+                workspace_is_disposable(cx, ws),
+                "the shape #554 leaves behind: an emptied window that still speaks for a \
+                 machine holding live panes, and may delete the workspace off it"
+            );
+
+            resync_window_from_tree(cx, ws);
+
+            assert!(
+                !workspace_is_disposable(cx, ws),
+                "this is the regression: closing the window after a refused handoff sent \
+                 WorkspaceRemove and took the whole workspace, live panes and all"
+            );
+            let state = &cx.default_global::<TreeSync>().windows[&ws];
+            assert!(
+                matches!(state.sync, SyncPhase::Unprimed { .. }),
+                "the mirror the emptied window would diff into 'close every tab' has to be \
+                 dropped, not carried into the next sync"
+            );
+            assert!(
+                state.queue.is_empty(),
+                "operations queued from the emptied window speak for a layout that is being \
+                 pulled again; sending them would close the tabs it is pulling"
+            );
+        });
+    }
+
     #[gpui::test]
     fn a_hydration_that_died_on_a_stale_link_is_owed_back(cx: &mut gpui::TestAppContext) {
         cx.update(|cx| {


### PR DESCRIPTION
## 修复内容

`restart_daemon_confirmed` 在尝试 `hand_off()` 之前就把窗口 tab 全部清空,而 Err 分支只设置 `startup_error`——窗口停在空主页。按复核确认的因果链:

- handoff 被拒时 daemon 原封不动、pane 全活着,但 GUI 的恢复路径全是 tree 驱动的;`informed` 仍为 true,下一次 `SyncScope::Full` 的 `sync_window` 会把空窗口 diff 成 "close every tab"(`tree_sync.rs:711-716` 的注释自己承认了这条链路),`tab_close` 把活着的 pane 的记录从 machine tree 删掉 ⇒ **进程还在跑,GUI 里永远回不来**。
- 最坏路径是关窗:`detach_workspace` 此时判定 `workspace_is_disposable` 成立,直接发 `WorkspaceRemove`,整个工作区连同 pane 记录蒸发。
- 原稿中"孤儿清扫收割 shell"的说法不成立(已按复核更正):`spawn_orphan_sweep` 只打日志;危害是记录被删导致的永久失联,不是被杀。

## 修法(按复核意见)

Err 分支补上与 Ok 分支相同的 `invalidate` + `resync_window_from_tree`,并抽成 `tree_sync::resync_after_local_daemon_change`,供 #553 的实例比对复用。按复核验证过的安全性:

- daemon 还在(exec 前的拒绝、`:376` 旧 build):重连后 `hydrate` 拉回布局,attach 回活 pane;
- daemon 真没了(`:389` exec 后未重新监听):`invalidate` 必需(旧 socket 已死),pull 失败走 `owe_rehydration` 记债——恰好阻止后续推空布局,并按退避重试。

失败同时补一条 toast:resync 成功后窗口不在主页,`startup_error` 那行红字用户看不到。

## 测试

- `cargo test --locked --bin tty7-app`:1242 passed。该路径是 UI+daemon 集成(hand_off 走真实 socket),无单测锚点,与既有 restart 流程一样靠实机覆盖。

closes #554
