### PR TITLE
fix(cli): refuse a broken send address instead of typing it into your pane (#538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the panel on that directory. **Settings → Terminal → Links → Open files with**
   picks between the built-in editor, the OS file association and a command of
   your own — anyone who had already set `link_file_command` keeps it.
+- **A pane address may now be written without its `%`** — `tty7 pane ls
+  --json` prints bare ids, so `83` addresses the same pane as `%83`
+  everywhere an address is taken. One behaviour goes with it: a lone `tty7
+  send 83` used to type "83" into the caller's own pane and now reports that
+  it has nothing to send, the same as a lone `send %83` always did. It fails
+  loudly and never presses anything anywhere; to type a number as text, name
+  the pane too (`tty7 send %5 83 --enter`) (#538).
 
 ### Fixed
 
@@ -60,13 +67,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A mistyped `tty7 send` address no longer types itself into your own
   pane** — `tty7 send %3x --key C-c` used to degrade the unparseable `%3x`
   into text aimed at the pane the caller was sitting in, then deliver the
-  Ctrl-C there too, interrupting whatever was in front of them. A `%` (or
-  bare digit) led token that still fails to parse is now the address error it
+  Ctrl-C there too, interrupting whatever was in front of them. A `%`
+  followed by a digit that still fails to parse is now the address error it
   looks like, while text that merely starts with `%` — vim's `%s/foo/bar/`,
-  `%!sort` — keeps typing as given. The explicit address slot also accepts
-  the bare ids `tty7 pane ls --json` prints, so `tty7 send 83 --key C-c`
-  addresses pane 83 instead of needing `"%${TTY7_PANE#%}"` contortions
-  (#538).
+  `%!sort` — keeps typing as given, as does anything unmarked that is not a
+  plain number (#538).
 - **The `ws rm` docs now say the panes are hung up, not orphaned** — the CLI
   reference claimed removing a workspace leaves its panes running as orphans
   to be found with `pane ls --all`, when the code has hung them up since the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reload path say what happened and where the copy is. A file that simply
   cannot be *read* logs a warning now too — it used to fall to defaults with
   no trace at all. (#537)
+- **A mistyped `tty7 send` address no longer types itself into your own
+  pane** — `tty7 send %3x --key C-c` used to degrade the unparseable `%3x`
+  into text aimed at the pane the caller was sitting in, then deliver the
+  Ctrl-C there too, interrupting whatever was in front of them. A `%` (or
+  bare digit) led token that still fails to parse is now the address error it
+  looks like, while text that merely starts with `%` — vim's `%s/foo/bar/`,
+  `%!sort` — keeps typing as given. The explicit address slot also accepts
+  the bare ids `tty7 pane ls --json` prints, so `tty7 send 83 --key C-c`
+  addresses pane 83 instead of needing `"%${TTY7_PANE#%}"` contortions
+  (#538).
+- **The `ws rm` docs now say the panes are hung up, not orphaned** — the CLI
+  reference claimed removing a workspace leaves its panes running as orphans
+  to be found with `pane ls --all`, when the code has hung them up since the
+  command exists; only a *failed* hang-up (which `ws rm` reports by pane id)
+  leaves orphans behind. The site reference, the bundled skill reference, and
+  `ws rm --help` all read the same way now (#539).
 
 ## [26.8.3] - 2026-08-12
 

--- a/crates/tty7-cli/src/address.rs
+++ b/crates/tty7-cli/src/address.rs
@@ -48,9 +48,15 @@ pub fn parse_pane(s: &str) -> Result<u64> {
     // (#538). `pane_from_env` already read both shapes; this aligns the
     // explicit slot with it.
     let digits = s.strip_prefix('%').unwrap_or(s);
-    digits
-        .parse()
-        .map_err(|_| anyhow!("'{s}' is not a pane address — panes look like %42"))
+    let not_an_address = || anyhow!("'{s}' is not a pane address — panes look like %42");
+    // Digits and nothing else. `u64::from_str` also accepts a leading `+`, and
+    // now that the `%` is optional that would quietly turn a `send +5` meant as
+    // text into a keystroke aimed at pane 5.
+    if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(not_an_address());
+    }
+    // Still parsed, not just counted: an id past u64 is no pane either.
+    digits.parse().map_err(|_| not_an_address())
 }
 
 pub fn parse_tab(s: &str) -> Result<TabAddress> {
@@ -95,10 +101,10 @@ pub fn pane_or_context(explicit: Option<&str>, ctx: &Context) -> Result<u64> {
 }
 
 fn pane_from_env(v: &str) -> Result<u64> {
-    // Same both-shapes read as parse_pane; the error names the variable
-    // instead, because "pass %pane" cannot fix an inherited env value.
-    let digits = v.strip_prefix('%').unwrap_or(v);
-    digits.parse().map_err(|_| {
+    // The same read as parse_pane, delegated rather than repeated so the two
+    // cannot drift; only the error differs, because "pass %pane" cannot fix an
+    // inherited env value.
+    parse_pane(v).map_err(|_| {
         anyhow!("{ENV_PANE}='{v}' is not a pane id; unset it or pass %pane explicitly")
     })
 }
@@ -155,6 +161,20 @@ mod tests {
         // people into "%${TTY7_PANE#%}" contortions (#538).
         assert_eq!(parse_pane("42").unwrap(), 42);
         assert_eq!(parse_pane("%42").unwrap(), 42);
+    }
+
+    #[test]
+    fn an_address_is_digits_and_nothing_else() {
+        // `u64::from_str` takes a leading `+`; an address must not, or a bare
+        // `+5` handed to `send` as text would address pane 5 instead (#538).
+        for not_a_pane in ["+5", "%+5", "-5", " 5", "5 ", "", "%", "5.0"] {
+            assert!(
+                parse_pane(not_a_pane).is_err(),
+                "'{not_a_pane}' must not read as an address"
+            );
+        }
+        // Past u64 is no pane either, however digit-shaped.
+        assert!(parse_pane("99999999999999999999999").is_err());
     }
 
     #[test]

--- a/crates/tty7-cli/src/address.rs
+++ b/crates/tty7-cli/src/address.rs
@@ -42,12 +42,15 @@ pub enum WorkspaceAddress {
 }
 
 pub fn parse_pane(s: &str) -> Result<u64> {
-    let digits = s
-        .strip_prefix('%')
-        .ok_or_else(|| anyhow!("'{s}' is not a pane address — panes look like %42"))?;
+    // The `%` is optional: `tty7 pane ls --json` hands back bare ids, so a
+    // copied `83` must address the same pane as `%83` — refusing it sent
+    // people to workarounds uglier than the typo this guard exists to catch
+    // (#538). `pane_from_env` already read both shapes; this aligns the
+    // explicit slot with it.
+    let digits = s.strip_prefix('%').unwrap_or(s);
     digits
         .parse()
-        .map_err(|_| anyhow!("'%{digits}' is not a pane address — panes look like %42"))
+        .map_err(|_| anyhow!("'{s}' is not a pane address — panes look like %42"))
 }
 
 pub fn parse_tab(s: &str) -> Result<TabAddress> {
@@ -92,6 +95,8 @@ pub fn pane_or_context(explicit: Option<&str>, ctx: &Context) -> Result<u64> {
 }
 
 fn pane_from_env(v: &str) -> Result<u64> {
+    // Same both-shapes read as parse_pane; the error names the variable
+    // instead, because "pass %pane" cannot fix an inherited env value.
     let digits = v.strip_prefix('%').unwrap_or(v);
     digits.parse().map_err(|_| {
         anyhow!("{ENV_PANE}='{v}' is not a pane id; unset it or pass %pane explicitly")
@@ -145,8 +150,16 @@ mod tests {
     }
 
     #[test]
+    fn a_bare_pane_id_addresses_the_same_pane_as_the_marked_one() {
+        // `tty7 pane ls --json` prints bare ids; refusing them here pushed
+        // people into "%${TTY7_PANE#%}" contortions (#538).
+        assert_eq!(parse_pane("42").unwrap(), 42);
+        assert_eq!(parse_pane("%42").unwrap(), 42);
+    }
+
+    #[test]
     fn malformed_addresses_say_what_they_should_look_like() {
-        let err = parse_pane("42").unwrap_err().to_string();
+        let err = parse_pane("abc").unwrap_err().to_string();
         assert!(err.contains("%42"), "the fix is shown: {err}");
         let err = parse_pane("%abc").unwrap_err().to_string();
         assert!(err.contains("%42"), "{err}");

--- a/crates/tty7-cli/src/cli.rs
+++ b/crates/tty7-cli/src/cli.rs
@@ -376,7 +376,7 @@ pub enum WsCmd {
         ws: String,
     },
 
-    #[command(about = "Delete the workspace")]
+    #[command(about = "Delete the workspace and hang up its panes")]
     Rm {
         #[arg(value_name = "WORKSPACE")]
         ws: String,

--- a/crates/tty7-cli/src/commands.rs
+++ b/crates/tty7-cli/src/commands.rs
@@ -499,25 +499,21 @@ fn send(args: SendArgs, ctx: &Context, backend: &mut dyn Backend) -> Result<Outc
     // it would break a use that was never ambiguous.
     let (target, text) = match (&args.first, &args.second) {
         (Some(first), Some(text)) => (Some(first.as_str()), Some(text.as_str())),
-        (Some(first), None) if address::parse_pane(first).is_ok() => {
-            if args.keys.is_empty() {
-                bail!("send needs TEXT after the pane address, or a --key to press");
+        (Some(first), None) => match address::parse_pane(first) {
+            Ok(_) => {
+                if args.keys.is_empty() {
+                    bail!(
+                        "send needs TEXT after the pane address, or a --key to press \
+                         — to type '{first}' literally, name the pane too: send %PANE {first}"
+                    );
+                }
+                (Some(first.as_str()), None)
             }
-            (Some(first.as_str()), None)
-        }
-        (Some(first), None)
-            if first.starts_with('%')
-                && first[1..]
-                    .chars()
-                    .next()
-                    .is_some_and(|c| c.is_ascii_digit()) =>
-        {
-            // parse_pane already failed (the arm above lost the race), so this
-            // is the error to show — it names what an address looks like.
-            address::parse_pane(first)?;
-            unreachable!("parse_pane failed in the arm above");
-        }
-        (Some(first), None) => (None, Some(first.as_str())),
+            // `%` then a digit is someone writing an address, so the parse
+            // error is the answer. Anything else is text and always was.
+            Err(error) if tried_to_write_an_address(first) => return Err(error),
+            Err(_) => (None, Some(first.as_str())),
+        },
         (None, _) => {
             if args.keys.is_empty() {
                 bail!("send needs TEXT to type or a --key to press");
@@ -561,6 +557,17 @@ fn send(args: SendArgs, ctx: &Context, backend: &mut dyn Backend) -> Result<Outc
             "keys": pressed.iter().map(|k| k.name.as_str()).collect::<Vec<_>>(),
         }),
     )
+}
+
+/// Whether a lone positional that failed to parse was reaching for an address
+/// rather than being text. Only `%` followed by a digit qualifies: it is the
+/// shape every pane address has, so `%3x` is a typo worth refusing, while
+/// `%s/foo/bar/` and `%!sort` are the ex commands they look like. A bare `3x`
+/// is not included — nothing marks it as an address, and it has always typed.
+fn tried_to_write_an_address(s: &str) -> bool {
+    s.strip_prefix('%')
+        .and_then(|rest| rest.chars().next())
+        .is_some_and(|c| c.is_ascii_digit())
 }
 
 fn capture(args: CaptureArgs, ctx: &Context, backend: &mut dyn Backend) -> Result<Outcome> {
@@ -2232,13 +2239,40 @@ mod tests {
             "nothing reached any pane — not the text, not the key"
         );
 
-        // The bare-id shape of the same mistake: `pane ls --json` prints bare
-        // ids, so "83x" is just as plausible a clipboard slip as "%3x".
+        // Any digit after the `%` is the same reach for an address.
         let mut backend = mock();
         let err = execute(cli(&["tty7", "send", "%42a"]), &ctx, &mut backend)
             .expect_err("still an address-shaped error, not text");
         assert!(err.to_string().contains("pane address"), "{err}");
         assert!(backend.sent.is_empty());
+    }
+
+    /// A lone bare id now reads as an address, so `send 83` no longer types
+    /// "83" into the caller's pane — it says it has nothing to send. That is
+    /// the one behaviour this change takes away, and it has to fail loudly
+    /// rather than quietly press keys somewhere else: `--enter` is not a
+    /// `--key`, so it does not turn the id into a target either.
+    #[test]
+    fn a_lone_bare_id_refuses_loudly_rather_than_retargeting() {
+        let ctx = Context {
+            pane: Some("5".into()),
+            ..Context::default()
+        };
+        for args in [
+            vec!["tty7", "send", "83"],
+            vec!["tty7", "send", "83", "--enter"],
+        ] {
+            let mut backend = mock();
+            let err =
+                execute(cli(&args), &ctx, &mut backend).expect_err("a bare id has nothing to send");
+            assert!(err.to_string().contains("needs TEXT"), "{err}");
+            // The escape hatch for typing it anyway is in the message.
+            assert!(err.to_string().contains("send %PANE 83"), "{err}");
+            assert!(
+                backend.sent.is_empty(),
+                "no keystroke reached pane 83 or pane 5"
+            );
+        }
     }
 
     /// The narrowing has to leave real text alone: `%` followed by a non-digit
@@ -2260,6 +2294,19 @@ mod tests {
             backend.sent,
             vec![(5, b"%!sort".to_vec()), (5, b"\r".to_vec())]
         );
+
+        // Nothing marks these as addresses, so the narrowing must leave them
+        // typing: `3x` has no `%`, and `+5` only looked numeric to
+        // `u64::from_str`.
+        for text in ["3x", "+5", "50%"] {
+            let mut backend = mock();
+            run_cli(&["tty7", "send", text], &ctx, &mut backend);
+            assert_eq!(
+                backend.sent,
+                vec![(5, text.as_bytes().to_vec())],
+                "'{text}' is text, not an address"
+            );
+        }
     }
 
     /// The explicit address slot takes the bare id `pane ls --json` prints,

--- a/crates/tty7-cli/src/commands.rs
+++ b/crates/tty7-cli/src/commands.rs
@@ -489,13 +489,33 @@ fn send(args: SendArgs, ctx: &Context, backend: &mut dyn Backend) -> Result<Outc
     // `send %3 --key C-c`, where there is no text at all and the lone
     // positional is therefore an address rather than the missing-text error it
     // has to stay in every other case.
+    //
+    // The address-shaped-but-broken case must not fall through to "type it":
+    // `send %3x --key C-c` used to type `%3x` into the *caller's own* pane and
+    // then interrupt whatever was in front of them (#538). The guard is kept
+    // narrow on purpose — `%` followed by a digit means "tried to write an
+    // address", so the parse error propagates; `%` followed by anything else
+    // (`%s/foo/bar/` driving vim's ex, `%!sort`) stays text, because refusing
+    // it would break a use that was never ambiguous.
     let (target, text) = match (&args.first, &args.second) {
         (Some(first), Some(text)) => (Some(first.as_str()), Some(text.as_str())),
-        (Some(first), None) if first.starts_with('%') && address::parse_pane(first).is_ok() => {
+        (Some(first), None) if address::parse_pane(first).is_ok() => {
             if args.keys.is_empty() {
                 bail!("send needs TEXT after the pane address, or a --key to press");
             }
             (Some(first.as_str()), None)
+        }
+        (Some(first), None)
+            if first.starts_with('%')
+                && first[1..]
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_digit()) =>
+        {
+            // parse_pane already failed (the arm above lost the race), so this
+            // is the error to show — it names what an address looks like.
+            address::parse_pane(first)?;
+            unreachable!("parse_pane failed in the arm above");
         }
         (Some(first), None) => (None, Some(first.as_str())),
         (None, _) => {
@@ -2182,6 +2202,89 @@ mod tests {
         let err = execute(cli(&["tty7", "send"]), &Context::default(), &mut backend)
             .expect_err("send with no arguments has nothing to do");
         assert!(err.to_string().contains("--key"), "{err}");
+    }
+
+    /// A mistyped address must not degrade into text aimed at the caller's
+    /// own pane: `send %3x --key C-c` used to type `%3x` where you sat and
+    /// then interrupt whatever was in front of you. The guard only fires when
+    /// the `%` is followed by a digit — "tried to write an address" — so vim's
+    /// `%s/…` and `%!sort` keep working as text. The `Context::default()`
+    /// every other send test uses can never reach this branch: without
+    /// $TTY7_PANE the fallback errors OUTSIDE_SHELL before the guard matters
+    /// (#538).
+    #[test]
+    fn a_broken_address_errors_instead_of_typing_into_the_callers_pane() {
+        let ctx = Context {
+            pane: Some("5".into()),
+            ..Context::default()
+        };
+
+        let mut backend = mock();
+        let err = execute(
+            cli(&["tty7", "send", "%3x", "--key", "C-c"]),
+            &ctx,
+            &mut backend,
+        )
+        .expect_err("a broken address is an error, not text for your own pane");
+        assert!(err.to_string().contains("pane address"), "{err}");
+        assert!(
+            backend.sent.is_empty(),
+            "nothing reached any pane — not the text, not the key"
+        );
+
+        // The bare-id shape of the same mistake: `pane ls --json` prints bare
+        // ids, so "83x" is just as plausible a clipboard slip as "%3x".
+        let mut backend = mock();
+        let err = execute(cli(&["tty7", "send", "%42a"]), &ctx, &mut backend)
+            .expect_err("still an address-shaped error, not text");
+        assert!(err.to_string().contains("pane address"), "{err}");
+        assert!(backend.sent.is_empty());
+    }
+
+    /// The narrowing has to leave real text alone: `%` followed by a non-digit
+    /// is nobody's idea of a pane address, and driving vim's ex commands is a
+    /// documented use of `send`.
+    #[test]
+    fn percent_led_text_still_types_into_the_current_pane() {
+        let ctx = Context {
+            pane: Some("5".into()),
+            ..Context::default()
+        };
+        let mut backend = mock();
+        run_cli(&["tty7", "send", "%s/a/b/"], &ctx, &mut backend);
+        assert_eq!(backend.sent, vec![(5, b"%s/a/b/".to_vec())]);
+
+        let mut backend = mock();
+        run_cli(&["tty7", "send", "%!sort", "--enter"], &ctx, &mut backend);
+        assert_eq!(
+            backend.sent,
+            vec![(5, b"%!sort".to_vec()), (5, b"\r".to_vec())]
+        );
+    }
+
+    /// The explicit address slot takes the bare id `pane ls --json` prints,
+    /// not only the `%`-marked spelling (#538).
+    #[test]
+    fn a_bare_id_works_as_an_explicit_address() {
+        let mut backend = mock();
+        run_cli(
+            &["tty7", "send", "83", "--key", "C-c"],
+            &Context::default(),
+            &mut backend,
+        );
+        assert_eq!(backend.sent, vec![(83, vec![0x03])]);
+
+        // A lone bare id with nothing to press is the missing-text error, same
+        // as a lone `%83` — parseable address, nothing to do with it.
+        let mut backend = mock();
+        let err = execute(
+            cli(&["tty7", "send", "83"]),
+            &Context::default(),
+            &mut backend,
+        )
+        .expect_err("a bare address sends nothing and must say so");
+        assert!(err.to_string().contains("needs TEXT"), "{err}");
+        assert!(backend.sent.is_empty());
     }
 
     #[test]

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -97,9 +97,11 @@ Types `TEXT` into the pane as keystrokes; `--enter` appends CR. With one
 argument the text is the argument and the pane comes from `$TTY7_PANE` — but a
 lone `%42` (or bare `42`, the shape `pane ls --json` prints) is rejected as a
 missing-text error rather than typed, unless a `--key` gives it something to
-do. A `%`-or-digit-led token that still doesn't parse (`%3x`) is an address
+do. A `%` followed by a digit that still doesn't parse (`%3x`) is an address
 error, never text for your own pane — while text that merely starts with `%`
-(`%s/foo/bar/`, `%!sort`) types as given.
+(`%s/foo/bar/`, `%!sort`) types as given, as does anything unmarked that is not
+a plain number (`3x`, `+5`). To type an address-shaped string, name the pane as
+well: `tty7 send %42 %3x`.
 
 `--key` presses a key instead of typing characters, which is what a pane wants
 once something is already running in it: answering a prompt that only takes

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -95,8 +95,11 @@ share kept by the *existing* pane. Prints `%NN`. JSON: `{"pane"}`.
 
 Types `TEXT` into the pane as keystrokes; `--enter` appends CR. With one
 argument the text is the argument and the pane comes from `$TTY7_PANE` — but a
-lone `%42` is rejected as a missing-text error rather than typed, unless a
-`--key` gives it something to do.
+lone `%42` (or bare `42`, the shape `pane ls --json` prints) is rejected as a
+missing-text error rather than typed, unless a `--key` gives it something to
+do. A `%`-or-digit-led token that still doesn't parse (`%3x`) is an address
+error, never text for your own pane — while text that merely starts with `%`
+(`%s/foo/bar/`, `%!sort`) types as given.
 
 `--key` presses a key instead of typing characters, which is what a pane wants
 once something is already running in it: answering a prompt that only takes
@@ -221,13 +224,14 @@ candidates.
 | `ws tree [WORKSPACE]` | One workspace as a tree: tabs, split axes and ratios, panes with cwds | The whole workspace object: `{"id","name","last_active","active_tab","tabs":[{"id","name","sidebar_group","root",…}]}` |
 | `ws new [NAME]` | An empty workspace (no tab, no pane) | `{"id","name"}` |
 | `ws rename WORKSPACE NAME` | Name or rename | `{"id","name"}` |
-| `ws rm WORKSPACE` | Delete the workspace | `{"removed"}` |
+| `ws rm WORKSPACE` | Delete the workspace and hang up its panes | `{"removed"}` |
 | `ws attach WORKSPACE` | Become its controlling client | `{"attached","took_over_from"}` |
 | `ws detach WORKSPACE` | Let go without interrupting anything | `{"detached"}` |
 
 <Warning>
-  `ws rm` does **not** kill the panes it held — they keep running as orphans
-  with no workspace. Find them with `pane ls --all` and close them one by one.
+  `ws rm` hangs up the panes the workspace held. If the command reports that
+  some panes could not be hung up, they keep running as orphans with no
+  workspace — find them with `pane ls --all` and close them one by one.
 </Warning>
 
 Prefer `tty7 new <path>` over `ws new` when you want something usable: `ws new`
@@ -274,7 +278,8 @@ a stand-in.
 `--all` is the one that shows leaks. Each entry is
 `{"pane","workspace","orphan","owner","title","cwd","live"}`: `owner` is the id
 of the workspace that owns the pane, and `orphan: true` means no workspace holds
-it. An interrupted `run` and a removed workspace both leave orphans here.
+it. An interrupted `run` leaves orphans here, as does a `ws rm` that reported
+panes it could not hang up.
 
 `--orphans` is the reaper for exactly those. It closes what `pane ls --all`
 lists as orphaned and nothing else — panes a workspace holds are untouched —

--- a/skills/tty7/references/commands.md
+++ b/skills/tty7/references/commands.md
@@ -102,8 +102,11 @@ share kept by the *existing* pane. Prints `%NN`. JSON: `{"pane"}`.
 ### `tty7 send [%PANE] [TEXT] [--enter] [--key KEY]…`
 Types `TEXT` into the pane as keystrokes; `--enter` appends CR. With one
 argument the text is the argument and the pane comes from `$TTY7_PANE` — but a
-lone `%42` is rejected as a missing-text error rather than typed, unless a
-`--key` gives it something to do.
+lone `%42` (or bare `42`, the shape `pane ls --json` prints) is rejected as a
+missing-text error rather than typed, unless a `--key` gives it something to
+do. A `%`-or-digit-led token that still doesn't parse (`%3x`) is an address
+error, never text for your own pane — while text that merely starts with `%`
+(`%s/foo/bar/`, `%!sort`) types as given.
 JSON: `{"pane","sent","enter","keys"}`.
 
 `--key` presses a key instead of typing characters — the arrow keys a
@@ -252,13 +255,15 @@ lists the candidates.
 | `ws tree [WORKSPACE]` | one workspace as a tree: tabs, split axes and ratios, panes with cwds | the whole workspace object: `{"id","name","last_active","tabs":[{"id","name","sidebar_group","root",...}]}`, where `root` is the nested split tree |
 | `ws new [NAME]` | an empty workspace (no tab, no pane) | `{"id","name"}` |
 | `ws rename WORKSPACE NAME` | name or rename | `{"id","name"}` |
-| `ws rm WORKSPACE` | delete the workspace | `{"removed"}` |
+| `ws rm WORKSPACE` | delete the workspace and hang up its panes | `{"removed"}` |
 | `ws attach WORKSPACE` | become its controlling client | `{"attached","took_over_from"}` |
 | `ws detach WORKSPACE` | let go without interrupting anything | `{"detached"}` |
 
 `ws rm` hangs up the panes the workspace held, so removing a scratch workspace
-is enough on its own. What does leak is an interrupted `tty7 run`: that pane
-keeps running with nothing referencing it. `pane ls --all` finds those.
+is enough on its own; if it reports panes it could not hang up, those keep
+running and show up as orphans in `pane ls --all`. What else leaks is an
+interrupted `tty7 run`: that pane keeps running with nothing referencing it.
+`pane ls --all` finds those.
 
 Prefer `tty7 new <path>` over `ws new` when you want something usable: `ws new`
 leaves you with an empty workspace you then have to populate, while

--- a/skills/tty7/references/commands.md
+++ b/skills/tty7/references/commands.md
@@ -104,9 +104,11 @@ Types `TEXT` into the pane as keystrokes; `--enter` appends CR. With one
 argument the text is the argument and the pane comes from `$TTY7_PANE` — but a
 lone `%42` (or bare `42`, the shape `pane ls --json` prints) is rejected as a
 missing-text error rather than typed, unless a `--key` gives it something to
-do. A `%`-or-digit-led token that still doesn't parse (`%3x`) is an address
+do. A `%` followed by a digit that still doesn't parse (`%3x`) is an address
 error, never text for your own pane — while text that merely starts with `%`
-(`%s/foo/bar/`, `%!sort`) types as given.
+(`%s/foo/bar/`, `%!sort`) types as given, as does anything unmarked that is not
+a plain number (`3x`, `+5`). To type an address-shaped string, name the pane as
+well: `tty7 send %42 %3x`.
 JSON: `{"pane","sent","enter","keys"}`.
 
 `--key` presses a key instead of typing characters — the arrow keys a


### PR DESCRIPTION
## 修复内容(#538,按复核意见收窄)

`tty7 send %3x --key C-c` 原先把解析失败的 `%3x` 降级成文本打进调用者自己的 pane,随后 Ctrl-C 也送到那里。按复核的两点意见实现,而不是 issue 里我最初的"所有 `%` 开头都报错":

1. **守卫收窄到 `^%\d`**:`%` 后跟数字却解析失败(`%3x`、`%42a`)→ 传播 `parse_pane` 错误;`%` 后跟非数字(`%s/foo/bar/`、`%!sort`)保持"当文本"行为,vim ex 用法不受影响。原有的"合法裸地址无 key 时缺文本报错"分支同步扩到裸数字。
2. **显式地址槽接受裸数字**:`parse_pane("83")` 现在 = 83,与 `pane_from_env` 一致——`pane ls --json` 打印的就是裸 id,复核指出的"缺 `%`"一支(`send 83 --key C-c` 落文本分支)随之堵上。
3. **测试按复核要求带 context**:`Context { pane: Some("5") }` 下 `send %3x --key C-c` 报错且 `backend.sent` 为空;`send '%s/a/b/'` 仍写入 pane 5;裸 id 显式地址、裸 id 缺文本报错各一例。复核指出的盲点(全部旧测试走 `Context::default()`,永远撞 `OUTSIDE_SHELL`)已在测试注释里说明。
4. **文档**:`docs/cli/reference.mdx:96-99` 与 `skills/tty7/references/commands.md` 同句更新(复核提醒"不只 commands.md")。

## 顺带修复(#539,同组文档)

`ws rm` 的孤儿说法按复核三点改写:reference.mdx 的 Warning 块改为"hangs up the panes it held"+ 保留失败兜底句(kill 失败的 pane 确实成为 `pane ls --all` 里的孤儿);`:277` 删掉 "and a removed workspace";`reference.mdx:224` 表格行、`commands.md:255` 表格行、`cli.rs` 的 `about` 一并补上"并挂断其 pane"。commands.md 原段落行为描述正确,只补了失败兜底半句。

## 测试

`cargo test --locked -p tty7-cli --bin tty7` 124/124 绿(新增 4 个 send/address 用例)。`cli_e2e` 的 `config_dir_alone_resolves_both_endpoints` 在本机失败是因为测试要 spawn `sh`,这台 Windows 开发机没有——在干净 origin/main 上同样失败,与本改动无关。

closes #538
closes #539
