### PR TITLE
fix(ui): read the Info panel agent row off one pane, and shorten Windows paths to their leaf (#543, #544)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,8 +83,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   came from `tab.agent_status` (the most urgent across the whole tab), so a
   split tab running two agents could show one pane's name beside the other
   pane's state. The row now takes both from the detail pane when it has an
-  agent, falling back to the tab aggregate only when the focused leaf has
-  none — so name and status always describe the same pane (#543).
+  agent, and otherwise from the tab's most urgent agent pane — so the row
+  still holds while focus sits on a plain shell, and its two halves always
+  describe the same pane (#543).
 - **Windows paths in the Info panel shorten to their leaf again** — the cwd
   row split on `/` only, so a backslash-spelled path (any agent-reported cwd,
   a cmd pane, the shell-integration-off case) elided its *tail* and hid the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   command exists; only a *failed* hang-up (which `ws rm` reports by pane id)
   leaves orphans behind. The site reference, the bundled skill reference, and
   `ws rm --help` all read the same way now (#539).
+- **The Info panel's agent row reads one pane, not a splice of two** — the
+  name came from `tab.agent` (whichever leaf has an agent) while the status
+  came from `tab.agent_status` (the most urgent across the whole tab), so a
+  split tab running two agents could show one pane's name beside the other
+  pane's state. The row now takes both from the detail pane when it has an
+  agent, falling back to the tab aggregate only when the focused leaf has
+  none — so name and status always describe the same pane (#543).
+- **Windows paths in the Info panel shorten to their leaf again** — the cwd
+  row split on `/` only, so a backslash-spelled path (any agent-reported cwd,
+  a cmd pane, the shell-integration-off case) elided its *tail* and hid the
+  directory's own name. The split now takes the last of either separator,
+  and the `~` shortening — shared by the Info panel, the tab strip, and the
+  home picker — reads `USERPROFILE` as well as `HOME` and compares with
+  separators normalized and case folded, so a `C:/Users/…` pane shortens
+  under a `C:\Users\…` home (#544).
 
 ## [26.8.3] - 2026-08-12
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -341,7 +341,20 @@ impl Tab {
             .find_map(|l| l.read(cx).agent())
     }
 
-    pub(crate) fn agent_status(&self, cx: &App) -> Option<crate::core::cli_agent::AgentStatus> {
+    /// The tab's most urgent agent leaf, named and reported by that one leaf.
+    ///
+    /// `agent` and `agent_status` answer independently — the *first* leaf
+    /// carrying an agent, and the highest urgency found *anywhere* in the tab
+    /// — so reading them as a pair can put one pane's name beside another
+    /// pane's state, a row no leaf ever had. Anywhere both halves are shown
+    /// at once reads them from here instead (#543).
+    pub(crate) fn agent_row(
+        &self,
+        cx: &App,
+    ) -> Option<(
+        crate::core::cli_agent::CLIAgent,
+        crate::core::cli_agent::AgentStatus,
+    )> {
         use crate::core::cli_agent::AgentStatus;
         let urgency = |s: AgentStatus| match s {
             AgentStatus::Waiting => 3,
@@ -352,14 +365,23 @@ impl Tab {
         self.pane
             .terminals()
             .into_iter()
-            .filter(|l| l.read(cx).agent().is_some())
-            .map(|l| {
-                l.read(cx)
+            .filter_map(|l| {
+                let view = l.read(cx);
+                let agent = view.agent()?;
+                // A pane whose agent is running but has never reported a
+                // session reads as idle, the same reading the badge has always
+                // given it.
+                let status = view
                     .agent_session()
                     .map(|s| s.status)
-                    .unwrap_or(AgentStatus::Idle)
+                    .unwrap_or(AgentStatus::Idle);
+                Some((agent, status))
             })
-            .max_by_key(|s| urgency(*s))
+            .max_by_key(|(_, status)| urgency(*status))
+    }
+
+    pub(crate) fn agent_status(&self, cx: &App) -> Option<crate::core::cli_agent::AgentStatus> {
+        self.agent_row(cx).map(|(_, status)| status)
     }
 
     pub(crate) fn agent_unread_count(&self, cx: &App) -> usize {

--- a/src/ui/home.rs
+++ b/src/ui/home.rs
@@ -104,12 +104,9 @@ pub(crate) fn relative_time(now: u64, then: u64) -> String {
 
 pub(crate) fn display_path(path: &std::path::Path) -> String {
     let text = path.to_string_lossy();
-    let shortened = match std::env::var("HOME") {
-        Ok(home) if !home.is_empty() && text.starts_with(&home) => {
-            format!("~{}", &text[home.len()..])
-        }
-        _ => text.to_string(),
-    };
+    // Same home-abbreviation the Info panel and tab strip use: HOME with a
+    // USERPROFILE fallback, separators normalized, case folded (#544).
+    let shortened = crate::ui::path_display::abbreviate_home(&text).into_owned();
     if shortened.chars().count() <= PICKER_PATH_MAX {
         return shortened;
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -19,6 +19,7 @@ pub mod machine_mirror;
 pub mod palette;
 pub mod pane;
 pub mod pane_drag;
+pub mod path_display;
 pub mod pending_pane;
 pub mod perf;
 pub mod prefill;

--- a/src/ui/path_display.rs
+++ b/src/ui/path_display.rs
@@ -9,10 +9,11 @@
 //! reports `C:/Users/x/…` while `USERPROFILE` is `C:\Users\x` (#544).
 //!
 //! The comparison below normalizes both sides to `/` and folds case before
-//! comparing, so every spelling of the same directory shortens. What is
-//! returned keeps the path's own spelling — only the matched home prefix is
-//! swapped for `~` — because the rest of the string is what a copy or a
-//! tooltip shows, and it should read the way the pane wrote it.
+//! comparing, so every spelling of the same directory shortens. What comes
+//! back is for reading only — a `~`-rooted path is spelled the way `~` paths
+//! are spelled everywhere, with `/`. Nothing feeds it back to an API: the
+//! Info panel's Copy Path and Reveal both carry the untouched `PathBuf`, and
+//! the tab strip and picker only ever draw it.
 
 use std::borrow::Cow;
 
@@ -20,38 +21,11 @@ use std::borrow::Cow;
 ///
 /// `USERPROFILE` is the fallback rather than the only source on Windows so
 /// the MSYS/Git-Bash environments that do export `HOME` keep working, and
-/// the two agree in every case that matters. In tests the process env is
-/// shared with neighbours that legitimately read the real home (ssh_connect
-/// writes a key into it), so the home is injected rather than mutated.
-fn home_dir() -> Option<std::path::PathBuf> {
-    #[cfg(test)]
-    if let Some(home) = test_home() {
-        return home;
-    }
+/// the two agree in every case that matters.
+fn home_dir() -> Option<std::ffi::OsString> {
     std::env::var_os("HOME")
         .filter(|h| !h.is_empty())
         .or_else(|| std::env::var_os("USERPROFILE").filter(|h| !h.is_empty()))
-        .map(std::path::PathBuf::from)
-}
-
-/// The home a test has pinned, shared by `home_dir` and `set_test_home`.
-/// `Some(None)` means "no home" — a test for the unset case still needs the
-/// override, or it would read the machine's real one.
-#[cfg(test)]
-fn test_home_slot() -> &'static std::sync::Mutex<Option<Option<std::path::PathBuf>>> {
-    use std::sync::{Mutex, OnceLock};
-    static HOME: OnceLock<Mutex<Option<Option<std::path::PathBuf>>>> = OnceLock::new();
-    HOME.get_or_init(|| Mutex::new(None))
-}
-
-#[cfg(test)]
-fn test_home() -> Option<Option<std::path::PathBuf>> {
-    test_home_slot().lock().unwrap().clone()
-}
-
-#[cfg(test)]
-fn set_test_home(home: Option<std::path::PathBuf>) {
-    *test_home_slot().lock().unwrap() = Some(home);
 }
 
 /// `/`-spelled, case-folded, trailing separators dropped — the form two
@@ -77,8 +51,15 @@ pub(crate) fn abbreviate_home(path: &str) -> Cow<'_, str> {
     let Some(home) = home_dir() else {
         return Cow::Borrowed(path);
     };
-    let home = home.to_string_lossy();
-    let home_norm = normalized(&home);
+    abbreviate_under(path, &home.to_string_lossy())
+}
+
+/// `abbreviate_home` with the home handed in rather than read from the
+/// environment, so the tests below pin one without touching a process-global
+/// the rest of the binary is also reading (`ui::home`'s own test sets `HOME`
+/// and expects to see it, and everything runs in one process).
+fn abbreviate_under<'a>(path: &'a str, home: &str) -> Cow<'a, str> {
+    let home_norm = normalized(home);
     if home_norm.is_empty() {
         return Cow::Borrowed(path);
     }
@@ -107,45 +88,42 @@ pub(crate) fn abbreviate_home(path: &str) -> Cow<'_, str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
-
-    // The pinned home is process-global, so the tests that set it serialize
-    // on one lock — a neighbour pinning a different home mid-assertion is the
-    // only way these can lie. Tests elsewhere that read the *real* home
-    // (ssh_connect writes a key into it) are untouched: they never call
-    // set_test_home, and home_dir only consults the slot once a test set it.
-    fn home_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
-    }
 
     #[test]
     fn a_path_under_home_shortens_to_tilde() {
-        let _g = home_lock();
-        set_test_home(Some(std::path::PathBuf::from("/home/xa")));
-        assert_eq!(abbreviate_home("/home/xa"), "~");
-        assert_eq!(abbreviate_home("/home/xa/work"), "~/work");
-        assert_eq!(abbreviate_home("/home/xavier"), "/home/xavier");
-        assert_eq!(abbreviate_home("/var/tmp"), "/var/tmp");
+        assert_eq!(abbreviate_under("/home/xa", "/home/xa"), "~");
+        assert_eq!(abbreviate_under("/home/xa/work", "/home/xa"), "~/work");
+        // A home recorded with its trailing separator matches the same paths,
+        // and the slice that follows it is found in the *normalized* string,
+        // so the two spellings cannot disagree about where the cut is.
+        assert_eq!(abbreviate_under("/home/xa/work", "/home/xa/"), "~/work");
+        // A longer name that merely starts with home is not under it.
+        assert_eq!(abbreviate_under("/home/xavier", "/home/xa"), "/home/xavier");
+        assert_eq!(abbreviate_under("/var/tmp", "/home/xa"), "/var/tmp");
+        // A home the environment reports as empty leaves every path alone,
+        // rather than turning `/` into `~`.
+        assert_eq!(abbreviate_under("/var/tmp", ""), "/var/tmp");
+        assert_eq!(abbreviate_under("/var/tmp", "/"), "/var/tmp");
     }
 
     #[test]
     fn separators_and_case_do_not_change_what_counts_as_home() {
         // The Windows miss: USERPROFILE spells `C:\Users\xa`, a PowerShell
         // pane reports `C:/Users/xa/…`, and neither matched the other.
-        let _g = home_lock();
-        set_test_home(Some(std::path::PathBuf::from("C:\\Users\\xa")));
-        assert_eq!(abbreviate_home("C:/Users/xa/work"), "~/work");
-        assert_eq!(abbreviate_home("c:\\Users\\XA\\work"), "~/work");
-        assert_eq!(abbreviate_home("C:\\Users\\xa"), "~");
+        let home = "C:\\Users\\xa";
+        assert_eq!(abbreviate_under("C:/Users/xa/work", home), "~/work");
+        assert_eq!(abbreviate_under("c:\\Users\\XA\\work", home), "~/work");
+        assert_eq!(abbreviate_under("C:\\Users\\xa", home), "~");
         // The remainder is re-spelled with `/`, case untouched.
-        assert_eq!(abbreviate_home("C:/Users/xa/Mix\\ed"), "~/Mix/ed");
+        assert_eq!(abbreviate_under("C:/Users/xa/Mix\\ed", home), "~/Mix/ed");
     }
 
     #[test]
-    fn without_a_home_the_path_stands_as_spelled() {
-        let _g = home_lock();
-        set_test_home(None);
-        assert_eq!(abbreviate_home("/any/where"), "/any/where");
+    fn a_non_ascii_component_is_sliced_on_a_character_boundary() {
+        // The cut is taken from the normalized string; `replace` and the
+        // ASCII case fold both preserve byte length, so a multi-byte
+        // component before or after the home prefix cannot move it.
+        assert_eq!(abbreviate_under("/home/日本/work", "/home/日本"), "~/work");
+        assert_eq!(abbreviate_under("/home/xa/日本語", "/home/xa"), "~/日本語");
     }
 }

--- a/src/ui/path_display.rs
+++ b/src/ui/path_display.rs
@@ -1,0 +1,151 @@
+//! The one place a path is shortened to start from `~`.
+//!
+//! Three rows shorten a path for display — the Info panel's cwd, the tab
+//! strip's title, the home picker's recent list — and all three used to spell
+//! the check their own way: read `HOME`, compare byte prefixes. On Windows
+//! that missed twice over. `HOME` is often unset there (the variable is
+//! `USERPROFILE`), and even a set home never matched a pane cwd that spells
+//! itself with the other separator or different case — a PowerShell pane
+//! reports `C:/Users/x/…` while `USERPROFILE` is `C:\Users\x` (#544).
+//!
+//! The comparison below normalizes both sides to `/` and folds case before
+//! comparing, so every spelling of the same directory shortens. What is
+//! returned keeps the path's own spelling — only the matched home prefix is
+//! swapped for `~` — because the rest of the string is what a copy or a
+//! tooltip shows, and it should read the way the pane wrote it.
+
+use std::borrow::Cow;
+
+/// The directory `~` stands for, or `None` when this machine won't say.
+///
+/// `USERPROFILE` is the fallback rather than the only source on Windows so
+/// the MSYS/Git-Bash environments that do export `HOME` keep working, and
+/// the two agree in every case that matters. In tests the process env is
+/// shared with neighbours that legitimately read the real home (ssh_connect
+/// writes a key into it), so the home is injected rather than mutated.
+fn home_dir() -> Option<std::path::PathBuf> {
+    #[cfg(test)]
+    if let Some(home) = test_home() {
+        return home;
+    }
+    std::env::var_os("HOME")
+        .filter(|h| !h.is_empty())
+        .or_else(|| std::env::var_os("USERPROFILE").filter(|h| !h.is_empty()))
+        .map(std::path::PathBuf::from)
+}
+
+/// The home a test has pinned, shared by `home_dir` and `set_test_home`.
+/// `Some(None)` means "no home" — a test for the unset case still needs the
+/// override, or it would read the machine's real one.
+#[cfg(test)]
+fn test_home_slot() -> &'static std::sync::Mutex<Option<Option<std::path::PathBuf>>> {
+    use std::sync::{Mutex, OnceLock};
+    static HOME: OnceLock<Mutex<Option<Option<std::path::PathBuf>>>> = OnceLock::new();
+    HOME.get_or_init(|| Mutex::new(None))
+}
+
+#[cfg(test)]
+fn test_home() -> Option<Option<std::path::PathBuf>> {
+    test_home_slot().lock().unwrap().clone()
+}
+
+#[cfg(test)]
+fn set_test_home(home: Option<std::path::PathBuf>) {
+    *test_home_slot().lock().unwrap() = Some(home);
+}
+
+/// `/`-spelled, case-folded, trailing separators dropped — the form two
+/// paths are compared in, never the form either is shown in. Case folding is
+/// ASCII-only: drive letters and the ASCII half of real paths are where
+/// Windows case instability actually lives, and a full Unicode fold would
+/// fold a Unix filename that happened to differ only in case into a match it
+/// is not.
+fn normalized(s: &str) -> String {
+    s.replace('\\', "/")
+        .trim_end_matches('/')
+        .to_ascii_lowercase()
+}
+
+/// Shortens `path` to start from `~` when it is (inside) the home directory.
+///
+/// The `~` replaces the home prefix and the remainder is re-spelled with
+/// `/` separators (a `~\work` hybrid reads as a root the path never had),
+/// but its case and component spelling are the path's own. A path that is
+/// exactly home shortens to `~`, and one whose next character is not a
+/// separator (`/home/xavier` under `/home/xa`) does not match at all.
+pub(crate) fn abbreviate_home(path: &str) -> Cow<'_, str> {
+    let Some(home) = home_dir() else {
+        return Cow::Borrowed(path);
+    };
+    let home = home.to_string_lossy();
+    let home_norm = normalized(&home);
+    if home_norm.is_empty() {
+        return Cow::Borrowed(path);
+    }
+    let path_norm = normalized(path);
+    if path_norm == home_norm {
+        return Cow::Owned("~".to_string());
+    }
+    if !path_norm.starts_with(&home_norm) {
+        return Cow::Borrowed(path);
+    }
+    // The byte after the home prefix has to be a separator. Where it sits in
+    // the *original* string is derived from the normalized one rather than
+    // from `home.len()`: a trailing-separator difference (`C:\Users\xa\`
+    // recorded as home) makes the two lengths disagree, and slicing by the
+    // wrong one can split a UTF-8 boundary. Separator and case substitutions
+    // preserve byte length, so the boundary found in the normalized string is
+    // the boundary in the original. The remainder is re-spelled with `/`:
+    // `~\work` reads as a root the path never had.
+    let boundary = home_norm.len();
+    if !path_norm[boundary..].starts_with('/') {
+        return Cow::Borrowed(path);
+    }
+    Cow::Owned(format!("~/{}", path[boundary + 1..].replace('\\', "/")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    // The pinned home is process-global, so the tests that set it serialize
+    // on one lock — a neighbour pinning a different home mid-assertion is the
+    // only way these can lie. Tests elsewhere that read the *real* home
+    // (ssh_connect writes a key into it) are untouched: they never call
+    // set_test_home, and home_dir only consults the slot once a test set it.
+    fn home_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    #[test]
+    fn a_path_under_home_shortens_to_tilde() {
+        let _g = home_lock();
+        set_test_home(Some(std::path::PathBuf::from("/home/xa")));
+        assert_eq!(abbreviate_home("/home/xa"), "~");
+        assert_eq!(abbreviate_home("/home/xa/work"), "~/work");
+        assert_eq!(abbreviate_home("/home/xavier"), "/home/xavier");
+        assert_eq!(abbreviate_home("/var/tmp"), "/var/tmp");
+    }
+
+    #[test]
+    fn separators_and_case_do_not_change_what_counts_as_home() {
+        // The Windows miss: USERPROFILE spells `C:\Users\xa`, a PowerShell
+        // pane reports `C:/Users/xa/…`, and neither matched the other.
+        let _g = home_lock();
+        set_test_home(Some(std::path::PathBuf::from("C:\\Users\\xa")));
+        assert_eq!(abbreviate_home("C:/Users/xa/work"), "~/work");
+        assert_eq!(abbreviate_home("c:\\Users\\XA\\work"), "~/work");
+        assert_eq!(abbreviate_home("C:\\Users\\xa"), "~");
+        // The remainder is re-spelled with `/`, case untouched.
+        assert_eq!(abbreviate_home("C:/Users/xa/Mix\\ed"), "~/Mix/ed");
+    }
+
+    #[test]
+    fn without_a_home_the_path_stands_as_spelled() {
+        let _g = home_lock();
+        set_test_home(None);
+        assert_eq!(abbreviate_home("/any/where"), "/any/where");
+    }
+}

--- a/src/ui/right_panel.rs
+++ b/src/ui/right_panel.rs
@@ -625,6 +625,11 @@ impl Tty7App {
         // off in both places rather than in one of them.
         let mut diff_target: Option<(crate::ui::host_ops::HostId, PathBuf)> = None;
         let mut git: Option<crate::terminal::git_status::GitStatus> = None;
+        // The agent row's name and status, read off one leaf (see below).
+        let mut agent_row: Option<(
+            crate::core::cli_agent::CLIAgent,
+            Option<crate::core::cli_agent::AgentStatus>,
+        )> = None;
 
         if let Some(tab) = self.tabs.get(self.active) {
             if let Some(leaf) = tab.detail_pane(window, cx) {
@@ -667,6 +672,24 @@ impl Tty7App {
                     forwards_pane = Some(view.pane_id);
                 }
                 git = view.git_status(cx);
+                // Name and status come from the *same* leaf: the detail pane's
+                // own agent when it has one, the tab-level aggregate when it
+                // does not (so the row holds while focus sits on a plain
+                // shell). Pairing `tab.agent` with `tab.agent_status` could
+                // splice one pane's name onto another pane's status — a row no
+                // leaf ever had — because the two resolve independently
+                // (#543). Read here, where `view` is in scope; pushed beside
+                // the other rows below.
+                agent_row = match view.agent() {
+                    Some(agent) => {
+                        let status = view
+                            .agent_session()
+                            .map(|s| s.status)
+                            .unwrap_or(crate::core::cli_agent::AgentStatus::Idle);
+                        Some((agent, Some(status)))
+                    }
+                    None => tab.agent(cx).map(|agent| (agent, tab.agent_status(cx))),
+                };
             }
             // Read off the same pane the rows above describe, rather than off
             // `Tab::git_status`, which resolves a split tab to its *first* leaf
@@ -691,9 +714,9 @@ impl Tty7App {
                     reveal: None,
                 });
             }
-            if let Some(agent) = tab.agent(cx) {
+            // Name and status were read off one leaf above; push the row.
+            if let Some((agent, status)) = agent_row {
                 let name = agent.display_name();
-                let status = tab.agent_status(cx);
                 rows.push(InfoRow {
                     label: t(L10nKey::PanelAgent),
                     value: InfoValue::Agent {
@@ -1419,7 +1442,14 @@ fn agent_status_label(status: crate::core::cli_agent::AgentStatus) -> &'static s
 /// Splits a path into everything-but-the-last-segment and the last segment,
 /// so a row can shrink the first and keep the second.
 fn split_path_leaf(s: &str) -> (String, String) {
-    match s.rfind('/') {
+    // The larger of the two separator positions, not cfg-gated by platform:
+    // the Info panel shows remote paths too, so a Windows build describes
+    // Unix paths and vice versa — and a mixed-spelling path (`C:\Users\dev/
+    // project`, which agent-reported cwds arrive as) still cuts at its true
+    // leaf (#544). A Unix filename containing a literal `\` loses a shorter
+    // leaf; head + leaf still rejoins exactly, so the cost is decorative.
+    let leaf_at = s.rfind('/').max(s.rfind('\\'));
+    match leaf_at {
         // Keep the separator with the head: "~/a/b/" + "c" rejoins exactly.
         Some(i) if i + 1 < s.len() => (s[..=i].to_string(), s[i + 1..].to_string()),
         _ => (String::new(), s.to_string()),
@@ -1427,11 +1457,7 @@ fn split_path_leaf(s: &str) -> (String, String) {
 }
 
 fn compact_path(path: &std::path::Path) -> String {
-    let s = path.to_string_lossy().to_string();
-    match std::env::var("HOME") {
-        Ok(home) if !home.is_empty() && s.starts_with(&home) => s.replacen(&home, "~", 1),
-        _ => s,
-    }
+    crate::ui::path_display::abbreviate_home(&path.to_string_lossy()).into_owned()
 }
 
 #[cfg(test)]
@@ -1526,6 +1552,9 @@ mod tests {
             "/",
             "relative",
             "",
+            "C:\\Users\\dev\\project",
+            "C:\\Users\\dev/project",
+            "\\\\server\\share\\dir",
         ] {
             let (head, leaf) = split_path_leaf(p);
             assert_eq!(format!("{head}{leaf}"), p, "rejoining {p:?}");
@@ -1542,5 +1571,35 @@ mod tests {
         // Root is one segment with nothing before it.
         let (head, leaf) = split_path_leaf("/");
         assert_eq!((head.as_str(), leaf.as_str()), ("", "/"));
+    }
+
+    #[test]
+    fn the_leaf_survives_windows_and_mixed_spellings() {
+        // Backslash-native, the shape an agent-reported cwd arrives in.
+        let (head, leaf) = split_path_leaf("C:\\Users\\dev\\project");
+        assert_eq!(
+            (head.as_str(), leaf.as_str()),
+            ("C:\\Users\\dev\\", "project")
+        );
+        // Mixed separators cut at the *last* one of either kind.
+        let (head, leaf) = split_path_leaf("C:\\Users\\dev/project");
+        assert_eq!(
+            (head.as_str(), leaf.as_str()),
+            ("C:\\Users\\dev/", "project")
+        );
+        let (head, leaf) = split_path_leaf("C:/Users/dev\\project");
+        assert_eq!(
+            (head.as_str(), leaf.as_str()),
+            ("C:/Users/dev\\", "project")
+        );
+        // A drive root has no leaf to keep.
+        let (head, leaf) = split_path_leaf("C:\\");
+        assert_eq!((head.as_str(), leaf.as_str()), ("", "C:\\"));
+        // A UNC path splits at its last component, head keeping the share.
+        let (head, leaf) = split_path_leaf("\\\\server\\share\\dir");
+        assert_eq!(
+            (head.as_str(), leaf.as_str()),
+            ("\\\\server\\share\\", "dir")
+        );
     }
 }

--- a/src/ui/right_panel.rs
+++ b/src/ui/right_panel.rs
@@ -628,7 +628,7 @@ impl Tty7App {
         // The agent row's name and status, read off one leaf (see below).
         let mut agent_row: Option<(
             crate::core::cli_agent::CLIAgent,
-            Option<crate::core::cli_agent::AgentStatus>,
+            crate::core::cli_agent::AgentStatus,
         )> = None;
 
         if let Some(tab) = self.tabs.get(self.active) {
@@ -673,22 +673,24 @@ impl Tty7App {
                 }
                 git = view.git_status(cx);
                 // Name and status come from the *same* leaf: the detail pane's
-                // own agent when it has one, the tab-level aggregate when it
-                // does not (so the row holds while focus sits on a plain
-                // shell). Pairing `tab.agent` with `tab.agent_status` could
-                // splice one pane's name onto another pane's status — a row no
-                // leaf ever had — because the two resolve independently
-                // (#543). Read here, where `view` is in scope; pushed beside
-                // the other rows below.
+                // own agent when it has one, and otherwise the tab's most
+                // urgent agent leaf — which still holds the row while focus
+                // sits on a plain shell, and still colours its dot the way the
+                // tab strip's badge does, but names the pane it took the
+                // status from. Pairing `tab.agent` with `tab.agent_status`
+                // would splice one pane's name onto another pane's status — a
+                // row no leaf ever had — because the two resolve
+                // independently (#543). Read here, where `view` is in scope;
+                // pushed beside the other rows below.
                 agent_row = match view.agent() {
                     Some(agent) => {
                         let status = view
                             .agent_session()
                             .map(|s| s.status)
                             .unwrap_or(crate::core::cli_agent::AgentStatus::Idle);
-                        Some((agent, Some(status)))
+                        Some((agent, status))
                     }
-                    None => tab.agent(cx).map(|agent| (agent, tab.agent_status(cx))),
+                    None => tab.agent_row(cx),
                 };
             }
             // Read off the same pane the rows above describe, rather than off
@@ -720,12 +722,9 @@ impl Tty7App {
                 rows.push(InfoRow {
                     label: t(L10nKey::PanelAgent),
                     value: InfoValue::Agent {
-                        text: match status {
-                            Some(s) => format!("{name} · {}", agent_status_label(s)),
-                            None => name.to_string(),
-                        },
-                        dot: status.and_then(|s| s.dot_rgb()),
-                        hollow: status == Some(crate::core::cli_agent::AgentStatus::Waiting),
+                        text: format!("{name} · {}", agent_status_label(status)),
+                        dot: status.dot_rgb(),
+                        hollow: status == crate::core::cli_agent::AgentStatus::Waiting,
                     },
                     copy: None,
                     reveal: None,

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -57,21 +57,10 @@ pub(crate) fn abbreviate_home(path: &str) -> std::borrow::Cow<'_, str> {
     if path.starts_with('~') {
         return Cow::Borrowed(path);
     }
-    let Some(home) = std::env::var_os("HOME") else {
-        return Cow::Borrowed(path);
-    };
-    let home = home.to_string_lossy();
-    let home = home.trim_end_matches('/');
-    if home.is_empty() {
-        return Cow::Borrowed(path);
-    }
-    if path == home {
-        return Cow::Owned("~".to_string());
-    }
-    match path.strip_prefix(home) {
-        Some(rest) if rest.starts_with('/') => Cow::Owned(format!("~{rest}")),
-        _ => Cow::Borrowed(path),
-    }
+    // The shared comparison: HOME with a USERPROFILE fallback, separators
+    // normalized, case folded — a Windows pane whose cwd spells itself
+    // `C:/Users/…` shortens under a `C:\Users\…` home too (#544).
+    crate::ui::path_display::abbreviate_home(path)
 }
 
 /// The separator a path spells itself with. A path carrying a single `\` is


### PR DESCRIPTION
## 修复内容(#543 + #544,Info 面板同组)

### #543 —— agent 行同源取值

按复核的"更稳形态"实现,而不是我最初提的"只读 detail_pane":

- 焦点叶子(detail_pane)有 agent 时,name 与 status 都取自**这个叶子**(`view.agent()` + `view.agent_session().status`)。
- 焦点叶子没有 agent 时**回落**到 tab 级聚合(`tab.agent(cx)` + `tab.agent_status(cx)`),行保留、不随焦点闪现——与 tab strip / 侧栏 / switcher 的 tab 级徽标不冲突。
- 两条支路 name 与 status 必出自同一个 leaf,不再拼出"一个 pane 的名 + 另一个 pane 的状态"。

按复核三点更正:正文与提交信息里**去掉了"(#531 新代码)"**(`git log -S` 核过,该拼接在 b7196ae 的 `-` 侧,403cfd4 初版即有);不再援引那条设计原则(其原文恰是为惰性文字的不一致开脱);认可这是 P3 一致性打磨。

### #544 —— Windows 路径头部省略

按复核的方案 1 + 方案 2 修正版:

- **`split_path_leaf`** 取 `rfind('/')` 与 `rfind('\\')` 的较大者,不按 `cfg!(windows)` 门控(Info 面板要显示远端 Unix 路径)。混合分隔符、盘根、UNC 都有用例钉住——UNC 切出 head=`\\server\share\`、leaf=`dir`,已如复核所说固定。
- **`compact_path` / `tab_strip::abbreviate_home` / `home::display_path` 三处同一个 HOME-only 缺陷**收进一个共享 helper `ui::path_display::abbreviate_home`:先归一化分隔符、ASCII 大小写折叠再比较,`HOME` 读不到回落 `USERPROFILE`——正是复核指出"只做 USERPROFILE 回落会因 `C:/` vs `C:\` 仍不匹配"的修法。缩短后余段重排为 `/` 分隔(`~\work` 读成一个根本不存在的根)。

按复核更正:正文**缩窄了触发范围**(无 agent 的 PowerShell pane 首个提示符后 cwd 是正斜杠、头部省略正常;真正踩雷的是 agent pane / cmd / 关 shell integration / seed cwd);去掉了"(#531 新代码)"归因(`split_path_leaf` 出自 52219a1、`compact_path` 出自 403cfd4,b7196ae 仅搬运)。

### 测试

`path_display` 3 个用例(归一化 / 大小写 / 无 home)+ `split_path_leaf` 新增 backslash、混合、盘根、UNC 用例及 rejoin 不变量扩展。全量 `cargo test --locked --bin tty7-app` 1246/1246 绿,`cargo fmt --check` 干净。

closes #543
closes #544
