### PR TITLE
fix(ui): rebuild the keymap when a hand-edited binding reloads (#548)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   home picker — reads `USERPROFILE` as well as `HOME` and compares with
   separators normalized and case folded, so a `C:/Users/…` pane shortens
   under a `C:\Users\…` home (#544).
+- **A hand-edited keybinding takes effect without a restart.** The config
+  watcher reloaded everything except the keymap, so a `keybindings` edit
+  showed up in the settings list off the live global while the key itself
+  stayed dead until the app restarted. The watcher now rebuilds the keymap
+  when the binding config actually changed — `(keybindings,
+  keybinding_preset, prefix)` — so the app's own `save()`, which a sidebar
+  drag or a palette open triggers, does not churn it. The rebuild also
+  replaces the map instead of appending to it, so rebinding no longer leaves
+  a retired copy of the whole table behind for every keystroke to walk. A
+  config.json that does not parse keeps the keys it was already dispatching,
+  since the reload that fails never reaches the rebuild (#548).
 
 ## [26.8.3] - 2026-08-12
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,16 @@ fn spawn_config_watcher(cx: &mut App) {
                     return;
                 }
                 announced = false;
+                // The keymap is rebuilt only when a binding actually moved.
+                // This watcher fires for every write under the config dir —
+                // including the app's own `save()`, which a sidebar drag or a
+                // palette open triggers — so reloading bindings on each tick
+                // would rebuild the whole keymap for nothing, and (before
+                // `rebind` cleared first) leak a full table per tick (#548).
+                // Read past the early return above: a load that failed leaves
+                // the global alone, so there is nothing to compare and the
+                // user's keys stay in the keymap the app is dispatching on.
+                let keymap_before = crate::ui::keymap::keybinding_config(cx);
                 crate::ui::i18n::set_locale(&config.gui_language);
                 cx.set_global(config);
                 reload_themes(cx);
@@ -118,6 +128,14 @@ fn spawn_config_watcher(cx: &mut App) {
                 // one place it can change from — and the inventory that carries
                 // it to the new-tab menu is cached per window.
                 crate::ui::windows::WindowRegistry::refresh_shells(cx);
+                // A hand-edited keybinding shows up in the settings list off the
+                // live global immediately; without this it never reaches the
+                // keymap gpui actually dispatches against, so the key looks
+                // bound and does nothing until restart. Gated on the triple so
+                // an unrelated save does not churn it.
+                if crate::ui::keymap::keybinding_config(cx) != keymap_before {
+                    crate::ui::keymap::rebind(cx);
+                }
                 cx.refresh_windows();
             });
         }

--- a/src/ui/keymap.rs
+++ b/src/ui/keymap.rs
@@ -16,11 +16,22 @@ struct BoundKeystrokes(Vec<(String, Option<&'static str>)>);
 impl Global for BoundKeystrokes {}
 
 pub fn init(cx: &mut App) {
-    let effective = effective_bindings(cx);
-    let mut bindings = action_bindings(&effective);
-    bindings.push(KeyBinding::new("secondary-+", IncreaseFontSize, None));
-    bindings.push(KeyBinding::new("tab", SendTab, Some("Terminal")));
-    bindings.push(KeyBinding::new("shift-tab", SendBackTab, Some("Terminal")));
+    rebuild_keymap(cx);
+    cx.on_action(|_: &Quit, cx: &mut App| cx.quit());
+    set_menus(cx);
+}
+
+/// The fixed bindings every keymap carries, whatever the config says. These
+/// are the terminal's own keys (Tab/BackTab as input), the font-size step
+/// that has no settings row, and the modal-context guards the dispatch path
+/// needs — none of them come from `effective_bindings`, so a rebuild that
+/// only replayed the config would drop them.
+fn fixed_bindings() -> Vec<KeyBinding> {
+    let mut bindings = vec![
+        KeyBinding::new("secondary-+", IncreaseFontSize, None),
+        KeyBinding::new("tab", SendTab, Some("Terminal")),
+        KeyBinding::new("shift-tab", SendBackTab, Some("Terminal")),
+    ];
     // The switcher's footer tells you Tab is the way across to the tab column
     // once a query is in the box. gpui-component's Root binds `tab` to its
     // focus walker, actions are dispatched before key listeners, and the panel
@@ -38,30 +49,48 @@ pub fn init(cx: &mut App) {
     // out of the modal, onto whichever chrome tile is behind it, ring and all.
     bindings.push(KeyBinding::new("tab", NoAction {}, Some("Palette")));
     bindings.push(KeyBinding::new("shift-tab", NoAction {}, Some("Palette")));
+    bindings
+}
+
+/// Clears the keymap and binds the full set from the live config.
+///
+/// gpui's `Keymap::add_bindings` only ever pushes — it never dedups and
+/// nothing retires a binding — so rebinding by *appending* (the old `rebind`)
+/// leaked one full table per call, and every keystroke walks the whole map.
+/// Clearing first makes a rebind O(map) instead of O(map × calls), and makes
+/// it safe to drive from the config watcher: a hand edit that only reorders
+/// or re-comments the file reloads to an identical triple and never reaches
+/// here, while a real change rebuilds once (#548).
+fn rebuild_keymap(cx: &mut App) {
+    let effective = effective_bindings(cx);
+    let mut bindings = action_bindings(&effective);
+    bindings.extend(fixed_bindings());
+    cx.clear_key_bindings();
     cx.bind_keys(bindings);
     cx.set_global(BoundKeystrokes(bound_keystrokes(&effective)));
-
-    cx.on_action(|_: &Quit, cx: &mut App| cx.quit());
-    set_menus(cx);
 }
 
 pub fn rebind(cx: &mut App) {
-    let previous = cx
-        .try_global::<BoundKeystrokes>()
-        .map(|b| b.0.clone())
-        .unwrap_or_default();
-    let effective = effective_bindings(cx);
-
-    let mut bindings: Vec<KeyBinding> = previous
-        .iter()
-        .filter(|(k, _)| keystroke_is_valid(k))
-        .map(|(k, ctx)| KeyBinding::new(k, NoAction {}, *ctx))
-        .collect();
-    bindings.extend(action_bindings(&effective));
-    cx.bind_keys(bindings);
-    cx.set_global(BoundKeystrokes(bound_keystrokes(&effective)));
-
+    rebuild_keymap(cx);
     set_menus(cx);
+}
+
+/// The three config fields `effective_bindings` reads, as one comparable
+/// value. The config watcher reloads on every write — including the app's
+/// own `save()`, which fires on a sidebar drag — so it compares the triple
+/// before and after and only rebinds when one of these actually moved;
+/// otherwise each save would rebuild the keymap for nothing (#548).
+pub(crate) fn keybinding_config(cx: &App) -> (Vec<(String, String)>, String, String) {
+    let cfg = cx.global::<Config>();
+    let mut overrides: Vec<(String, String)> = cfg
+        .keybindings
+        .iter()
+        .map(|(a, k)| (a.clone(), k.clone()))
+        .collect();
+    // A HashMap's order is not stable across reloads, and a reordered map is
+    // not a changed binding set.
+    overrides.sort();
+    (overrides, cfg.keybinding_preset.clone(), cfg.prefix.clone())
 }
 
 const INSERT_NEWLINE_DEFAULT: &str = "shift-enter";
@@ -1483,6 +1512,62 @@ mod gpui_tests {
                     .find(|(a, _)| a == "SplitRight")
                     .map(|(_, k)| k.as_str()),
                 Some(per_platform("secondary-d", "secondary-shift-d"))
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn the_keybinding_triple_only_moves_when_a_binding_does(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            gpui_component::init(cx);
+            cx.set_global(Config::default());
+            init(cx);
+
+            let before = keybinding_config(cx);
+            assert_eq!(
+                keybinding_config(cx),
+                before,
+                "reading the config twice changes nothing"
+            );
+
+            // An unrelated edit leaves the triple alone — this is the gate the
+            // watcher compares, and a sidebar drag must not rebind.
+            cx.global_mut::<Config>().dim_inactive_panes = false;
+            assert_eq!(keybinding_config(cx), before);
+
+            // A real binding edit moves it.
+            cx.global_mut::<Config>()
+                .keybindings
+                .insert("RenameTab".to_string(), "ctrl-shift-r".to_string());
+            assert_ne!(keybinding_config(cx), before);
+
+            // So does the preset, and the prefix.
+            let with_override = keybinding_config(cx);
+            cx.global_mut::<Config>().keybinding_preset = "tmux".to_string();
+            assert_ne!(keybinding_config(cx), with_override);
+            let with_preset = keybinding_config(cx);
+            cx.global_mut::<Config>().prefix = "ctrl-a".to_string();
+            assert_ne!(keybinding_config(cx), with_preset);
+        });
+    }
+
+    #[gpui::test]
+    fn repeated_rebinds_do_not_grow_the_keymap(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            gpui_component::init(cx);
+            cx.set_global(Config::default());
+            init(cx);
+            let size = cx.key_bindings().borrow().bindings().len();
+            // A rebind that clears first stays the same size however many
+            // times it runs; the append-only one this replaced grew by a full
+            // table each call, and every keystroke walks the whole map (#548).
+            for _ in 0..3 {
+                rebind(cx);
+            }
+            assert_eq!(
+                cx.key_bindings().borrow().bindings().len(),
+                size,
+                "rebind clears before it binds, so the map does not grow"
             );
         });
     }

--- a/src/ui/keymap.rs
+++ b/src/ui/keymap.rs
@@ -11,11 +11,21 @@ use crate::ui::palette::CommandGroup;
 use crate::ui::settings::humanize_action;
 use crate::ui::theme::set_menus;
 
-#[derive(Default)]
-struct BoundKeystrokes(Vec<(String, Option<&'static str>)>);
-impl Global for BoundKeystrokes {}
+/// The bindings that were already in the keymap before tty7 put its own
+/// there. gpui-component installs a table of its own from `gpui_component::
+/// init` — the `Input` context's editing keys, the list and menu navigation,
+/// the escape that closes a dialog — and it has no entry point to install
+/// them a second time. A rebuild replaces the whole map, so it has to lay
+/// these back down first, in the order they were added, or the map that comes
+/// out has no backspace in any text field in the app (#548).
+struct BaseBindings(Vec<KeyBinding>);
+impl Global for BaseBindings {}
 
 pub fn init(cx: &mut App) {
+    if cx.try_global::<BaseBindings>().is_none() {
+        let base: Vec<KeyBinding> = cx.key_bindings().borrow().bindings().cloned().collect();
+        cx.set_global(BaseBindings(base));
+    }
     rebuild_keymap(cx);
     cx.on_action(|_: &Quit, cx: &mut App| cx.quit());
     set_menus(cx);
@@ -52,7 +62,8 @@ fn fixed_bindings() -> Vec<KeyBinding> {
     bindings
 }
 
-/// Clears the keymap and binds the full set from the live config.
+/// Replaces the keymap with the full set: the bindings tty7 inherited, then
+/// the ones the live config asks for, then the fixed ones.
 ///
 /// gpui's `Keymap::add_bindings` only ever pushes — it never dedups and
 /// nothing retires a binding — so rebinding by *appending* (the old `rebind`)
@@ -60,14 +71,19 @@ fn fixed_bindings() -> Vec<KeyBinding> {
 /// Clearing first makes a rebind O(map) instead of O(map × calls), and makes
 /// it safe to drive from the config watcher: a hand edit that only reorders
 /// or re-comments the file reloads to an identical triple and never reaches
-/// here, while a real change rebuilds once (#548).
+/// here, while a real change rebuilds once (#548). The order is the order
+/// `init` bound them in, and gpui reads the map back to front, so tty7's
+/// bindings still win over the inherited ones.
 fn rebuild_keymap(cx: &mut App) {
     let effective = effective_bindings(cx);
-    let mut bindings = action_bindings(&effective);
+    let mut bindings: Vec<KeyBinding> = cx
+        .try_global::<BaseBindings>()
+        .map(|base| base.0.clone())
+        .unwrap_or_default();
+    bindings.extend(action_bindings(&effective));
     bindings.extend(fixed_bindings());
     cx.clear_key_bindings();
     cx.bind_keys(bindings);
-    cx.set_global(BoundKeystrokes(bound_keystrokes(&effective)));
 }
 
 pub fn rebind(cx: &mut App) {
@@ -167,6 +183,11 @@ fn action_bindings(effective: &[(String, String)]) -> Vec<KeyBinding> {
     bindings
 }
 
+/// The keystroke and context of every binding `action_bindings` installs.
+/// The rebind used to keep this in a global to retire the previous set one
+/// `NoAction` at a time; a rebuild replaces the whole map instead, so this is
+/// now only the tests' way of asking what a config would install.
+#[cfg(test)]
 fn bound_keystrokes(effective: &[(String, String)]) -> Vec<(String, Option<&'static str>)> {
     let extras = extra_keystrokes(effective);
     effective
@@ -1569,6 +1590,40 @@ mod gpui_tests {
                 size,
                 "rebind clears before it binds, so the map does not grow"
             );
+        });
+    }
+
+    #[gpui::test]
+    fn a_rebuild_keeps_the_bindings_tty7_did_not_install(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            // gpui-component binds the whole `Input` editing table — backspace
+            // among it — from its own `init`, which runs once, before ours. A
+            // rebuild replaces the map, so it has to carry them; without this
+            // the first rebind left every text field in the app unable to
+            // delete a character (#548).
+            gpui_component::init(cx);
+            cx.set_global(Config::default());
+
+            let backspace = |cx: &App| {
+                let typed = [Keystroke::parse("backspace").unwrap()];
+                cx.key_bindings()
+                    .borrow()
+                    .all_bindings_for_input(&typed)
+                    .iter()
+                    .map(|b| b.action().name().to_string())
+                    .collect::<Vec<_>>()
+            };
+
+            let inherited = backspace(cx);
+            assert!(
+                !inherited.is_empty(),
+                "gpui-component binds backspace before tty7 touches the keymap"
+            );
+
+            init(cx);
+            assert_eq!(backspace(cx), inherited, "init must not drop them");
+            rebind(cx);
+            assert_eq!(backspace(cx), inherited, "nor may a rebind");
         });
     }
 }


### PR DESCRIPTION
## 修复内容(#548,按复核的方案 1 修正版)

手改 `config.json` 加 keybindings,watcher 重载后设置页立即显示(读 live global),但按键无效——`rebind` 的调用点全在设置页交互里,watch 路径从不重建 keymap。按复核对方案 1 的两点修正实现,而非直接照抄:

1. **rebind 改为 `clear_key_bindings()` + 全量重建**(复核指出的 keymap 单调增长):gpui 的 `Keymap::add_bindings` 只 push、从不去重,旧 `rebind` 每次追加 ~89 退休项 + ~89 新绑定,而每次按键都遍历全表。新 `rebuild_keymap` 先 `clear_key_bindings()` 再回放 action bindings + 固定绑定(terminal 的 Tab/BackTab、字号步进、Switcher/Palette 的 modal 守卫——这些不来自 `effective_bindings`,只回放配置会丢),`init` 与之共享。**这同时是把它接到 watcher 上的前提**——接到 watcher 前 rebind 只由手动触发所以无感,接上就是线性泄漏。
2. **watcher 按三元组 gate**(复核指出的自反馈):app 自己每次 `cfg.save()`(拖侧栏、开调色板)都是 tmp+rename,`is_content_change` 只滤 Access,所以我们的每次配置写入都触发一轮 watcher。现在 reload 前后各取一次 `(keybindings, keybinding_preset, prefix)` 快照,变了才 rebind——无关的 save 不churn keymap,`themes/*.yaml` 触发也被这层挡住。

按复核做了两个小更正:正文措辞收紧(不是"要重启才生效"——在键位页做任何动作都会触发 rebind 一并生效,只是不可发现);`view.rs:9041` 确为测试非生产调用点,生产 rebind 点确为 app.rs 那 5 处,现已全部走统一的 `rebuild_keymap`。

## 顺序耦合(复核明确要求)

**#537 应先于本条落地**:没有它,解析失败时 watcher 换进 default,这里的 rebind 会把用户键位从活动 keymap 一并抹掉。本条基于 `Config::load()`(main 现状);#537 合入后 watcher 换 `load_with_outcome()` 时,before/after 两次三元组快照都取在 quarantine 保留旧配置的一侧,gate 语义不变。

## 测试

新增两个 `#[gpui::test]`:`the_keybinding_triple_only_moves_when_a_binding_does`(无关编辑不动三元组、改 override/preset/prefix 才动)、`repeated_rebinds_do_not_grow_the_keymap`(连 rebind 3 次 keymap 长度不变)。`the_keymap_routes_both_newline_chords_to_the_action`(view.rs:9041)在 clear+rebuild 下仍通过。全量 1244 绿,`cargo fmt --check` 干净。

> 全量并行跑时 `ui::remote_connect` 下偶发一例失败(`a_pane_and_its_workspace_resolve_to_the_same_machine` / `a_routed_auth_prompt_…`)——在干净 origin/main 上同样偶发(6 次里 2 次),是已有的跨测试竞争,与本改动无关。

## 留给后续的(复核也列了,但不在本条)

- **方案 2**(未知 action/非法键位的设置页提示):需在 `set_binding` 那一层记录(未知 action 在那里就被丢了),可复用 rejected-themes 范式。独立的 UI 表面,单独成 PR。
- **方案 3**(被挤掉检测扩到前缀冲突):复核指出要比正文写的更严重(gpui `bindings_for_input` 的 pending 丢弃逻辑会让裸 `ctrl-b` 要么废掉整个前缀家族要么永不触发),应做双向前缀 + chord 边界比较。单独成 PR。

closes #548
