### PR TITLE
fix(settings): put the custom controls on the keyboard, and keep Tab inside (#552)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,6 +247,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   used to fail into a logfile line and nothing else; the click now raises the
   same kind of toast a failed image upload does, naming the path and the
   error. (#542)
+- **Settings' custom controls joined the keyboard** — the keybinding page's
+  record chips are focusable now, and a focused chip starts capture on
+  Enter/Space (gpui turns that key-up into a click on its own; a guard keeps a
+  re-triggered chip from wiping the chord it just gathered). Every segmented
+  control — bell mode, cursor shape, scrollback buckets, presets and the rest —
+  can be tabbed to and stepped with the arrow keys, clamped at the ends, and
+  the focused group wears the accent border the page already used for its
+  recording state. And the overlay itself now traps focus: Tab used to walk
+  straight out of Settings onto the workspace chrome behind it and paint focus
+  rings there, because the panel occluded the mouse but never contained the
+  focus walk. (#552)
 
 ## [26.8.3] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,17 +247,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   used to fail into a logfile line and nothing else; the click now raises the
   same kind of toast a failed image upload does, naming the path and the
   error. (#542)
-- **Settings' custom controls joined the keyboard** — the keybinding page's
-  record chips are focusable now, and a focused chip starts capture on
-  Enter/Space (gpui turns that key-up into a click on its own; a guard keeps a
-  re-triggered chip from wiping the chord it just gathered). Every segmented
-  control — bell mode, cursor shape, scrollback buckets, presets and the rest —
-  can be tabbed to and stepped with the arrow keys, clamped at the ends, and
-  the focused group wears the accent border the page already used for its
-  recording state. And the overlay itself now traps focus: Tab used to walk
-  straight out of Settings onto the workspace chrome behind it and paint focus
-  rings there, because the panel occluded the mouse but never contained the
-  focus walk. (#552)
+- **Settings' custom controls joined the keyboard** — the page was reachable
+  with a mouse and with nothing else. The section list, every segmented control
+  (bell mode, cursor shape, scrollback buckets, presets and the rest), the font
+  size and line height steppers, every switch, and — on a page whose whole
+  audience is people at a keyboard — the keybinding recorder were all bare
+  click targets with no focus handle between them, so Tab stepped over all five
+  and no key could press any of them. Tab now stops on each, Enter or Space
+  presses what it finds, and the section list and the segmented groups also
+  step with the arrow keys, clamped at the ends rather than wrapping: these are
+  pickers, not dials. A focused control wears a ring, drawn beside it rather
+  than in the layout so arriving at one cannot nudge the row it sits in. The
+  recorder starts capture on the key down, and re-entering capture for the row
+  already capturing is a no-op — otherwise recording a bare Enter or Space
+  would re-press the chip and throw away the chord it had just gathered. And
+  the overlay itself now traps focus: Tab used to walk straight out of Settings
+  onto the workspace chrome behind it and paint focus rings there, because the
+  panel occluded the mouse but never contained the focus walk. The pickers the
+  diff overlay and the forwards editor build out of the same code are left as
+  they were — mouse-only, and deaf to the arrow keys. (#552)
 
 ## [26.8.3] - 2026-08-12
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -5720,6 +5720,18 @@ impl Tty7App {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Re-entering capture for the row that is already capturing must not
+        // wipe the chords gathered so far. It is reachable by accident now
+        // that the chip is focusable (#552): gpui turns an Enter/Space key-up
+        // on a focused element into a click, and the recorder below only
+        // intercepts key-downs — so binding a bare Enter or Space would
+        // restart capture and throw the just-recorded chord away.
+        if self
+            .active_settings()
+            .is_some_and(|s| s.recording.as_ref().is_some_and(|r| r.action == action))
+        {
+            return;
+        }
         let this = cx.weak_entity();
         let intercept = cx.intercept_keystrokes(move |ev, _window, cx| {
             let keystroke = ev.keystroke.clone();
@@ -8450,6 +8462,28 @@ mod keybinding_gpui_tests {
         vcx.simulate_keystrokes("secondary-b");
         vcx.simulate_keystrokes("x");
         wait_for_binding(&mut vcx, "CloseActiveTab", "secondary-b x");
+    }
+
+    /// #552 made the chip focusable, and gpui clicks a focused element on an
+    /// Enter/Space key-up while the recorder only intercepts key-downs — so
+    /// binding a bare Enter or Space would re-enter capture and wipe the chord
+    /// it just gathered. Re-entry for the row already capturing is a no-op.
+    #[gpui::test]
+    fn reentering_capture_for_the_same_row_keeps_the_captured_chord(cx: &mut TestAppContext) {
+        let (app, mut vcx) = harness(cx);
+        begin_capture(&app, &mut vcx, "NewTab");
+        vcx.simulate_keystrokes("secondary-shift-n");
+        // The chord sits uncommitted for the commit delay; re-entering capture
+        // while it does must leave the recording exactly as it was.
+        app.update_in(&mut vcx, |app, window, cx| {
+            app.start_recording_key("NewTab".to_string(), window, cx);
+        });
+        let chords = app.update_in(&mut vcx, |app, _, _| {
+            app.active_settings()
+                .and_then(|s| s.recording.as_ref().map(|r| r.chords.len()))
+        });
+        assert_eq!(chords, Some(1), "re-entry wiped the captured chord");
+        wait_for_binding(&mut vcx, "NewTab", "secondary-shift-n");
     }
 
     #[gpui::test]

--- a/src/ui/diff_overlay.rs
+++ b/src/ui/diff_overlay.rs
@@ -2229,6 +2229,32 @@ mod overlay_gpui_tests {
         });
     }
 
+    /// #552 put a focus stop and the arrow keys on the settings page's
+    /// segmented groups. This picker is built by the same code and asked for
+    /// neither: Tab must not stop on it, and an unmodified arrow anywhere in
+    /// the overlay must not swap the view out from under the reader.
+    #[gpui::test]
+    fn the_view_picker_stays_off_the_keyboard(cx: &mut TestAppContext) {
+        let (app, mut vcx, _pane) = test_window::harness_with_tabs(cx, 1);
+        show(&app, &mut vcx, DiffSource::Worktree);
+        vcx.simulate_resize(gpui::size(gpui::px(1100.), gpui::px(800.)));
+        vcx.run_until_parked();
+
+        let was = vcx.update(|_, cx| view_mode(cx));
+        // Walk the window's own tab-stop map rather than pressing Tab: with a
+        // terminal pane focused, `tab` is bound to SendTab and never reaches
+        // the focus walker, which would make this pass for the wrong reason.
+        for _ in 0..80 {
+            vcx.update(|window, cx| window.focus_next(cx));
+            vcx.simulate_keystrokes("right");
+        }
+        assert_eq!(
+            vcx.update(|_, cx| view_mode(cx)),
+            was,
+            "the overlay's view picker joined the tab order behind the page's back",
+        );
+    }
+
     /// Every header branch, every row renderer, once each. A missing icon, an
     /// unset global or a panicking helper shows up here rather than the first
     /// time somebody opens a commit.

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -3,6 +3,7 @@ use gpui::{
     Image, ImageFormat, KeyDownEvent, MouseButton, SharedString, Stateful, Subscription, Window,
     div, img, prelude::*, px, relative, rgb,
 };
+use gpui_component::FocusTrapElement as _;
 use gpui_component::InteractiveElementExt as _;
 use gpui_component::button::{Button, ButtonVariants as _};
 use gpui_component::color_picker::{ColorPicker, ColorPickerState};
@@ -1431,12 +1432,215 @@ fn seed_input(
     })
 }
 
+/// The keybinding page's record chip, a component for the same reason as
+/// `SegmentedControl`: its render needs the `Window` to mint a stable focus
+/// handle and to know whether to draw the ring. Once focused, gpui itself
+/// turns an Enter/Space key-up into a click on the element (its keyboard-click
+/// path), so "press Enter to record" takes nothing beyond the handle (#552).
+struct KeyCaptureChip {
+    app: gpui::WeakEntity<Tty7App>,
+    action: String,
+    is_recording: bool,
+    captured: AnyElement,
+    kbd_bg: gpui::Hsla,
+    accent: gpui::Hsla,
+}
+
+impl gpui::RenderOnce for KeyCaptureChip {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let Self {
+            app,
+            action,
+            is_recording,
+            captured,
+            kbd_bg,
+            accent,
+        } = self;
+        let focus = window
+            .use_keyed_state(format!("kb-{action}"), cx, |_, cx| cx.focus_handle())
+            .read(cx)
+            .clone();
+        let focused = focus.is_focused(window);
+        div()
+            .id(SharedString::from(format!("kb-{action}")))
+            .track_focus(&focus)
+            .flex()
+            .items_center()
+            .gap_2()
+            .px_2()
+            .py_1()
+            .rounded_md()
+            .cursor_pointer()
+            // One accent outline for "this chip is live", whether the keyboard
+            // put it there or a recording is in flight.
+            .when(is_recording || focused, |d| {
+                d.border_1().border_color(accent)
+            })
+            .hover(|d| d.bg(kbd_bg))
+            .child(captured)
+            .on_click(move |_, window, cx| {
+                app.update(cx, |this, cx| {
+                    this.start_recording_key(action.clone(), window, cx)
+                })
+                .ok();
+            })
+    }
+}
+
+/// Arrow-key stepping for a focused segmented group (#552). Up pairs with Left
+/// and Down with Right, the way every toolkit's radio groups read them, and
+/// the walk clamps at the ends instead of wrapping — a segmented is a picker,
+/// not a dial. Modified chords are left alone for whoever else wants them.
+///
+/// `buckets` counts the cells that carry a value, so the trailing "Custom (N)"
+/// cell of a [`Tty7App::segmented_valued`] is never stepped onto — there is no
+/// value behind it to write (#550). `selected` is `None` exactly when that cell
+/// holds the highlight, and since it is painted after the last bucket, a step
+/// left off it lands on that bucket and a step right has nowhere to go.
+fn segmented_arrow_step(
+    key: &str,
+    modifiers: &gpui::Modifiers,
+    selected: Option<usize>,
+    buckets: usize,
+) -> Option<usize> {
+    if modifiers.control || modifiers.alt || modifiers.shift || modifiers.platform {
+        return None;
+    }
+    let Some(selected) = selected else {
+        return match key {
+            "left" | "up" => buckets.checked_sub(1),
+            _ => None,
+        };
+    };
+    match key {
+        "left" | "up" => selected.checked_sub(1),
+        "right" | "down" => (selected + 1 < buckets).then_some(selected + 1),
+        _ => None,
+    }
+}
+
+/// The settings segmented control as a component rather than a bare row of
+/// click targets. Building it as a `RenderOnce` is what gets its render the
+/// `Window` the section renderers never see — and the window is what a stable
+/// focus handle (`use_keyed_state`, the same way gpui-component's `Button`
+/// gets one) and the focus query for the ring need (#552).
+struct SegmentedControl {
+    app: gpui::WeakEntity<Tty7App>,
+    sf: presets::Surface,
+    id: SharedString,
+    options: Vec<String>,
+    selected: Option<usize>,
+    custom_label: Option<String>,
+    on_pick: std::rc::Rc<dyn Fn(&mut Tty7App, usize, &mut Window, &mut Context<Tty7App>)>,
+}
+
+impl gpui::RenderOnce for SegmentedControl {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let SegmentedControl {
+            app,
+            sf,
+            id,
+            options,
+            selected,
+            custom_label,
+            on_pick,
+        } = self;
+        let theme = cx.theme();
+        let (border, accent) = (theme.border, theme.accent);
+        let buckets = options.len();
+        // The display cells: the fixed buckets, then the custom cell if the
+        // live value matched none of them.
+        let cells: Vec<(String, Option<usize>)> = options
+            .into_iter()
+            .enumerate()
+            .map(|(i, label)| (label, Some(i)))
+            .chain(custom_label.map(|label| (label, None)))
+            .collect();
+        let count = cells.len();
+        // A focus handle of its own is what puts the group in the tab order.
+        // Keyed by the control id so a re-render finds the same handle and
+        // focus survives it; the focused group wears the accent border the
+        // key-capture chip already uses for its recording state.
+        let focus = window
+            .use_keyed_state(id.clone(), cx, |_, cx| cx.focus_handle())
+            .read(cx)
+            .clone();
+        let focused = focus.is_focused(window);
+        h_flex()
+            .id(gpui::ElementId::Name(id.clone()))
+            .track_focus(&focus)
+            .h(px(24.))
+            .rounded(rounding::TRACK_RADIUS)
+            .border_1()
+            .border_color(if focused { accent } else { border })
+            .bg(gpui::rgb(sf.base))
+            .overflow_hidden()
+            .on_key_down({
+                let app = app.clone();
+                let on_pick = on_pick.clone();
+                move |ev: &KeyDownEvent, window, cx| {
+                    let Some(next) = segmented_arrow_step(
+                        &ev.keystroke.key,
+                        &ev.keystroke.modifiers,
+                        selected,
+                        buckets,
+                    ) else {
+                        return;
+                    };
+                    cx.stop_propagation();
+                    app.update(cx, |this, cx| on_pick(this, next, window, cx))
+                        .ok();
+                }
+            })
+            .children(cells.into_iter().enumerate().map(|(i, (label, bucket))| {
+                // A bucket is highlighted only on an exact match, and the
+                // custom cell (`bucket == None`) exactly when no bucket was.
+                let active = bucket == selected;
+                let on_pick = on_pick.clone();
+                let app = app.clone();
+                let corners =
+                    rounding::segment_corners(i, count, rounding::TRACK_RADIUS, rounding::HAIRLINE);
+                let cell = h_flex()
+                    .id(gpui::ElementId::NamedInteger(id.clone(), i as u64))
+                    .items_center()
+                    .justify_center()
+                    .h_full()
+                    .px_2p5()
+                    .text_sm()
+                    .rounded_corners(corners)
+                    .when(i > 0, |s| s.border_l_1().border_color(border))
+                    .when(active, |s| {
+                        s.bg(gpui::rgb(sf.selected))
+                            .text_color(gpui::rgb(sf.text_selected))
+                            .font_weight(FontWeight::MEDIUM)
+                    })
+                    .when(!active, |s| {
+                        s.text_color(gpui::rgb(sf.text_resting))
+                            .hover(|h| h.bg(gpui::rgb(sf.hover)))
+                    })
+                    .child(label);
+                match bucket {
+                    Some(ix) => cell
+                        .cursor_pointer()
+                        .active(|s| s.bg(gpui::rgb(sf.pressed)))
+                        .on_click(move |_, window, cx| {
+                            app.update(cx, |this, cx| on_pick(this, ix, window, cx))
+                                .ok();
+                        }),
+                    // The custom cell names the current value; it is not a
+                    // button, because there is no bucket value to write.
+                    None => cell,
+                }
+            }))
+    }
+}
+
 impl Tty7App {
     pub(crate) fn render_settings(
         &self,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> impl IntoElement + use<> {
+    ) -> AnyElement {
         let theme = cx.theme();
         // The settings panel covers the whole window. Paint it on an opaque
         // surface so the workspace translucency (window opacity / backdrop
@@ -1459,7 +1663,7 @@ impl Tty7App {
                 s.theme_panel_open,
                 s.search.clone(),
             ),
-            None => return div(),
+            None => return div().into_any_element(),
         };
         let query = search.read(cx).value().trim().to_lowercase();
         let show_theme_panel = theme_panel_open && section == SettingsSection::Appearance;
@@ -1699,7 +1903,13 @@ impl Tty7App {
             .flex_row()
             .bg(background)
             .text_color(foreground)
-            .track_focus(&focus_handle)
+            // Occluding stops the mouse, but only the trap stops Tab: without
+            // it the focus walk steps straight out of the overlay onto the
+            // workspace chrome behind it and paints focus rings there (#552) —
+            // the same leak the Palette guards against in `keymap.rs`. The
+            // container tracks the page's own focus handle, so the explicit
+            // `track_focus` the Escape handler relied on comes with it.
+            .focus_trap("settings", &focus_handle)
             // Escape peels one layer at a time. With the theme picker open that
             // layer is the picker: closing the whole page instead threw away a
             // panel the user had opened a moment ago, and left them to walk
@@ -1779,7 +1989,7 @@ impl Tty7App {
         if let Some((start, label)) = prof {
             crate::ui::perf::record(label, start.elapsed());
         }
-        root
+        root.into_any_element()
     }
 
     /// The column widths this render settled on. `settings_columns` is pure and
@@ -2023,65 +2233,16 @@ impl Tty7App {
         cx: &mut Context<Self>,
         on_pick: impl Fn(&mut Self, usize, &mut Window, &mut Context<Self>) + 'static,
     ) -> AnyElement {
-        let border = cx.theme().border;
-        let id: SharedString = id.into();
-        let on_pick = std::rc::Rc::new(on_pick);
-        let count = options.len() + usize::from(custom_label.is_some());
-        // The display cells: the fixed buckets, then the custom cell if the
-        // live value matched none of them.
-        let cells: Vec<(String, Option<usize>)> = options
-            .iter()
-            .enumerate()
-            .map(|(i, l)| (l.to_string(), Some(i)))
-            .chain(custom_label.map(|l| (l, None)))
-            .collect();
-        h_flex()
-            .id(gpui::ElementId::Name(id.clone()))
-            .h(px(24.))
-            .rounded(rounding::TRACK_RADIUS)
-            .border_1()
-            .border_color(border)
-            .bg(gpui::rgb(sf.base))
-            .overflow_hidden()
-            .children(cells.into_iter().enumerate().map(|(i, (label, bucket))| {
-                // A bucket is highlighted only on an exact match, and the
-                // custom cell (`bucket == None`) exactly when no bucket was.
-                let active = bucket == selected;
-                let on_pick = on_pick.clone();
-                let corners =
-                    rounding::segment_corners(i, count, rounding::TRACK_RADIUS, rounding::HAIRLINE);
-                let cell = h_flex()
-                    .id(gpui::ElementId::NamedInteger(id.clone(), i as u64))
-                    .items_center()
-                    .justify_center()
-                    .h_full()
-                    .px_2p5()
-                    .text_sm()
-                    .rounded_corners(corners)
-                    .when(i > 0, |s| s.border_l_1().border_color(border))
-                    .when(active, |s| {
-                        s.bg(gpui::rgb(sf.selected))
-                            .text_color(gpui::rgb(sf.text_selected))
-                            .font_weight(FontWeight::MEDIUM)
-                    })
-                    .when(!active, |s| {
-                        s.text_color(gpui::rgb(sf.text_resting))
-                            .hover(|h| h.bg(gpui::rgb(sf.hover)))
-                    })
-                    .child(label);
-                match bucket {
-                    Some(ix) => cell
-                        .cursor_pointer()
-                        .active(|s| s.bg(gpui::rgb(sf.pressed)))
-                        .on_click(cx.listener(move |this, _, window, cx| {
-                            on_pick(this, ix, window, cx);
-                        })),
-                    // The custom cell names the current value; it is not a
-                    // button, because there is no bucket value to write.
-                    None => cell,
-                }
-            }))
-            .into_any_element()
+        gpui::Component::new(SegmentedControl {
+            app: cx.entity().downgrade(),
+            sf,
+            id: id.into(),
+            options: options.iter().map(|option| (*option).to_string()).collect(),
+            selected,
+            custom_label,
+            on_pick: std::rc::Rc::new(on_pick),
+        })
+        .into_any_element()
     }
 
     fn render_settings_appearance(&self, cx: &mut Context<Self>) -> AnyElement {
@@ -6513,22 +6674,14 @@ impl Tty7App {
                 keycaps(&key).into_any_element()
             };
 
-            let action_for_click = action.clone();
-            let capture = div()
-                .id(SharedString::from(format!("kb-{action}")))
-                .flex()
-                .items_center()
-                .gap_2()
-                .px_2()
-                .py_1()
-                .rounded_md()
-                .cursor_pointer()
-                .when(is_recording, |d| d.border_1().border_color(accent))
-                .hover(|d| d.bg(kbd_bg))
-                .child(captured)
-                .on_click(cx.listener(move |this, _, window, cx| {
-                    this.start_recording_key(action_for_click.clone(), window, cx)
-                }));
+            let capture = gpui::Component::new(KeyCaptureChip {
+                app: cx.entity().downgrade(),
+                action: action.clone(),
+                is_recording,
+                captured,
+                kbd_bg,
+                accent,
+            });
 
             let action_for_reset = action.clone();
             let right = h_flex()
@@ -7844,6 +7997,27 @@ mod tests {
         assert_eq!(profiles_sharing_endpoint(&cfg, staging_id), 0);
         // A profile that is no longer on the list shares with nobody.
         assert_eq!(profiles_sharing_endpoint(&cfg, Uuid::new_v4()), 0);
+    }
+
+    /// The #552 keyboard contract: arrows step the selection, clamped at the
+    /// ends without wrapping, and a modified chord is never eaten.
+    #[test]
+    fn segmented_arrows_step_and_clamp_without_wrapping() {
+        let plain = gpui::Modifiers::default();
+        assert_eq!(segmented_arrow_step("left", &plain, Some(1), 3), Some(0));
+        assert_eq!(segmented_arrow_step("up", &plain, Some(1), 3), Some(0));
+        assert_eq!(segmented_arrow_step("right", &plain, Some(1), 3), Some(2));
+        assert_eq!(segmented_arrow_step("down", &plain, Some(1), 3), Some(2));
+        // The ends clamp instead of wrapping.
+        assert_eq!(segmented_arrow_step("left", &plain, Some(0), 3), None);
+        assert_eq!(segmented_arrow_step("right", &plain, Some(2), 3), None);
+        // Anything else — letters, Tab, a modified arrow — is not ours.
+        assert_eq!(segmented_arrow_step("tab", &plain, Some(1), 3), None);
+        let ctrl = gpui::Modifiers {
+            control: true,
+            ..Default::default()
+        };
+        assert_eq!(segmented_arrow_step("left", &ctrl, Some(1), 3), None);
     }
 }
 

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -8133,4 +8133,31 @@ mod gpui_tests {
         }
         panic!("Tab never reached the cursor-shape segmented group");
     }
+
+    /// The other half of #552: the overlay occludes the mouse, and the focus
+    /// trap is what keeps Tab from walking out of it onto the chrome behind —
+    /// which would paint a focus ring on a workspace the user cannot see.
+    #[gpui::test]
+    fn tab_never_walks_out_of_the_settings_overlay(cx: &mut TestAppContext) {
+        let (app, mut vcx) = crate::ui::app::test_window::harness(cx);
+        app.update_in(&mut vcx, |app, window, cx| {
+            app.open_settings_section(SettingsSection::Appearance, window, cx);
+        });
+        vcx.simulate_resize(size(px(1100.), px(800.)));
+        vcx.run_until_parked();
+
+        for step in 0..120 {
+            vcx.simulate_keystrokes("tab");
+            let inside = app.update_in(&mut vcx, |app, window, cx| {
+                app.active_settings()
+                    .map(|s| s.focus_handle.contains_focused(window, cx))
+            });
+            assert_eq!(
+                inside,
+                Some(true),
+                "Tab left the settings overlay after {} steps",
+                step + 1,
+            );
+        }
+    }
 }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -1456,10 +1456,14 @@ impl gpui::RenderOnce for KeyCaptureChip {
             kbd_bg,
             accent,
         } = self;
+        // `tab_stop` is what the focus walker looks at: a tracked handle that
+        // never sets it is focusable by click but stepped straight over by Tab.
+        // gpui-component's `Button` sets it the same way, at `track_focus`.
         let focus = window
             .use_keyed_state(format!("kb-{action}"), cx, |_, cx| cx.focus_handle())
             .read(cx)
-            .clone();
+            .clone()
+            .tab_stop(true);
         let focused = focus.is_focused(window);
         div()
             .id(SharedString::from(format!("kb-{action}")))
@@ -1557,14 +1561,17 @@ impl gpui::RenderOnce for SegmentedControl {
             .chain(custom_label.map(|label| (label, None)))
             .collect();
         let count = cells.len();
-        // A focus handle of its own is what puts the group in the tab order.
-        // Keyed by the control id so a re-render finds the same handle and
-        // focus survives it; the focused group wears the accent border the
+        // A focus handle of its own is what puts the group in the tab order —
+        // and `tab_stop`, the way gpui-component's `Button` sets it, is what
+        // makes the walker stop on it rather than step over a merely focusable
+        // element. Keyed by the control id so a re-render finds the same handle
+        // and focus survives it; the focused group wears the accent border the
         // key-capture chip already uses for its recording state.
         let focus = window
             .use_keyed_state(id.clone(), cx, |_, cx| cx.focus_handle())
             .read(cx)
-            .clone();
+            .clone()
+            .tab_stop(true);
         let focused = focus.is_focused(window);
         h_flex()
             .id(gpui::ElementId::Name(id.clone()))
@@ -8019,12 +8026,26 @@ mod tests {
         };
         assert_eq!(segmented_arrow_step("left", &ctrl, Some(1), 3), None);
     }
+
+    /// The custom cell of a valued segmented (#550) holds no value to write, so
+    /// the arrows step off it onto the last bucket and never onto it.
+    #[test]
+    fn segmented_arrows_step_off_the_custom_cell_but_never_onto_it() {
+        let plain = gpui::Modifiers::default();
+        assert_eq!(segmented_arrow_step("left", &plain, None, 3), Some(2));
+        assert_eq!(segmented_arrow_step("up", &plain, None, 3), Some(2));
+        assert_eq!(segmented_arrow_step("right", &plain, None, 3), None);
+        assert_eq!(segmented_arrow_step("down", &plain, None, 3), None);
+        // The last bucket is the end of the walk even when the custom cell is
+        // painted beside it.
+        assert_eq!(segmented_arrow_step("right", &plain, Some(2), 3), None);
+    }
 }
 
 #[cfg(test)]
 mod gpui_tests {
     use super::SettingsSection;
-    use crate::core::config::Config;
+    use crate::core::config::{Config, CursorStyle};
     use crate::core::session::Session;
     use crate::ui::app::Tty7App;
     use gpui::{AppContext as _, Entity, TestAppContext, VisualTestContext, px, size};
@@ -8078,5 +8099,38 @@ mod gpui_tests {
             matches!(section, Some(SettingsSection::Appearance)),
             "the panel should still be on Appearance after two paint passes",
         );
+    }
+
+    /// The #552 contract end to end: a segmented group has to be *reachable*,
+    /// not merely focusable. A handle that is tracked but never marked a tab
+    /// stop is stepped straight over by gpui's focus walker, so this walks the
+    /// page with Tab the way a keyboard user would and lets the arrow key step
+    /// the cursor-shape group once it gets there.
+    #[gpui::test]
+    fn tab_reaches_a_segmented_group_and_an_arrow_steps_it(cx: &mut TestAppContext) {
+        let (app, mut vcx) = crate::ui::app::test_window::harness(cx);
+        app.update_in(&mut vcx, |app, window, cx| {
+            app.open_settings_section(SettingsSection::Appearance, window, cx);
+        });
+        vcx.simulate_resize(size(px(1100.), px(800.)));
+        vcx.run_until_parked();
+
+        let cursor_style =
+            |vcx: &mut VisualTestContext| vcx.update(|_, cx| cx.global::<Config>().cursor_style);
+        assert_eq!(
+            cursor_style(&mut vcx),
+            CursorStyle::Block,
+            "the fixture starts on the first cell of the cursor-shape group",
+        );
+        // One lap of the trapped focus ring is plenty; the page has nothing
+        // like this many stops.
+        for _ in 0..120 {
+            vcx.simulate_keystrokes("tab");
+            vcx.simulate_keystrokes("right");
+            if cursor_style(&mut vcx) == CursorStyle::Bar {
+                return;
+            }
+        }
+        panic!("Tab never reached the cursor-shape segmented group");
     }
 }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -1482,6 +1482,26 @@ impl gpui::RenderOnce for KeyCaptureChip {
             })
             .hover(|d| d.bg(kbd_bg))
             .child(captured)
+            // Enter and Space open capture on the key *down*. gpui would do it
+            // on the key up anyway, through the click path a focused element
+            // gets for free, but a recorder that starts half a keystroke late
+            // is a recorder that can miss the chord the user is already
+            // typing — and the key-up click still arrives, where
+            // `start_recording_key`'s re-entry guard absorbs it.
+            .on_key_down({
+                let app = app.clone();
+                let action = action.clone();
+                move |ev: &KeyDownEvent, window, cx| {
+                    if !crate::ui::theme::is_activation_key(&ev.keystroke) {
+                        return;
+                    }
+                    cx.stop_propagation();
+                    app.update(cx, |this, cx| {
+                        this.start_recording_key(action.clone(), window, cx)
+                    })
+                    .ok();
+                }
+            })
             .on_click(move |_, window, cx| {
                 app.update(cx, |this, cx| {
                     this.start_recording_key(action.clone(), window, cx)
@@ -1523,6 +1543,108 @@ fn segmented_arrow_step(
     }
 }
 
+/// The cell a key press picks on a focused segmented group: the arrows step
+/// the selection, and Enter or Space presses the highlighted cell — the same
+/// thing clicking it does, so the gesture every other control on the page
+/// answers cannot be the one gesture this one ignores. Enter on the custom
+/// cell picks nothing: there is no bucket value behind it to write (#550).
+fn segmented_key_pick(
+    keystroke: &gpui::Keystroke,
+    selected: Option<usize>,
+    buckets: usize,
+) -> Option<usize> {
+    if crate::ui::theme::is_activation_key(keystroke) {
+        return selected;
+    }
+    segmented_arrow_step(&keystroke.key, &keystroke.modifiers, selected, buckets)
+}
+
+/// One end of a settings stepper — the − or the + beside a font size, a UI
+/// font size or a line height. A bare click target until #552: no focus
+/// handle, so no tab stop and no key that could press it, on a page whose
+/// whole audience is people at a keyboard. A component for the same reason as
+/// the chip and the group: only a render with the `Window` in it can mint a
+/// focus handle that survives the next frame.
+struct StepperButton {
+    app: gpui::WeakEntity<Tty7App>,
+    id: &'static str,
+    glyph: &'static str,
+    slot: usize,
+    foreground: gpui::Hsla,
+    border: gpui::Hsla,
+    hover_bg: gpui::Rgba,
+    on_press: std::rc::Rc<dyn Fn(&mut Tty7App, &mut Context<Tty7App>)>,
+}
+
+impl gpui::RenderOnce for StepperButton {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let StepperButton {
+            app,
+            id,
+            glyph,
+            slot,
+            foreground,
+            border,
+            hover_bg,
+            on_press,
+        } = self;
+        let corners =
+            rounding::segment_corners(slot, 3, rounding::TRACK_RADIUS, rounding::HAIRLINE);
+        let focus = window
+            .use_keyed_state(id, cx, |_, cx| cx.focus_handle())
+            .read(cx)
+            .clone()
+            .tab_stop(true);
+        let focused = focus.is_focused(window);
+        h_flex()
+            .id(id)
+            .track_focus(&focus)
+            .items_center()
+            .justify_center()
+            .h_full()
+            .px_2p5()
+            .text_sm()
+            .cursor_pointer()
+            .text_color(foreground)
+            .when(slot > 0, |s| s.border_l_1().border_color(border))
+            .rounded_corners(corners)
+            .hover(|h| h.bg(hover_bg))
+            // The stepper track clips its children, so this one says where the
+            // keyboard is with a wash rather than the ring the page uses
+            // elsewhere: a ring drawn outside these bounds would be cut off by
+            // the track's own `overflow_hidden`.
+            .when(focused, |s| s.bg(cx.theme().ring.opacity(0.28)))
+            .child(glyph)
+            .on_key_down({
+                let app = app.clone();
+                let on_press = on_press.clone();
+                move |ev: &KeyDownEvent, _window, cx| {
+                    if !crate::ui::theme::is_activation_key(&ev.keystroke) {
+                        return;
+                    }
+                    cx.stop_propagation();
+                    app.update(cx, |this, cx| on_press(this, cx)).ok();
+                }
+            })
+            .on_click(move |_, _window, cx| {
+                app.update(cx, |this, cx| on_press(this, cx)).ok();
+            })
+    }
+}
+
+/// Whether a segmented group takes a focus stop of its own.
+///
+/// The settings page wants one on every group it draws (#552). The diff
+/// overlay and the forwards editor build theirs through the same code for a
+/// two-cell picker in a toolbar, and nobody asked for those to enter the tab
+/// order or to start eating unmodified arrow keys — so they stay exactly the
+/// mouse-only control they have always been.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SegmentedKeys {
+    Focusable,
+    MouseOnly,
+}
+
 /// The settings segmented control as a component rather than a bare row of
 /// click targets. Building it as a `RenderOnce` is what gets its render the
 /// `Window` the section renderers never see — and the window is what a stable
@@ -1535,6 +1657,7 @@ struct SegmentedControl {
     options: Vec<String>,
     selected: Option<usize>,
     custom_label: Option<String>,
+    keys: SegmentedKeys,
     on_pick: std::rc::Rc<dyn Fn(&mut Tty7App, usize, &mut Window, &mut Context<Tty7App>)>,
 }
 
@@ -1547,6 +1670,7 @@ impl gpui::RenderOnce for SegmentedControl {
             options,
             selected,
             custom_label,
+            keys,
             on_pick,
         } = self;
         let theme = cx.theme();
@@ -1567,37 +1691,37 @@ impl gpui::RenderOnce for SegmentedControl {
         // element. Keyed by the control id so a re-render finds the same handle
         // and focus survives it; the focused group wears the accent border the
         // key-capture chip already uses for its recording state.
-        let focus = window
-            .use_keyed_state(id.clone(), cx, |_, cx| cx.focus_handle())
-            .read(cx)
-            .clone()
-            .tab_stop(true);
-        let focused = focus.is_focused(window);
+        let focus = (keys == SegmentedKeys::Focusable).then(|| {
+            window
+                .use_keyed_state(id.clone(), cx, |_, cx| cx.focus_handle())
+                .read(cx)
+                .clone()
+                .tab_stop(true)
+        });
+        let focused = focus.as_ref().is_some_and(|focus| focus.is_focused(window));
         h_flex()
             .id(gpui::ElementId::Name(id.clone()))
-            .track_focus(&focus)
+            .when_some(focus, |group, focus| group.track_focus(&focus))
             .h(px(24.))
             .rounded(rounding::TRACK_RADIUS)
             .border_1()
             .border_color(if focused { accent } else { border })
             .bg(gpui::rgb(sf.base))
             .overflow_hidden()
-            .on_key_down({
-                let app = app.clone();
-                let on_pick = on_pick.clone();
-                move |ev: &KeyDownEvent, window, cx| {
-                    let Some(next) = segmented_arrow_step(
-                        &ev.keystroke.key,
-                        &ev.keystroke.modifiers,
-                        selected,
-                        buckets,
-                    ) else {
-                        return;
-                    };
-                    cx.stop_propagation();
-                    app.update(cx, |this, cx| on_pick(this, next, window, cx))
-                        .ok();
-                }
+            .when(keys == SegmentedKeys::Focusable, |group| {
+                group.on_key_down({
+                    let app = app.clone();
+                    let on_pick = on_pick.clone();
+                    move |ev: &KeyDownEvent, window, cx| {
+                        let Some(next) = segmented_key_pick(&ev.keystroke, selected, buckets)
+                        else {
+                            return;
+                        };
+                        cx.stop_propagation();
+                        app.update(cx, |this, cx| on_pick(this, next, window, cx))
+                            .ok();
+                    }
+                })
             })
             .children(cells.into_iter().enumerate().map(|(i, (label, bucket))| {
                 // A bucket is highlighted only on an exact match, and the
@@ -1813,6 +1937,52 @@ impl Tty7App {
                     ),
             )
             .child(nav_body);
+
+        // The section list joins the keyboard as one stop with arrows inside
+        // it, the way a list of choices is walked everywhere else — Tab lands
+        // on the list, Up and Down move the section, and the page follows at
+        // once. Per-item stops would have meant eight, and gpui-component's
+        // `SidebarMenuItem` has no focus handle to give them anyway; the
+        // container is ours to make focusable (#552).
+        let nav_focus = window
+            .use_keyed_state("settings-nav", cx, |_, cx| cx.focus_handle())
+            .read(cx)
+            .clone()
+            .tab_stop(true);
+        let nav_focused = nav_focus.is_focused(window);
+        let sidebar = div()
+            .id("settings-nav")
+            .track_focus(&nav_focus)
+            .relative()
+            .flex_shrink_0()
+            .h_full()
+            .child(sidebar)
+            .when(nav_focused, |nav| {
+                nav.child(crate::ui::theme::focus_ring(px(0.), px(0.), cx))
+            })
+            .on_key_down(cx.listener({
+                let nav_focus = nav_focus.clone();
+                move |this, ev: &KeyDownEvent, window, cx| {
+                    // Only when the list itself holds the focus. The search box
+                    // sits inside this container, and the Up, Down and Enter a
+                    // reader presses in a text field are the text field's.
+                    if !nav_focus.is_focused(window) {
+                        return;
+                    }
+                    let sections = SettingsSection::ALL;
+                    let at = sections.iter().position(|s| *s == section).unwrap_or(0);
+                    // A section list is the same kind of picker a segmented
+                    // group is, so it answers the same keys by the same rules:
+                    // clamped at the ends, and Enter presses what is already
+                    // highlighted.
+                    let Some(next) = segmented_key_pick(&ev.keystroke, Some(at), sections.len())
+                    else {
+                        return;
+                    };
+                    cx.stop_propagation();
+                    this.select_settings_section(sections[next], cx);
+                }
+            }));
 
         let content = match section {
             SettingsSection::Appearance => self.render_settings_appearance(cx),
@@ -2189,9 +2359,21 @@ impl Tty7App {
         on_pick: impl Fn(&mut Self, usize, &mut Window, &mut Context<Self>) + 'static,
     ) -> AnyElement {
         let sf = cx.global::<presets::Surfaces>().window;
-        self.segmented_on(sf, id, options, selected, cx, on_pick)
+        self.segmented_full(
+            sf,
+            id,
+            options,
+            Some(selected),
+            None,
+            SegmentedKeys::Focusable,
+            cx,
+            on_pick,
+        )
     }
 
+    /// The same control on a caller's own surface. This is the one the diff
+    /// overlay and the forwards editor reach for, and they get the mouse-only
+    /// group they have always had — see [`SegmentedKeys`].
     pub(crate) fn segmented_on(
         &self,
         sf: presets::Surface,
@@ -2201,7 +2383,16 @@ impl Tty7App {
         cx: &mut Context<Self>,
         on_pick: impl Fn(&mut Self, usize, &mut Window, &mut Context<Self>) + 'static,
     ) -> AnyElement {
-        self.segmented_full(sf, id, options, Some(selected), None, cx, on_pick)
+        self.segmented_full(
+            sf,
+            id,
+            options,
+            Some(selected),
+            None,
+            SegmentedKeys::MouseOnly,
+            cx,
+            on_pick,
+        )
     }
 
     /// A segmented control over a fixed set of values, used where the config
@@ -2227,9 +2418,19 @@ impl Tty7App {
         on_pick: impl Fn(&mut Self, usize, &mut Window, &mut Context<Self>) + 'static,
     ) -> AnyElement {
         let sf = cx.global::<presets::Surfaces>().window;
-        self.segmented_full(sf, id, options, selected, custom_label, cx, on_pick)
+        self.segmented_full(
+            sf,
+            id,
+            options,
+            selected,
+            custom_label,
+            SegmentedKeys::Focusable,
+            cx,
+            on_pick,
+        )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn segmented_full(
         &self,
         sf: presets::Surface,
@@ -2237,6 +2438,7 @@ impl Tty7App {
         options: &[&str],
         selected: Option<usize>,
         custom_label: Option<String>,
+        keys: SegmentedKeys,
         cx: &mut Context<Self>,
         on_pick: impl Fn(&mut Self, usize, &mut Window, &mut Context<Self>) + 'static,
     ) -> AnyElement {
@@ -2247,6 +2449,7 @@ impl Tty7App {
             options: options.iter().map(|option| (*option).to_string()).collect(),
             selected,
             custom_label,
+            keys,
             on_pick: std::rc::Rc::new(on_pick),
         })
         .into_any_element()
@@ -2280,62 +2483,64 @@ impl Tty7App {
                     .any(|(tag, value)| tag == "liga" && *value != 0)
         });
 
-        let step = move |id: &'static str, glyph: &'static str, slot: usize| {
-            let corners =
-                rounding::segment_corners(slot, 3, rounding::TRACK_RADIUS, rounding::HAIRLINE);
-            h_flex()
-                .id(id)
-                .items_center()
-                .justify_center()
-                .h_full()
-                .px_2p5()
-                .text_sm()
-                .cursor_pointer()
-                .text_color(foreground)
-                .when(slot > 0, |s| s.border_l_1().border_color(border))
-                .rounded_corners(corners)
-                .hover(|h| h.bg(hover_bg))
-                .child(glyph)
+        let app = cx.entity().downgrade();
+        // The press is handed over once and drives both ways in: the click and
+        // the Enter or Space that a focused step now answers.
+        let step = move |id: &'static str,
+                         glyph: &'static str,
+                         slot: usize,
+                         on_press: fn(&mut Self, &mut Context<Self>)| {
+            gpui::Component::new(StepperButton {
+                app: app.clone(),
+                id,
+                glyph,
+                slot,
+                foreground,
+                border,
+                hover_bg,
+                on_press: std::rc::Rc::new(on_press),
+            })
+            .into_any_element()
         };
         let control_h = px(24.);
-        let stepper_row =
-            move |dec: Stateful<Div>, value: String, inc: Stateful<Div>, reset: Button| {
-                h_flex()
-                    .items_center()
-                    .gap_3()
-                    .child(reset)
-                    .child(
-                        h_flex()
-                            .items_center()
-                            .h(control_h)
-                            .rounded(rounding::TRACK_RADIUS)
-                            .bg(stepper_bg)
-                            .border_1()
-                            .border_color(border)
-                            .overflow_hidden()
-                            .child(dec)
-                            .child(
-                                div()
-                                    .min_w(px(40.))
-                                    .border_l_1()
-                                    .border_color(border)
-                                    .py_1()
-                                    .text_center()
-                                    .text_sm()
-                                    .text_color(foreground)
-                                    .child(value),
-                            )
-                            .child(inc),
-                    )
-                    .into_any_element()
-            };
+        let stepper_row = move |dec: AnyElement, value: String, inc: AnyElement, reset: Button| {
+            h_flex()
+                .items_center()
+                .gap_3()
+                .child(reset)
+                .child(
+                    h_flex()
+                        .items_center()
+                        .h(control_h)
+                        .rounded(rounding::TRACK_RADIUS)
+                        .bg(stepper_bg)
+                        .border_1()
+                        .border_color(border)
+                        .overflow_hidden()
+                        .child(dec)
+                        .child(
+                            div()
+                                .min_w(px(40.))
+                                .border_l_1()
+                                .border_color(border)
+                                .py_1()
+                                .text_center()
+                                .text_sm()
+                                .text_color(foreground)
+                                .child(value),
+                        )
+                        .child(inc),
+                )
+                .into_any_element()
+        };
         let font_size_control = stepper_row(
-            step("font-dec", "−", 0).on_click(
-                cx.listener(|this, _, _w, cx| this.change_font_size(-FONT_SIZE_STEP, cx)),
-            ),
+            step("font-dec", "−", 0, |this, cx| {
+                this.change_font_size(-FONT_SIZE_STEP, cx)
+            }),
             format!("{:.0}", font_size),
-            step("font-inc", "+", 2)
-                .on_click(cx.listener(|this, _, _w, cx| this.change_font_size(FONT_SIZE_STEP, cx))),
+            step("font-inc", "+", 2, |this, cx| {
+                this.change_font_size(FONT_SIZE_STEP, cx)
+            }),
             Button::new("font-reset")
                 .label(t(L10nKey::Reset))
                 .ghost()
@@ -2345,13 +2550,13 @@ impl Tty7App {
 
         let ui_font_size = self.ui_font_size(cx);
         let ui_font_size_control = stepper_row(
-            step("ui-font-dec", "−", 0).on_click(
-                cx.listener(|this, _, _w, cx| this.change_ui_font_size(-UI_FONT_SIZE_STEP, cx)),
-            ),
+            step("ui-font-dec", "−", 0, |this, cx| {
+                this.change_ui_font_size(-UI_FONT_SIZE_STEP, cx)
+            }),
             format!("{ui_font_size:.0}"),
-            step("ui-font-inc", "+", 2).on_click(
-                cx.listener(|this, _, _w, cx| this.change_ui_font_size(UI_FONT_SIZE_STEP, cx)),
-            ),
+            step("ui-font-inc", "+", 2, |this, cx| {
+                this.change_ui_font_size(UI_FONT_SIZE_STEP, cx)
+            }),
             Button::new("ui-font-reset")
                 .label(t(L10nKey::Reset))
                 .ghost()
@@ -2361,13 +2566,13 @@ impl Tty7App {
 
         let line_height = self.line_height;
         let line_height_control = stepper_row(
-            step("lh-dec", "−", 0).on_click(
-                cx.listener(|this, _, _w, cx| this.change_line_height(-LINE_HEIGHT_STEP, cx)),
-            ),
+            step("lh-dec", "−", 0, |this, cx| {
+                this.change_line_height(-LINE_HEIGHT_STEP, cx)
+            }),
             format!("{:.2}", line_height),
-            step("lh-inc", "+", 2).on_click(
-                cx.listener(|this, _, _w, cx| this.change_line_height(LINE_HEIGHT_STEP, cx)),
-            ),
+            step("lh-inc", "+", 2, |this, cx| {
+                this.change_line_height(LINE_HEIGHT_STEP, cx)
+            }),
             Button::new("lh-reset")
                 .label(t(L10nKey::Reset))
                 .ghost()
@@ -8027,6 +8232,20 @@ mod tests {
         assert_eq!(segmented_arrow_step("left", &ctrl, Some(1), 3), None);
     }
 
+    /// Enter and Space press the highlighted cell, exactly as clicking it
+    /// does. The custom cell has nothing to press.
+    #[test]
+    fn enter_and_space_press_the_highlighted_cell() {
+        let key = |k: &str| gpui::Keystroke::parse(k).unwrap();
+        assert_eq!(segmented_key_pick(&key("enter"), Some(1), 3), Some(1));
+        assert_eq!(segmented_key_pick(&key("space"), Some(2), 3), Some(2));
+        assert_eq!(segmented_key_pick(&key("enter"), None, 3), None);
+        // A chord with a modifier in it belongs to whoever bound it.
+        assert_eq!(segmented_key_pick(&key("ctrl-enter"), Some(1), 3), None);
+        // And the arrows still step through the same door.
+        assert_eq!(segmented_key_pick(&key("right"), Some(1), 3), Some(2));
+    }
+
     /// The custom cell of a valued segmented (#550) holds no value to write, so
     /// the arrows step off it onto the last bucket and never onto it.
     #[test]
@@ -8159,5 +8378,103 @@ mod gpui_tests {
                 step + 1,
             );
         }
+    }
+
+    /// Walk the page with Tab, pressing Space at every stop, until `found`
+    /// says the control under test answered. Space is the safe probe: gpui
+    /// only fires its own keyboard-click on the key *up*, which no test
+    /// dispatches, so nothing but the page's own key-down handlers can react.
+    /// The first Tab moves off the search box before any key is typed into it.
+    fn walk_pressing(
+        app: &Entity<Tty7App>,
+        vcx: &mut VisualTestContext,
+        key: &str,
+        what: &str,
+        mut found: impl FnMut(&Entity<Tty7App>, &mut VisualTestContext) -> bool,
+    ) {
+        for _ in 0..160 {
+            vcx.simulate_keystrokes("tab");
+            vcx.simulate_keystrokes(key);
+            if found(app, vcx) {
+                return;
+            }
+        }
+        panic!("Tab never reached {what}");
+    }
+
+    fn open_appearance(cx: &mut TestAppContext) -> (Entity<Tty7App>, VisualTestContext) {
+        let (app, mut vcx) = crate::ui::app::test_window::harness(cx);
+        app.update_in(&mut vcx, |app, window, cx| {
+            app.open_settings_section(SettingsSection::Appearance, window, cx);
+        });
+        vcx.simulate_resize(size(px(1100.), px(800.)));
+        vcx.run_until_parked();
+        (app, vcx)
+    }
+
+    /// #552's switches: gpui-component's `Switch` has no focus handle in the
+    /// whole file, so one had to be wrapped in a stop of the page's own.
+    #[gpui::test]
+    fn tab_reaches_a_switch_and_space_toggles_it(cx: &mut TestAppContext) {
+        let (app, mut vcx) = open_appearance(cx);
+        let was = vcx.update(|_, cx| cx.global::<Config>().cursor_blink);
+        walk_pressing(&app, &mut vcx, "space", "a switch", |_, vcx| {
+            vcx.update(|_, cx| cx.global::<Config>().cursor_blink) != was
+        });
+    }
+
+    /// #552's steppers: the − and the + beside a font size were bare click
+    /// targets with no handle and no key that could press them.
+    #[gpui::test]
+    fn tab_reaches_a_stepper_and_space_presses_it(cx: &mut TestAppContext) {
+        let (app, mut vcx) = open_appearance(cx);
+        let was = vcx.update(|_, cx| cx.global::<Config>().font_size);
+        walk_pressing(&app, &mut vcx, "space", "a stepper button", |_, vcx| {
+            vcx.update(|_, cx| cx.global::<Config>().font_size) != was
+        });
+    }
+
+    /// #552's section nav. The list sits one stop *before* the search box the
+    /// page opens focused, so Shift-Tab is the short way onto it — and Down
+    /// walks it from there.
+    #[gpui::test]
+    fn shift_tab_reaches_the_section_nav_and_down_walks_it(cx: &mut TestAppContext) {
+        let (app, mut vcx) = open_appearance(cx);
+        let section = |app: &Entity<Tty7App>, vcx: &mut VisualTestContext| {
+            vcx.update(|_, cx| app.read(cx).active_settings().map(|s| s.section))
+        };
+        for _ in 0..160 {
+            vcx.simulate_keystrokes("shift-tab");
+            vcx.simulate_keystrokes("down");
+            if section(&app, &mut vcx) == Some(SettingsSection::Terminal) {
+                // And back up again, to prove the walk is a walk.
+                vcx.simulate_keystrokes("up");
+                assert!(
+                    section(&app, &mut vcx) == Some(SettingsSection::Appearance),
+                    "Up did not step back to the section above",
+                );
+                return;
+            }
+        }
+        panic!("Shift-Tab never reached the section nav");
+    }
+
+    /// #552's record chip, end to end: the page's whole audience is people at
+    /// a keyboard, and starting a capture was a mouse-only gesture.
+    #[gpui::test]
+    fn tab_reaches_the_record_chip_and_enter_starts_capture(cx: &mut TestAppContext) {
+        let (app, mut vcx) = crate::ui::app::test_window::harness(cx);
+        app.update_in(&mut vcx, |app, window, cx| {
+            app.open_settings_section(SettingsSection::Keybindings, window, cx);
+        });
+        vcx.simulate_resize(size(px(1100.), px(800.)));
+        vcx.run_until_parked();
+        walk_pressing(&app, &mut vcx, "enter", "a record chip", |app, vcx| {
+            vcx.update(|_, cx| {
+                app.read(cx)
+                    .active_settings()
+                    .is_some_and(|s| s.recording.is_some())
+            })
+        });
     }
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -825,9 +825,128 @@ pub(crate) fn apply_theme(mut window: Option<&mut Window>, cx: &mut App) {
     }
 }
 
-pub(crate) fn switch(id: impl Into<gpui::ElementId>, cx: &App) -> gpui_component::switch::Switch {
-    let accent = cx.global::<presets::ActiveAccent>().0;
-    gpui_component::switch::Switch::new(id).color(Hsla::from(rgb(accent)))
+/// The ring that says where the keyboard is, drawn as an overlay rather than
+/// as a border in the layout: a ring that took space of its own would nudge
+/// whatever row it landed on every time focus arrived. Sits just outside the
+/// control it rings, so the control's own edge stays visible under it.
+///
+/// The caller is responsible for `.relative()` on the element being ringed,
+/// and for an `inset` its own clipping can live with: a container that hides
+/// its overflow will cut off a ring drawn outside its bounds.
+pub(crate) fn focus_ring(radius: Pixels, inset: Pixels, cx: &App) -> gpui::Div {
+    use gpui::Styled as _;
+    gpui::div()
+        .absolute()
+        .top(inset)
+        .left(inset)
+        .right(inset)
+        .bottom(inset)
+        .rounded(radius)
+        .border_1()
+        .border_color(cx.theme().ring)
+}
+
+/// A switch the keyboard can work.
+///
+/// gpui-component's own `Switch` has no focus handle anywhere in the file, so
+/// it never entered the tab order and had no activation key — one of the five
+/// classes of settings control that were mouse-only (#552). This wraps one in
+/// a focus stop: Tab lands on it, Enter or Space toggles it through the very
+/// same callback the mouse click uses, so the two can never drift apart.
+///
+/// The flag has to be set on the handle, at `track_focus`: a handle from
+/// `cx.focus_handle()` is minted with `tab_stop: false`, and `Interactivity`'s
+/// own `tab_stop()` is ignored once a handle is tracked from outside — so a
+/// tracked handle that never sets it is focusable by mouse and stepped
+/// straight over by the walker.
+#[derive(gpui::IntoElement)]
+pub(crate) struct Switch {
+    id: gpui::SharedString,
+    checked: bool,
+    on_click: Option<std::rc::Rc<dyn Fn(&bool, &mut Window, &mut App)>>,
+}
+
+impl Switch {
+    /// Set the checked state of the switch.
+    pub(crate) fn checked(mut self, checked: bool) -> Self {
+        self.checked = checked;
+        self
+    }
+
+    /// The handler for both ways of flipping it: a click, and the Enter or
+    /// Space that a focused switch now answers.
+    pub(crate) fn on_click<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(&bool, &mut Window, &mut App) + 'static,
+    {
+        self.on_click = Some(std::rc::Rc::new(handler));
+        self
+    }
+}
+
+impl gpui::RenderOnce for Switch {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl gpui::IntoElement {
+        use gpui::prelude::FluentBuilder as _;
+        use gpui::{InteractiveElement as _, ParentElement as _, Styled as _};
+
+        let Self {
+            id,
+            checked,
+            on_click,
+        } = self;
+        let accent = cx.global::<presets::ActiveAccent>().0;
+        let focus = window
+            .use_keyed_state(
+                gpui::SharedString::from(format!("{id}-focus")),
+                cx,
+                |_, cx| cx.focus_handle(),
+            )
+            .read(cx)
+            .clone()
+            .tab_stop(true);
+        let focused = focus.is_focused(window);
+
+        let mut inner = gpui_component::switch::Switch::new(id.clone())
+            .color(Hsla::from(rgb(accent)))
+            .checked(checked);
+        if let Some(handler) = on_click.clone() {
+            inner = inner.on_click(move |on, window, cx| handler(on, window, cx));
+        }
+
+        gpui::div()
+            .id(gpui::SharedString::from(format!("{id}-stop")))
+            .track_focus(&focus)
+            .relative()
+            .flex()
+            .child(inner)
+            .when(focused, |d| d.child(focus_ring(px(999.), px(-2.), cx)))
+            .on_key_down(move |ev: &gpui::KeyDownEvent, window, cx| {
+                if !is_activation_key(&ev.keystroke) {
+                    return;
+                }
+                cx.stop_propagation();
+                if let Some(handler) = on_click.as_ref() {
+                    handler(&!checked, window, cx);
+                }
+            })
+    }
+}
+
+/// Enter and Space press whatever has the focus — the one gesture every
+/// toolkit agrees on. gpui gives this away for free to elements that carry a
+/// click listener, but only on the key *up*, and the controls this page had to
+/// teach are driven from the key down, so they ask here instead. A chord with
+/// a modifier in it belongs to whoever bound it.
+pub(crate) fn is_activation_key(keystroke: &gpui::Keystroke) -> bool {
+    matches!(keystroke.key.as_str(), "enter" | "space") && !keystroke.modifiers.modified()
+}
+
+pub(crate) fn switch(id: impl Into<gpui::SharedString>, _cx: &App) -> Switch {
+    Switch {
+        id: id.into(),
+        checked: false,
+        on_click: None,
+    }
 }
 
 pub(crate) fn apply_cursor_hide_mode(cx: &mut App) {


### PR DESCRIPTION
## 修复内容(#552,按复核确认的优先级)

1. **录制控件可聚焦、Enter 开录**:录制 chip 改为 `RenderOnce` 组件 `KeyCaptureChip`——组件化是为了让它的 render 拿到 `Window`:section 渲染链(`render_settings_*(&self, cx)`)都没有 window,而稳定 focus handle(`window.use_keyed_state`,与 gpui-component `Button` 同款取法)和焦点环的 `is_focused(window)` 查询都需要它。获得焦点后,Enter/Space 触发由 gpui 的 keyboard-click 路径(div.rs 里 focused 元素 KeyUp → click listener)免费提供,chip 一个 `track_focus` 即可开录。聚焦态画 accent 描边,复用录制态既有的视觉语言。
2. **分段组接方向键**:`segmented`/`segmented_on` 同样改为构造 `SegmentedControl` 组件(**18 个调用点签名零改动**,构造仍只需原来的 cx)。组级 `track_focus` 入 Tab 序;Left/Up 退一步、Right/Down 进一步,端点钳制不回绕(分段是 picker 不是 dial),带修饰键的组合键一律放行不吃。步进直接调原有 `on_pick`,提交语义与点击完全一致。
3. **设置根 focus trap**:根 div 挂 gpui-component 的 `focus_trap`(组件库的容器自己的 `new()` 会 `track_focus` 同一个 handle,原来的显式调用随之并入)。`Root::on_action_tab` 发现焦点在 trap 内时,越界即回卷——Tab/Shift-Tab 从此在遮罩内循环,不再走到背后工作区的 chrome 上画焦点环。焦点在 trap 之外时(如调色板、弹窗)`find_active_trap` 返回 None,行为与今天一致;设置关闭即 `settings.take()`,弱引用失效,trap 自动清理。

## 实现过程中发现并修掉的一个新竞态

录制器用 `cx.intercept_keystrokes` 只拦 **KeyDown**,而 gpui 的 keyboard-click 在 **KeyUp** 上触发:chip 可聚焦后,给某动作录一个裸 `Enter`/`Space` 键位时,KeyDown 被录下、KeyUp 却会对聚焦的 chip 再触发一次 click → 重开录制、刚录的 chord 被清空。修法:`start_recording_key` 对"该行正在录制"的重入直接返回(gpui 测试 `reentering_capture_for_the_same_row_keeps_the_captured_chord` 钉住:重入后 chords 原样保留、提交照常)。

## 按复核修正的两处正文口径(未改动 issue 正文,先在此说明)

- **"除搜索框与 Esc 外键盘不可达"在页面层面不成立**:Tab 焦点遍历生效(gpui-component `Root` 注册 tab/shift-tab → focus_next/prev,设置页未覆写),34 个 `Button::new`、`Select`、各 Input 本就 Tab 可达、Enter 可触发;字号步进有全局 action 兜底。准确说法应为:**自定义控件(导航/分段/步进/开关/录制)未接入焦点系统,焦点序里只剩标准组件**。
- **漏掉的更糟的点**:overlay 只 `.occlude()` 不做焦点收容——已按复核指出的 `focus_trap.rs` 方案修掉(本 PR 第 3 条)。
- **行号漂移**:确认,录制捕获在 `settings.rs:6136-6150`(本 PR 后该段已组件化搬走)。

## 测试

- 新增:`segmented_arrows_step_and_clamp_without_wrapping`(方向键步进/端点钳制/修饰键放行)、`reentering_capture_for_the_same_row_keeps_the_captured_chord`(gpui)。
- `keybinding` 5/5、`settings` 39/39、`diff_overlay` 21/21、`forwards` 9/9 全绿(后两组是 `segmented_on` 的组外调用方);`cargo fmt --check` 干净;全量套件此前在本分支基线(origin/main)上除两例已知并行抖动外全绿,本改动仅触及设置渲染路径。

closes #552
