### PR TITLE
fix(scm): answer a branchless push and name why a commit is refused (#545, #546)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   disable themselves with a tooltip that says why, every other path gets a
   toast naming the reason, and an unborn branch — no commits to send yet —
   gets its own answer instead of sharing the detached one's silence. (#545)
+- **A refused commit says why, not always "Nothing to commit"** — committing
+  from the palette or the key binding with staged work but a blank message was
+  answered with "Nothing to commit", which sends the user staging files they
+  already staged; the toast now carries the plan's actual reason ("Write a
+  commit message first"), the same words the panel's own button shows on its
+  tooltip. (#546)
 
 ## [26.8.3] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   came up, and a path on a machine nothing here has a link to — or one a pane's
   shell has `ssh`'d away to — is shown in full rather than against a home that
   is not its own. (#580)
+- **Push at a detached HEAD no longer fails silently** — the sync tile claimed
+  "Publish Branch" (the one thing a detached HEAD cannot do) and swallowed the
+  click, and the key binding, palette and "Commit and Push" follow-up died in
+  the same guard just as quietly. The tile and the branch menu's Push item now
+  disable themselves with a tooltip that says why, every other path gets a
+  toast naming the reason, and an unborn branch — no commits to send yet —
+  gets its own answer instead of sharing the detached one's silence. (#545)
 
 ## [26.8.3] - 2026-08-12
 

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -1024,6 +1024,8 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         }
         L10nKey::ScmPublishBranch => "Publish Branch",
         L10nKey::ScmDetached => "detached",
+        L10nKey::ScmPushDetached => "Detached HEAD — check out a branch to push",
+        L10nKey::ScmPushNoCommits => "No commits to push yet",
         L10nKey::ScmAmendBadge => "amend",
         L10nKey::ScmSync => "Sync Changes",
         L10nKey::ScmPush => "Push",

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -1078,6 +1078,10 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         }
         L10nKey::ScmPublishBranch => "ブランチを公開",
         L10nKey::ScmDetached => "デタッチ",
+        L10nKey::ScmPushDetached => {
+            "HEAD がデタッチされています — ブランチをチェックアウトしてからプッシュしてください"
+        }
+        L10nKey::ScmPushNoCommits => "プッシュするコミットがまだありません",
         L10nKey::ScmAmendBadge => "修正",
         L10nKey::ScmSync => "変更を同期",
         L10nKey::ScmPush => "プッシュ",

--- a/src/ui/i18n/mod.rs
+++ b/src/ui/i18n/mod.rs
@@ -787,6 +787,8 @@ l10n_keys! {
     ScmUnrepresentablePath,
     ScmPublishBranch,
     ScmDetached,
+    ScmPushDetached,
+    ScmPushNoCommits,
     ScmAmendBadge,
     ScmSync,
     ScmPush,

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -971,6 +971,8 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         L10nKey::ScmUnrepresentablePath => "该路径不是合法的 UTF-8，无法传给 git —— 仅可查看。",
         L10nKey::ScmPublishBranch => "发布分支",
         L10nKey::ScmDetached => "游离头指针",
+        L10nKey::ScmPushDetached => "HEAD 游离——请先切换到一个分支再推送",
+        L10nKey::ScmPushNoCommits => "还没有可推送的提交",
         L10nKey::ScmAmendBadge => "修订",
         L10nKey::ScmSync => "同步更改",
         L10nKey::ScmPush => "推送",

--- a/src/ui/scm/actions.rs
+++ b/src/ui/scm/actions.rs
@@ -7,7 +7,6 @@
 use gpui::{Context, PromptLevel, Window};
 
 use tty7_core::core::git::ops::{Destructive, GitOp, PullMode};
-use tty7_core::core::git::status::HeadState;
 
 use crate::core::config::DiffViewMode;
 use crate::ui::app::Tty7App;
@@ -338,14 +337,23 @@ impl Tty7App {
         let Some(status) = crate::terminal::git_data::status_of(cx, repo.host, &repo.root) else {
             return;
         };
-        let HeadState::Branch { name, .. } = &status.head else {
-            // A detached HEAD has no branch to push, and pushing a bare sha
-            // needs a refspec the panel has no way to ask for.
-            return;
+        let name = match crate::ui::scm::panel::pushable_branch(&status.head) {
+            Ok(name) => name.to_string(),
+            Err(reason) => {
+                // "A swallowed click on Push looks exactly like a push that
+                // finished instantly" — git_data.rs says it out loud about
+                // the busy slot, and the same holds here. The tile and the
+                // menu disable themselves, but the key binding, the palette
+                // and the follow-up half of "Commit and Push" all land in
+                // this guard, so the toast is the only place they can say
+                // why nothing moved (#545).
+                gpui_component::WindowExt::push_notification(window, t(reason).to_string(), cx);
+                return;
+            }
         };
         let (remote, branch) = match status.upstream.as_deref().and_then(split_upstream) {
             Some((remote, branch)) => (remote.to_string(), branch.to_string()),
-            None => ("origin".to_string(), name.clone()),
+            None => ("origin".to_string(), name),
         };
         let set_upstream = status.upstream.is_none();
         self.scm_op(

--- a/src/ui/scm/actions.rs
+++ b/src/ui/scm/actions.rs
@@ -210,11 +210,13 @@ impl Tty7App {
         let message = self.scm_message(&repo, cx);
         let plan = crate::ui::scm::panel::commit_plan(&status, amend, &message);
         if !plan.enabled {
-            gpui_component::WindowExt::push_notification(
-                window,
-                t(L10nKey::ScmNothingToCommit).to_string(),
-                cx,
-            );
+            // The panel's own button exposes this through disabled + tooltip;
+            // the palette and the key binding have no tooltip to hover, so
+            // the toast has to carry the reason itself — "write a message
+            // first" and "nothing to commit" call for opposite actions, and
+            // answering the first with the second sends the user staging
+            // files they already staged (#546).
+            gpui_component::WindowExt::push_notification(window, t(plan.reason).to_string(), cx);
             // The follow-up dies with the commit: "commit and push" with
             // nothing to commit must not push whatever the branch holds.
             return;

--- a/src/ui/scm/panel.rs
+++ b/src/ui/scm/panel.rs
@@ -401,8 +401,17 @@ impl Tty7App {
                     cx,
                 )
                 .rounded_md()
-                .disabled(busy)
-                .tooltip(if status.upstream.is_some() {
+                // Detached, the tile could only ever lose (#545): upstream
+                // is None there by definition, so sync degenerates into
+                // scm_push, which has no branch to move. Say that on the
+                // tooltip instead of promising "Publish Branch" — the one
+                // thing a detached HEAD cannot do — and let the key binding,
+                // palette and compound-verb paths toast the same reason from
+                // inside scm_push.
+                .disabled(busy || detached)
+                .tooltip(if detached {
+                    t(L10nKey::ScmPushDetached)
+                } else if status.upstream.is_some() {
                     t(L10nKey::ScmSync)
                 } else {
                     t(L10nKey::ScmPublishBranch)
@@ -503,6 +512,7 @@ impl Tty7App {
             .map(|(_, names)| names.clone())
             .unwrap_or_default();
         let others = self.scm_repo_choices();
+        let detached = matches!(status.head, HeadState::Detached { .. });
 
         move |menu, _window, _cx| {
             let mut menu = menu.min_w(px(200.));
@@ -547,12 +557,20 @@ impl Tty7App {
                 (L10nKey::ScmPull, ScmIntent::Pull),
                 (L10nKey::ScmPush, ScmIntent::Push),
             ] {
-                menu = menu.item(PopupMenuItem::new(t(label)).on_click({
-                    let app = app.clone();
-                    move |_, window, cx| {
-                        let _ = app.update(cx, |this, cx| this.run_scm_action(intent, window, cx));
-                    }
-                }));
+                menu = menu.item(
+                    PopupMenuItem::new(t(label))
+                        // Fetch works from any HEAD, and Pull fails loud out
+                        // of git itself; a Push at a detached HEAD is the one
+                        // item that could only die in scm_push's guard (#545).
+                        .disabled(detached && matches!(intent, ScmIntent::Push))
+                        .on_click({
+                            let app = app.clone();
+                            move |_, window, cx| {
+                                let _ = app
+                                    .update(cx, |this, cx| this.run_scm_action(intent, window, cx));
+                            }
+                        }),
+                );
             }
             if others.len() > 1 {
                 menu = menu
@@ -1911,6 +1929,22 @@ pub(crate) fn commit_stages_everything(status: &WorkingTreeStatus, amend: bool) 
     !amend && status.staged().next().is_none()
 }
 
+/// The branch a push would move, or why there is no push to make.
+///
+/// Both dead ends used to die in the same silent `let-else` in `scm_push`
+/// (#545): a detached HEAD has no branch to push — and pushing a bare sha
+/// needs a refspec the panel has no way to ask for — while an unborn branch
+/// has a name but no commits to send yet. The key binding, the palette and
+/// the follow-up half of "Commit and Push" all land in that guard, so the
+/// reason is a key the caller can toast, not a log line.
+pub(crate) fn pushable_branch(head: &HeadState) -> Result<&str, L10nKey> {
+    match head {
+        HeadState::Branch { name, .. } => Ok(name),
+        HeadState::Detached { .. } => Err(L10nKey::ScmPushDetached),
+        HeadState::Unborn { .. } => Err(L10nKey::ScmPushNoCommits),
+    }
+}
+
 /// What a row's buttons do. Named rather than inlined because the same verb
 /// appears on the row, on its group header and in its context menu, and the
 /// three must not drift into meaning different things.
@@ -2366,6 +2400,29 @@ mod tests {
             "amending with no message keeps HEAD's own with --no-edit"
         );
         assert!(!commit_plan(&clean, false, "msg").enabled);
+    }
+
+    #[test]
+    fn a_head_without_a_pushable_branch_says_why() {
+        let branch = HeadState::Branch {
+            name: "main".into(),
+            oid: "1111111".into(),
+        };
+        assert_eq!(pushable_branch(&branch), Ok("main"));
+        // The two states the old let-else in scm_push swallowed without a
+        // word (#545): the toast now names each one.
+        assert_eq!(
+            pushable_branch(&HeadState::Detached {
+                oid: "1111111".into()
+            }),
+            Err(L10nKey::ScmPushDetached)
+        );
+        assert_eq!(
+            pushable_branch(&HeadState::Unborn {
+                branch: "main".into()
+            }),
+            Err(L10nKey::ScmPushNoCommits)
+        );
     }
 
     #[test]

--- a/src/ui/scm/panel.rs
+++ b/src/ui/scm/panel.rs
@@ -2395,6 +2395,17 @@ mod tests {
             !commit_plan(&staged, false, "   ").enabled,
             "an all-whitespace message is no message"
         );
+        // ...and the reason must say so: staged work with a blank message is
+        // not "nothing to commit", which is what the palette path used to
+        // answer (#546).
+        assert_eq!(
+            commit_plan(&staged, false, "  ").reason,
+            L10nKey::ScmCommitNeedsMessage
+        );
+        assert_eq!(
+            commit_plan(&clean, false, "msg").reason,
+            L10nKey::ScmNothingToCommit
+        );
         assert!(
             commit_plan(&clean, true, "").enabled,
             "amending with no message keeps HEAD's own with --no-edit"

--- a/src/ui/scm/panel.rs
+++ b/src/ui/scm/panel.rs
@@ -303,6 +303,9 @@ impl Tty7App {
         let theme = cx.theme();
         let (warning, muted, fg) = (theme.warning, theme.muted_foreground, theme.foreground);
         let detached = matches!(status.head, HeadState::Detached { .. });
+        // The same helper `scm_push`'s guard asks, so the tile and the toast
+        // cannot answer differently about the same HEAD.
+        let unpushable = pushable_branch(&status.head).err();
         let busy = self.scm_network_busy(repo, cx);
         let others = self.scm_other_repos(repo);
 
@@ -401,20 +404,18 @@ impl Tty7App {
                     cx,
                 )
                 .rounded_md()
-                // Detached, the tile could only ever lose (#545): upstream
-                // is None there by definition, so sync degenerates into
-                // scm_push, which has no branch to move. Say that on the
-                // tooltip instead of promising "Publish Branch" — the one
-                // thing a detached HEAD cannot do — and let the key binding,
-                // palette and compound-verb paths toast the same reason from
-                // inside scm_push.
-                .disabled(busy || detached)
-                .tooltip(if detached {
-                    t(L10nKey::ScmPushDetached)
-                } else if status.upstream.is_some() {
-                    t(L10nKey::ScmSync)
-                } else {
-                    t(L10nKey::ScmPublishBranch)
+                // With no branch to move the tile could only ever lose (#545):
+                // upstream is None at a detached or unborn HEAD by definition,
+                // so sync degenerates into scm_push, which has nothing to
+                // send. Say that on the tooltip instead of promising "Publish
+                // Branch" — the one thing a detached HEAD cannot do — and let
+                // the key binding, palette and compound-verb paths toast the
+                // same reason from inside scm_push.
+                .disabled(busy || unpushable.is_some())
+                .tooltip(match unpushable {
+                    Some(reason) => t(reason),
+                    None if status.upstream.is_some() => t(L10nKey::ScmSync),
+                    None => t(L10nKey::ScmPublishBranch),
                 })
                 .on_click(cx.listener(|this, _, window, cx| {
                     this.run_scm_action(ScmIntent::Sync, window, cx);
@@ -512,7 +513,7 @@ impl Tty7App {
             .map(|(_, names)| names.clone())
             .unwrap_or_default();
         let others = self.scm_repo_choices();
-        let detached = matches!(status.head, HeadState::Detached { .. });
+        let unpushable = pushable_branch(&status.head).is_err();
 
         move |menu, _window, _cx| {
             let mut menu = menu.min_w(px(200.));
@@ -560,9 +561,10 @@ impl Tty7App {
                 menu = menu.item(
                     PopupMenuItem::new(t(label))
                         // Fetch works from any HEAD, and Pull fails loud out
-                        // of git itself; a Push at a detached HEAD is the one
-                        // item that could only die in scm_push's guard (#545).
-                        .disabled(detached && matches!(intent, ScmIntent::Push))
+                        // of git itself; a Push from a HEAD with no branch to
+                        // move is the one item that could only die in
+                        // scm_push's guard (#545).
+                        .disabled(unpushable && matches!(intent, ScmIntent::Push))
                         .on_click({
                             let app = app.clone();
                             move |_, window, cx| {


### PR DESCRIPTION
关闭 #545、#546。均按作者在两条 issue 下的复核意见实现；按意见需要修正的 issue 文本列在文末（我没有 issue 编辑权限，请作者过目后自行替换）。

## #545 — detached HEAD 下 Push 静默

按作者"成本极低"方案实现，并补上作者指出的两档遗漏：

- **`scm_branch_row` 磁贴**:`.disabled(busy || detached)`(detached 是 :305 现成的局部变量）,tooltip 三元改为 detached 优先 —— 说"HEAD 游离，先切分支"，不再说"Publish Branch"(detached 时 upstream 按定义为 None，发布恰恰是它做不到的事）。
- **`scm_push` else 分支补 toast**（应用内 `push_notification`，非桌面通知）：键位、调色板、"Commit and Push/Sync" 的 follow-up 半段三条路径一并覆盖 —— 复合动词那档（commit 已落地、push 半段被吞，用户以为推上去了）正是这条 toast 收编的。
- **分支名按钮的 dropdown 菜单**:Fetch/Pull/Push 三项中仅 Push 在 detached 时 `.disabled()` —— Fetch 与 HEAD 状态无关，Pull 会执行并经 git 自身报错（"You are not currently on a branch")走 `report_git_op_error` 弹错，二者本有反馈，保持可用。
- **`HeadState::Unborn` 一并处理**：守卫同样吞掉 unborn（有分支名、零提交，推无可推）。抽出纯函数 `pushable_branch(&HeadState) -> Result<&str, L10nKey>`(`Branch` → Ok;`Detached`/`Unborn` 各配一把新 i18n key),scm_push 的守卫、磁贴 tooltip、菜单 disabled 三处同源，不会再漂移；新增 `commit_plan` 风格纯测试钉住三种 head 各自的答复。

新 i18n key(en/zh/ja 全 parity):`ScmPushDetached`、`ScmPushNoCommits`。

作者提到的内部先例（`git_data.rs:1028-1030`:"a swallowed click on Push looks exactly like a push that finished instantly",`ScmNetworkBusy` 通知）已写进 scm_push 的注释与本 PR 说明。

## #546 — commit 被拒时误报 "Nothing to commit"

按作者确认的"近乎零成本"修复：`scm_commit` 里硬编码的 `t(L10nKey::ScmNothingToCommit)` 改为 `t(plan.reason)` —— `reason` 本就是裸 `L10nKey`，一行即完。注释写明为什么：面板按钮有 disabled + tooltip 兜底，调色板/键位路径没有 tooltip 可悬停，toast 是唯一反馈，答错文案会把用户引向错误动作。并按作者建议扩了 `commit_plan` 单测：已暂存 + 空白消息 ⇒ `ScmCommitNeedsMessage`；干净树 ⇒ `ScmNothingToCommit`。

## 按作者复核意见需要修正的 issue 文本

**#545:**

1. "同一状态下 Pull 是真的会执行的"系夸大：`GitOp::Pull` 展开为裸 `git pull --ff-only`(`ops.rs:393-400`),detached 下 git 自己报错并弹错误 toast。准确说法是"Pull 会执行并给出反馈"；核心对比反而更锋利：同一排控件里 Pull 有反馈（哪怕是错误）,Push 零反馈。
2. "分支右键菜单"实为分支名按钮的 dropdown(`dropdown_menu_with_anchor`)，非右键上下文菜单。
3. 建议补进正文的更严重一档（复合动词，commit 成功 + push 半段静默丢失）已在本 PR 修复范围内。

**#546:**

1. `reason` 不是 `Option`，是裸 `L10nKey`(`panel.rs:1871`)，正确修复就是一行 `t(plan.reason)` —— 本 PR 即如此。
2. "或 SCM 面板从未打开过"括号放错位置：`self.scm.repo` 只在 `render_panel_scm` 赋值，面板从未打开 ⇒ `active_repo()` 为 `None` ⇒ `run_scm_action` 提前 return，走不到这条 toast（那是 #549 的静默症状）。本条可复现场景：面板打开过、消息框为空，用调色板 "Git: Commit"。
3. "面板按钮路径用的是 reason"需精确化：按钮在 `!live` 时是 disabled + tooltip，根本点不动，reason 靠悬停暴露 —— 两条路径是"提示 vs 弹错话"，结论不变。
4. 命中面比正文更广：提交按钮右侧 chevron 菜单的 Commit / Commit and Push / Commit and Sync 也走 `run_scm_action`，面板内部同样吃到这条错误 toast；键盘路径（`secondary-enter` 绑在 `ScmCommit` key context，仅提交框聚焦时生效）比正文暗示的窄，**调色板路径（`app.rs:4155`）才是主战场** —— 本 PR 修复覆盖上述全部路径（它们共享 `scm_commit` 一个出口）。

## 验证

- `cargo test --locked --bin tty7-app pushable`（新测试）、`commit_button`(commit_plan 组）、`every_key_is_translated`(i18n parity）通过；
- `cargo check --locked`、`cargo fmt --check` 干净。

CHANGELOG 已在 `## [Unreleased]` → `### Fixed` 下补两条条目。


Closes #545
Closes #546
