### PR TITLE
fix(icons): draw the plus on the same optical bound as the rest of the set

### DIFF
--- a/assets/icons/plus.svg
+++ b/assets/icons/plus.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round"><path d="M12 6v12"/><path d="M6 12h12"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2308" stroke-linecap="round"><path d="M12 5.3077v13.3846"/><path d="M5.3077 12h13.3846"/></svg>

--- a/assets/icons/plus.svg
+++ b/assets/icons/plus.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2308" stroke-linecap="round"><path d="M12 5.3077v13.3846"/><path d="M5.3077 12h13.3846"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5846" stroke-linecap="round"><path d="M12 4.9846v14.0308"/><path d="M4.9846 12h14.0308"/></svg>

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -150,10 +150,11 @@ pub(crate) const TILE_GLYPH_XS: f32 = 11.;
 /// stroke. `plus` had been leaning on that, so moving it to [`TILE_GLYPH`]
 /// thinned it by a fifth even though it got *longer*, and it had to take that
 /// weight back in its own `stroke-width` — a cross is two hairlines with no
-/// fill to hide behind, so it is the one glyph in the set whose weight had to
-/// be settled by looking rather than by arithmetic. `ui::assets`' test carries
-/// the band it landed in and what was rejected either side. Anything else that
-/// leaves here owes the same accounting.
+/// fill to hide behind, so it is the one glyph in the set drawn off the
+/// family's weight, by exactly the 16/13 it lost and no more. `ui::assets`'
+/// test carries that arithmetic. Anything else that leaves here owes the same
+/// accounting, in both directions: an asset redrawn for the tiles that scaled
+/// it up is still drawn beside the ones that never did.
 pub(crate) const TILE_GLYPH_LINE: f32 = 16.;
 
 pub(crate) const TILE_PAD: f32 = (TILE_SIZE - TILE_GLYPH) / 2.;

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -132,6 +132,28 @@ pub(crate) const TILE_GLYPH_SM: f32 = TILE_GLYPH;
 pub(crate) const TILE_SIZE_XS: f32 = 18.;
 pub(crate) const TILE_GLYPH_XS: f32 = 11.;
 
+/// The compensation a glyph gets when its art does not fill the box the rest
+/// of the set fills.
+///
+/// Every icon tty7 draws itself sits on the same optical bound — 3.4..20.6 of
+/// a 24 viewBox, 19.3 units of ink once the round caps are counted. Stock
+/// lucide `close` is a bare 6..18 cross, 14 units, so at [`TILE_GLYPH`] it
+/// carries a quarter less ink than the tiles beside it and reads as the one
+/// disabled control in the row. 16 buys that back.
+///
+/// Reach for this only for art we do not own. `plus` used to be here for the
+/// same reason and is not any more: it is ours, so it was redrawn onto the
+/// bound instead of being scaled up at the call site — the fix that also
+/// reaches the 24px tiles, which have no `_LINE` step to grow into.
+///
+/// Note what scaling a glyph up quietly buys along with the extent: 16/13 more
+/// stroke. `plus` had been leaning on that, so moving it to [`TILE_GLYPH`]
+/// thinned it by a fifth even though it got *longer*, and it had to take that
+/// weight back in its own `stroke-width` — a cross is two hairlines with no
+/// fill to hide behind, so it is the one glyph in the set whose weight had to
+/// be settled by looking rather than by arithmetic. `ui::assets`' test carries
+/// the band it landed in and what was rejected either side. Anything else that
+/// leaves here owes the same accounting.
 pub(crate) const TILE_GLYPH_LINE: f32 = 16.;
 
 pub(crate) const TILE_PAD: f32 = (TILE_SIZE - TILE_GLYPH) / 2.;

--- a/src/ui/assets.rs
+++ b/src/ui/assets.rs
@@ -115,6 +115,75 @@ mod tests {
     }
 
     #[test]
+    fn the_plus_is_drawn_on_the_bound_the_rest_of_the_set_uses() {
+        // Two bare strokes fail quietly. A tightened `plus` does not look
+        // broken, it just reads a size smaller than the tiles beside it — which
+        // is how it spent a while being scaled up at the call site instead. The
+        // icons tty7 draws itself put 19.3 units of ink in a 24 viewBox (a 17.2
+        // shape straddled by a 2.1 stroke). A cross gets to sit a little inside
+        // that, but not at the 14.1 it had, and not at stock lucide's 14 — so a
+        // re-tightened path or a re-sync from upstream lands here rather than in
+        // someone's peripheral vision.
+        let svg =
+            String::from_utf8(Assets.load("icons/plus.svg").unwrap().unwrap().to_vec()).unwrap();
+        let field = |after: &str, upto: char| -> &str {
+            svg.split_once(after)
+                .and_then(|(_, rest)| rest.split_once(upto))
+                .map(|(n, _)| n)
+                .unwrap_or_else(|| panic!("plus.svg has no `{after}…{upto}`: {svg}"))
+        };
+        // The vertical arm, as `M12 <top>v<len>`.
+        let (top, len) = field("d=\"M12 ", '"')
+            .split_once('v')
+            .unwrap_or_else(|| panic!("plus.svg's vertical arm is not a `v` run: {svg}"));
+        let (top, len): (f32, f32) = (top.parse().unwrap(), len.parse().unwrap());
+        let stroke: f32 = field("stroke-width=\"", '"').parse().unwrap();
+
+        assert!(
+            (top + len / 2. - 12.).abs() < 0.01,
+            "plus.svg's arm runs {top}..{} and so is not centred in the viewBox",
+            top + len
+        );
+        let ink = len + stroke;
+        assert!(
+            ink / 19.3 >= 0.85,
+            "plus.svg puts {ink} units of ink in the box where the rest of the \
+             set puts 19.3, so it will read a size small beside them"
+        );
+
+        // Extent is only half of it; the other half is landing on the pixel
+        // grid. The set's other glyphs are closed shapes carrying solid fills,
+        // so a soft edge costs them little — a cross is two hairlines and
+        // nothing else, and a stroke that straddles pixel columns turns the
+        // whole glyph into a smudge.
+        //
+        // The arm sits at the middle of the box, 6.5 CSS px into the 13, so a
+        // whole-CSS-pixel stroke is the only one whose edges land on whole
+        // device pixels. That argued for 1 or 2 and nothing between — but the
+        // range was walked on a real screen and the eye disagreed with the
+        // arithmetic: 1 still read thin against the closed shapes, 2 read
+        // heavy-handed, and the fractional weight in between is fine, because
+        // at 2x its edge columns come out ~75% lit rather than the ~35% that
+        // made the first attempt look smeared. Sharpness was worth less than
+        // this note assumed; the number below is eyeballed, not derived, so
+        // keep the band wide and re-check on a screen before moving it.
+        let css_px = stroke * crate::ui::app::TILE_GLYPH / 24.;
+        assert!(
+            (1.5..=1.9).contains(&css_px),
+            "plus.svg strokes {css_px} CSS px at the {}px glyph; 1.0 was judged \
+             thin and 2.0 heavy on a real screen, so it belongs in 1.5..=1.9",
+            crate::ui::app::TILE_GLYPH
+        );
+        // Same argument for the arm ends: a round cap reaches stroke/2 past the
+        // path, so the tip wants to land on a whole pixel too.
+        let tip = (top - stroke / 2.) * crate::ui::app::TILE_GLYPH / 24.;
+        assert!(
+            (tip - tip.round()).abs() < 0.01,
+            "plus.svg's cap tip lands at {tip} CSS px, not on a whole pixel"
+        );
+    }
+
+    #[test]
     fn stock_prefix_works_for_unoverridden_glyphs() {
         assert_eq!(
             Assets.load("stock/icons/check.svg").unwrap(),

--- a/src/ui/assets.rs
+++ b/src/ui/assets.rs
@@ -114,69 +114,123 @@ mod tests {
         }
     }
 
+    fn glyph(name: &str) -> String {
+        let bytes = Assets
+            .load(&format!("icons/{name}.svg"))
+            .unwrap()
+            .unwrap_or_else(|| panic!("nothing serves `icons/{name}.svg`"));
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    fn attr<'a>(svg: &'a str, name: &str) -> &'a str {
+        svg.split_once(&format!("{name}=\""))
+            .and_then(|(_, rest)| rest.split_once('"'))
+            .map(|(value, _)| value)
+            .unwrap_or_else(|| panic!("no `{name}` in: {svg}"))
+    }
+
     #[test]
     fn the_plus_is_drawn_on_the_bound_the_rest_of_the_set_uses() {
         // Two bare strokes fail quietly. A tightened `plus` does not look
         // broken, it just reads a size smaller than the tiles beside it — which
         // is how it spent a while being scaled up at the call site instead. The
         // icons tty7 draws itself put 19.3 units of ink in a 24 viewBox (a 17.2
-        // shape straddled by a 2.1 stroke). A cross gets to sit a little inside
-        // that, but not at the 14.1 it had, and not at stock lucide's 14 — so a
-        // re-tightened path or a re-sync from upstream lands here rather than in
-        // someone's peripheral vision.
-        let svg =
-            String::from_utf8(Assets.load("icons/plus.svg").unwrap().unwrap().to_vec()).unwrap();
-        let field = |after: &str, upto: char| -> &str {
-            svg.split_once(after)
-                .and_then(|(_, rest)| rest.split_once(upto))
-                .map(|(n, _)| n)
-                .unwrap_or_else(|| panic!("plus.svg has no `{after}…{upto}`: {svg}"))
-        };
-        // The vertical arm, as `M12 <top>v<len>`.
-        let (top, len) = field("d=\"M12 ", '"')
-            .split_once('v')
-            .unwrap_or_else(|| panic!("plus.svg's vertical arm is not a `v` run: {svg}"));
-        let (top, len): (f32, f32) = (top.parse().unwrap(), len.parse().unwrap());
-        let stroke: f32 = field("stroke-width=\"", '"').parse().unwrap();
+        // shape straddled by the family's stroke). A cross gets to sit a little
+        // inside that, but not at the 14.1 it had, and not at stock lucide's 14
+        // — so a re-tightened path or a re-sync from upstream lands here rather
+        // than in someone's peripheral vision.
+        let plus = glyph("plus");
+        let stroke: f32 = attr(&plus, "stroke-width").parse().unwrap();
 
-        assert!(
-            (top + len / 2. - 12.).abs() < 0.01,
-            "plus.svg's arm runs {top}..{} and so is not centred in the viewBox",
-            top + len
+        // Each arm is `M<x> <y><axis><len>`: the vertical first, then the
+        // horizontal. Both are checked, because a cross edited on one axis
+        // only is exactly the kind of miss that survives a glance.
+        let arms: Vec<&str> = plus
+            .split("d=\"")
+            .skip(1)
+            .map(|rest| rest.split_once('"').expect("unterminated `d`").0)
+            .collect();
+        let arm = |d: &str| -> (char, f32, f32, f32) {
+            let axis = d
+                .chars()
+                .find(|c| matches!(c, 'v' | 'h'))
+                .unwrap_or_else(|| panic!("plus.svg's `{d}` is neither a `v` nor an `h` run"));
+            let (from, len) = d.trim_start_matches('M').split_once(axis).unwrap();
+            let (x, y) = from.split_once(' ').unwrap();
+            (
+                axis,
+                x.parse().unwrap(),
+                y.parse().unwrap(),
+                len.parse().unwrap(),
+            )
+        };
+        assert_eq!(arms.len(), 2, "plus.svg is not two paths: {plus}");
+        let (v_axis, v_x, v_top, v_len) = arm(arms[0]);
+        let (h_axis, h_left, h_y, h_len) = arm(arms[1]);
+        assert_eq!(
+            (v_axis, h_axis),
+            ('v', 'h'),
+            "plus.svg should be a vertical arm then a horizontal one: {plus}"
         );
-        let ink = len + stroke;
+
+        for (label, across, along, len) in [
+            ("vertical", v_x, v_top, v_len),
+            ("horizontal", h_y, h_left, h_len),
+        ] {
+            assert!(
+                (across - 12.).abs() < 0.01 && (along + len / 2. - 12.).abs() < 0.01,
+                "plus.svg's {label} arm runs {along}..{} at {across} and so is not \
+                 centred in the viewBox",
+                along + len
+            );
+        }
+        assert!(
+            (v_len - h_len).abs() < 0.01,
+            "plus.svg's arms are {v_len} and {h_len} long, so it is not square"
+        );
+
+        let ink = v_len + stroke;
         assert!(
             ink / 19.3 >= 0.85,
             "plus.svg puts {ink} units of ink in the box where the rest of the \
              set puts 19.3, so it will read a size small beside them"
         );
 
-        // Extent is only half of it; the other half is landing on the pixel
-        // grid. The set's other glyphs are closed shapes carrying solid fills,
-        // so a soft edge costs them little — a cross is two hairlines and
-        // nothing else, and a stroke that straddles pixel columns turns the
-        // whole glyph into a smudge.
+        // The weight is the one part of this that is not free to be chosen.
+        // `plus` is the only glyph in the set drawn off the family's own
+        // `stroke-width`, and the amount it is off by is not a taste call: it
+        // is what the three chrome tiles were already rendering. Scaling a
+        // glyph up buys stroke along with extent, so the old art drew
+        // `TILE_GLYPH_LINE / TILE_GLYPH` wider at those call sites; dropping
+        // the scale-up without putting that back would have thinned the `+` by
+        // a fifth even as it got *longer*. The art carries it instead, which is
+        // what lets the same asset serve the tiles that never had a `_LINE`
+        // step to grow into.
         //
-        // The arm sits at the middle of the box, 6.5 CSS px into the 13, so a
-        // whole-CSS-pixel stroke is the only one whose edges land on whole
-        // device pixels. That argued for 1 or 2 and nothing between — but the
-        // range was walked on a real screen and the eye disagreed with the
-        // arithmetic: 1 still read thin against the closed shapes, 2 read
-        // heavy-handed, and the fractional weight in between is fine, because
-        // at 2x its edge columns come out ~75% lit rather than the ~35% that
-        // made the first attempt look smeared. Sharpness was worth less than
-        // this note assumed; the number below is eyeballed, not derived, so
-        // keep the band wide and re-check on a screen before moving it.
-        let css_px = stroke * crate::ui::app::TILE_GLYPH / 24.;
+        // Note what this does not license: any *more* weight than that. `plus`
+        // is drawn beside stock lucide hairlines as well as beside the set's
+        // own closed shapes — `minus` and `undo-2` in the Source Control row
+        // strip at `TILE_GLYPH_XS`, `search` in the switcher's gutter — and a
+        // cross heavier than the glyph next to it reads as the emphasised
+        // control in the row, which is the same failure as reading small.
+        let family: f32 = attr(&glyph("panel-left"), "stroke-width").parse().unwrap();
+        let shipped = family * crate::ui::app::TILE_GLYPH_LINE / crate::ui::app::TILE_GLYPH;
         assert!(
-            (1.5..=1.9).contains(&css_px),
-            "plus.svg strokes {css_px} CSS px at the {}px glyph; 1.0 was judged \
-             thin and 2.0 heavy on a real screen, so it belongs in 1.5..=1.9",
-            crate::ui::app::TILE_GLYPH
+            (stroke - shipped).abs() < 0.01,
+            "plus.svg strokes {stroke} where the set strokes {family}; off the \
+             family weight it should be off it by exactly the {}/{} the call \
+             site used to scale it by, which is {shipped}",
+            crate::ui::app::TILE_GLYPH_LINE,
+            crate::ui::app::TILE_GLYPH,
         );
-        // Same argument for the arm ends: a round cap reaches stroke/2 past the
-        // path, so the tip wants to land on a whole pixel too.
-        let tip = (top - stroke / 2.) * crate::ui::app::TILE_GLYPH / 24.;
+
+        // Extent and weight are only two thirds of it; the last is landing on
+        // the pixel grid. The set's other glyphs are closed shapes carrying
+        // solid fills, so a soft edge costs them little — a cross is two
+        // hairlines and nothing else, and an arm end that straddles pixel rows
+        // turns the tip into a smudge. A round cap reaches stroke/2 past the
+        // path, so that is where the whole pixel has to land.
+        let tip = (v_top - stroke / 2.) * crate::ui::app::TILE_GLYPH / 24.;
         assert!(
             (tip - tip.round()).abs() < 0.01,
             "plus.svg's cap tip lands at {tip} CSS px, not on a whole pixel"

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -917,10 +917,8 @@ impl Tty7App {
             .child(
                 div().occlude().flex_shrink_0().child(
                     self.attach_new_tab_menu(
-                        crate::ui::tab_strip::chrome_tile_sized(
+                        crate::ui::tab_strip::chrome_tile(
                             Button::new("sidebar-add").icon(Icon::new(IconName::Plus)),
-                            crate::ui::app::TILE_SIZE,
-                            crate::ui::app::TILE_GLYPH_LINE,
                             false,
                             cx,
                         )

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -20,7 +20,7 @@ use crate::core::actions::{
 use crate::core::config::RightPanelTab;
 use crate::core::shells::DetectedShell;
 use crate::daemon::protocol::ShellSpec;
-use crate::ui::app::{TILE_GLYPH, TILE_GLYPH_LINE, TILE_SIZE, Tab, Tty7App, tile_trailing_inset};
+use crate::ui::app::{TILE_GLYPH, TILE_SIZE, Tab, Tty7App, tile_trailing_inset};
 use crate::ui::hints::tab_badge_label;
 use crate::ui::i18n::{L10nKey, t, t_fmt};
 use crate::ui::reorder::{self, Reorder, Surface};
@@ -1527,10 +1527,8 @@ impl Tty7App {
 
         let add_button = div().occlude().flex_shrink_0().child(
             self.attach_new_tab_menu(
-                chrome_tile_sized(
+                chrome_tile(
                     Button::new("tab-add").icon(Icon::new(IconName::Plus)),
-                    TILE_SIZE,
-                    TILE_GLYPH_LINE,
                     false,
                     cx,
                 )
@@ -1559,11 +1557,9 @@ impl Tty7App {
                 .child(
                     div().occlude().flex_shrink_0().child(
                         self.attach_new_tab_menu(
-                            chrome_tile_sized(
+                            chrome_tile(
                                 Button::new("titlebar-add-collapsed")
                                     .icon(Icon::new(IconName::Plus)),
-                                TILE_SIZE,
-                                TILE_GLYPH_LINE,
                                 false,
                                 cx,
                             )


### PR DESCRIPTION
Redraws `plus.svg` onto the optical bound every other tty7-drawn icon sits on, so the `+` stops being scaled up at the call site to hide a too-small asset — which also fixes the one `+` the compensation never reached.

## What changed

| | Before | After |
|---|---|---|
| `plus.svg` ink extent | 14.1 of 24 (59%) | 16.6 of 24 (69%) |
| `plus.svg` stroke | 2.1 | 2.5846 (1.4 CSS px at a 13px glyph) |
| `+` in titlebar (`tab-add`, `titlebar-add-collapsed`) | 16px glyph via `TILE_GLYPH_LINE` | 13px glyph, plain `chrome_tile` |
| `+` in left sidebar header (`sidebar-add`) | 16px glyph via `TILE_GLYPH_LINE` | 13px glyph, plain `chrome_tile` |
| `+` in port-forward section (24px tile) | 7.6px of ink vs 10.5px for the icons around it | matches the rest |
| `TILE_GLYPH_LINE` | used by `plus` and stock lucide `close` | `close` only, with the rule documented |

## Why

Every icon tty7 draws itself is on one bound — `3.4..20.6` of a 24 viewBox, 19.3 units of ink once round caps count. `plus` was the exception at `6..18`, tighter even than the stock lucide glyph it replaced:

| icon | path range | ink | % of viewBox |
|---|---|---|---|
| `panel-left` / `panel-right` / `info` / `folder-closed` | 3.4..20.6 | 19.3 | 80% |
| `git-branch` | 2.8..21.3 | 18.5 | 77% |
| `ellipsis` | 3.15..20.85 | 17.7 | 74% |
| **`plus` (before)** | **6..18** | **14.1** | **59%** |

That gap was papered over at the call site by giving the three chrome tiles carrying a `+` a 16px glyph where every neighbour in the same row gets 13. It worked exactly where it was applied. The port-forward section's `+` lives in a 24px tile, which has no `_LINE` step to grow into, so it rendered a size small against everything beside it. Fixing the asset fixes that one for free and removes the special case from three call sites.

## On the stroke weight

Scaling a glyph up buys stroke as well as extent, which is the easy part to miss: at 16px the old art drew 16/13 wider too, so moving the `+` to 13px would have thinned it by a fifth even as it got *longer*. A cross is two hairlines with no fill to hide behind, so the weight has to come back in the art itself.

It comes back by exactly that factor and no more: `2.1 × 16/13 = 2.5846`, the family's own `stroke-width` times the scale-up the three chrome tiles were already applying. At `TILE_GLYPH` that renders at 1.4 CSS px, which is precisely what the titlebar `+` has always drawn at — the redraw changes the glyph's *extent*, and leaves the weight where it has been.

Holding to that factor matters because `plus` is not only drawn next to the set's own closed shapes. Three of its six call sites put it beside stock lucide hairlines that stroke 2:

- Source Control's row strip draws it (Stage) directly beside stock `undo-2` (Discard) at an 11px glyph, and pairs it with stock `minus` (Unstage) one group up.
- The switcher's *Add SSH Host* row draws it at 16px in the same gutter column as `search`.
- Settings → SSH puts it next to stock `search` and stock `ellipsis`.

An earlier revision of this PR took the stroke to 3.2308 (1.75 CSS px), tuned by eye against `panel-left` / `panel-right` / `ellipsis` in the titlebar. Those all carry solid fills; the three sites above do not, and at 11px a 1.48 CSS px `+` against their 0.92 reads as the emphasised control in a strip where nothing is emphasised — and a stage/unstage pair stops looking like a pair. Reading a size heavy is the same failure as reading a size small.

The arm ends sit at `4.9846..19.0154` so the round-cap tips land on whole pixels at 13px. `TILE_GLYPH_LINE` stays for stock lucide `close`, which has the same tight geometry and is not ours to redraw; its doc comment now spells out when to reach for it, why `plus` no longer does, and that an asset redrawn for the tiles that scaled it up is still drawn beside the ones that never did.

## Testing

- New `ui::assets::tests::the_plus_is_drawn_on_the_bound_the_rest_of_the_set_uses` — parses the asset and asserts both arms are centred and equal, the ink extent is at least 85% of the family's 19.3, the stroke is the family's own (read out of `panel-left.svg`, not hardcoded) scaled by `TILE_GLYPH_LINE / TILE_GLYPH`, and the round-cap tips fall on whole pixels. Verified it fails on the old geometry (`plus.svg puts 14.1 units of ink in the box where the rest of the set puts 19.3`), on a re-sync from stock lucide, on the 3.2308 overweight, and on a cross edited on one axis only.
- Full suite: green.
- Manually accepted in an isolated dev instance (`--config-dir`, own daemon) on a 2x display: titlebar `+`, collapsed-titlebar `+`, and left-sidebar `+` compared against `panel-left` / `panel-right` / `ellipsis` in the same row.
- The Source Control, switcher, Settings → SSH and port-forward `+` were compared against their actual neighbours by rasterising the assets at 11 / 13 / 16px rather than on screen — the port-forward section only renders for a connected SSH pane or a remote workspace. All four are the same asset at a weight the titlebar case pins.
