### PR TITLE
fix(ui): stop a rebuilt window renaming its workspace to a codename (#604)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A workspace no longer renames itself to a codename it was never shown.**
+  Every workspace a window creates is handed a generated name — `keen-marten` —
+  so the machine tree and `tty7 ws ls` have something to call it, while the
+  window itself reads the directory its shells are working in. The window is
+  left out of the deltas its own edits raise, so it never heard which codename
+  it got; the first time it pulled the whole tree again — a daemon restart, a
+  rebuild, or simply launching tty7 the next morning — the codename took the
+  workspace chip and was stamped into `views.json` from there, and that pull
+  had by then also cost the window the pane record it read the directory from.
+  A generated name is now treated as the placeholder it is: it still names the
+  workspace in the tree and to the CLI, but on screen only a name someone
+  actually chose outranks the directory, which the window now remembers across
+  a rebuild. A workspace with no directory to borrow still reads its codename
+  rather than "Untitled" (#604).
 - **A local daemon that dies and comes back no longer leaves a window of dead
   panes looking live** — from the client's side a killed daemon is
   indistinguishable from one whose shells all exited at once, so the window

--- a/crates/tty7-core/src/core/codename.rs
+++ b/crates/tty7-core/src/core/codename.rs
@@ -74,6 +74,32 @@ pub fn unique(taken: impl Fn(&str) -> bool) -> String {
     Names::new().unique(taken)
 }
 
+/// Does this read like a name minted here rather than typed by a person?
+///
+/// A client names every workspace it creates, so "this workspace has a name"
+/// and "somebody chose that name" are two different questions — and only the
+/// second one should outrank the directory a window's shells are working in.
+/// The tree cannot tell them apart, so the words themselves have to (#604).
+///
+/// Someone who names a workspace "wild-yak" by hand loses this coin flip and
+/// reads the directory in the chip instead. 576 pairs of animal words is a
+/// cheap thing to give up against every window renaming itself the next time
+/// its machine tree is pulled.
+pub fn is_generated(name: &str) -> bool {
+    // `unique` gives up on bare pairs after enough collisions and starts
+    // hanging a number off the end, so "keen-marten-7" is one of ours too.
+    let stem = match name.rsplit_once('-') {
+        Some((stem, count)) if !count.is_empty() && count.bytes().all(|b| b.is_ascii_digit()) => {
+            stem
+        }
+        _ => name,
+    };
+    matches!(
+        stem.split_once('-'),
+        Some((adjective, noun)) if ADJECTIVES.contains(&adjective) && NOUNS.contains(&noun)
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -91,6 +117,34 @@ mod tests {
         let first = Names::seeded(7).candidate();
         let picked = Names::seeded(7).unique(|n| n == first);
         assert_ne!(picked, first);
+    }
+
+    #[test]
+    fn every_name_this_module_mints_is_recognised_as_one_of_ours() {
+        for seed in 1..200u64 {
+            let bare = Names::seeded(seed).candidate();
+            assert!(is_generated(&bare), "{bare} came from here");
+            let numbered = Names::seeded(seed).unique(|n| n.matches('-').count() < 2);
+            assert!(is_generated(&numbered), "{numbered} came from here too");
+        }
+    }
+
+    #[test]
+    fn a_name_a_person_would_type_is_not_mistaken_for_one() {
+        for chosen in [
+            "deploy",
+            "api",
+            "tty7",
+            "verify-main",
+            "quiet",
+            "otter",
+            "keen-marten-ish",
+            "quiet-otter-",
+            "Quiet-Otter",
+            "",
+        ] {
+            assert!(!is_generated(chosen), "{chosen:?} is nobody's codename");
+        }
     }
 
     #[test]

--- a/src/ui/machine_mirror.rs
+++ b/src/ui/machine_mirror.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use gpui::{App, Global};
+use tty7_core::core::codename;
 use tty7_core::core::machine::{LayoutDelta, Machine, PaneRecord, Tab, TabId, Workspace};
 use tty7_core::daemon::control::{ControlRequest, ReplyOk};
 use tty7_core::host::HostId;
@@ -248,23 +249,48 @@ fn view_of<'a>(
 }
 
 pub fn display_name(cx: &App, entry: &crate::core::session::WindowView) -> Option<String> {
-    match view_of(cx, entry) {
-        Some((ws, panes)) => Some(display_name_of(ws, panes)),
-        None => entry.label.clone(),
-    }
+    let Some((ws, _)) = view_of(cx, entry) else {
+        return entry.label.clone();
+    };
+    // `subject_path` rather than `subject_path_of`: the entry remembers the
+    // directory from when the tree could still say, which is what a rebuilt
+    // window has to read it from (#604, see `subject_path`).
+    Some(name_from(
+        ws.name.as_deref(),
+        subject_path(cx, entry).as_deref(),
+    ))
 }
 
 pub fn display_name_of(ws: &Workspace, panes: &[PaneRecord]) -> String {
-    if let Some(name) = ws.name.as_deref().map(str::trim).filter(|n| !n.is_empty()) {
-        return name.to_string();
+    name_from(ws.name.as_deref(), subject_path_of(ws, panes).as_deref())
+}
+
+/// What to call a workspace, from its name and the directory its shells are
+/// working in.
+///
+/// A name somebody chose wins outright. A codename does not: every workspace a
+/// client creates is handed one so the tree and the CLI have something to call
+/// it, and the window that asked for it is never told which one it got — its
+/// mirror carries the workspace unnamed until the tree is pulled whole again.
+/// Letting a name nobody chose outrank the directory meant that pull renamed
+/// the workspace on screen, and a daemon restart is only one of the things
+/// that pulls (#604).
+fn name_from(name: Option<&str>, subject: Option<&str>) -> String {
+    let named = name.map(str::trim).filter(|n| !n.is_empty());
+    if let Some(chosen) = named.filter(|n| !codename::is_generated(n)) {
+        return chosen.to_string();
     }
-    subject_path_of(ws, panes)
+    subject
         .and_then(|path| {
-            std::path::Path::new(&path)
+            std::path::Path::new(path)
                 .file_name()
                 .map(|n| n.to_string_lossy().into_owned())
         })
         .filter(|s| !s.is_empty())
+        // No directory to borrow from — an empty workspace, or one nobody has
+        // ever recorded a cwd for. A codename still beats "Untitled" at telling
+        // two of those apart in a list, which is what it was minted for.
+        .or_else(|| named.map(str::to_string))
         .unwrap_or_else(|| t(L10nKey::WindowUntitled).to_string())
 }
 
@@ -361,6 +387,17 @@ pub fn unclaimed_local_workspaces(cx: &App) -> Vec<UnclaimedWorkspace> {
         .collect()
 }
 
+/// Where this workspace is working, as the tree has it — falling back to what
+/// the entry remembers.
+///
+/// The fallback is not only for a machine that has not answered yet. A window
+/// is left out of the deltas its own edits raise, and the pane records ride
+/// along inside those deltas, so a pane this window created is in its mirror's
+/// tabs while the mirror holds no record for it — no cwd, no directory. The
+/// daemon closes the gap only when some fact later *changes*, and a pane
+/// restored with the cwd it will keep changes nothing. So after a rebuild the
+/// tree this window reads has forgotten where it is, and the entry is the only
+/// one still holding it (#604).
 pub fn subject_path(cx: &App, entry: &crate::core::session::WindowView) -> Option<String> {
     match view_of(cx, entry) {
         Some((ws, panes)) => subject_path_of(ws, panes).or_else(|| entry.subject.clone()),
@@ -372,8 +409,12 @@ pub fn display_hint(
     cx: &App,
     entry: &crate::core::session::WindowView,
 ) -> Option<(String, Option<String>)> {
-    let (ws, panes) = view_of(cx, entry)?;
-    Some((display_name_of(ws, panes), subject_path_of(ws, panes)))
+    let (ws, _) = view_of(cx, entry)?;
+    // Both halves read through the fallback, so the save this feeds writes the
+    // directory back rather than dropping it the first time the mirror cannot
+    // name one (#604).
+    let subject = subject_path(cx, entry);
+    Some((name_from(ws.name.as_deref(), subject.as_deref()), subject))
 }
 
 pub fn pane_ids(cx: &App, entry: &crate::core::session::WindowView) -> Option<Vec<u64>> {
@@ -444,6 +485,114 @@ mod tests {
                 Some("web"),
                 "which is what the next save stamps"
             );
+        });
+    }
+
+    /// #604: a window creates its workspace with a codename it is never told,
+    /// so its mirror carries the workspace unnamed and the chip reads the
+    /// directory. Pulling the tree whole — which a daemon restart, a rebuild
+    /// and a plain relaunch all do — used to hand that codename to the chip and
+    /// stamp it into `views.json` from there, and the rebuild had by then also
+    /// cost the mirror the pane record the directory was read from.
+    #[gpui::test]
+    fn a_rebuild_does_not_rename_a_workspace_to_its_codename(cx: &mut gpui::TestAppContext) {
+        use crate::core::session::{WindowView, WindowViews, WorkspaceStore};
+
+        cx.update(|cx| {
+            let mut entry = WindowView::default();
+            let id = entry.id;
+            WorkspaceStore::install_for_test(
+                cx,
+                WindowViews {
+                    views: vec![entry.clone()],
+                    active: None,
+                },
+            );
+
+            let holding = |pane: u64| Workspace {
+                id,
+                tabs: vec![leaf_tab(pane)],
+                ..Workspace::default()
+            };
+            let working_in = |pane: u64| {
+                vec![PaneRecord {
+                    cwd: Some("/work/verify-main".into()),
+                    ..PaneRecord::new(pane)
+                }]
+            };
+
+            // As the window that created the workspace sees it: the codename it
+            // asked for came back in no delta it was sent.
+            MachineMirrors::install(
+                cx,
+                HostId::LOCAL,
+                Machine {
+                    workspaces: vec![holding(1)],
+                    panes: working_in(1),
+                },
+            );
+            assert_eq!(display_name(cx, &entry).as_deref(), Some("verify-main"));
+            let (label, subject) = display_hint(cx, &entry).expect("the machine has answered");
+            assert_eq!(label, "verify-main");
+            assert_eq!(subject.as_deref(), Some("/work/verify-main"));
+            // What the next save stamps.
+            entry.label = Some(label);
+            entry.subject = subject;
+
+            // The rebuild: the tree as the machine really holds it, codename and
+            // all, and the pane on screen is one this window restored — in the
+            // workspace's tabs, in no pane record the window was sent.
+            MachineMirrors::install(
+                cx,
+                HostId::LOCAL,
+                Machine {
+                    workspaces: vec![Workspace {
+                        name: Some("keen-marten".into()),
+                        ..holding(2)
+                    }],
+                    panes: Vec::new(),
+                },
+            );
+            assert_eq!(
+                display_name(cx, &entry).as_deref(),
+                Some("verify-main"),
+                "a name nobody chose does not outrank the directory"
+            );
+            assert_eq!(
+                display_hint(cx, &entry),
+                Some(("verify-main".to_string(), Some("/work/verify-main".into()))),
+                "and the save that follows writes that back rather than the codename"
+            );
+
+            // A name the user did choose wins, rebuild or no rebuild.
+            MachineMirrors::install(
+                cx,
+                HostId::LOCAL,
+                Machine {
+                    workspaces: vec![Workspace {
+                        name: Some("deploy".into()),
+                        ..holding(2)
+                    }],
+                    panes: Vec::new(),
+                },
+            );
+            assert_eq!(display_name(cx, &entry).as_deref(), Some("deploy"));
+
+            // With no directory anywhere to borrow from, the codename is still
+            // better than "Untitled" — that is the list it was minted for.
+            entry.subject = None;
+            MachineMirrors::install(
+                cx,
+                HostId::LOCAL,
+                Machine {
+                    workspaces: vec![Workspace {
+                        name: Some("keen-marten".into()),
+                        ..holding(2)
+                    }],
+                    panes: Vec::new(),
+                },
+            );
+            assert_eq!(display_name(cx, &entry).as_deref(), Some("keen-marten"));
         });
     }
 


### PR DESCRIPTION
Fixes #604.

## What was happening

Two things, and the bug needs both of them.

**The codename was never shown to the window that asked for it.** Every
workspace a window creates is created with a generated name —
`fresh_workspace_name` mints it and `pull_or_create` / `pull_workspace` send it
with `WorkspaceCreate`. The tree mutation excludes the origin subscriber from
its own deltas, so the `WorkspaceCreated` delta carrying that name never comes
back, and `note_synced_workspace` files the workspace in the mirror as
`Workspace { id, ..default }` — unnamed. `display_name_of` preferred `ws.name`,
so up to that point the chip read the directory the shells were working in, and
that is the only reason it ever did.

The first time the window pulled the whole tree again, the codename arrived and
took the chip. A daemon restart does that (`resync_local_windows_from_tree` →
`hydrate` → `MachineGet` → `MachineMirrors::install`), but so does every local
reconnect (`LocalLink` refreshes the mirror on connect), every mirror re-pull
after a delta falls behind, and simply launching tty7 the next morning — a
restored window hydrates from the tree before it draws. `record_geometry` then
stamped the new name into `views.json` as the entry's label.

**The rebuild also cost the window its directory.** Pane records ride inside the
deltas a window is excluded from, so a pane it restored is in its mirror's tabs
with no record behind it — no cwd. The daemon closes that gap only when some
fact later *changes*, and a pane restored with the cwd it will keep changes
nothing. So after a rebuild `subject_path_of` answers `None`, and
`record_geometry` wrote that `None` back over the subject the entry remembered.

Verified in a dev instance rather than read off the code: on `664b766`, a fresh
config dir gives `machine.json` `name: "dusky-tern"` with the chip reading
`verify-main`; killing the GUI and relaunching it — daemon untouched — is enough
to leave the chip reading `dusky-tern` and `views.json` holding
`"label": "dusky-tern"`.

## The fix

- `codename::is_generated` recognises a name this codebase minted, including the
  numbered form `unique` falls back to.
- A generated name is treated as the placeholder it is. It still names the
  workspace in the tree and to the CLI — `tty7 ws ls` and `tty7 ws rename
  keen-marten …` are unchanged — but on screen only a name someone chose
  outranks the directory. A workspace with no directory to borrow still reads
  its codename rather than "Untitled", which is the list codenames were minted
  for.
- The directory is read through `subject_path`, which already falls back to the
  subject the entry remembers, and `display_hint` now reads both halves through
  it, so the save that follows a rebuild writes the directory back instead of
  dropping it.

Someone who names a workspace "wild-yak" by hand loses this coin flip and reads
their directory in the chip instead; 576 pairs of animal words seemed a cheap
thing to give up against every window renaming itself.

## Neighbouring cases

- **An explicitly renamed workspace keeps its name** through a rebuild — it is
  in the tree and is not a codename. Checked by hand: `tty7 ws rename pale-otter
  deploy`, chip reads `deploy`, still `deploy` after `kill -9` of the daemon.
- **Remote workspaces** go through the same create, the same mirror and the same
  `display_name`, so they are covered by the same change.
- **`views.json` quarantine-and-rebuild** is untouched: no field was added or
  removed, and an entry written by an older build still parses.

## Verification

A local debug build driven by hand in an isolated dev instance
(`--config-dir`, own daemon), plus the unit tests:

| | before | after |
|---|---|---|
| fresh launch, tree name `pale-otter` | `verify-main` | `verify-main` |
| `kill -9` the daemon, window rebuilt | `dusky-tern` | `verify-main` |
| quit and relaunch tty7 | `dusky-tern` | `verify-main` |
| renamed to `deploy`, then `kill -9` | — | `deploy` |

`a_rebuild_does_not_rename_a_workspace_to_its_codename` walks that whole
sequence against the mirror, including the rebuild that leaves the workspace's
pane with no record behind it. Two tests in `codename` pin the recogniser to
what the generator actually produces.

## Known follow-up, not fixed here

The mirror genuinely loses the pane records for panes its own window created —
`subject_path`'s memory papers over it for the workspace's directory, but the
mirror is wrong until something else re-pulls it. Worth its own issue.
