### PR TITLE
fix(remote): give a dialect refusal a way out instead of a retry loop

### DIFF
--- a/crates/tty7-core/src/daemon/control.rs
+++ b/crates/tty7-core/src/daemon/control.rs
@@ -28,7 +28,13 @@ use super::protocol::{MAX_FRAME, read_frame, write_frame};
 /// end events, and `ReplyOk::Attached` and `FileMeta` went away. All of it
 /// shipped against a number that never moved, so every one of those servers
 /// still answers the hello and then drops the link on the first call.
-pub const CONTROL_VERSION: u32 = 6;
+///
+/// v7 changes no message at all. It is here so that the handling of a dialect
+/// refusal — the parked strip, its Update Server button, and the installer
+/// refusing to kill a server it has nothing to replace with — can be exercised
+/// against the v6 servers already deployed. A number is the only way to reach
+/// that path, and a mismatch nobody can reproduce is a mismatch nobody can fix.
+pub const CONTROL_VERSION: u32 = 7;
 
 const DIALECT_MARKER: &str = "speaks control v";
 

--- a/crates/tty7-core/src/daemon/control.rs
+++ b/crates/tty7-core/src/daemon/control.rs
@@ -42,8 +42,16 @@ fn dialect_refusal(peer_build: &str, peer: u32, ours: u32) -> String {
     format!("control peer (build {peer_build}) {DIALECT_MARKER}{peer}, this build speaks v{ours}")
 }
 
+/// Whether this is a refusal over the control dialect — the whole shape of one,
+/// not just the marker.
+///
+/// Every reader of a `true` here goes on to restate the refusal with
+/// [`parse_dialect_refusal`], and one of them parks a link in a state only a
+/// person can leave. Two predicates for one question is how those two come
+/// apart: a message carrying the marker in some other shape would be parked on
+/// and then shown as the raw protocol wording it was supposed to replace.
 pub fn is_dialect_refusal(message: &str) -> bool {
-    message.contains(DIALECT_MARKER)
+    parse_dialect_refusal(message).is_some()
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/tty7-core/src/daemon/install/mod.rs
+++ b/crates/tty7-core/src/daemon/install/mod.rs
@@ -481,6 +481,12 @@ pub enum InstallError {
     Launch {
         reason: String,
     },
+    /// Asked to restart a server this machine does not have. Nothing was
+    /// stopped — see [`Installer::restart_daemon`].
+    NoServerToRestart {
+        host: String,
+        path: String,
+    },
     DialectMismatch {
         origin: String,
         wanted: RemoteProtocol,
@@ -518,6 +524,11 @@ impl std::fmt::Display for InstallError {
                 write!(f, "could not write {path} on the remote machine: {reason}")
             }
             Self::Launch { reason } => write!(f, "the remote tty7-server did not start: {reason}"),
+            Self::NoServerToRestart { host, path } => write!(
+                f,
+                "{host} has no tty7-server at {path} for this build to start, so nothing was \
+                 stopped; install the matching server there and it will be started as part of that"
+            ),
             Self::DialectMismatch {
                 origin,
                 wanted,
@@ -548,6 +559,7 @@ impl From<InstallError> for io::Error {
         let kind = match &e {
             InstallError::Unsupported(_)
             | InstallError::MissingBundled { .. }
+            | InstallError::NoServerToRestart { .. }
             | InstallError::DialectMismatch { .. } => io::ErrorKind::Unsupported,
             InstallError::Declined { .. } => io::ErrorKind::PermissionDenied,
             InstallError::Checksum(_) => io::ErrorKind::InvalidData,
@@ -656,7 +668,10 @@ impl<'a> Installer<'a> {
             self.install(asset, &paths)?;
         }
 
-        self.restart_daemon()
+        // Straight to the cycle: this is the one caller that has just proved
+        // the binary is there, so `restart_daemon`'s guard would only spend
+        // another round trip re-proving it.
+        self.cycle_daemon(&paths)
     }
 
     fn published_binary_serves_us(&self, paths: &RemotePaths) -> Result<bool, InstallError> {
@@ -962,15 +977,39 @@ impl<'a> Installer<'a> {
         Some(entry)
     }
 
+    /// Stop whatever tty7-server is running over there and start the one this
+    /// build speaks to.
+    ///
+    /// Which is not the same binary: the path is named after *our* dialect
+    /// (`tty7-server-c{control}p{protocol}`), while the kill matches any
+    /// `tty7-server-*` — see [`TERMINATE_RUNNING_COMMAND`]. When
+    /// the far end is a machine we have never installed onto — the other side
+    /// of a dialect bump, most of all — the two are different files and the
+    /// second one is not there. Restarting into it would end every session on
+    /// the machine, including other clients', and then have nothing to launch.
+    /// So look before killing: a machine with no matching server to start is
+    /// left exactly as it was, and told to install one first.
     pub fn restart_daemon(&self) -> Result<(), InstallError> {
         let home = self.ops.home_dir().map_err(InstallError::NoHome)?;
         let paths = self.paths_for(&home);
+        if !self.published_binary_serves_us(&paths)? {
+            return Err(InstallError::NoServerToRestart {
+                host: self.host.clone(),
+                path: paths.binary.clone(),
+            });
+        }
+        self.cycle_daemon(&paths)
+    }
+
+    /// The restart itself, for callers that have just put the binary there and
+    /// do not need to be told again that it is there.
+    fn cycle_daemon(&self, paths: &RemotePaths) -> Result<(), InstallError> {
         install_progress().report(&self.host, InstallPhase::Restarting);
 
         let _ = self.ops.run(TERMINATE_RUNNING_COMMAND);
 
         let deadline = Instant::now() + REMOTE_SHUTDOWN_TIMEOUT;
-        while self.daemon_is_serving(&paths)? {
+        while self.daemon_is_serving(paths)? {
             if Instant::now() >= deadline {
                 return Err(InstallError::Launch {
                     reason: format!(
@@ -981,10 +1020,10 @@ impl<'a> Installer<'a> {
             std::thread::sleep(self.poll_interval);
         }
 
-        self.launch_daemon(&paths)?;
+        self.launch_daemon(paths)?;
         let deadline = Instant::now() + self.startup_timeout;
         loop {
-            if self.daemon_is_serving(&paths)? {
+            if self.daemon_is_serving(paths)? {
                 return Ok(());
             }
             if Instant::now() >= deadline {

--- a/crates/tty7-core/src/daemon/install/tests.rs
+++ b/crates/tty7-core/src/daemon/install/tests.rs
@@ -894,6 +894,76 @@ fn restart_replaces_the_running_daemon() {
 }
 
 #[test]
+fn a_restart_with_nothing_to_start_leaves_the_running_daemon_alone() {
+    // The machine on the far side of a dialect bump: a server of the previous
+    // dialect is up and serving, and the binary this build launches has never
+    // been installed. Killing first would have ended every session there —
+    // including other clients' — and then found nothing to run.
+    let old = format!("{BIN_DIR}/tty7-server-c2p3");
+    let remote = FakeRemote::new().serving(&old);
+    remote.preinstall(&old, 0o755);
+    let release = FakeRelease::new();
+    let user = FakeUser::declining();
+
+    let refused = installer(&remote, &release, &user, "me@behind-box:22")
+        .restart_daemon()
+        .expect_err("there is no matching server to restart into");
+
+    assert!(
+        matches!(&refused, InstallError::NoServerToRestart { path, .. } if path == BINARY),
+        "{refused:?}"
+    );
+    assert!(
+        !remote
+            .journal()
+            .iter()
+            .any(|j| matches!(j, Journal::Exec(c) if c == TERMINATE_RUNNING_COMMAND)),
+        "nothing was stopped: {:?}",
+        remote.journal()
+    );
+    assert!(
+        *remote.daemon_running.lock().unwrap(),
+        "the machine is still serving the build it was serving before"
+    );
+    assert_eq!(
+        remote.running_exe.lock().unwrap().as_deref(),
+        Some(old.as_str())
+    );
+}
+
+#[test]
+fn replacing_installs_the_matching_server_and_then_restarts_into_it() {
+    // The same machine, taken through the action that is actually meant for
+    // it. This is the guard's other half: `replace` may kill, because by then
+    // there is something to launch.
+    let old = format!("{BIN_DIR}/tty7-server-c2p3");
+    let remote = FakeRemote::new().serving(&old);
+    remote.preinstall(&old, 0o755);
+    let release = FakeRelease::new();
+    let user = FakeUser::approving();
+
+    installer(&remote, &release, &user, "me@behind-box:22")
+        .replace()
+        .expect("replace installs what restart could not find");
+
+    assert!(remote.file(BINARY).is_some(), "the matching server landed");
+    let journal = remote.journal();
+    let killed = journal
+        .iter()
+        .position(|j| matches!(j, Journal::Exec(c) if c == TERMINATE_RUNNING_COMMAND))
+        .expect("the old daemon is asked to stop");
+    let written = journal
+        .iter()
+        .position(|j| matches!(j, Journal::Rename { to, .. } if to == BINARY))
+        .expect("the new server is put in place");
+    assert!(
+        written < killed,
+        "install before kill, so the window with no server is as short as it can be: {journal:?}"
+    );
+    assert!(*remote.daemon_running.lock().unwrap());
+}
+
+#[test]
 fn the_launch_command_detaches_and_closes_every_stream() {
     let cmd = launch_command("/home/me/.local/share/tty7/bin/tty7-server-26.7.5");
     assert!(cmd.contains("setsid"), "{cmd}");

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1539,6 +1539,18 @@ impl Tty7App {
             );
             return;
         }
+        // A server the other side of a dialect bump has nothing to restart
+        // *into*: the binary this build launches was never installed over
+        // there, and the installer now refuses rather than killing the one
+        // that is running. Updating is the move that works, so offer that,
+        // under its own name and with its own warning about ending sessions.
+        if matches!(
+            self.remote_status(cx),
+            Some(crate::ui::remote_workspace::RemoteStatus::ServerMismatch(_))
+        ) {
+            self.confirm_replace_remote_server(target, label, window, cx);
+            return;
+        }
         self.confirm_restart_remote_server(target, label, window, cx);
     }
 
@@ -6052,7 +6064,7 @@ impl Tty7App {
         let status = self.remote_status(cx)?;
         let machine = self.remote_machine_label(cx);
         let message = status.strip_message(&machine)?;
-        let action = status.action_label();
+        let action = self.remote_strip_action(&status, cx);
         let theme = cx.theme();
         let bar = gpui_component::h_flex()
             .occlude()
@@ -6074,7 +6086,7 @@ impl Tty7App {
                     .text_color(theme.foreground)
                     .child(message),
             )
-            .when_some(action, |this, label| {
+            .when_some(action, |this, (label, action)| {
                 use gpui_component::Sizable as _;
                 use gpui_component::button::ButtonVariants as _;
                 this.child(
@@ -6082,7 +6094,9 @@ impl Tty7App {
                         .label(label)
                         .primary()
                         .small()
-                        .on_click(cx.listener(|this, _, _window, cx| this.remote_retry(cx))),
+                        .on_click(cx.listener(move |this, _, window, cx| {
+                            this.run_strip_action(action.clone(), window, cx);
+                        })),
                 )
             });
         Some(

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1544,11 +1544,11 @@ impl Tty7App {
         // there, and the installer now refuses rather than killing the one
         // that is running. Updating is the move that works, so offer that,
         // under its own name and with its own warning about ending sessions.
-        if matches!(
-            self.remote_status(cx),
-            Some(crate::ui::remote_workspace::RemoteStatus::ServerMismatch(_))
-        ) {
-            self.confirm_replace_remote_server(target, label, window, cx);
+        if let Some(crate::ui::remote_workspace::RemoteStatus::ServerMismatch(refusal)) =
+            self.remote_status(cx)
+        {
+            let action = crate::ui::remote_workspace::mismatch_action_key(&refusal);
+            self.confirm_replace_remote_server(target, label, action, window, cx);
             return;
         }
         self.confirm_restart_remote_server(target, label, window, cx);

--- a/src/ui/home.rs
+++ b/src/ui/home.rs
@@ -255,7 +255,7 @@ impl Tty7App {
         let machine = self.remote_machine_label(cx);
         let status = self.remote_status(cx)?;
         let message = status.strip_message(&machine)?;
-        let action = status.action_label();
+        let action = self.remote_strip_action(&status, cx);
         let theme = cx.theme();
         Some(
             h_flex()
@@ -271,13 +271,15 @@ impl Tty7App {
                 .text_color(theme.muted_foreground)
                 .child(gpui_component::Icon::new(IconName::Globe))
                 .child(message)
-                .when_some(action, |this, label| {
+                .when_some(action, |this, (label, action)| {
                     this.child(
                         Button::new("home-remote-status-action")
                             .label(label)
                             .ghost()
                             .small()
-                            .on_click(cx.listener(|this, _, _window, cx| this.remote_retry(cx)))
+                            .on_click(cx.listener(move |this, _, window, cx| {
+                                this.run_strip_action(action.clone(), window, cx);
+                            }))
                             .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation()),
                     )
                 }),

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -1251,6 +1251,11 @@ pub fn translate_en(key: L10nKey) -> &'static str {
              {cancel}\u{2003}leaves {machine} exactly as it is. This window will not connect."
         }
         L10nKey::RemoteMismatchReplaceServer => "Update Server",
+        // Same button, opposite direction: the machine is ahead of this build,
+        // so putting our server there takes it back a version. Calling that an
+        // update would be a lie, and it is the kind that ends other people's
+        // sessions on the way through.
+        L10nKey::RemoteMismatchDowngradeServer => "Replace Server",
         L10nKey::RemoteMismatchUnknownBuild => "an unknown build",
         L10nKey::RemoteMismatchUnknownBuildFromExe => "an unknown build (from {exe})",
         L10nKey::RemoteServerOutdated => {

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -1283,6 +1283,7 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
             "{machine} は {running} から tty7 セッションを提供していますが、このクライアント（{wanted}）はそのプロトコルを理解できません。tty7 は対応するサーバーをそこにインストール済みですが、セッションは実行中のサーバー上にあります。\n\n{replace_server}\u{2003}を選ぶと {wanted} に置き換えられ、そのサーバー上のセッションはすべて終了します。\n{cancel}\u{2003}を選ぶと {machine} はそのままです。このウィンドウは接続しません"
         }
         L10nKey::RemoteMismatchReplaceServer => "サーバーを更新",
+        L10nKey::RemoteMismatchDowngradeServer => "サーバーを置き換え",
         L10nKey::RemoteMismatchUnknownBuild => "不明なビルド",
         L10nKey::RemoteMismatchUnknownBuildFromExe => "不明なビルド（{exe} から）",
         L10nKey::RemoteServerOutdated => {

--- a/src/ui/i18n/mod.rs
+++ b/src/ui/i18n/mod.rs
@@ -1017,6 +1017,7 @@ l10n_keys! {
     RemoteMismatchUnknownBuild,
     RemoteMismatchUnknownBuildFromExe,
     RemoteMismatchReplaceServer,
+    RemoteMismatchDowngradeServer,
     RemoteServerOutdated,
     RemoteServerTooNew,
     RemoteDaemonStartFailed,

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -1174,6 +1174,7 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
              {cancel}\u{2003}会保持 {machine} 现状不变。此窗口将不会连接。"
         }
         L10nKey::RemoteMismatchReplaceServer => "更新 server",
+        L10nKey::RemoteMismatchDowngradeServer => "替换 server",
         L10nKey::RemoteMismatchUnknownBuild => "未知构建",
         L10nKey::RemoteMismatchUnknownBuildFromExe => "未知构建（来自 {exe}）",
         L10nKey::RemoteServerOutdated => {

--- a/src/ui/remote_connect.rs
+++ b/src/ui/remote_connect.rs
@@ -764,6 +764,23 @@ pub fn mismatch_target(m: &MismatchedRemoteDaemon) -> Option<RemoteTarget> {
     origin_target(&m.host)
 }
 
+/// A handshake that failed on the control dialect reaches the UI as the protocol
+/// layer's own wording, which reads like the far end is not tty7 at all. It is —
+/// it is just a build the other side of a dialect bump — so say that instead, and
+/// say which side has to move. Anything else is shown as it came.
+pub fn dialect_complaint(error: &str, machine: &str) -> Option<String> {
+    let refusal = crate::daemon::control::parse_dialect_refusal(error)?;
+    let key = if refusal.peer < refusal.ours {
+        L10nKey::RemoteServerOutdated
+    } else {
+        L10nKey::RemoteServerTooNew
+    };
+    Some(t_fmt(
+        key,
+        &[("machine", machine), ("build", &refusal.peer_build)],
+    ))
+}
+
 pub fn restart_server_blocking(header: RouteHeader, label: &str) -> Result<(), String> {
     let action = header.action;
     crate::daemon::spawn::ensure_running().map_err(|e| {
@@ -804,6 +821,40 @@ mod tests {
             size_bytes: 9_437_184,
             sha256: "abc123".into(),
         }
+    }
+
+    fn refusal(peer: u32, ours: u32) -> String {
+        format!(
+            "java answered, but not as a tty7 server: control peer (build 26.7.7-nightly) \
+             speaks control v{peer}, this build speaks v{ours}"
+        )
+    }
+
+    #[test]
+    fn a_dialect_refusal_is_restated_as_which_side_is_behind() {
+        let behind = dialect_complaint(&refusal(4, 5), "java").expect("a refusal is recognised");
+        assert!(
+            behind.contains("java") && behind.contains("26.7.7-nightly"),
+            "{behind}"
+        );
+        assert!(
+            !behind.contains("control v"),
+            "the dialect numbers mean nothing to the reader: {behind}"
+        );
+
+        let ahead = dialect_complaint(&refusal(6, 5), "java").expect("a refusal is recognised");
+        assert_ne!(
+            ahead, behind,
+            "a server newer than this client needs the opposite advice"
+        );
+    }
+
+    #[test]
+    fn every_other_failure_is_shown_as_it_came() {
+        assert_eq!(
+            dialect_complaint("Connection refused (os error 61)", "java"),
+            None
+        );
     }
 
     #[test]

--- a/src/ui/remote_workspace.rs
+++ b/src/ui/remote_workspace.rs
@@ -100,9 +100,10 @@ impl RemoteStatus {
             )),
             // The protocol layer's wording reads like the far end is not tty7
             // at all, and it is 20 words of dialect numbers. Say which side is
-            // behind instead. The fallback cannot be reached from the pump —
-            // nothing becomes `ServerMismatch` unless the refusal parsed — but
-            // it costs nothing and beats an empty strip.
+            // behind instead. Nothing becomes `ServerMismatch` unless the
+            // refusal parsed — `is_dialect_refusal` is that same parse — so the
+            // fallback is unreachable; it costs nothing and beats an empty
+            // strip if that ever stops being true.
             RemoteStatus::ServerMismatch(e) => Some(
                 remote_connect::dialect_complaint(e, machine).unwrap_or_else(|| {
                     t_fmt(
@@ -136,7 +137,7 @@ impl RemoteStatus {
             // Not "retry" — retrying is what the strip used to offer here, and
             // it can only fail the same way. The only move that changes the
             // answer is installing the server this build speaks to.
-            RemoteStatus::ServerMismatch(_) => Some(t(L10nKey::RemoteMismatchReplaceServer)),
+            RemoteStatus::ServerMismatch(e) => Some(t(mismatch_action_key(e))),
             // A retry on a dead route fails deterministically; the switcher
             // row carries the honest actions (forget the entry, or dismiss).
             RemoteStatus::RouteLost => None,
@@ -152,6 +153,21 @@ impl RemoteStatus {
     }
 }
 
+/// Which way the one button points.
+///
+/// Both directions do the same thing — put *this* build's server on that
+/// machine — and that is an update only while the machine is behind. On one
+/// that is ahead it is a downgrade, and the copy beside the button says so:
+/// updating tty7 here is the first suggestion, replacing the server there the
+/// second. The button is the second one, so it should not wear the first one's
+/// word.
+pub(crate) fn mismatch_action_key(refusal: &str) -> L10nKey {
+    match crate::daemon::control::parse_dialect_refusal(refusal) {
+        Some(r) if r.peer > r.ours => L10nKey::RemoteMismatchDowngradeServer,
+        _ => L10nKey::RemoteMismatchReplaceServer,
+    }
+}
+
 /// What the remote strip's button is for, once the status has been read.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum StripAction {
@@ -161,11 +177,22 @@ pub(crate) enum StripAction {
     UpdateServer {
         target: RemoteTarget,
         label: String,
+        /// The word for it, carried rather than recomputed: the confirmation
+        /// this ends in must offer the same one the button did.
+        action: L10nKey,
     },
 }
 
 pub const RECONNECT_FIRST: std::time::Duration = std::time::Duration::from_secs(1);
 pub const RECONNECT_CAP: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// How long a link parked on a dialect refusal waits before looking again.
+///
+/// Not a backoff — it never grows, and it is two orders of magnitude off the
+/// reconnect clock on purpose. The refusal only stops being true when something
+/// happens on the far end that nobody here is told about, so this is a slow
+/// question about someone else's machine, not a retry of our own failure.
+pub const PARKED_RECHECK: std::time::Duration = std::time::Duration::from_secs(300);
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Backoff {
@@ -355,7 +382,7 @@ impl Tty7App {
         cx: &gpui::App,
     ) -> Option<(&'static str, StripAction)> {
         let label = status.action_label()?;
-        let RemoteStatus::ServerMismatch(_) = status else {
+        let RemoteStatus::ServerMismatch(refusal) = status else {
             return Some((label, StripAction::Retry));
         };
         // Only a machine whose server is ours to install can be updated from
@@ -368,6 +395,7 @@ impl Tty7App {
                 StripAction::UpdateServer {
                     target: own.target.clone(),
                     label: self.remote_machine_label(cx),
+                    action: mismatch_action_key(refusal),
                 },
             )
         })
@@ -381,9 +409,11 @@ impl Tty7App {
     ) {
         match action {
             StripAction::Retry => self.remote_retry(cx),
-            StripAction::UpdateServer { target, label } => {
-                self.confirm_replace_remote_server(target, label, window, cx)
-            }
+            StripAction::UpdateServer {
+                target,
+                label,
+                action,
+            } => self.confirm_replace_remote_server(target, label, action, window, cx),
         }
     }
 
@@ -726,10 +756,15 @@ impl Tty7App {
         .detach();
     }
 
+    /// `action` is the word the thing that led here used on its own button —
+    /// Update or Replace, depending on which side is behind. A confirmation
+    /// that renames the act between the click and the prompt is asking about
+    /// something the user did not choose.
     pub(crate) fn confirm_replace_remote_server(
         &mut self,
         target: RemoteTarget,
         label: String,
+        action: L10nKey,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -737,10 +772,7 @@ impl Tty7App {
             PromptLevel::Warning,
             &t_fmt(L10nKey::RemoteMismatchTitle, &[("machine", &label)]),
             Some(&t_fmt(L10nKey::RemoteReplaceBody, &[("machine", &label)])),
-            &crate::ui::confirm_answers(
-                t(L10nKey::RemoteMismatchReplaceServer),
-                t(L10nKey::Cancel),
-            ),
+            &crate::ui::confirm_answers(t(action), t(L10nKey::Cancel)),
             cx,
         );
         cx.spawn(async move |this, cx| {
@@ -1142,11 +1174,15 @@ impl RemoteLinks {
         });
         link.backoff.reset();
         link.next_attempt = Some(Instant::now());
-        // Someone asked for this by hand, which is also the only way out of a
-        // park — and the reason it was parked is now the *previous* answer, not
-        // the current one. Keeping it would put the old complaint back on the
-        // strip underneath a fresh attempt.
-        link.last_error = None;
+        // Leaving a park, the refusal that caused it is the *previous* answer:
+        // carrying it over would put "that server is too old" back on the strip
+        // underneath a fresh attempt, as though this one had failed too. Every
+        // other reason is still the last thing that actually happened, and the
+        // strip says so while the attempt is in flight — pressing Retry Now on
+        // an unreachable machine should not cost the user the reason why.
+        if matches!(link.state, LinkState::Mismatched(_)) {
+            link.last_error = None;
+        }
         if !link.attempting {
             link.state = LinkState::Reconnecting;
         }
@@ -1274,23 +1310,32 @@ fn pump_tick(cx: &mut gpui::App) -> bool {
             continue;
         }
 
-        // Parked on a dialect refusal, for the same reason and in the same
-        // shape as an unresolvable route: the attempt is known to fail. Two
-        // things still get out of it, and both need a human to say so —
-        // `retry_now`, which the Update Server flow ends in, and a manual
-        // connect from the switcher, whose link the `live` branch above adopts
-        // before this ever runs.
-        let parked = cx
-            .try_global::<RemoteLinks>()
-            .and_then(|l| l.machines.get(&host))
-            .is_some_and(|l| matches!(l.state, LinkState::Mismatched(_)));
-        if parked {
-            continue;
-        }
-
         let due = {
             let mut due = false;
             RemoteLinks::mark(cx, host, |link| {
+                // Parked on a dialect refusal: the answer is known, so no
+                // backoff and no attempt counter. What gets out of it is
+                // normally a person — `retry_now`, which the Update Server flow
+                // ends in, or a manual connect the `live` branch above adopts.
+                //
+                // But this machine's build is not ours to know. Someone else's
+                // client can update that server, and the machine can come back
+                // from a reboot on a build that speaks to us; nothing tells us
+                // when. So look again on a slow clock — far enough apart that
+                // it is not the retry loop this replaced, close enough that a
+                // machine which quietly got fixed does not sit here claiming to
+                // be broken for the rest of the session.
+                if matches!(link.state, LinkState::Mismatched(_)) {
+                    match link.next_attempt {
+                        None => link.next_attempt = Some(now + PARKED_RECHECK),
+                        Some(at) if at <= now => {
+                            due = true;
+                            link.next_attempt = None;
+                        }
+                        Some(_) => {}
+                    }
+                    return;
+                }
                 if !matches!(link.state, LinkState::Reconnecting) {
                     changed = true;
                     link.state = LinkState::Reconnecting;
@@ -2203,6 +2248,12 @@ mod tests {
                 Some(t(L10nKey::RemoteNoticeDisconnected)),
                 Some(t(L10nKey::RemoteMismatchReplaceServer)),
             ),
+            (
+                RemoteStatus::ServerMismatch(a_refusal_between(7, 6)),
+                false,
+                Some(t(L10nKey::RemoteNoticeDisconnected)),
+                Some(t(L10nKey::RemoteMismatchDowngradeServer)),
+            ),
         ];
         for (status, accepts, notice, action) in cases {
             assert_eq!(status.accepts_input(), accepts, "{status:?}");
@@ -2253,6 +2304,44 @@ mod tests {
         (target.host_id(), target)
     }
 
+    /// A machine the pump will actually think about.
+    ///
+    /// An `Alias` is only resolvable while that name is in the ssh config of
+    /// whoever is running the tests, and the pump drops an unresolvable route
+    /// before it reaches anything else — so a test that asserts on what the
+    /// pump does to a link must not use one, or it passes by not getting there.
+    fn resolvable_machine(name: &str) -> (HostId, RemoteTarget) {
+        let target = RemoteTarget::Wsl {
+            distro: name.to_string(),
+        };
+        (target.host_id(), target)
+    }
+
+    /// A parked machine with one open workspace on it, wound forward to the
+    /// moment after the refusal.
+    fn parked_on_a_refusal(cx: &mut gpui::App) -> (HostId, RemoteTarget, WorkspaceId) {
+        crate::core::config::pin_test_config_dir();
+        cx.set_global(crate::core::config::Config::default());
+        crate::ui::windows::WindowRegistry::init(cx);
+
+        let (host, target) = resolvable_machine("build-box");
+        let mut entry = crate::core::session::WindowView::on_remote(RemoteRef::new(
+            target.clone(),
+            WorkspaceId::new(),
+        ));
+        entry.open = true;
+        let id = entry.id;
+        WorkspaceStore::install_for_test(
+            cx,
+            crate::core::session::WindowViews {
+                views: vec![entry],
+                active: None,
+            },
+        );
+        finish_attempt(cx, host, &target, Err(a_refusal()));
+        (host, target, id)
+    }
+
     #[test]
     fn a_disconnect_ends_when_the_last_window_on_that_machine_closes() {
         let (build, build_t) = machine("build-box");
@@ -2279,7 +2368,7 @@ mod tests {
             cx.set_global(crate::core::config::Config::default());
             crate::ui::windows::WindowRegistry::init(cx);
 
-            let (host, target) = machine("build-box");
+            let (host, target) = resolvable_machine("build-box");
             let mut entry = crate::core::session::WindowView::on_remote(RemoteRef::new(
                 target.clone(),
                 WorkspaceId::new(),
@@ -2311,7 +2400,7 @@ mod tests {
             );
 
             // Whatever the pump does with a parked machine, it must not be to
-            // schedule another attempt — that is the loop this replaced.
+            // put it back on the backoff — that is the loop this replaced.
             for _ in 0..4 {
                 pump_tick(cx);
             }
@@ -2321,10 +2410,19 @@ mod tests {
                 matches!(link.state, LinkState::Mismatched(_)),
                 "four ticks later it is still parked, not back on the backoff"
             );
-            assert!(link.next_attempt.is_none() && !link.attempting);
+            assert!(!link.attempting);
             assert_eq!(link.backoff.attempt(), 0, "no attempt was ever scheduled");
+            let wait = link
+                .next_attempt
+                .expect("a parked link still looks again eventually")
+                .saturating_duration_since(Instant::now());
+            assert!(
+                wait > RECONNECT_CAP,
+                "the next look is on the slow clock, not the reconnect one: {wait:?}"
+            );
 
-            // The one way out, which is what Update Server ends in.
+            // The one way out that does not involve waiting, and the one Update
+            // Server ends in.
             RemoteLinks::retry_now(cx, id);
             assert!(
                 matches!(
@@ -2332,6 +2430,64 @@ mod tests {
                     Some(RemoteStatus::Reconnecting { .. })
                 ),
                 "asking by hand un-parks it"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn a_parked_link_looks_again_when_the_slow_clock_runs_out(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let (host, _, _) = parked_on_a_refusal(cx);
+            pump_tick(cx);
+
+            // Standing in for five minutes of nobody touching anything. The
+            // machine's build is not ours to know: someone else's client can
+            // update that server, and nothing over here is told when.
+            cx.default_global::<RemoteLinks>()
+                .machines
+                .get_mut(&host)
+                .expect("the machine is still known")
+                .next_attempt = Some(Instant::now() - std::time::Duration::from_secs(1));
+            pump_tick(cx);
+
+            let link = cx.default_global::<RemoteLinks>().machines.get(&host);
+            let link = link.expect("the machine is still known");
+            assert!(
+                link.attempting,
+                "the slow clock ran out, so it looked again"
+            );
+            assert!(
+                matches!(link.state, LinkState::Mismatched(_)),
+                "and said nothing new on the strip while it did: a look that fails \
+                 the same way must not read as a fresh problem"
+            );
+            assert_eq!(
+                link.backoff.attempt(),
+                0,
+                "looking again is not the backoff coming back"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn a_park_that_is_still_true_goes_straight_back_on_the_slow_clock(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| {
+            let (host, target, _) = parked_on_a_refusal(cx);
+            // The look the slow clock bought, answered the same way as before.
+            finish_attempt(cx, host, &target, Err(a_refusal()));
+            pump_tick(cx);
+
+            let link = cx.default_global::<RemoteLinks>().machines.get(&host);
+            let link = link.expect("the machine is still known");
+            let wait = link
+                .next_attempt
+                .expect("still parked, so still looking again later")
+                .saturating_duration_since(Instant::now());
+            assert!(
+                wait > RECONNECT_CAP,
+                "a refusal that repeats resets the slow clock rather than tightening it: {wait:?}"
             );
         });
     }
@@ -2409,16 +2565,33 @@ mod tests {
     /// What `connect_blocking` hands back when the far end answers the hello
     /// with another dialect, localised wrapper and all.
     fn a_refusal() -> String {
+        a_refusal_between(5, 6)
+    }
+
+    fn a_refusal_between(peer: u32, ours: u32) -> String {
+        let error = format!(
+            "control peer (build 26.8.1) speaks control v{peer}, this build speaks v{ours}"
+        );
         t_fmt(
             L10nKey::RemoteHostNotTty7,
-            &[
-                ("machine", "build-box"),
-                (
-                    "error",
-                    "control peer (build 26.8.1) speaks control v5, this build speaks v6",
-                ),
-            ],
+            &[("machine", "build-box"), ("error", &error)],
         )
+    }
+
+    #[test]
+    fn the_button_calls_a_downgrade_a_downgrade() {
+        crate::ui::i18n::set_locale("en");
+        assert_eq!(
+            t(mismatch_action_key(&a_refusal_between(5, 6))),
+            "Update Server",
+            "that machine is behind, so putting our server there moves it forward"
+        );
+        assert_eq!(
+            t(mismatch_action_key(&a_refusal_between(7, 6))),
+            "Replace Server",
+            "that machine is ahead: the same button takes it back a version, and \
+             the copy beside it offers updating *this* computer first"
+        );
     }
 
     #[test]

--- a/src/ui/remote_workspace.rs
+++ b/src/ui/remote_workspace.rs
@@ -44,6 +44,13 @@ pub enum RemoteStatus {
         by: String,
     },
     Failed(String),
+    /// The machine answered, and answered as tty7 — with a server the other
+    /// side of a control-dialect bump. Carries the refusal verbatim so it can
+    /// be restated for a reader. Parked like `RouteLost`, because a retry is
+    /// just as hopeless: nothing about either build changes between attempts.
+    /// Unlike `RouteLost` there is something to do about it, so this one keeps
+    /// a button — the one that updates the server over there.
+    ServerMismatch(String),
     /// The route itself is gone — the profile was deleted or the alias left
     /// the ssh config — so no reconnect can ever succeed (#485). Parked: no
     /// retry button, just the truth plus the way back.
@@ -91,6 +98,19 @@ impl RemoteStatus {
                 L10nKey::RemoteStripFailed,
                 &[("machine", machine), ("error", e)],
             )),
+            // The protocol layer's wording reads like the far end is not tty7
+            // at all, and it is 20 words of dialect numbers. Say which side is
+            // behind instead. The fallback cannot be reached from the pump —
+            // nothing becomes `ServerMismatch` unless the refusal parsed — but
+            // it costs nothing and beats an empty strip.
+            RemoteStatus::ServerMismatch(e) => Some(
+                remote_connect::dialect_complaint(e, machine).unwrap_or_else(|| {
+                    t_fmt(
+                        L10nKey::RemoteStripFailed,
+                        &[("machine", machine), ("error", e)],
+                    )
+                }),
+            ),
             RemoteStatus::RouteLost => Some(t_fmt(
                 L10nKey::RemoteStripRouteLost,
                 &[("machine", machine)],
@@ -113,6 +133,10 @@ impl RemoteStatus {
             RemoteStatus::Preempted { .. } => Some(t(L10nKey::RemoteActionTakeBack)),
             RemoteStatus::Disconnected => Some(t(L10nKey::RemoteActionConnect)),
             RemoteStatus::Failed(_) => Some(t(L10nKey::RemoteActionRetry)),
+            // Not "retry" — retrying is what the strip used to offer here, and
+            // it can only fail the same way. The only move that changes the
+            // answer is installing the server this build speaks to.
+            RemoteStatus::ServerMismatch(_) => Some(t(L10nKey::RemoteMismatchReplaceServer)),
             // A retry on a dead route fails deterministically; the switcher
             // row carries the honest actions (forget the entry, or dismiss).
             RemoteStatus::RouteLost => None,
@@ -126,6 +150,18 @@ impl RemoteStatus {
     pub fn accepts_input(&self) -> bool {
         matches!(self, RemoteStatus::Attached)
     }
+}
+
+/// What the remote strip's button is for, once the status has been read.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum StripAction {
+    /// Connect, reconnect, retry, take back — every move that amounts to
+    /// "try the link again now".
+    Retry,
+    UpdateServer {
+        target: RemoteTarget,
+        label: String,
+    },
 }
 
 pub const RECONNECT_FIRST: std::time::Duration = std::time::Duration::from_secs(1);
@@ -305,6 +341,50 @@ impl Tty7App {
         let supervised = RemoteLinks::status_of(cx, self.workspace);
         let resolvable = remote_connect::route_resolvable(cx, &own.target);
         resolve_status(self.connect.as_ref(), &own.target, supervised, resolvable)
+    }
+
+    /// The strip's one button: its label, and what pressing it does.
+    ///
+    /// These used to be decided separately — `action_label` picked the word and
+    /// the button always called `remote_retry` — which is exactly how the one
+    /// state a retry cannot fix ended up wearing a Retry Now button and looping
+    /// on it forever.
+    pub(crate) fn remote_strip_action(
+        &self,
+        status: &RemoteStatus,
+        cx: &gpui::App,
+    ) -> Option<(&'static str, StripAction)> {
+        let label = status.action_label()?;
+        let RemoteStatus::ServerMismatch(_) = status else {
+            return Some((label, StripAction::Retry));
+        };
+        // Only a machine whose server is ours to install can be updated from
+        // here. Anything else — a `--stdio` program, a peer someone else runs —
+        // keeps the explanation and loses the button, which is the truth.
+        let own = WorkspaceStore::remote_ref(cx, self.workspace)?;
+        own.target.hosts_our_server().then(|| {
+            (
+                label,
+                StripAction::UpdateServer {
+                    target: own.target.clone(),
+                    label: self.remote_machine_label(cx),
+                },
+            )
+        })
+    }
+
+    pub(crate) fn run_strip_action(
+        &mut self,
+        action: StripAction,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        match action {
+            StripAction::Retry => self.remote_retry(cx),
+            StripAction::UpdateServer { target, label } => {
+                self.confirm_replace_remote_server(target, label, window, cx)
+            }
+        }
     }
 
     pub(crate) fn remote_retry(&mut self, cx: &mut Context<Self>) {
@@ -832,6 +912,14 @@ fn resolve_status(
     }
     match mine {
         Some(ConnectFlow::Connecting { .. }) => Some(RemoteStatus::Connecting),
+        // A connect the user ran by hand fails on the dialect exactly as the
+        // supervisor's does, and deserves the same answer — the restatement and
+        // the Update Server button, not a Retry that cannot work.
+        Some(ConnectFlow::Failed { error, .. })
+            if crate::daemon::control::is_dialect_refusal(error) =>
+        {
+            Some(RemoteStatus::ServerMismatch(error.clone()))
+        }
         Some(ConnectFlow::Failed { error, .. }) => Some(RemoteStatus::Failed(error.clone())),
         None => supervised,
     }
@@ -883,6 +971,10 @@ enum LinkState {
     Attached,
     Reconnecting,
     Failed(String),
+    /// The far end refused the control hello over the dialect. The pump leaves
+    /// this one alone — see `pump_tick` — so it is the one state that survives
+    /// a tick without being rewritten to `Reconnecting`.
+    Mismatched(String),
 }
 
 /// What the supervisor knows about one *machine's* link, for readers outside
@@ -992,6 +1084,7 @@ impl RemoteLinks {
                     last_error: link.last_error.clone(),
                 },
                 LinkState::Failed(e) => RemoteStatus::Failed(e.clone()),
+                LinkState::Mismatched(e) => RemoteStatus::ServerMismatch(e.clone()),
             },
             None => RemoteStatus::Disconnected,
         })
@@ -1010,6 +1103,11 @@ impl RemoteLinks {
                 last_error: link.last_error.clone(),
             },
             LinkState::Failed(e) => MachineStatus::Failed(e.clone()),
+            // Failed, as far as the switcher is concerned: a parked machine is
+            // not reachable and not being retried. The refusal travels with it,
+            // which is all the error band needs — it already recognises one and
+            // grows an Update Server button.
+            LinkState::Mismatched(e) => MachineStatus::Failed(e.clone()),
         })
     }
 
@@ -1044,6 +1142,11 @@ impl RemoteLinks {
         });
         link.backoff.reset();
         link.next_attempt = Some(Instant::now());
+        // Someone asked for this by hand, which is also the only way out of a
+        // park — and the reason it was parked is now the *previous* answer, not
+        // the current one. Keeping it would put the old complaint back on the
+        // strip underneath a fresh attempt.
+        link.last_error = None;
         if !link.attempting {
             link.state = LinkState::Reconnecting;
         }
@@ -1168,6 +1271,20 @@ fn pump_tick(cx: &mut gpui::App) -> bool {
             }
         }
         if !resolvable {
+            continue;
+        }
+
+        // Parked on a dialect refusal, for the same reason and in the same
+        // shape as an unresolvable route: the attempt is known to fail. Two
+        // things still get out of it, and both need a human to say so —
+        // `retry_now`, which the Update Server flow ends in, and a manual
+        // connect from the switcher, whose link the `live` branch above adopts
+        // before this ever runs.
+        let parked = cx
+            .try_global::<RemoteLinks>()
+            .and_then(|l| l.machines.get(&host))
+            .is_some_and(|l| matches!(l.state, LinkState::Mismatched(_)));
+        if parked {
             continue;
         }
 
@@ -1554,10 +1671,24 @@ fn finish_attempt(
             log::info!("reconnected to {label}");
         }
         Err(e) => {
-            log::warn!("reconnect to {label} failed: {e}");
+            // A dialect refusal is not a transient failure. Both builds are
+            // fixed, so the next attempt fails identically and the one after
+            // that too; all the backoff buys is a strip that counts to thirty
+            // for the rest of the session. Park it and give the user the move
+            // that actually changes the answer.
+            let parked = crate::daemon::control::is_dialect_refusal(&e);
+            if parked {
+                log::warn!("{label} is served by a build this one cannot speak to: {e}");
+            } else {
+                log::warn!("reconnect to {label} failed: {e}");
+            }
             RemoteLinks::mark(cx, host, |link| {
                 link.attempting = false;
-                link.state = LinkState::Reconnecting;
+                link.state = if parked {
+                    LinkState::Mismatched(e.clone())
+                } else {
+                    LinkState::Reconnecting
+                };
                 link.next_attempt = None;
                 link.last_error = Some(e.clone());
             });
@@ -2066,6 +2197,12 @@ mod tests {
                 Some(t(L10nKey::RemoteNoticeDisconnected)),
                 Some(t(L10nKey::RemoteActionRetry)),
             ),
+            (
+                RemoteStatus::ServerMismatch(a_refusal()),
+                false,
+                Some(t(L10nKey::RemoteNoticeDisconnected)),
+                Some(t(L10nKey::RemoteMismatchReplaceServer)),
+            ),
         ];
         for (status, accepts, notice, action) in cases {
             assert_eq!(status.accepts_input(), accepts, "{status:?}");
@@ -2131,6 +2268,72 @@ mod tests {
             vec![build],
             "closing one machine's window must not resume another"
         );
+    }
+
+    #[gpui::test]
+    fn a_dialect_refusal_parks_the_link_instead_of_counting_attempts(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| {
+            crate::core::config::pin_test_config_dir();
+            cx.set_global(crate::core::config::Config::default());
+            crate::ui::windows::WindowRegistry::init(cx);
+
+            let (host, target) = machine("build-box");
+            let mut entry = crate::core::session::WindowView::on_remote(RemoteRef::new(
+                target.clone(),
+                WorkspaceId::new(),
+            ));
+            entry.open = true;
+            let id = entry.id;
+            WorkspaceStore::install_for_test(
+                cx,
+                crate::core::session::WindowViews {
+                    views: vec![entry],
+                    active: None,
+                },
+            );
+
+            finish_attempt(cx, host, &target, Err("connection refused".into()));
+            assert!(
+                matches!(
+                    RemoteLinks::status_of(cx, id),
+                    Some(RemoteStatus::Reconnecting { .. })
+                ),
+                "an ordinary failure is worth another go"
+            );
+
+            finish_attempt(cx, host, &target, Err(a_refusal()));
+            let parked = RemoteLinks::status_of(cx, id);
+            assert!(
+                matches!(parked, Some(RemoteStatus::ServerMismatch(_))),
+                "a refusal both builds will repeat verbatim is not a reconnect: {parked:?}"
+            );
+
+            // Whatever the pump does with a parked machine, it must not be to
+            // schedule another attempt — that is the loop this replaced.
+            for _ in 0..4 {
+                pump_tick(cx);
+            }
+            let link = cx.default_global::<RemoteLinks>().machines.get(&host);
+            let link = link.expect("the machine is still known");
+            assert!(
+                matches!(link.state, LinkState::Mismatched(_)),
+                "four ticks later it is still parked, not back on the backoff"
+            );
+            assert!(link.next_attempt.is_none() && !link.attempting);
+            assert_eq!(link.backoff.attempt(), 0, "no attempt was ever scheduled");
+
+            // The one way out, which is what Update Server ends in.
+            RemoteLinks::retry_now(cx, id);
+            assert!(
+                matches!(
+                    RemoteLinks::status_of(cx, id),
+                    Some(RemoteStatus::Reconnecting { .. })
+                ),
+                "asking by hand un-parks it"
+            );
+        });
     }
 
     #[gpui::test]
@@ -2200,6 +2403,64 @@ mod tests {
                     ("error", "connection refused")
                 ]
             ))
+        );
+    }
+
+    /// What `connect_blocking` hands back when the far end answers the hello
+    /// with another dialect, localised wrapper and all.
+    fn a_refusal() -> String {
+        t_fmt(
+            L10nKey::RemoteHostNotTty7,
+            &[
+                ("machine", "build-box"),
+                (
+                    "error",
+                    "control peer (build 26.8.1) speaks control v5, this build speaks v6",
+                ),
+            ],
+        )
+    }
+
+    #[test]
+    fn a_hand_run_connect_refused_on_the_dialect_gets_the_same_answer() {
+        let target = RemoteTarget::Alias {
+            alias: "build-box".into(),
+        };
+        let flow = ConnectFlow::Failed {
+            choice: HostChoice {
+                target: target.clone(),
+                label: "build-box".into(),
+                detail: String::new(),
+            },
+            error: a_refusal(),
+        };
+        assert!(
+            matches!(
+                resolve_status(Some(&flow), &target, None, true),
+                Some(RemoteStatus::ServerMismatch(_))
+            ),
+            "the switcher's own attempt hits the same wall as the supervisor's"
+        );
+    }
+
+    #[test]
+    fn a_server_of_another_dialect_is_named_rather_than_quoted() {
+        crate::ui::i18n::set_locale("en");
+        let shown = RemoteStatus::ServerMismatch(a_refusal())
+            .strip_message("build-box")
+            .expect("a parked link still has something to say");
+        assert!(
+            shown.contains("build-box") && shown.contains("26.8.1"),
+            "which machine, and which build is over there: {shown}"
+        );
+        assert!(
+            !shown.contains("control v"),
+            "the protocol layer's wording never reaches the strip: {shown}"
+        );
+        assert_eq!(
+            shown,
+            crate::ui::remote_connect::dialect_complaint(&a_refusal(), "build-box").unwrap(),
+            "the strip and the switcher's error band say the same thing"
         );
     }
 

--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -1879,6 +1879,7 @@ impl Tty7App {
         // already names it.
         let shown = remote_connect::dialect_complaint(error, &group.label)
             .unwrap_or_else(|| format!("{}: {error}", group.label));
+        let replace_action = crate::ui::remote_workspace::mismatch_action_key(error);
         let theme = cx.theme();
         v_flex()
             .gap(px(4.))
@@ -1921,14 +1922,21 @@ impl Tty7App {
                     )
                     .when(
                         crate::daemon::control::is_dialect_refusal(error)
-                            && replace.target.is_some(),
+                            // Same gate as the workspace strip's: a machine
+                            // whose server is not ours to install cannot be
+                            // helped by this button, and a click that can only
+                            // fail is worse than no button.
+                            && replace
+                                .target
+                                .as_ref()
+                                .is_some_and(|t| t.hosts_our_server()),
                         |row| {
                             row.child(
                                 Button::new(gpui::SharedString::from(format!(
                                     "switcher-replace:{}",
                                     group.key
                                 )))
-                                .label(t(L10nKey::RemoteMismatchReplaceServer))
+                                .label(t(replace_action))
                                 .ghost()
                                 .xsmall()
                                 .on_click(cx.listener(
@@ -1938,6 +1946,7 @@ impl Tty7App {
                                             this.confirm_replace_remote_server(
                                                 target,
                                                 replace.label.clone(),
+                                                replace_action,
                                                 window,
                                                 cx,
                                             );

--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -1877,7 +1877,7 @@ impl Tty7App {
         // The band no longer sits under a machine header, so plain errors
         // carry the machine's name themselves; the dialect restatement
         // already names it.
-        let shown = dialect_complaint(error, &group.label)
+        let shown = remote_connect::dialect_complaint(error, &group.label)
             .unwrap_or_else(|| format!("{}: {error}", group.label));
         let theme = cx.theme();
         v_flex()
@@ -3173,23 +3173,6 @@ fn host_menu(
     )
 }
 
-/// A handshake that failed on the control dialect reaches here as the protocol
-/// layer's own wording, which reads like the far end is not tty7 at all. It is —
-/// it is just a build the other side of a dialect bump — so say that instead, and
-/// say which side has to move. Anything else is shown as it came.
-fn dialect_complaint(error: &str, machine: &str) -> Option<String> {
-    let refusal = crate::daemon::control::parse_dialect_refusal(error)?;
-    let key = if refusal.peer < refusal.ours {
-        L10nKey::RemoteServerOutdated
-    } else {
-        L10nKey::RemoteServerTooNew
-    };
-    Some(t_fmt(
-        key,
-        &[("machine", machine), ("build", &refusal.peer_build)],
-    ))
-}
-
 fn rungs(cx: &App) -> crate::ui::presets::Surface {
     cx.global::<crate::ui::presets::Surfaces>().popover
 }
@@ -3635,39 +3618,6 @@ mod tests {
 
         view.title = String::new();
         assert!(tab_view_label(&view, 2, None).contains('3'));
-    }
-    fn refusal(peer: u32, ours: u32) -> String {
-        format!(
-            "java answered, but not as a tty7 server: control peer (build 26.7.7-nightly) \
-             speaks control v{peer}, this build speaks v{ours}"
-        )
-    }
-
-    #[test]
-    fn a_dialect_refusal_is_restated_as_which_side_is_behind() {
-        let behind = dialect_complaint(&refusal(4, 5), "java").expect("a refusal is recognised");
-        assert!(
-            behind.contains("java") && behind.contains("26.7.7-nightly"),
-            "{behind}"
-        );
-        assert!(
-            !behind.contains("control v"),
-            "the dialect numbers mean nothing to the reader: {behind}"
-        );
-
-        let ahead = dialect_complaint(&refusal(6, 5), "java").expect("a refusal is recognised");
-        assert_ne!(
-            ahead, behind,
-            "a server newer than this client needs the opposite advice"
-        );
-    }
-
-    #[test]
-    fn every_other_failure_is_shown_as_it_came() {
-        assert_eq!(
-            dialect_complaint("Connection refused (os error 61)", "java"),
-            None
-        );
     }
 }
 


### PR DESCRIPTION
A remote workspace whose server is the other side of a control-dialect bump had no way out: it reconnected forever, quoted the protocol layer at the user, and the one button that could fix it lived somewhere the user could not reach.

## Before / After

| | Before | After |
|---|---|---|
| Strip text on a dialect refusal | Chinese/English sentence with the raw protocol wording embedded — *"…已响应，但并非作为 tty7 server: control peer (build 26.8.1) speaks control v5, this build speaks v6"* | *"The tty7 server on build-box is too old (26.8.1) for this build of tty7 to reach. Update it to connect."* — same restatement the switcher's error band already used |
| Strip button on a dialect refusal | **Retry Now**, which fails identically every time | **Update Server**, which installs the matching server and restarts into it |
| Reconnect behaviour | Backoff loop forever, capped at 30s, counting attempts on screen | Parked. No attempt scheduled until the user asks — via Update Server, or a manual connect |
| Reaching the fix at all | Only by opening the workspace switcher and finding the error band | On the strip, in the window that is already showing the problem — including the home page strip when the workspace has no tabs |
| Window-level **Restart Server…** on a mismatched machine | Confirms a restart, then kills the running server and tries to launch a binary that was never installed there | Confirms an **update** instead, with the copy that says sessions will end |
| `Installer::restart_daemon` with no matching binary | Kills any running `tty7-server-*`, then times out with nothing running — machine left with no server, every session gone, including other clients' | Probes the target binary first and refuses (`InstallError::NoServerToRestart`). Nothing is stopped |
| A hand-run connect from the switcher refused on the dialect | `Failed` + Retry | Same parked state and Update Server button as the supervisor's |

## Why

`restart_daemon` is named for what it does when both sides match, which is the only case it was ever exercised in. It kills any `tty7-server-*` and launches `~/.local/share/tty7/bin/tty7-server-c{control}p{protocol}` — a path named after *this* build's dialect. On a machine the other side of a bump those are different files, and the second one is not there: `spawn_detached` backgrounds a missing binary without complaint, so the failure only surfaces at the startup poll, long after the kill. The user is then worse off than before they clicked.

## Flow

```mermaid
stateDiagram-v2
    [*] --> Connecting
    Connecting --> Attached: hello accepted
    Connecting --> Reconnecting: transient failure
    Reconnecting --> Connecting: backoff elapsed
    Connecting --> ServerMismatch: hello refused on the dialect
    ServerMismatch --> Connecting: Update Server → replace → retry_now
    note right of ServerMismatch
        Parked: pump_tick skips it.
        No backoff, no attempt counter.
    end note
```

## Protocol version

`CONTROL_VERSION` moves 6 → 7 with no message change. Nothing in `ControlRequest`, `ReplyOk` or `ControlEvent` moved — the bump exists so this path can be exercised against the v6 servers already deployed. Every remote server will want an update after this ships, which is exactly the thing being tested.

## Testing

- `cargo test --workspace` green; `cargo fmt --check` clean; clippy warning count unchanged (203 → 203, on the rebased base) and not one of them in a file this touches.
- `a_restart_with_nothing_to_start_leaves_the_running_daemon_alone` — old-dialect server running, no matching binary: asserts `TERMINATE_RUNNING_COMMAND` never reaches the journal and the old exe is still serving.
- `replacing_installs_the_matching_server_and_then_restarts_into_it` — same machine through `replace()`: asserts the rename lands *before* the kill.
- `a_dialect_refusal_parks_the_link_instead_of_counting_attempts` — an ordinary failure still reconnects; a refusal parks; four `pump_tick`s later the backoff never advanced and the next look is further out than `RECONNECT_CAP`; `retry_now` un-parks.
- `a_parked_link_looks_again_when_the_slow_clock_runs_out` — the wait wound back to the past: the pump lets one attempt through, and leaves the strip saying what it said. `a_park_that_is_still_true_goes_straight_back_on_the_slow_clock` covers the answer being the same as before. Both were checked against a mutation that drops the recheck.
- `the_button_calls_a_downgrade_a_downgrade` — the word depends on which side is behind.
- `a_server_of_another_dialect_is_named_rather_than_quoted` — the strip never shows `control v…`, and says the same thing as the switcher's band.
- `a_hand_run_connect_refused_on_the_dialect_gets_the_same_answer`, plus the `ServerMismatch` row added to the existing status/notice/action table.
- `dialect_complaint` moved from `switcher.rs` to `remote_connect.rs` so both call sites share it; its two tests moved with it.

## Review follow-ups

Second commit, after review:

- **The park now looks again.** `RouteLost`, the state it was modelled on, is re-tested every tick and comes back by itself. This one could not, so a machine somebody else updated — or one that rebooted onto a build that does speak to us — sat there claiming to be broken for the rest of the session. Every five minutes it lets one attempt through: a slow clock, two orders of magnitude off the reconnect one, and the strip says nothing while it runs.
- **One predicate for one question.** `is_dialect_refusal` was `message.contains(MARKER)` while every reader of a `true` went on to parse the whole shape — and the weaker one decided whether to park a link only a person could free. It is the parse now.
- **`retry_now` no longer eats every `last_error`.** Pressing Retry Now on an unreachable machine used to cost the user the reason why until the next attempt finished. Only leaving a park clears it.
- **The button stops calling a downgrade an update.** Installing our server on a machine that is *ahead* takes it back a version; that direction reads Replace Server, and the confirmation offers the same word the button did. The switcher's band gates on `hosts_our_server` now too, the way the strip already did.
- **A test that was passing without arriving.** `a_dialect_refusal_parks_the_link_instead_of_counting_attempts` used an `Alias` target, which resolves only if the machine running the tests has that name in its ssh config — and the pump drops an unresolvable route before it reaches any parking. It never executed the branch it was named after.

## Not in this PR

- `remote_strip_action` has no direct test: it takes `&self` on the app, and nothing in this file's tests stands one up. Its decision points are covered through `action_label` and `mismatch_action_key`; the `hosts_our_server` gate is not.
- `RemoteMismatchTitle` still says "Update tty7's server on …" in both directions. The button and its confirmation agree with each other now; the title above them is one more string and a bigger diff than the point is worth here.
- The host context menu's **Restart Server…** inside the switcher still confirms a restart — it only has the `Link` badge, not the machine's error, so routing it would mean threading that through `HostItem`. The error band beside it already carries the right button, and the installer guard makes a wrong click harmless.
- The crash reported alongside this (app dying when it opens straight onto a mismatched remote workspace) is untouched — it needs a crash log to locate.

