### PR TITLE
fix(tree-sync): stop workspace switches from rereading the app mid-update

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1320,7 +1320,11 @@ impl Tty7App {
         crate::ui::windows::WindowRegistry::rebind(cx, previous, claimed);
         crate::ui::remote_workspace::RemoteLinks::supervise(cx, claimed);
         self.adopt_workspace(claimed, Session::default(), window, cx);
-        crate::ui::tree_sync::hydrate_window_from_tree(cx, claimed);
+        // This method runs under the app's own update lease, so the tabs the
+        // pull must see are the ones just adopted here — reading the app back
+        // out of `cx` (as `tabs_on_screen` would) is an abort in gpui.
+        let showing = self.tabs.iter().map(|t| t.tree_id.get()).collect();
+        crate::ui::tree_sync::hydrate_window_with_tabs(cx, claimed, showing);
     }
 
     pub(crate) fn adopt_workspace(

--- a/src/ui/tree_sync.rs
+++ b/src/ui/tree_sync.rs
@@ -797,7 +797,9 @@ pub(crate) fn sync_window(app: &Tty7App, cx: &mut App) {
     }
     let showing: Vec<TabId> = app.tabs.iter().map(|t| t.tree_id.get()).collect();
     if let Some(adopt) = take_rehydrate(cx, client_ws, &showing) {
-        hydrate(cx, client_ws, adopt);
+        // The app is mid-update here, so the tabs it knows it is showing come
+        // from `app` itself, not from reading the entity back.
+        hydrate_with(cx, client_ws, adopt, showing);
         return;
     }
     adopt_tab_ids(app, cx);
@@ -1322,6 +1324,17 @@ pub(crate) fn hydrate_window_from_tree(cx: &mut App, client_ws: WorkspaceId) {
     hydrate(cx, client_ws, Adopt::IfEmpty);
 }
 
+/// Hydrates a window whose on-screen tabs are already known to the caller.
+///
+/// Reading them back with `tabs_on_screen` is illegal while the app's own
+/// update lease is held — gpui aborts on a read of an entity that is already
+/// being updated — and `switch_workspace` runs inside exactly that lease. The
+/// ids are the same ones the read would produce: the tabs the window shows
+/// right now.
+pub(crate) fn hydrate_window_with_tabs(cx: &mut App, client_ws: WorkspaceId, showing: Vec<TabId>) {
+    hydrate_with(cx, client_ws, Adopt::IfEmpty, showing);
+}
+
 /// Pulls this window's layout, then opens `path` as one more tab in it.
 ///
 /// This is what a launch carrying a directory does — Explorer's "Open in tty7",
@@ -1385,9 +1398,13 @@ fn tabs_on_screen(cx: &mut App, client_ws: WorkspaceId) -> Vec<TabId> {
 }
 
 fn hydrate(cx: &mut App, client_ws: WorkspaceId, adopt: Adopt) {
+    let showing = tabs_on_screen(cx, client_ws);
+    hydrate_with(cx, client_ws, adopt, showing);
+}
+
+fn hydrate_with(cx: &mut App, client_ws: WorkspaceId, adopt: Adopt, showing: Vec<TabId>) {
     let host = WorkspaceStore::host_of(cx, client_ws);
     let machine_ws = tree_workspace_id(cx, client_ws);
-    let showing = tabs_on_screen(cx, client_ws);
     let (epoch, failures) = {
         let state = cx
             .default_global::<TreeSync>()


### PR DESCRIPTION
Switching workspaces crashed the app on every switch. The panic — gpui's double-lease abort — then unwound through the Win32 window procedure and aborted the process (0xc0000409):

```
thread 'main' panicked at gpui/src/app/entity_map.rs:164:32:
cannot read tty7_app::ui::app::Tty7App while it is already being updated
```

## Root cause

The switcher's tab click listener updates the `Tty7App` entity, so `switch_workspace` runs *inside* that entity's update lease. The hydration it starts (`hydrate_window_from_tree` → `hydrate`) looked the window's on-screen tabs back up through `tabs_on_screen`, which reads the `Tty7App` entity out of `cx` (`WindowRegistry::app_for` → `read`). Reading an entity that is already being updated is an abort in gpui.

`sync_window` had the same latent panic: it runs inside `save_session` and `app.update` closures (the same lease) and re-read the entity whenever a failed pull left a rehydrate debt — so any session save after a failed hydration would crash the same way.

## Fix

Stop re-reading the entity when the caller already has the tabs. Both
in-lease callers know what the window is showing:

- `hydrate` now takes the showing tab ids as an argument (`hydrate_with`); the old `hydrate` keeps reading through `tabs_on_screen` for callers outside the lease.
- `switch_workspace` passes the ids of the tabs it just adopted (identical to what the read would have produced).
- `sync_window` passes the ids it had already collected for `take_rehydrate`.