### PR TITLE
fix(switcher): scrub a deleted remote workspace from the listing snapshots

### DIFF
--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -3658,6 +3658,86 @@ mod gpui_tests {
     use super::Column;
     use crate::ui::app::test_window::harness_with_tabs;
 
+    /// Deleting a remote workspace has to take the listing snapshot's row with
+    /// it. The snapshot every window keeps for the switcher is merged into the
+    /// panel every frame, and with the store entry gone nothing dedups that
+    /// row any more — the workspace the user just deleted popped straight back
+    /// as an adoptable machine row until the next reconnect replaced the
+    /// snapshot.
+    #[gpui::test]
+    fn a_deleted_remote_workspace_leaves_the_switcher(cx: &mut TestAppContext) {
+        use gpui::VisualContext as _;
+
+        use crate::core::session::{RemoteRef, RemoteTarget, WindowView, WorkspaceId};
+
+        let (app, vcx) = crate::ui::app::test_window::harness(cx);
+        let handle = vcx.window_handle();
+        let weak = app.downgrade();
+
+        let target = RemoteTarget::Alias {
+            alias: "build-box".into(),
+        };
+        let machine_ws = WorkspaceId::new();
+        let kept_ws = WorkspaceId::new();
+        let view = WindowView::on_remote(RemoteRef::new(target.clone(), machine_ws));
+        let doomed = view.id;
+
+        app.update(cx, |app, cx| {
+            crate::core::session::WorkspaceStore::install_for_test(
+                cx,
+                crate::core::session::WindowViews {
+                    views: vec![view],
+                    active: None,
+                },
+            );
+            crate::ui::windows::WindowRegistry::init(cx);
+            crate::ui::windows::WindowRegistry::register(cx, app.workspace, handle, weak);
+            app.host_snapshots.insert(
+                target.host_id(),
+                super::HostSnapshot {
+                    target: target.clone(),
+                    rows: vec![
+                        crate::ui::remote_connect::RemoteWorkspaceRow {
+                            id: machine_ws,
+                            name: "doomed".into(),
+                            panes: 0,
+                            last_active: 0,
+                        },
+                        crate::ui::remote_connect::RemoteWorkspaceRow {
+                            id: kept_ws,
+                            name: "kept".into(),
+                            panes: 0,
+                            last_active: 0,
+                        },
+                    ],
+                },
+            );
+        });
+
+        // From a plain app context, the way `confirm_and_delete`'s spawned
+        // task calls it — inside the entity's own update this would abort on
+        // the reentrant read (#617's lesson).
+        cx.update(|cx| {
+            crate::ui::windows::delete_workspace(cx, doomed);
+        });
+
+        app.update(cx, |app, cx| {
+            let listed: Vec<WorkspaceId> = app
+                .switcher_groups(cx)
+                .iter()
+                .flat_map(|g| g.rows.iter().filter_map(|r| r.remote_id))
+                .collect();
+            assert!(
+                !listed.contains(&machine_ws),
+                "the deleted workspace came back from the listing snapshot"
+            );
+            assert!(
+                listed.contains(&kept_ws),
+                "its machine's other workspaces are still on offer"
+            );
+        });
+    }
+
     #[gpui::test]
     fn ctrl_tab_raises_the_panel_on_the_previously_used_tab(cx: &mut TestAppContext) {
         let (app, mut vcx, _streams) = harness_with_tabs(cx, 3);

--- a/src/ui/windows.rs
+++ b/src/ui/windows.rs
@@ -542,11 +542,39 @@ fn stop_workspace_keeping(cx: &mut App, workspace: WorkspaceId, ids: Vec<u64>) {
 }
 
 pub fn delete_workspace(cx: &mut App, workspace: WorkspaceId) {
+    let remote = WorkspaceStore::remote_ref(cx, workspace);
     let doomed = delete_from_tree(cx, workspace);
     stop_workspace_keeping(cx, workspace, doomed);
     WorkspaceStore::remove(cx, workspace);
+    if let Some(remote) = remote {
+        scrub_host_snapshots(cx, &remote);
+    }
     release_unused_hosts(cx);
     refresh_menu(cx);
+}
+
+/// Drops a deleted workspace's row from every window's machine-listing
+/// snapshot. The snapshot is captured at connect time and merged into the
+/// switcher every frame, deduped against the store — so with the store entry
+/// just removed, nothing holds that row back any more and the workspace the
+/// user deleted pops straight back into the panel as an adoptable machine row
+/// until the next reconnect replaces the snapshot. `forget_workspace` must
+/// *not* do this: forgetting keeps the machine's session, and re-discovering
+/// it from the listing is that flow's whole point (#485).
+fn scrub_host_snapshots(cx: &mut App, remote: &crate::core::session::RemoteRef) {
+    let host = remote.host_id();
+    let machine_ws = remote.workspace;
+    for (_, app) in WindowRegistry::open_windows(cx) {
+        let Some(app) = app.upgrade() else {
+            continue;
+        };
+        app.update(cx, |app, cx| {
+            if let Some(snapshot) = app.host_snapshots.get_mut(&host) {
+                snapshot.rows.retain(|row| row.id != machine_ws);
+                cx.notify();
+            }
+        });
+    }
 }
 
 /// Drop a workspace's local bookmark without telling its machine anything.


### PR DESCRIPTION
Deleting a remote workspace no longer leaves a ghost row in the workspace switcher.

| | Before | After |
|---|---|---|
| Delete a remote workspace | The row reappears in the switcher immediately, listed as a stopped machine workspace, until the next reconnect | The row is gone from every window's switcher at once |
| Forget a remote workspace | Row stays adoptable from the machine listing | Unchanged — forgetting keeps the machine's session on offer (#485) |

## Why

Every window keeps a snapshot of the machine's own workspace listing, captured at connect time and merged into the switcher every frame. The merge dedups against the workspace store — so `delete_workspace`, which removes the store entry but never touched the snapshots, un-deduped the very row it was deleting. The snapshot resurrected it each frame as an adoptable machine row.

`delete_workspace` now captures the workspace's `RemoteRef` before removing the store entry and scrubs that machine workspace's row from every open window's snapshot. `forget_workspace` deliberately does not scrub: forgetting keeps the session on the machine, and re-discovery from the listing is that flow's point.

## Testing

- New gpui test `a_deleted_remote_workspace_leaves_the_switcher`: builds a store-backed remote workspace plus a two-row listing snapshot, deletes the workspace, and asserts against the real `switcher_groups` output that the deleted row is gone while the machine's other workspace is still offered. Confirmed to fail without the scrub.
- Full suite: 2883 tests green, rustfmt clean.
