### PR TITLE
fix(worktree): lift the new-worktree prompt to a window-level modal

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -6347,9 +6347,6 @@ impl Render for Tty7App {
             })
             .when_some(self.render_remote_input_notice(cx), |this, el| {
                 this.child(el)
-            })
-            .when_some(self.render_worktree_prompt_overlay(cx), |this, el| {
-                this.child(el)
             });
 
         let diff_overlay = self.render_diff_overlay(window, cx);
@@ -6771,6 +6768,14 @@ impl Render for Tty7App {
                 .children(bg_image)
                 .child(main_layout)
                 .when_some(settings_overlay, |this, overlay| this.child(overlay))
+                // Window-level, like the switcher and the palette: the prompt
+                // blocks the whole app, so its scrim has to reach the title bar
+                // and the side panels too. Parented to `body_area` it was
+                // clipped to the terminal area, which read as "only the
+                // terminal is busy".
+                .when_some(self.render_worktree_prompt_overlay(cx), |this, el| {
+                    this.child(el)
+                })
                 .children(self.render_switcher(window, cx))
                 .when_some(self.palette.clone(), |this, palette| this.child(palette))
                 .children(gpui_component::Root::render_notification_layer(window, cx));

--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -32,7 +32,7 @@ const FORM_LIST_H: f32 = 8.5 * (ROW_H + 8.0);
 
 const LEFT_W: f32 = 340.0;
 
-const CARD_TOP: f32 = 120.0;
+pub(crate) const CARD_TOP: f32 = 120.0;
 
 /// Breathing room the card keeps from the window edge, and the height its own
 /// search row and footer take on top of the body.

--- a/src/ui/worktree_prompt.rs
+++ b/src/ui/worktree_prompt.rs
@@ -174,11 +174,6 @@ impl Tty7App {
             .border_color(cx.theme().border)
             .rounded_lg()
             .shadow_lg()
-            .on_key_down(cx.listener(|this, ev: &gpui::KeyDownEvent, window, cx| {
-                if ev.keystroke.key == "escape" {
-                    this.cancel_worktree_prompt(window, cx);
-                }
-            }))
             .child(
                 div()
                     .text_sm()
@@ -232,6 +227,11 @@ impl Tty7App {
                 // waiting, and clicking it backs out — the same gesture the
                 // palette and the switcher already answer to.
                 .bg(crate::ui::presets::scrim_fill(cx))
+                .on_key_down(cx.listener(|this, ev: &gpui::KeyDownEvent, window, cx| {
+                    if ev.keystroke.key == "escape" {
+                        this.cancel_worktree_prompt(window, cx);
+                    }
+                }))
                 .on_mouse_down(
                     gpui::MouseButton::Left,
                     cx.listener(|this, _: &gpui::MouseDownEvent, window, cx| {
@@ -242,7 +242,7 @@ impl Tty7App {
                 .flex_col()
                 .items_center()
                 .justify_start()
-                .pt(px(48.))
+                .pt(px(crate::ui::switcher::CARD_TOP))
                 .child(card)
                 .into_any_element(),
         )


### PR DESCRIPTION
Makes the new-worktree prompt a window-level modal, like the new-workspace form already is.

| | Before | After |
|---|---|---|
| Scrim coverage | Clipped to the terminal area — title bar, tab sidebar and right panel stayed lit | Covers the whole window |
| Card position | `pt(48px)` from the top of `body_area` | `pt(CARD_TOP)` from the top of the window, aligned with the switcher card |
| Esc | Handled on the card, so it only fired while focus was inside the card subtree | Handled on the scrim, covering the whole overlay |

Neither dialog uses `ModalLayer`; both are a hand-rolled `div().absolute().inset_0()` plus a scrim. The only difference was the parent: the switcher hangs off the root element, while this prompt hung off `body_area` (`.relative().overflow_hidden()`), so `inset_0` resolved to the terminal area and the scrim got clipped there. The prompt blocks the whole app, so a scrim that only dims the terminal reads as "only the terminal is busy". Moving the call to the root children chain fixes it; the `pt` had to change with it because 48px was measured from below the title bar.

`CARD_TOP` in `switcher.rs` becomes `pub(crate)` so both cards share one constant instead of drifting apart.

## Testing

- `cargo build -p tty7`, `cargo fmt --all -- --check` — clean.
- Handed to the author for manual acceptance in an isolated dev instance (`--config-dir`, throwaway git repo seeded as the pane cwd). No automated UI check and no unit test covers the mount point — the change is a parent swap in the element tree.

Note: `render_ssh_prompt_overlay` has the same problem — still parented to `body_area`. Left alone here to keep the diff to the reported bug.
