### PR TITLE
fix(tree-sync): record the panes a window seeded in its own mirror (#612)

### DIFF
--- a/crates/tty7-core/src/core/machine.rs
+++ b/crates/tty7-core/src/core/machine.rs
@@ -354,7 +354,12 @@ impl PaneSeed {
         }
     }
 
-    fn into_record(self, live: bool) -> PaneRecord {
+    /// The record `register_pane` mints for this seed. Public because the
+    /// window that pushed the seed mirrors the machine's tree, and this
+    /// record reaches it in nothing it is sent — a client is left out of the
+    /// deltas its own ops raise — so it puts the same record in its mirror
+    /// itself (#612).
+    pub fn into_record(self, live: bool) -> PaneRecord {
         PaneRecord {
             id: self.pane,
             cwd: self.cwd,

--- a/src/ui/machine_mirror.rs
+++ b/src/ui/machine_mirror.rs
@@ -111,6 +111,29 @@ impl MachineMirrors {
         ws.active_tab = active;
     }
 
+    /// Records for the panes this window itself seeded into the machine.
+    ///
+    /// A window is left out of the deltas its own ops raise, and `TabCreated`
+    /// carries no pane record for anyone anyway, so the record the machine
+    /// mints for a pane this window created reaches it in nothing it is sent.
+    /// `PaneFacts` only close that gap when a fact changes, and a pane spawned
+    /// into its cwd and left at the prompt never changes one — the mirror held
+    /// tabs full of panes it knew nothing about, the window's own workspace
+    /// answered no subject path, an unnamed one read "Untitled" (#612). The
+    /// window knows what it seeded, so it records that itself. Insert only: a
+    /// record already here came from the machine — a pull, a rider on
+    /// `TabRestructured`, `PaneFacts` — and outranks what a seed knows.
+    pub fn note_seeded_panes(cx: &mut App, host: HostId, records: Vec<PaneRecord>) {
+        let Some(machine) = cx.default_global::<Self>().machines.get_mut(&host) else {
+            return;
+        };
+        for record in records {
+            if !machine.panes.iter().any(|p| p.id == record.id) {
+                machine.panes.push(record);
+            }
+        }
+    }
+
     /// The name the machine has for a workspace, from a pull that saw it.
     ///
     /// A window is left out of the deltas its own ops raise, so the name it
@@ -414,7 +437,7 @@ pub fn pane_count(cx: &App, entry: &crate::core::session::WindowView) -> Option<
 
 #[cfg(test)]
 mod tests {
-    use tty7_core::core::machine::{Axis, PaneNode, Tab, TabId};
+    use tty7_core::core::machine::{Axis, PaneNode, PaneSeed, Tab, TabId};
 
     use super::*;
 
@@ -534,6 +557,108 @@ mod tests {
             assert_eq!(display_name(cx, &entry).as_deref(), Some("verify-main"));
             MachineMirrors::note_workspace_name(cx, HostId::LOCAL, id, None);
             assert_eq!(display_name(cx, &entry).as_deref(), Some("verify-main"));
+        });
+    }
+
+    /// #612: the deltas that carry a pane's record — `TabRestructured`'s
+    /// rider, `PaneFacts` on a change; `TabCreated` carries none at all —
+    /// reach every window but the one whose op raised them. The window seeded
+    /// the pane, so it records what it seeded; the full tree a rebuild pulls
+    /// then says the same thing and nothing on screen moves. Until it did,
+    /// the window's own workspace answered no subject path: an unnamed one
+    /// read "Untitled", and saving geometry stamped a null subject over what
+    /// views.json remembered.
+    #[gpui::test]
+    fn a_seeded_pane_reads_the_same_before_and_after_a_full_pull(cx: &mut gpui::TestAppContext) {
+        use crate::core::session::{WindowView, WindowViews, WorkspaceStore};
+
+        cx.update(|cx| {
+            let entry = WindowView::default();
+            let id = entry.id;
+            WorkspaceStore::install_for_test(
+                cx,
+                WindowViews {
+                    views: vec![entry.clone()],
+                    active: None,
+                },
+            );
+
+            // What the window knows the moment it pushes its first tab: the
+            // tab it made, and the seed it sent along.
+            MachineMirrors::install(cx, HostId::LOCAL, Machine::default());
+            MachineMirrors::note_synced_workspace(cx, HostId::LOCAL, id, vec![leaf_tab(1)], None);
+            let seeded = PaneSeed {
+                cwd: Some("/work/verify-main".into()),
+                ..PaneSeed::bare(1)
+            }
+            .into_record(true);
+            MachineMirrors::note_seeded_panes(cx, HostId::LOCAL, vec![seeded.clone()]);
+            assert_eq!(display_name(cx, &entry).as_deref(), Some("verify-main"));
+            assert_eq!(
+                subject_path(cx, &entry).as_deref(),
+                Some("/work/verify-main")
+            );
+
+            // The rebuild, pulling the whole tree: the same answer.
+            MachineMirrors::install(
+                cx,
+                HostId::LOCAL,
+                Machine {
+                    workspaces: vec![Workspace {
+                        id,
+                        tabs: vec![leaf_tab(1)],
+                        ..Workspace::default()
+                    }],
+                    panes: vec![seeded],
+                },
+            );
+            assert_eq!(display_name(cx, &entry).as_deref(), Some("verify-main"));
+            assert_eq!(
+                subject_path(cx, &entry).as_deref(),
+                Some("/work/verify-main")
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn a_seed_fills_only_the_records_the_mirror_lacks(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            // Facts the machine broadcast before the sync write got here: a
+            // reported title, a deeper cwd. The seed's flat idea of the pane
+            // must not roll them back.
+            let facts = PaneRecord {
+                cwd: Some("/work/deeper".into()),
+                osc_title: Some("me@host:~/work/deeper".into()),
+                live: true,
+                ..PaneRecord::new(1)
+            };
+            MachineMirrors::install(
+                cx,
+                HostId::LOCAL,
+                Machine {
+                    workspaces: Vec::new(),
+                    panes: vec![facts.clone()],
+                },
+            );
+            let known = PaneSeed {
+                cwd: Some("/work".into()),
+                ..PaneSeed::bare(1)
+            }
+            .into_record(false);
+            let fresh = PaneSeed {
+                cwd: Some("/work/api".into()),
+                ..PaneSeed::bare(2)
+            }
+            .into_record(true);
+            MachineMirrors::note_seeded_panes(cx, HostId::LOCAL, vec![known, fresh]);
+            let machine = MachineMirrors::machine(cx, HostId::LOCAL).expect("installed");
+            assert_eq!(machine.panes.len(), 2);
+            assert_eq!(
+                machine.panes[0], facts,
+                "what the machine said outranks the seed"
+            );
+            assert_eq!(machine.panes[1].cwd.as_deref(), Some("/work/api"));
+            assert!(machine.panes[1].live);
         });
     }
 

--- a/src/ui/machine_mirror.rs
+++ b/src/ui/machine_mirror.rs
@@ -592,7 +592,7 @@ mod tests {
                 ..PaneSeed::bare(1)
             }
             .into_record(true);
-            MachineMirrors::note_seeded_panes(cx, HostId::LOCAL, vec![seeded.clone()]);
+            MachineMirrors::note_seeded_panes(cx, HostId::LOCAL, vec![seeded]);
             assert_eq!(display_name(cx, &entry).as_deref(), Some("verify-main"));
             assert_eq!(
                 subject_path(cx, &entry).as_deref(),
@@ -609,7 +609,15 @@ mod tests {
                         tabs: vec![leaf_tab(1)],
                         ..Workspace::default()
                     }],
-                    panes: vec![seeded],
+                    // The record the machine minted for the same seed, written
+                    // out rather than the copy above reused: a pull that hands
+                    // back the very value the window put in is only agreeing
+                    // with itself.
+                    panes: vec![PaneRecord {
+                        cwd: Some("/work/verify-main".into()),
+                        live: true,
+                        ..PaneRecord::new(1)
+                    }],
                 },
             );
             assert_eq!(display_name(cx, &entry).as_deref(), Some("verify-main"));

--- a/src/ui/machine_mirror.rs
+++ b/src/ui/machine_mirror.rs
@@ -8,10 +8,25 @@ use tty7_core::host::HostId;
 use crate::core::session::WorkspaceId;
 use crate::ui::i18n::{L10nKey, t};
 
+/// A write a window made to its own mirror, kept for as long as a pull that
+/// was already on its way when it happened has still to land.
+type MirrorWrite = Box<dyn Fn(&mut Machine)>;
+
 #[derive(Default)]
 pub struct MachineMirrors {
     machines: HashMap<HostId, Machine>,
     pulling: Vec<HostId>,
+    /// What this client wrote into a mirror while a pull of it was in flight.
+    ///
+    /// The tree a `MachineGet` answers is authoritative for everything the
+    /// machine knew when it built it — and what it did not know is exactly the
+    /// ops a window has just pushed, since a client is left out of the deltas
+    /// its own ops raise. The write here is the only copy of those there is,
+    /// and a pull dispatched before it and installed after it took that copy
+    /// away: the seeded pane records and the pushed tabs went missing again,
+    /// by another route (#612, #604). Replayed on top of the tree that lands,
+    /// in the order they were made.
+    since_pull: HashMap<HostId, Vec<MirrorWrite>>,
 }
 
 impl Global for MachineMirrors {}
@@ -34,11 +49,9 @@ impl MachineMirrors {
             }
             crate::ui::tree_sync::TreeLink::Down => return,
         };
-        let mirrors = cx.default_global::<Self>();
-        if mirrors.pulling.contains(&host) {
+        if !Self::start_pull(cx, host) {
             return;
         }
-        mirrors.pulling.push(host);
         cx.spawn(async move |cx| {
             let pulled = cx
                 .background_executor()
@@ -56,16 +69,63 @@ impl MachineMirrors {
                     }
                 })
                 .await;
-            cx.update(|cx| {
-                let mirrors = cx.default_global::<Self>();
-                mirrors.pulling.retain(|h| *h != host);
-                if let Some(machine) = pulled {
-                    mirrors.machines.insert(host, *machine);
-                    cx.refresh_windows();
-                }
-            });
+            cx.update(|cx| Self::finish_pull(cx, host, pulled.map(|machine| *machine)));
         })
         .detach();
+    }
+
+    /// Claims the one pull a host is allowed to have on its way, and starts
+    /// keeping what this client writes until it lands. `false` if a pull is
+    /// already running: its answer is as fresh as this one's would have been.
+    fn start_pull(cx: &mut App, host: HostId) -> bool {
+        let mirrors = cx.default_global::<Self>();
+        if mirrors.pulling.contains(&host) {
+            return false;
+        }
+        mirrors.pulling.push(host);
+        mirrors.since_pull.entry(host).or_default();
+        true
+    }
+
+    /// Installs a pulled tree, and replays over it what this client wrote
+    /// while it was on its way.
+    ///
+    /// The tree wins on everything it speaks about: it is the machine's own
+    /// answer, and a mirror that kept its older values over it would be
+    /// resurrecting what a pane's death or another window's op had settled.
+    /// What it cannot speak about is an op that had not reached the machine
+    /// when it was built — the window's own, whose deltas never come back to
+    /// it. Those writes go on top: against a tree that turned out to hold
+    /// them anyway each one is a no-op, since the seeded records insert only
+    /// and the tabs are the tabs the window pushed.
+    fn finish_pull(cx: &mut App, host: HostId, pulled: Option<Machine>) {
+        let mirrors = cx.default_global::<Self>();
+        mirrors.pulling.retain(|h| *h != host);
+        let since = mirrors.since_pull.remove(&host).unwrap_or_default();
+        let Some(machine) = pulled else {
+            return;
+        };
+        mirrors.machines.insert(host, machine);
+        let machine = mirrors.machines.get_mut(&host).expect("just inserted");
+        for write in since {
+            write(machine);
+        }
+        cx.refresh_windows();
+    }
+
+    /// Writes into a mirror what a window knows about its own machine, and
+    /// keeps the write for a pull already on its way (see [`Self::finish_pull`]).
+    ///
+    /// A mirror that is not here yet is no reason to drop the write: the pull
+    /// that will install it is the very one the write has to survive.
+    fn write(cx: &mut App, host: HostId, edit: impl Fn(&mut Machine) + 'static) {
+        let mirrors = cx.default_global::<Self>();
+        if let Some(machine) = mirrors.machines.get_mut(&host) {
+            edit(machine);
+        }
+        if let Some(since) = mirrors.since_pull.get_mut(&host) {
+            since.push(Box::new(edit));
+        }
     }
 
     pub fn install(cx: &mut App, host: HostId, machine: Machine) {
@@ -94,21 +154,20 @@ impl MachineMirrors {
         tabs: Vec<Tab>,
         active: Option<TabId>,
     ) {
-        let Some(machine) = cx.default_global::<Self>().machines.get_mut(&host) else {
-            return;
-        };
-        let ws = match machine.workspaces.iter_mut().find(|w| w.id == machine_ws) {
-            Some(ws) => ws,
-            None => {
-                machine.workspaces.push(Workspace {
-                    id: machine_ws,
-                    ..Workspace::default()
-                });
-                machine.workspaces.last_mut().expect("just pushed")
-            }
-        };
-        ws.tabs = tabs;
-        ws.active_tab = active;
+        Self::write(cx, host, move |machine| {
+            let ws = match machine.workspaces.iter_mut().find(|w| w.id == machine_ws) {
+                Some(ws) => ws,
+                None => {
+                    machine.workspaces.push(Workspace {
+                        id: machine_ws,
+                        ..Workspace::default()
+                    });
+                    machine.workspaces.last_mut().expect("just pushed")
+                }
+            };
+            ws.tabs = tabs.clone();
+            ws.active_tab = active;
+        });
     }
 
     /// Records for the panes this window itself seeded into the machine.
@@ -124,14 +183,13 @@ impl MachineMirrors {
     /// record already here came from the machine — a pull, a rider on
     /// `TabRestructured`, `PaneFacts` — and outranks what a seed knows.
     pub fn note_seeded_panes(cx: &mut App, host: HostId, records: Vec<PaneRecord>) {
-        let Some(machine) = cx.default_global::<Self>().machines.get_mut(&host) else {
-            return;
-        };
-        for record in records {
-            if !machine.panes.iter().any(|p| p.id == record.id) {
-                machine.panes.push(record);
+        Self::write(cx, host, move |machine| {
+            for record in &records {
+                if !machine.panes.iter().any(|p| p.id == record.id) {
+                    machine.panes.push(record.clone());
+                }
             }
-        }
+        });
     }
 
     /// The name the machine has for a workspace, from a pull that saw it.
@@ -148,20 +206,21 @@ impl MachineMirrors {
         machine_ws: WorkspaceId,
         name: Option<String>,
     ) {
-        let Some(machine) = cx.default_global::<Self>().machines.get_mut(&host) else {
-            return;
-        };
-        if let Some(ws) = machine.workspaces.iter_mut().find(|w| w.id == machine_ws) {
-            ws.name = name;
-        }
+        Self::write(cx, host, move |machine| {
+            if let Some(ws) = machine.workspaces.iter_mut().find(|w| w.id == machine_ws) {
+                ws.name = name.clone();
+            }
+        });
         cx.refresh_windows();
     }
 
     pub fn note_workspace_op(cx: &mut App, host: HostId, request: &ControlRequest) {
-        let Some(machine) = cx.default_global::<Self>().machines.get_mut(&host) else {
-            return;
-        };
-        match request {
+        let request = request.clone();
+        // Read now rather than inside the write: a replay of the touch is the
+        // same touch, and it should not creep forward to the moment a pull
+        // happened to land.
+        let touched = crate::ui::home::now_secs();
+        Self::write(cx, host, move |machine| match &request {
             ControlRequest::WorkspaceRename { workspace, name } => {
                 if let Some(ws) = machine.workspaces.iter_mut().find(|w| w.id == *workspace) {
                     ws.name = name.clone();
@@ -169,14 +228,14 @@ impl MachineMirrors {
             }
             ControlRequest::WorkspaceTouch { workspace } => {
                 if let Some(ws) = machine.workspaces.iter_mut().find(|w| w.id == *workspace) {
-                    ws.last_active = crate::ui::home::now_secs();
+                    ws.last_active = touched;
                 }
             }
             ControlRequest::WorkspaceRemove { workspace } => {
                 machine.workspaces.retain(|w| w.id != *workspace);
             }
             _ => {}
-        }
+        });
     }
 }
 
@@ -667,6 +726,101 @@ mod tests {
             );
             assert_eq!(machine.panes[1].cwd.as_deref(), Some("/work/api"));
             assert!(machine.panes[1].live);
+        });
+    }
+
+    /// #612 by its other route: a `MachineGet` already on its way when the
+    /// window wrote down what it had just pushed was built before that push,
+    /// and landing it whole put the mirror back to a tree that has never heard
+    /// of the tab or the pane — the same workspace answering no subject path,
+    /// with no later op to write it down again. What the window pushed goes
+    /// back on top of the tree that lands; what that tree does say still
+    /// outranks it; and once it has landed the writes are spent.
+    #[gpui::test]
+    fn a_pull_already_on_its_way_lands_under_what_the_window_pushed(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            // Nothing pulled yet, which is where a window that opens with its
+            // machine's link coming up starts: the pull below is the one that
+            // will install this mirror at all.
+            let id = WorkspaceId::new();
+            assert!(MachineMirrors::start_pull(cx, HostId::LOCAL));
+
+            // What the window pushes while that pull is on its way: a tab of
+            // its own, and the seeds behind the panes in it.
+            let pushed = leaf_tab(5);
+            MachineMirrors::note_synced_workspace(
+                cx,
+                HostId::LOCAL,
+                id,
+                vec![pushed.clone()],
+                None,
+            );
+            let seeded = |pane, cwd: &str| {
+                PaneSeed {
+                    cwd: Some(cwd.into()),
+                    ..PaneSeed::bare(pane)
+                }
+                .into_record(true)
+            };
+            MachineMirrors::note_seeded_panes(
+                cx,
+                HostId::LOCAL,
+                vec![seeded(5, "/work/verify-main"), seeded(6, "/work")],
+            );
+
+            // The tree the machine built before any of that: an older tab, and
+            // a pane 6 it has since watched move on. Pane 5 it has never seen.
+            MachineMirrors::finish_pull(
+                cx,
+                HostId::LOCAL,
+                Some(Machine {
+                    workspaces: vec![Workspace {
+                        id,
+                        tabs: vec![leaf_tab(4)],
+                        ..Workspace::default()
+                    }],
+                    panes: vec![PaneRecord {
+                        cwd: Some("/work/deeper".into()),
+                        osc_title: Some("me@host:~/work/deeper".into()),
+                        live: true,
+                        ..PaneRecord::new(6)
+                    }],
+                }),
+            );
+
+            let machine = MachineMirrors::machine(cx, HostId::LOCAL).expect("the pull installed");
+            assert_eq!(
+                machine.workspaces[0].tabs,
+                vec![pushed],
+                "the tabs the window pushed are not rolled back by a tree older than them"
+            );
+            let cwd_of = |pane: u64| {
+                machine
+                    .panes
+                    .iter()
+                    .find(|p| p.id == pane)
+                    .and_then(|p| p.cwd.clone())
+            };
+            assert_eq!(
+                cwd_of(5).as_deref(),
+                Some("/work/verify-main"),
+                "and the record for the pane it seeded is still the only one there is"
+            );
+            assert_eq!(
+                cwd_of(6).as_deref(),
+                Some("/work/deeper"),
+                "while a pane the machine did speak about keeps what it said"
+            );
+
+            // Spent: the next pull is the machine's own word, with nothing of
+            // the window's replayed under it a second time.
+            assert!(MachineMirrors::start_pull(cx, HostId::LOCAL));
+            MachineMirrors::finish_pull(cx, HostId::LOCAL, Some(Machine::default()));
+            let machine = MachineMirrors::machine(cx, HostId::LOCAL).expect("installed");
+            assert!(
+                machine.workspaces.is_empty() && machine.panes.is_empty(),
+                "a tree that has dropped them says so: {machine:?}"
+            );
         });
     }
 

--- a/src/ui/tree_sync.rs
+++ b/src/ui/tree_sync.rs
@@ -232,6 +232,28 @@ fn desired_node(pane: &Pane, remote_window: bool, cx: &App) -> Option<DesiredNod
     }
 }
 
+/// The records the machine's `register_pane` will mint from the seeds a sync
+/// pushes, for the window to mirror itself — they come back to it in nothing
+/// it is sent (#612). Its own terminals stand in for the machine's liveness
+/// probe: a pane this window holds open is one that registry answers alive, and
+/// one still connecting is not yet anyone's to call — later facts settle it.
+fn seeded_records(desired: &[DesiredTab], live: impl Fn(u64) -> bool) -> Vec<PaneRecord> {
+    fn walk(node: &DesiredNode, live: &impl Fn(u64) -> bool, out: &mut Vec<PaneRecord>) {
+        match node {
+            DesiredNode::Leaf { pane, seed } => out.push(seed.clone().into_record(live(*pane))),
+            DesiredNode::Split { a, b, .. } => {
+                walk(a, live, out);
+                walk(b, live, out);
+            }
+        }
+    }
+    let mut out = Vec::new();
+    for tab in desired {
+        walk(&tab.root, &live, &mut out);
+    }
+    out
+}
+
 #[derive(Debug, Clone, Default, PartialEq)]
 pub(crate) struct WsMirror {
     pub tabs: Vec<TreeTab>,
@@ -842,6 +864,17 @@ pub(crate) fn sync_window(app: &Tty7App, cx: &mut App) {
                 let host = WorkspaceStore::host_of(cx, client_ws);
                 crate::ui::machine_mirror::MachineMirrors::note_synced_workspace(
                     cx, host, machine_ws, tabs, active,
+                );
+                let open: Vec<u64> = app
+                    .tabs
+                    .iter()
+                    .flat_map(|t| t.pane.terminals())
+                    .map(|v| v.read(cx).pane_id)
+                    .collect();
+                crate::ui::machine_mirror::MachineMirrors::note_seeded_panes(
+                    cx,
+                    host,
+                    seeded_records(&desired, |pane| open.contains(&pane)),
                 );
                 pump(cx, client_ws);
             }
@@ -3475,6 +3508,26 @@ mod tests {
             group: None,
             root,
         }
+    }
+
+    #[test]
+    fn seeded_records_carry_the_seed_and_the_windows_own_liveness() {
+        let desired = vec![
+            tab(
+                TabId::new(),
+                split(TreeAxis::Vertical, 0.5, leaf(1), leaf(2)),
+            ),
+            tab(TabId::new(), leaf(3)),
+        ];
+        let records = seeded_records(&desired, |pane| pane != 2);
+        assert_eq!(
+            records.iter().map(|r| r.id).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+        assert_eq!(records[0].cwd.as_deref(), Some("/work/1"));
+        assert!(records[0].live, "a pane the window holds open is live");
+        assert!(!records[1].live, "one still connecting is not yet");
+        assert!(records[2].live);
     }
 
     fn assert_converged(mirror: &WsMirror, desired: &[DesiredTab]) {


### PR DESCRIPTION
Fixes #612.

## The bug

A window's mirror of its machine held no `PaneRecord` for a pane the window itself created. Pane records ride inside layout deltas — `TabRestructured` carries one for a split and a replace, and it turns out `TabCreated` carries none for anyone — and a client is left out of the deltas its own ops raise, so the record the daemon mints when it registers a seed reaches every window but the one showing the pane. `PaneFacts` close the gap only when a fact changes, and a pane spawned into its directory and left at its prompt never changes one.

The cost is what the issue logged: the workspace answers no subject path, an unnamed one (`tty7 new`) reads "Untitled" instead of its directory, and `record_geometry` stamps a null subject over the path views.json remembered.

One correction to the issue's diagnosis discovered on the way: `TabCreated` does not carry a pane record at all, so the "stop excluding the origin" shape would also have needed a wire change. The client-side shape needs nothing on the wire.

## The fix

The window knows what it seeded. In the shape #604 set for the workspace's name (`note_workspace_name`), the sync that pushes ops carrying `PaneSeed`s now puts the records those seeds become into its own mirror, through the same `PaneSeed::into_record` the daemon mints with — opened up rather than duplicated, so ssh-secret stripping stays shared — with the window's own Ready terminals standing in for the daemon's liveness probe. The write is insert-only: a record the mirror already holds came from the machine (a pull, a restructure rider, `PaneFacts`) and outranks what a seed knows.

## Tests

`cargo test -p tty7` and `-p tty7-core` fully green. New: `a_seeded_pane_reads_the_same_before_and_after_a_full_pull` (the #604 test's invariant, for subject path and display name), `a_seed_fills_only_the_records_the_mirror_lacks` (facts arriving first are not rolled back), and `seeded_records_carry_the_seed_and_the_windows_own_liveness`. Existing mirror/tree-sync suites untouched and passing.
