### PR TITLE
fix(shell): stop injecting into a zsh or fish the user gave arguments to (#624)

### DIFF
--- a/crates/tty7-core/src/daemon/shell_integration.rs
+++ b/crates/tty7-core/src/daemon/shell_integration.rs
@@ -1047,20 +1047,24 @@ fn wsl_cd(args: &[String]) -> Option<String> {
 
 #[cfg_attr(not(windows), allow(unused_variables))]
 pub fn setup(program: Option<&str>, args: &[String], has_custom_args: bool) -> Option<Injection> {
-    // Every arm defers to user-authored args: argv injection would collide
-    // with them outright, and even zsh's env-only ZDOTDIR swap changes which
-    // startup files run.
+    // Every shell defers to user-authored args, so the gate sits ahead of the
+    // dispatch rather than once per arm — a shell added below inherits it
+    // instead of having to remember it. Argv injection would collide with those
+    // args outright, and even zsh's env-only ZDOTDIR swap changes which startup
+    // files run. Arguments tty7's own detection supplied (Git Bash's `-i -l`,
+    // a WSL row's `--distribution`) are not user-authored and never land here;
+    // `daemon::pane::has_custom_args` is where that line is drawn.
+    if has_custom_args {
+        return None;
+    }
     let mut injection = match shell_kind(program)? {
-        ShellKind::Zsh if !has_custom_args => setup_zsh(),
-        ShellKind::Zsh => None,
-        ShellKind::Fish if !has_custom_args => setup_fish(),
-        ShellKind::Fish => None,
-        ShellKind::Bash if !has_custom_args => setup_bash(),
-        ShellKind::Bash => None,
-        ShellKind::PowerShell if !has_custom_args => setup_powershell(),
-        ShellKind::PowerShell => None,
+        ShellKind::Zsh => setup_zsh(),
+        ShellKind::Fish => setup_fish(),
+        ShellKind::Bash => setup_bash(),
+        ShellKind::PowerShell => setup_powershell(),
         #[cfg(windows)]
-        ShellKind::Wsl if !has_custom_args => setup_wsl(args),
+        ShellKind::Wsl => setup_wsl(args),
+        #[cfg(not(windows))]
         ShellKind::Wsl => None,
     }?;
 

--- a/crates/tty7-core/src/daemon/shell_integration.rs
+++ b/crates/tty7-core/src/daemon/shell_integration.rs
@@ -1047,9 +1047,14 @@ fn wsl_cd(args: &[String]) -> Option<String> {
 
 #[cfg_attr(not(windows), allow(unused_variables))]
 pub fn setup(program: Option<&str>, args: &[String], has_custom_args: bool) -> Option<Injection> {
+    // Every arm defers to user-authored args: argv injection would collide
+    // with them outright, and even zsh's env-only ZDOTDIR swap changes which
+    // startup files run.
     let mut injection = match shell_kind(program)? {
-        ShellKind::Zsh => setup_zsh(),
-        ShellKind::Fish => setup_fish(),
+        ShellKind::Zsh if !has_custom_args => setup_zsh(),
+        ShellKind::Zsh => None,
+        ShellKind::Fish if !has_custom_args => setup_fish(),
+        ShellKind::Fish => None,
         ShellKind::Bash if !has_custom_args => setup_bash(),
         ShellKind::Bash => None,
         ShellKind::PowerShell if !has_custom_args => setup_powershell(),
@@ -2312,8 +2317,12 @@ mod tests {
             let _ = std::fs::remove_dir_all(d);
         }
 
+        assert!(setup(Some("zsh"), &[], true).is_none());
+
         let inj = setup(Some("fish"), &[], false).expect("fish setup");
         assert!(inj.env.contains_key("TTY7_SHELL_INTEGRATION"));
+
+        assert!(setup(Some("fish"), &[], true).is_none());
 
         let bash = if cfg!(windows) {
             "C:/Program Files/Git/bin/bash.exe"

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -84,8 +84,8 @@ their id from the file name. [More about themes →](/customization/themes)
 
 | Key | Type | Default | |
 |---|---|---|---|
-| `shell` | object | — | `{"program": "fish", "args": ["-l"]}`. Unset uses the platform default. |
-| `custom_shells` | array | `[]` | Extra entries for the new-tab menu: `[{"label": "Ubuntu", "program": "wsl.exe", "args": ["-d", "Ubuntu"]}]`. Launched exactly as written, listed after the detected shells. Give an entry arguments and tty7 also skips shell integration for it, so it has no prompt marks, working-directory tracking, or command-finished notifications; an entry without arguments is integrated like the detected row beside it. An entry with no `program` is skipped; with no `label` it is named after its program. |
+| `shell` | object | — | `{"program": "fish", "args": ["-l"]}`. Unset uses the platform default. `args` you write are launched verbatim, which also turns off [shell integration](/reference/shell-integration) for that shell — leave them out to keep it. |
+| `custom_shells` | array | `[]` | Extra entries for the new-tab menu: `[{"label": "Ubuntu", "program": "wsl.exe", "args": ["-d", "Ubuntu"]}]`. Launched exactly as written, listed after the detected shells. Give an entry arguments and tty7 also skips [shell integration](/reference/shell-integration) for it, so it has no prompt marks, working-directory tracking, or command-finished notifications; an entry with no arguments, on a shell tty7 recognizes, is integrated like the detected row beside it. An entry with no `program` is skipped; with no `label` it is named after its program. |
 | `working_directory` | object | `{"strategy":"inherit"}` | `strategy` is `inherit`, `home`, or `custom`; `path` is used when custom. |
 | `env` | object | `{}` | Extra environment variables for every pane. |
 | `scrollback_limit` | number | `10000` | Lines per pane (100–100,000). New panes only. |

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -85,7 +85,7 @@ their id from the file name. [More about themes →](/customization/themes)
 | Key | Type | Default | |
 |---|---|---|---|
 | `shell` | object | — | `{"program": "fish", "args": ["-l"]}`. Unset uses the platform default. |
-| `custom_shells` | array | `[]` | Extra entries for the new-tab menu: `[{"label": "Ubuntu", "program": "wsl.exe", "args": ["-d", "Ubuntu"]}]`. Launched exactly as written, listed after the detected shells — which also means tty7 adds no shell integration to one, so a custom entry has no prompt marks, working-directory tracking, or command-finished notifications even where the detected row beside it does. An entry with no `program` is skipped; with no `label` it is named after its program. |
+| `custom_shells` | array | `[]` | Extra entries for the new-tab menu: `[{"label": "Ubuntu", "program": "wsl.exe", "args": ["-d", "Ubuntu"]}]`. Launched exactly as written, listed after the detected shells. Give an entry arguments and tty7 also skips shell integration for it, so it has no prompt marks, working-directory tracking, or command-finished notifications; an entry without arguments is integrated like the detected row beside it. An entry with no `program` is skipped; with no `label` it is named after its program. |
 | `working_directory` | object | `{"strategy":"inherit"}` | `strategy` is `inherit`, `home`, or `custom`; `path` is used when custom. |
 | `env` | object | `{}` | Extra environment variables for every pane. |
 | `scrollback_limit` | number | `10000` | Lines per pane (100–100,000). New panes only. |

--- a/docs/reference/shell-integration.mdx
+++ b/docs/reference/shell-integration.mdx
@@ -26,8 +26,11 @@ removes itself from the equation if you run the same shell elsewhere.
 injection when shells nest.
 
 <Note>
-  A shell launched with custom arguments is left alone, because tty7's
-  injection would conflict with the flags you chose.
+  A shell launched with arguments *you* wrote — `shell.args`, or a
+  `custom_shells` entry — is left alone, because tty7's injection would
+  conflict with the flags you chose. Arguments tty7's own detection supplied
+  (Git Bash's `-i -l`, a WSL row's `--distribution`) do not count, so those
+  rows are still integrated.
 </Note>
 
 ## What it reports

--- a/docs/reference/shell-integration.mdx
+++ b/docs/reference/shell-integration.mdx
@@ -26,8 +26,8 @@ removes itself from the equation if you run the same shell elsewhere.
 injection when shells nest.
 
 <Note>
-  A shell launched with custom arguments is left alone for bash, PowerShell, and
-  WSL, because tty7's injection would conflict with the flags you chose.
+  A shell launched with custom arguments is left alone, because tty7's
+  injection would conflict with the flags you chose.
 </Note>
 
 ## What it reports


### PR DESCRIPTION
The custom-arguments half of #624 (the report's "Using a zsh entry under `custom_shells` is not sufficient" finding). The native-input-mode half is a separate PR.

## The bug

Custom arguments are the line where tty7 backs off: the bash, PowerShell and WSL arms of `shell_integration::setup` all check `has_custom_args` and skip integration when the user authored the flags. The zsh and fish arms never did — a zsh or fish launched with the user's own arguments was injected anyway, which is not what the shell-integration page promised.

fish belongs in the gate at least as much as bash does: its injection prepends `-C <script>` to the argv the user wrote. zsh's is env-only — a ZDOTDIR swap — but that still decides which startup files the shell reads.

## The fix

Both arms now sit behind `!has_custom_args`, same as their neighbours. The dispatch test grows the two cases, and the docs stop enumerating shells: "left alone with custom arguments" now simply holds.

The configuration page's claim that a `custom_shells` entry gets no integration at all was never true and still is not — an entry with no args has `has_custom_args == false` and is integrated like a detected shell. The page now says what the code does. Making a custom entry uninjected regardless would need a came-from-custom_shells flag on `ChosenShell`; that is a separate change if you want it.

## Tests

`cargo test -p tty7-core` — fully green, including the extended `setup_dispatches_by_shell_and_sets_sentinel`.
