### PR TITLE
fix(resize): defer the reflow to the daemon's Size echo on remote routes too (#416)

### DIFF
--- a/crates/tty7-core/src/host/server.rs
+++ b/crates/tty7-core/src/host/server.rs
@@ -371,6 +371,15 @@ fn handshake<R: Read>(
     if services.machine.is_some() {
         features.push(feature::MACHINE_TREE.to_string());
     }
+    // The pane daemon's features ride along, same as `protocol_version` above:
+    // a pane connection answers exactly one message, so a client that wanted
+    // them from `ClientMsg::Version` would pay a whole routed connection — for
+    // ssh and WSL, a whole bridge process — per pane. The hello already travels
+    // once per host and is cached on the link, so this is where a client can
+    // afford to learn what the panes it routes here will do (the resize echo
+    // above all). Additive names are safe: every check on either end asks for
+    // a name, never for the exact list.
+    features.extend(crate::daemon::protocol::DaemonVersion::current().features);
 
     sink.send(&ControlServerMsg::HelloOk(ControlHelloOk {
         control_version: CONTROL_VERSION,
@@ -2303,6 +2312,24 @@ mod tests {
         assert!(
             !peer.home.is_empty(),
             "the server's $HOME backs `new workspace in ~`"
+        );
+    }
+
+    #[test]
+    fn the_handshake_advertises_the_pane_daemons_features() {
+        let p = pair();
+        let peer = p.host.peer();
+        for name in crate::daemon::protocol::DaemonVersion::current().features {
+            assert!(
+                peer.has_feature(&name),
+                "the hello must carry the pane feature {name:?}: a pane \
+                 connection answers one message, so this handshake is the \
+                 only affordable place for a client to learn it"
+            );
+        }
+        assert!(
+            peer.has_feature(crate::daemon::protocol::FEATURE_RESIZE_ECHO),
+            "the resize-echo deferral on remote routes hangs off this name"
         );
     }
 

--- a/crates/tty7-server/tests/machine_tree.rs
+++ b/crates/tty7-server/tests/machine_tree.rs
@@ -131,6 +131,21 @@ fn the_server_advertises_the_machine_tree() {
 }
 
 #[test]
+fn the_server_advertises_the_pane_daemons_features() {
+    let dir = data_dir();
+    let client = connect(dir.path(), "pane-cap");
+    assert!(
+        client
+            .peer_features
+            .iter()
+            .any(|f| f == tty7_core::daemon::protocol::FEATURE_RESIZE_ECHO),
+        "a remote client learns what this machine's panes do from this hello and \
+         nowhere else — without the name it reflows at request time forever: {:?}",
+        client.peer_features
+    );
+}
+
+#[test]
 fn the_tree_is_built_by_operations_and_lives_in_the_servers_file() {
     let dir = data_dir();
     let client = connect(dir.path(), "ops");

--- a/crates/tty7-server/tests/routed_pane.rs
+++ b/crates/tty7-server/tests/routed_pane.rs
@@ -150,6 +150,29 @@ fn a_routed_pane_spawns_takes_input_and_survives_a_reconnect() {
 }
 
 #[test]
+fn a_routed_version_reply_names_the_resize_echo_feature() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = dir.path().join("remote-config");
+    std::fs::create_dir_all(&config).unwrap();
+
+    let (mut sock, hub_thread) = routed(dir.path(), "version-1.sock", &config);
+    ClientMsg::Version.encode(&mut sock).unwrap();
+    let version = match DaemonMsg::read(&mut sock).unwrap() {
+        DaemonMsg::Version(v) => v,
+        other => panic!("expected Version through the router, got {other:?}"),
+    };
+    assert!(
+        version.has_feature(tty7_core::daemon::protocol::FEATURE_RESIZE_ECHO),
+        "a routed daemon echoes Size like a local one; its features must say so: {:?}",
+        version.features
+    );
+    drop(sock);
+    let _ = hub_thread.join();
+
+    shutdown(dir.path(), &config);
+}
+
+#[test]
 fn the_channel_decides_which_dialect_the_route_carries() {
     let control = RouteHeader::local_stdio(EXE, &["--stdio"]);
     assert_eq!(control.channel, RouteChannel::Control);

--- a/src/terminal/remote.rs
+++ b/src/terminal/remote.rs
@@ -88,6 +88,12 @@ pub struct PaneWorkspace {
     pub workspace: crate::core::session::WorkspaceId,
     pub target: crate::core::session::RemoteTarget,
     pub spec: Option<Box<NativeSshSpec>>,
+    /// Whether the daemon serving this workspace's panes echoes a `Size` frame
+    /// when it applies a resize — read off the host's control hello by whoever
+    /// built this value, because this module may not ask the network itself.
+    /// `false` whenever the answer is unknown (link down, server too old to
+    /// advertise), which keeps the safe reflow-at-request behavior.
+    pub resize_echo: bool,
 }
 
 impl PaneWorkspace {
@@ -123,7 +129,15 @@ impl PaneWorkspace {
 pub enum PaneRoute {
     #[default]
     Local,
-    Remote(Box<crate::daemon::router::RouteHeader>),
+    Remote {
+        header: Box<crate::daemon::router::RouteHeader>,
+        /// Whether the daemon at the far end of this route echoes a `Size`
+        /// frame when it applies a resize, per its host's control hello (see
+        /// [`PaneWorkspace::resize_echo`]). Riding on the route puts the
+        /// answer everywhere a route is assigned — spawn, attach, relink —
+        /// and a relink builds its route fresh, so a reconnect re-answers it.
+        resize_echo: bool,
+    },
     Unroutable(String),
 }
 
@@ -132,7 +146,10 @@ impl PaneRoute {
         match workspace {
             None => PaneRoute::Local,
             Some(ws) => match ws.route_header() {
-                Ok(header) => PaneRoute::Remote(Box::new(header)),
+                Ok(header) => PaneRoute::Remote {
+                    header: Box::new(header),
+                    resize_echo: ws.resize_echo,
+                },
                 Err(e) => PaneRoute::Unroutable(e.to_string()),
             },
         }
@@ -140,7 +157,7 @@ impl PaneRoute {
 
     pub fn header(&self) -> Option<&crate::daemon::router::RouteHeader> {
         match self {
-            PaneRoute::Remote(header) => Some(header),
+            PaneRoute::Remote { header, .. } => Some(header),
             PaneRoute::Local | PaneRoute::Unroutable(_) => None,
         }
     }
@@ -202,10 +219,6 @@ pub struct RemoteTerminal {
     /// flag under the term lock before every grid mutation, so once it is set
     /// the abandoned thread can only exit, never write.
     reader_quit: Arc<AtomicBool>,
-    /// Test hook: pretend the daemon advertised `FEATURE_RESIZE_ECHO`.
-    /// Production code probes the real daemon per call in [`Self::resize`].
-    #[cfg(test)]
-    force_resize_echo: bool,
 }
 
 /// The workspace id a spawn carries, so the pane's shell gets `$TTY7_WS` and a
@@ -564,8 +577,6 @@ impl RemoteTerminal {
             proxy,
             reader_thread: Some(reader_thread),
             reader_quit,
-            #[cfg(test)]
-            force_resize_echo: false,
         })
     }
 
@@ -1095,24 +1106,21 @@ impl RemoteTerminal {
     /// geometry, and reflowing before it drains parses old-width bytes into a
     /// new-width grid (maximize during a burst of output garbled the pane).
     ///
-    /// Older daemons never echo, so those keep the reflow-at-request-time
-    /// behavior. Non-local routes keep it too, for a weaker reason: only the
-    /// local daemon's feature set is probed, so the client cannot *rely* on an
-    /// echo arriving. A current remote daemon does send one — the router
-    /// forwards frames it does not parse, and the reader applies it as a
-    /// same-size no-op after the eager reflow — but deferral can't hang on a
-    /// maybe. Follow-up: carry the remote daemon's advertised features on the
-    /// route handshake and consult them here; remote panes then get the
-    /// deferred path for free.
+    /// The local daemon is probed directly. A routed pane consults the answer
+    /// its route carries, read off the host's control hello when the route was
+    /// built — the daemon serves one `ClientMsg` per connection, so asking
+    /// `Version` per pane would cost a whole routed connection each time. The
+    /// remaining cases never defer: an older server does not advertise the
+    /// echo, an unroutable route reaches no daemon at all, and deferral must
+    /// not hang the grid on an echo nobody promised.
     fn resize_echoed(&self) -> bool {
-        #[cfg(test)]
-        if self.force_resize_echo {
-            return true;
-        }
-        self.route.is_local()
-            && crate::daemon::spawn::local_daemon_supports(
+        match &self.route {
+            PaneRoute::Local => crate::daemon::spawn::local_daemon_supports(
                 crate::daemon::protocol::FEATURE_RESIZE_ECHO,
-            )
+            ),
+            PaneRoute::Remote { resize_echo, .. } => *resize_echo,
+            PaneRoute::Unroutable(_) => false,
+        }
     }
 
     pub fn resize(&mut self, size: TermSize, cell_w: u16, cell_h: u16) {
@@ -2360,6 +2368,7 @@ mod tests {
                 )
                 .unwrap(),
             )),
+            resize_echo: false,
         }
     }
 
@@ -2381,6 +2390,19 @@ mod tests {
             "a pane must not be sent to the control socket"
         );
         assert_eq!(header.describe(), "ssh me@build-box:22");
+
+        let mut ws = ssh_workspace();
+        ws.resize_echo = true;
+        assert!(
+            matches!(
+                PaneRoute::for_workspace(Some(&ws)),
+                PaneRoute::Remote {
+                    resize_echo: true,
+                    ..
+                }
+            ),
+            "what the host's hello said about the resize echo rides the route"
+        );
     }
 
     #[test]
@@ -2391,6 +2413,7 @@ mod tests {
                 distro: "Ubuntu-22.04".into(),
             },
             spec: None,
+            resize_echo: false,
         };
         let route = PaneRoute::for_workspace(Some(&ws));
         let header = route.header().expect("WSL is routed");
@@ -2407,6 +2430,7 @@ mod tests {
                 args: vec!["--stdio".into()],
             },
             spec: None,
+            resize_echo: false,
         };
         let route = PaneRoute::for_workspace(Some(&ws));
         let header = route.header().expect("a local child is routable");
@@ -2428,6 +2452,7 @@ mod tests {
                 alias: "build-box".into(),
             },
             spec: None,
+            resize_echo: false,
         };
         let route = PaneRoute::for_workspace(Some(&ws));
         assert!(matches!(route, PaneRoute::Unroutable(_)));
@@ -3354,7 +3379,13 @@ mod tests {
 
         let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
         let mut term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
-        term.force_resize_echo = true;
+        // A remote route whose host advertised the echo. The local daemon's
+        // answer rides the same gate through `local_daemon_supports`, so this
+        // covers the deferral for both.
+        term.route = PaneRoute::Remote {
+            header: Box::new(crate::daemon::router::RouteHeader::wsl("Ubuntu-22.04")),
+            resize_echo: true,
+        };
 
         term.resize(TermSize::new(120, 30), 8, 17);
         assert!(matches!(
@@ -3407,6 +3438,37 @@ mod tests {
             'B',
             "bytes after the echo parse at the new width"
         );
+    }
+
+    #[test]
+    fn a_remote_route_without_the_advertised_echo_reflows_at_request_time() {
+        use alacritty_terminal::grid::Dimensions as _;
+
+        crate::core::config::pin_test_config_dir();
+        let (client_side, mut daemon_side) = UnixStream::pair().unwrap();
+        let mut term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
+        // What `for_workspace` builds when the host's hello named no echo —
+        // an older server, or a link that was down when the route was made.
+        term.route = PaneRoute::Remote {
+            header: Box::new(crate::daemon::router::RouteHeader::wsl("Ubuntu-22.04")),
+            resize_echo: false,
+        };
+
+        term.resize(TermSize::new(120, 30), 8, 17);
+        assert_eq!(
+            term.term.lock().columns(),
+            120,
+            "with no promised echo the grid must reflow at request time — \
+             deferring would leave it at the old width forever"
+        );
+        assert!(matches!(
+            ClientMsg::read(&mut daemon_side).unwrap(),
+            ClientMsg::Resize(ws) if ws.cols == 120 && ws.rows == 30
+        ));
+
+        // The other route with no daemon to promise anything.
+        term.route = PaneRoute::Unroutable("no ssh details".into());
+        assert!(!term.resize_echoed(), "no route, no echo to wait for");
     }
 
     #[test]

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -6829,6 +6829,7 @@ mod tests {
                     .unwrap(),
                 )
             }),
+            resize_echo: false,
         }
     }
 
@@ -7982,6 +7983,7 @@ mod tests {
             workspace: WorkspaceId::new(),
             target: target.clone(),
             spec: None,
+            resize_echo: false,
         };
 
         let remote = ws.target.host_id();
@@ -7997,6 +7999,7 @@ mod tests {
             workspace: WorkspaceId::new(),
             target,
             spec: None,
+            resize_echo: false,
         };
         assert_eq!(sibling.target.host_id(), remote);
     }
@@ -10626,6 +10629,7 @@ mod gpui_tests {
                 )
                 .unwrap(),
             )),
+            resize_echo: false,
         }));
         id
     }

--- a/src/ui/remote_connect.rs
+++ b/src/ui/remote_connect.rs
@@ -473,6 +473,17 @@ impl HostLinks {
         cx.try_global::<HostLinks>()?.homes.get(&id).cloned()
     }
 
+    /// Whether the daemon behind this host's link advertised `feature` on its
+    /// control hello — the per-host sibling of `local_daemon_supports`. `false`
+    /// while no link is up: a caller that cannot see the hello must assume
+    /// nothing of the far end, and every feature is gated so that "assume
+    /// nothing" degrades to the old behavior rather than breaking.
+    pub fn peer_supports(cx: &App, id: HostId, feature: &str) -> bool {
+        cx.try_global::<HostLinks>()
+            .and_then(|table| table.hosts.get(&id))
+            .is_some_and(|host| host.peer().has_feature(feature))
+    }
+
     pub fn insert(cx: &mut App, host: Arc<RemoteHost>, home: PathBuf) {
         let id = host.id();
         crate::ui::host_registry::HostRegistry::insert(cx, Arc::clone(&host).into_shared());

--- a/src/ui/remote_workspace.rs
+++ b/src/ui/remote_workspace.rs
@@ -1015,10 +1015,21 @@ pub(crate) fn pane_workspace_for(
     let spec = remote_connect::spec_for(&host.target, cx)
         .ok()
         .map(|spec| Box::new(spec.without_secrets()));
+    // Answered here because the terminal cannot ask the network itself: the
+    // host's control hello carries the pane daemon's features, and the route
+    // built from this value hands the answer to `resize_echoed`. A relink
+    // comes back through here too, so a reconnected (possibly upgraded)
+    // server is re-asked.
+    let resize_echo = remote_connect::HostLinks::peer_supports(
+        cx,
+        host.host_id(),
+        crate::daemon::protocol::FEATURE_RESIZE_ECHO,
+    );
     let pane = crate::terminal::PaneWorkspace {
         workspace,
         target: host.target,
         spec,
+        resize_echo,
     };
     if let Ok(header) = pane.route_header() {
         remote_connect::note_origin(&header.target, &pane.target);


### PR DESCRIPTION
Closes #416.

## The change

Since #415 the daemon echoes a `Size` frame at the exact stream position where the pty changes geometry, and the client defers its grid reflow to that marker — but only on local routes, because only the local daemon's features were ever probed. A remote pane kept reflowing at request time, so a resize landing mid-flood still parsed queued old-width bytes into the new-width grid — and network transport makes that backlog the largest.

One deviation from the issue's sketch, for a structural reason: the daemon serves exactly one `ClientMsg` per connection, so probing `Version` per pane costs a whole routed connection — for ssh and WSL, a whole bridge process — on every spawn and attach, the duplicated-round-trip shape #454 already measured in seconds. The per-host control handshake travels once and is cached on the link, so the server now advertises the pane protocol's features on its hello, and the client reads the answer off the host when it builds a pane's route. The route carries it to the terminal, which consults it wherever a route is assigned: spawn, attach, relink.

Both directions of skew keep today's behavior: an older server names no echo, so the client reflows at request time as it always has; an older client ignores the extra names. A route built while the link is down answers false — never defer on an echo nobody promised. Reconnect re-asks on its own: the hello runs again, relink builds routes fresh, and the re-sent size draws a fresh echo. The `resize_echoed` doc comment naming this exact follow-up is retired, and the old test-only force flag became the real route-carried field.

## Tests

Full suites green: tty7 1522, tty7-core 1127, tty7-server 97 (including a new routed `ClientMsg::Version` round-trip against a real `tty7-server --stdio` asserting `resize-echo` is advertised), tty7-cli 129. New unit tests cover a remote route deferring with the bit set and reflowing at request time without it. Unverified here: behavior against a live ssh/WSL host — covered by the routed integration test and unit proxies only.
