### PR TITLE
docs(shell): name custom arguments as a reason integration never engaged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A zsh or fish you gave your own arguments to is no longer injected into.**
+  Custom arguments have always been the line where tty7 backs off — the bash,
+  PowerShell and WSL setups checked for them — but the zsh and fish setups did
+  not, so a `fish` started with your flags had `-C <script>` appended to them
+  and a `zsh` had its `ZDOTDIR` swapped out from under its startup files. Both
+  now behave like the rest. **This turns shell integration off for a config
+  that sets `shell` or a `custom_shells` entry with `args`** — including the
+  `{"program": "fish", "args": ["-l"]}` the reference page used to print as an
+  example — so prompt marks, working directory reporting, command-finished
+  notifications, inline completion, <kbd>⌃ R</kbd> and per-pane history stop in
+  those panes. Drop the arguments to get them back, and the notice a pane
+  raises when integration never engaged now names this as a cause (#624, #629).
 - **An SSH pane is named after its host.** A fresh SSH tab reads the host's
   name, or its address when the host has none — every host imported from
   `~/.ssh/config` arrives nameless, and a window full of them all read `tty7`

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -1652,8 +1652,8 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         }
         L10nKey::IntegrationNoticeNotEngaged => {
             "tty7 shell integration hasn't engaged in this pane, so inline completion and the \
-             Ctrl+R menu are unavailable. A PTY wrapper (figterm-style) or an unsupported shell \
-             setup can cause this."
+             Ctrl+R menu are unavailable. A shell you started with your own arguments, a PTY \
+             wrapper (figterm-style), or an unsupported shell setup can cause this."
         }
         L10nKey::PaneTitleDisconnected => "{title} — disconnected",
         L10nKey::PaneTitleProcessExited => "{title} — process exited",

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -1700,7 +1700,8 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         }
         L10nKey::IntegrationNoticeNotEngaged => {
             "このペインでは tty7 シェル統合が有効になっていないため、インライン補完と Ctrl+R \
-             メニューは利用できません。PTY ラッパー（figterm 系）や未対応のシェル設定が原因の可能性があります。"
+             メニューは利用できません。独自の引数で起動したシェル、PTY ラッパー（figterm 系）、\
+             未対応のシェル設定が原因の可能性があります。"
         }
         L10nKey::PaneTitleDisconnected => "{title} — 切断されました",
         L10nKey::PaneTitleProcessExited => "{title} — プロセスが終了しました",

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -1549,7 +1549,8 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         }
         L10nKey::IntegrationNoticeNotEngaged => {
             "此窗格中的 tty7 shell 集成尚未生效，内联补全和 Ctrl+R 菜单不可用。\
-             PTY 包装器（figterm 类）或不受支持的 shell 配置可能导致此问题。"
+             用你自己参数启动的 shell、PTY 包装器（figterm 类）或不受支持的 shell 配置\
+             都可能导致此问题。"
         }
         L10nKey::PaneTitleDisconnected => "{title} — 已断开",
         L10nKey::PaneTitleProcessExited => "{title} — 进程已退出",


### PR DESCRIPTION
Follow-up to #629: tell the user, in the release notes and in the pane itself, that their own shell arguments are why integration went quiet.

#629 made a zsh or fish started with the user's own arguments skip shell integration, matching what bash, PowerShell and WSL already did. That is the intended behaviour, but for anyone whose `config.json` already sets `shell` or a `custom_shells` entry with `args` it lands as a silent regression on upgrade — including the `{"program": "fish", "args": ["-l"]}` the reference page used to print as its example. Nothing on screen connected the loss to the config line that caused it.

| | Before | After |
|---|---|---|
| Notice in a pane where integration never engaged | "A PTY wrapper (figterm-style) or an unsupported shell setup can cause this." | "A shell you started with your own arguments, a PTY wrapper (figterm-style), or an unsupported shell setup can cause this." |
| Release notes for #629 | Not mentioned | A **Changed** entry naming the configs that lose integration and how to get it back |

The new cause is named first because it is the only one of the three the user can undo by editing a line.

## Testing

- `cargo test -p tty7 --bin tty7-app i18n` — 6 passed, 0 failed, including `every_key_is_translated_in_every_locale` and each locale's coverage test.
- `cargo fmt --check` — clean.
- `grep -c '^## \[Unreleased\]' CHANGELOG.md` — 1, so no second heading was opened.
- Not verified in the running GUI: the notice's wrapped length in the pane banner. The string grew by a clause in all three locales; en is the longest at ~210 characters.
