### PR TITLE
fix(theme): stop the code editor painting its gutter and current line in the stock syntax theme's colours

### DIFF
--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -819,6 +819,27 @@ pub(crate) fn apply_theme(mut window: Option<&mut Window>, cx: &mut App) {
     // ring and the on-switch.
     t.drag_border = rgb(m.accent).into();
 
+    // The code editor's gutter fill and current-line band do not come from
+    // `Theme` at all — gpui-component reads them off the *syntax* theme, which
+    // is still its stock one. So the editor painted a #0a0a0a strip down the
+    // line-number column and a #171717 band across the cursor's line, on top of
+    // a preset background that is nowhere near either. That is the black edge.
+    //
+    // Cleared to transparent rather than repainted with the preset's own fill:
+    // the code panel sits on the window background, which may be a gradient or
+    // a wallpaper image, and any flat colour would show as a seam against it.
+    // The current line and the invisibles become translucent ink for the same
+    // reason — they read correctly on light and dark presets alike.
+    let ink: Hsla = rgb(m.foreground).into();
+    let mut highlight = (*t.highlight_theme).clone();
+    highlight.style.editor_background = Some(gpui::transparent_black());
+    highlight.style.editor_gutter_background = Some(gpui::transparent_black());
+    highlight.style.editor_active_line = Some(ink.opacity(0.06));
+    highlight.style.editor_line_number = Some(rgb(m.muted_foreground).into());
+    highlight.style.editor_active_line_number = Some(ink);
+    highlight.style.editor_invisible = Some(ink.opacity(0.25));
+    t.highlight_theme = std::sync::Arc::new(highlight);
+
     #[cfg(target_os = "macos")]
     if let Some(window) = window.as_deref_mut() {
         window.set_traffic_light_position(traffic_light_position());


### PR DESCRIPTION
Align the code editor's gutter, current-line band and line numbers with the active preset, instead of leaving them on gpui-component's stock syntax-theme colours.

The code editor's gutter fill and current-line highlight are not read from `Theme` — gpui-component takes them off the *syntax* theme (`highlight_theme.style.editor.*`, see `input/element.rs`). tty7 has never set that field, so the editor painted `#0a0a0a` down the line-number column and `#171717` across the cursor's line, on top of a preset background that is nowhere near either. On the Dracula preset (`#282a36`) that reads as a black strip along the left edge and a black band across the current line.

| | Before | After |
|---|---|---|
| Gutter (line-number column) | Flat `#0a0a0a` from the stock syntax theme | Transparent — the window fill shows through |
| Current-line band | Flat `#171717` from the stock syntax theme | Foreground ink at 6% — reads on light and dark presets alike |
| Line numbers | Fixed `#8F8F8F` / `#929292` | Preset's `muted_foreground` |
| Active line number | Fixed `#DDDDDD` / `#000000` | Preset's `foreground` |
| Invisibles | Fixed `#73737366` | Foreground ink at 25% |

Cleared to transparent rather than repainted with the preset's own background colour: the code panel sits on the window fill, which can be a gradient or a wallpaper image, so any flat colour would show as a seam against it. The same reasoning makes the current line and the invisibles translucent ink rather than blended solids.

Syntax colours (keywords, strings, comments) are untouched.

## Testing

- `cargo build -p tty7`, `cargo fmt --check` clean.
- Manual: isolated dev instance (`--config-dir`) seeded with the reporter's real config (Dracula preset), opened `LICENSE` in the editor. Gutter now matches the editor background, the current line is a faint highlight instead of a black band, and switching presets keeps the gutter following the background. Accepted by the reporter.
- Diagnosis was pixel-sampled off the original screenshot: gutter column `(10,10,10)`, current line `(23,23,23)`, editor body `(40,42,54)` — an exact match for `default-theme.json`'s `editor.background` / `editor.active_line.background` against Dracula's background.
