### PR TITLE
test(history): stop the sweep test deleting the panes of tests running beside it

### DIFF
--- a/crates/tty7-core/src/daemon/history.rs
+++ b/crates/tty7-core/src/daemon/history.rs
@@ -192,7 +192,11 @@ pub fn sweep(keep: &HashSet<u64>) {
     let Some(dir) = dir() else {
         return;
     };
-    let Ok(entries) = std::fs::read_dir(&dir) else {
+    sweep_in(&dir, keep);
+}
+
+fn sweep_in(dir: &Path, keep: &HashSet<u64>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
     for entry in entries.flatten() {
@@ -353,12 +357,19 @@ mod tests {
 
     #[test]
     fn the_sweep_keeps_only_the_panes_that_still_exist() {
-        pin_config_dir();
-        let origin = a_global_history("swept", "old\n");
-        let kept = seed(80_007, &origin);
-        let dropped = seed(80_008, &origin);
+        // A directory of its own, not the pinned one the rest of the suite
+        // shares: a sweep deletes every pane it was not told to keep, and the
+        // panes of whatever test is running alongside this one are exactly
+        // that. Hence `sweep_in` rather than `sweep`.
+        let dir = std::env::temp_dir().join(format!("tty7-sweeptest-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let kept = dir.join("pane-80007");
+        let dropped = dir.join("pane-80008");
+        std::fs::write(&kept, "old\n").unwrap();
+        std::fs::write(&dropped, "old\n").unwrap();
+        std::fs::write(with_suffix(&dropped, ".seed"), "0").unwrap();
 
-        sweep(&HashSet::from([80_007]));
+        sweep_in(&dir, &HashSet::from([80_007]));
 
         assert!(kept.exists(), "a live pane keeps its history");
         assert!(!dropped.exists(), "a pane that is gone does not");
@@ -366,8 +377,7 @@ mod tests {
             !with_suffix(&dropped, ".seed").exists(),
             "the sidecars go with it"
         );
-        retire(80_007);
-        let _ = std::fs::remove_file(&origin);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
`daemon::history::tests::a_restored_pane_inherits_its_predecessors_history` fails at random, most visibly on Windows, with `NotFound` on the file `carry` had just created:

```
thread '...a_restored_pane_inherits_its_predecessors_history' panicked at crates\tty7-core\src\daemon\history.rs:336:45:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound }
```

Nothing platform-specific is involved. `pin_config_dir` is backed by a process-wide `OnceLock`, so every test in the module shares one history directory, and `the_sweep_keeps_only_the_panes_that_still_exist` calls the real `sweep`, which deletes *every* `pane-*` file whose id is not in the set it was handed. Running beside the carry test, it deletes `pane-80006` in the window between `carry` moving the file there and the test reading it back. The other tests in the module are equally reachable; the carry test is just the one with the widest window.

Proven rather than guessed: injecting `sweep(&HashSet::from([80_007]))` immediately after the `carry` call — exactly what the sweep test does concurrently — reproduces the CI failure verbatim on macOS.

The fix splits the directory walk into `sweep_in(dir, keep)` and points the sweep test at a directory of its own, so it no longer touches files it does not own. `sweep`'s behaviour is unchanged.
