### PR TITLE
Retire to the tray on window close; cold start no longer stalls on stale daemon files

### DIFF
--- a/crates/tty7-core/src/daemon/server.rs
+++ b/crates/tty7-core/src/daemon/server.rs
@@ -527,7 +527,12 @@ fn report_conpty_host() {
 fn run_with(registry: Arc<Registry>) -> anyhow::Result<()> {
     crate::daemon::control::server_started();
 
-    if transport::endpoint_exists() {
+    // A stale daemon.port whose recorded daemon is gone cannot belong to a
+    // live server: skip the probe (which would pay the OS's refusal delay on
+    // the dead port) and let the bind below overwrite the file. A live
+    // recorded daemon still gets the connect — the singleton seat is held by
+    // this process, so it can only be a foreign server worth refusing.
+    if transport::endpoint_exists() && !crate::daemon::spawn::recorded_daemon_is_dead() {
         match transport::connect() {
             Ok(_) => {
                 anyhow::bail!(

--- a/crates/tty7-core/src/daemon/spawn.rs
+++ b/crates/tty7-core/src/daemon/spawn.rs
@@ -155,10 +155,22 @@ fn is_reapable_daemon_name(name: &str) -> bool {
 /// out the refusal delay on the stale `control.port` that `ensure_running`
 /// clears later. The probe skips itself instead.
 pub fn recorded_daemon_is_dead() -> bool {
-    let Some(pid) = pidfile::read() else {
+    recorded_daemon_is_dead_with(pidfile::read(), daemon_process_alive)
+}
+
+/// The rule alone, so it can be tested without a pidfile on disk — pinning a
+/// config directory would mean an env var, and that is process-global state
+/// every other test running beside this one would inherit.
+///
+/// Note what a missing pidfile answers: **not dead**, because nothing here
+/// knows otherwise. Callers must not read that as "alive" — a refused connect
+/// is still the authority, and `ensure_running` keeps its own stale branch for
+/// exactly that.
+fn recorded_daemon_is_dead_with(recorded: Option<u32>, alive: impl Fn(u32) -> bool) -> bool {
+    let Some(pid) = recorded else {
         return false;
     };
-    pid > 4 && pid != std::process::id() && !daemon_process_alive(pid)
+    pid > 4 && pid != std::process::id() && !alive(pid)
 }
 
 #[cfg(windows)]
@@ -247,9 +259,17 @@ pub fn ensure_running() -> anyhow::Result<()> {
                     stale = true;
                 }
             }
+        } else {
+            // A refused connect is the other stale signal, and it is the only
+            // one left when the pidfile cannot answer: it is missing (the
+            // daemon died between `bind` and `write_current`, or never managed
+            // to write it), or it records a pid the OS has since handed to an
+            // unrelated process. `recorded_daemon_is_dead` says "not dead" to
+            // both, so without this the endpoint file survives and the spawn
+            // poll below pays the refusal delay on it — the very cost this
+            // function was rewritten to avoid.
+            stale = true;
         }
-    } else {
-        stale = true;
     }
 
     if stale {
@@ -1111,6 +1131,44 @@ mod tests {
     use crate::daemon::control::CONTROL_VERSION;
     use std::io::ErrorKind;
     use std::os::unix::net::UnixStream;
+
+    #[test]
+    fn a_missing_pidfile_is_not_a_dead_daemon() {
+        let dead = |_| false;
+        let alive = |_| true;
+
+        // The case the caller has to keep handling itself: no pidfile is no
+        // evidence. The daemon may have died between `transport::bind` (which
+        // writes daemon.port) and `pidfile::write_current`, or never managed
+        // the write at all — a refused connect is then the only signal that
+        // the endpoint file is stale, and skipping the cleanup on it leaves
+        // the spawn poll paying the refusal delay this whole path exists to
+        // avoid.
+        assert!(!recorded_daemon_is_dead_with(None, dead));
+
+        // A recorded pid the OS has handed to something else is likewise not
+        // evidence of death — it is alive, just not ours. `reap_recorded_daemon`
+        // is what checks the executable before killing anything.
+        assert!(!recorded_daemon_is_dead_with(Some(4242), alive));
+
+        // Our own pid: an in-process daemon, so certainly not dead.
+        assert!(!recorded_daemon_is_dead_with(
+            Some(std::process::id()),
+            dead
+        ));
+
+        // Reserved low pids are never a daemon of ours; refuse to call them
+        // dead so nothing downstream reaps them.
+        for reserved in [0, 1, 4] {
+            assert!(
+                !recorded_daemon_is_dead_with(Some(reserved), dead),
+                "pid {reserved} must never be treated as our dead daemon"
+            );
+        }
+
+        // The one case that is evidence: a plausible pid that is gone.
+        assert!(recorded_daemon_is_dead_with(Some(4242), dead));
+    }
 
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]

--- a/crates/tty7-core/src/daemon/spawn.rs
+++ b/crates/tty7-core/src/daemon/spawn.rs
@@ -148,7 +148,13 @@ fn is_reapable_daemon_name(name: &str) -> bool {
 /// query, no TCP: a dead recorded daemon means a connect to the endpoint
 /// would only pay the OS's refusal delay (seconds on some machines) for
 /// information the pidfile already has.
-pub(crate) fn recorded_daemon_is_dead() -> bool {
+///
+/// The GUI's GuiOpen handoff probe relies on the same signal: the probe
+/// connects to the daemon's control listener, so a dead recorded daemon
+/// guarantees no GUI is registered there — running the probe would only wait
+/// out the refusal delay on the stale `control.port` that `ensure_running`
+/// clears later. The probe skips itself instead.
+pub fn recorded_daemon_is_dead() -> bool {
     let Some(pid) = pidfile::read() else {
         return false;
     };

--- a/crates/tty7-core/src/daemon/spawn.rs
+++ b/crates/tty7-core/src/daemon/spawn.rs
@@ -13,7 +13,10 @@ mod windows;
 
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(3);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
-const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
+// A version echo takes microseconds on a healthy daemon; a second is already
+// generous. The old two-second budget only made an unresponsive daemon's
+// stall that much longer before the bounded reap below takes over.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(1);
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(6);
 /// How long to wait for a refusal before assuming a handoff went through.
 ///
@@ -140,70 +143,121 @@ fn is_reapable_daemon_name(name: &str) -> bool {
             .any(|stem| exe_names_equal(stem, name))
 }
 
+/// Whether the recorded daemon process is gone — the cheap, certain signal
+/// that `daemon.port` and `control.port` are stale. One process-liveness
+/// query, no TCP: a dead recorded daemon means a connect to the endpoint
+/// would only pay the OS's refusal delay (seconds on some machines) for
+/// information the pidfile already has.
+pub(crate) fn recorded_daemon_is_dead() -> bool {
+    let Some(pid) = pidfile::read() else {
+        return false;
+    };
+    pid > 4 && pid != std::process::id() && !daemon_process_alive(pid)
+}
+
+#[cfg(windows)]
+fn daemon_process_alive(pid: u32) -> bool {
+    !crate::daemon::winproc::wait_for_exit(pid, Duration::ZERO)
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn daemon_process_alive(pid: u32) -> bool {
+    process_alive(pid as libc::pid_t)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+fn daemon_process_alive(_pid: u32) -> bool {
+    // No cheap liveness query on this platform: assume alive, which keeps
+    // the TCP probe as the authority.
+    true
+}
+
 pub fn ensure_running() -> anyhow::Result<()> {
-    if let Ok(mut stream) = transport::connect() {
-        match query_daemon_version(&mut stream) {
-            VersionProbe::Speaks(v) if v.protocol == PROTOCOL_VERSION => {
-                if !v.build.is_empty() && v.build != env!("CARGO_PKG_VERSION") {
-                    log::info!(
-                        "daemon build {} differs from this build {}; keeping it so its panes \
-                         survive the upgrade — Settings offers the restart",
-                        v.build,
-                        env!("CARGO_PKG_VERSION")
-                    );
+    // A dead recorded daemon is the cheap, certain signal that the endpoint
+    // files are stale: skip the connect entirely and let the cleanup below
+    // clear them before the fresh daemon is spawned — the spawn poll would
+    // otherwise keep paying the OS's refusal delay on the dead port.
+    let mut stale = recorded_daemon_is_dead();
+    if !stale {
+        if let Ok(mut stream) = transport::connect() {
+            match query_daemon_version(&mut stream) {
+                VersionProbe::Speaks(v) if v.protocol == PROTOCOL_VERSION => {
+                    if !v.build.is_empty() && v.build != env!("CARGO_PKG_VERSION") {
+                        log::info!(
+                            "daemon build {} differs from this build {}; keeping it so its panes \
+                             survive the upgrade — Settings offers the restart",
+                            v.build,
+                            env!("CARGO_PKG_VERSION")
+                        );
+                    }
+                    note_local_daemon(Some(v));
+                    // Agreeing here is only half the handshake: the control dialect
+                    // is versioned apart and moves on its own, so a daemon from
+                    // before a dialect bump passes this check and then refuses
+                    // every machine-tree call. Ask the other socket before calling
+                    // the daemon ours, or the window opens with no tabs and nothing
+                    // to explain why.
+                    if let Some(refusal) = control_dialect_refusal() {
+                        log::warn!(
+                            "daemon (build {}) speaks control v{}, this build speaks v{}; \
+                             its machine tree is out of reach until it restarts",
+                            refusal.peer_build,
+                            refusal.peer,
+                            refusal.ours
+                        );
+                        note_daemon_mismatch(DaemonMismatch::Dialect(refusal));
+                    }
+                    return Ok(());
                 }
-                note_local_daemon(Some(v));
-                // Agreeing here is only half the handshake: the control dialect
-                // is versioned apart and moves on its own, so a daemon from
-                // before a dialect bump passes this check and then refuses
-                // every machine-tree call. Ask the other socket before calling
-                // the daemon ours, or the window opens with no tabs and nothing
-                // to explain why.
-                if let Some(refusal) = control_dialect_refusal() {
+                VersionProbe::Speaks(v) => {
                     log::warn!(
-                        "daemon (build {}) speaks control v{}, this build speaks v{}; \
-                         its machine tree is out of reach until it restarts",
-                        refusal.peer_build,
-                        refusal.peer,
-                        refusal.ours
-                    );
-                    note_daemon_mismatch(DaemonMismatch::Dialect(refusal));
-                }
-                return Ok(());
-            }
-            VersionProbe::Speaks(v) => {
-                log::warn!(
-                    "daemon (build {}) speaks protocol {}, this build needs {}; \
+                        "daemon (build {}) speaks protocol {}, this build needs {}; \
                      keeping it and deferring to the user",
-                    v.build,
-                    v.protocol,
-                    PROTOCOL_VERSION
-                );
-                note_local_daemon(Some(v.clone()));
-                note_daemon_mismatch(DaemonMismatch::Protocol(Some(v)));
-                return Ok(());
-            }
-            VersionProbe::Legacy => {
-                log::warn!(
-                    "daemon predates protocol versioning; keeping it and deferring to the user"
-                );
-                note_local_daemon(None);
-                note_daemon_mismatch(DaemonMismatch::Protocol(None));
-                return Ok(());
-            }
-            VersionProbe::Unresponsive => {
-                log::info!("daemon did not answer the version handshake; restarting it");
-                note_local_daemon(None);
-                drop(stream);
-                stop();
+                        v.build,
+                        v.protocol,
+                        PROTOCOL_VERSION
+                    );
+                    note_local_daemon(Some(v.clone()));
+                    note_daemon_mismatch(DaemonMismatch::Protocol(Some(v)));
+                    return Ok(());
+                }
+                VersionProbe::Legacy => {
+                    log::warn!(
+                        "daemon predates protocol versioning; keeping it and deferring to the user"
+                    );
+                    note_local_daemon(None);
+                    note_daemon_mismatch(DaemonMismatch::Protocol(None));
+                    return Ok(());
+                }
+                VersionProbe::Unresponsive => {
+                    log::info!("daemon did not answer the version handshake; restarting it");
+                    note_local_daemon(None);
+                    drop(stream);
+                    // A graceful stop is wasted on a daemon that will not answer:
+                    // `stop` polls the still-connectable endpoint for its whole
+                    // SHUTDOWN_TIMEOUT before giving up. Reap the recorded process
+                    // instead — bounded on every platform — and clear the stale
+                    // endpoint below, exactly like a refused connect.
+                    stale = true;
+                }
             }
         }
     } else {
+        stale = true;
+    }
+
+    if stale {
         reap_recorded_daemon();
 
         if transport::endpoint_exists() {
             transport::remove_stale_endpoint();
         }
+        // The daemon's control listener probes control.port for a live
+        // predecessor before binding; a stale file would cost it the same
+        // refused-connect delay the probe above just skipped. The recorded
+        // daemon is known dead here, so the file cannot be live.
+        #[cfg(windows)]
+        crate::host::server::remove_control_endpoint();
     }
 
     // While an installer is replacing the installation, spawning a daemon

--- a/crates/tty7-core/src/daemon/transport.rs
+++ b/crates/tty7-core/src/daemon/transport.rs
@@ -429,8 +429,21 @@ mod imp_windows {
         connect_with_token(port, &token)
     }
 
+    /// How long a liveness connect may wait for the peer's TCP handshake.
+    ///
+    /// A live daemon on loopback completes it in well under a millisecond —
+    /// the kernel answers from the accept backlog, so even a busy daemon
+    /// connects instantly. The budget exists for the other direction: a stale
+    /// port file whose port now belongs to a filtered or firewall-dropped
+    /// socket must fail fast, or every cold start pays the OS's refusal delay
+    /// (seconds on some machines instead of the instant RST a closed loopback
+    /// port normally returns). Real clients never feel it: a daemon that
+    /// cannot answer a TCP handshake on loopback in half a second is not one
+    /// worth waiting for.
+    const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
+
     fn connect_with_token(port: u16, token: &Token) -> io::Result<Stream> {
-        let mut stream = TcpStream::connect(loopback(port))?;
+        let mut stream = TcpStream::connect_timeout(&loopback(port), CONNECT_TIMEOUT)?;
         tune(&stream);
         stream.write_all(token)?;
         Ok(stream)

--- a/crates/tty7-core/src/host/server.rs
+++ b/crates/tty7-core/src/host/server.rs
@@ -1548,15 +1548,22 @@ mod wsock {
         // GUI-hosted control server does not report itself as freshly started.
         super::server_started();
         let path = control_endpoint_path()?;
-        if let Ok(live) = transport::connect_endpoint(CONTROL_PORT_FILE) {
-            drop(live);
-            return Err(io::Error::new(
-                io::ErrorKind::AddrInUse,
-                format!(
-                    "a control server is already listening at {}",
-                    transport::endpoint_display_named(CONTROL_PORT_FILE)
-                ),
-            ));
+        // A control.port left by a dead daemon is stale: connecting to it
+        // would pay the OS's refusal delay for nothing. The pidfile says
+        // whether the daemon that wrote the port is still alive — when it is
+        // gone the port cannot hold a live control server, and the bind below
+        // simply overwrites the stale file.
+        if !crate::daemon::spawn::recorded_daemon_is_dead() {
+            if let Ok(live) = transport::connect_endpoint(CONTROL_PORT_FILE) {
+                drop(live);
+                return Err(io::Error::new(
+                    io::ErrorKind::AddrInUse,
+                    format!(
+                        "a control server is already listening at {}",
+                        transport::endpoint_display_named(CONTROL_PORT_FILE)
+                    ),
+                ));
+            }
         }
         let (listener, token) =
             transport::bind_endpoint(CONTROL_PORT_FILE).map_err(io::Error::other)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,11 +281,22 @@ fn explorer_menu_action_from(args: &[std::ffi::OsString]) -> Option<bool> {
 /// GUI to surface itself — restore its most recent workspace, or activate the
 /// window it already has — which is what lets a second launch hand the tray
 /// its window back instead of opening a second process.
+///
+/// `daemon_gone` reports whether the recorded daemon process is known dead.
+/// The probe connects to that daemon's control listener, so a dead daemon
+/// guarantees the request cannot reach a GUI — and the connect would only pay
+/// the OS's refusal delay on the stale `control.port` that `ensure_running`
+/// clears later. The probe is skipped instead of run.
 fn forward_open_path_with(
     open_path: Option<&std::path::Path>,
+    daemon_gone: impl FnOnce() -> bool,
     dispatch: impl FnOnce(Option<String>) -> std::io::Result<tty7_core::daemon::control::ReplyOk>,
 ) -> bool {
     use tty7_core::daemon::control::ReplyOk;
+
+    if daemon_gone() {
+        return false;
+    }
 
     let wire_path = match open_path {
         None => None,
@@ -336,19 +347,23 @@ fn forward_open_path(open_path: Option<&std::path::Path>) -> bool {
     use tty7_core::client::ControlClient;
     use tty7_core::daemon::control::{ControlHello, ControlRequest};
 
-    forward_open_path_with(open_path, |path| {
-        let hello = ControlHello::host_rpc(
-            format!("tty7-app-open-{}", std::process::id()),
-            "this computer",
-        );
-        let client = ControlClient::connect(&hello)?;
-        let reply = client.request(ControlRequest::GuiOpen {
-            path,
-            workspace: None,
-        });
-        client.close();
-        reply
-    })
+    forward_open_path_with(
+        open_path,
+        crate::daemon::spawn::recorded_daemon_is_dead,
+        |path| {
+            let hello = ControlHello::host_rpc(
+                format!("tty7-app-open-{}", std::process::id()),
+                "this computer",
+            );
+            let client = ControlClient::connect(&hello)?;
+            let reply = client.request(ControlRequest::GuiOpen {
+                path,
+                workspace: None,
+            });
+            client.close();
+            reply
+        },
+    )
 }
 
 #[cfg(unix)]
@@ -861,42 +876,93 @@ mod argument_tests {
 
     #[test]
     fn a_pathless_forward_asks_the_gui_to_surface_and_exits_only_on_bool_true() {
-        let delivered = forward_open_path_with(None, |actual| {
-            assert_eq!(actual, None, "a pathless request carries no wire path");
-            Ok(ReplyOk::Bool(true))
-        });
+        let delivered = forward_open_path_with(
+            None,
+            || false,
+            |actual| {
+                assert_eq!(actual, None, "a pathless request carries no wire path");
+                Ok(ReplyOk::Bool(true))
+            },
+        );
         assert!(delivered, "a GUI accepted the surface request");
 
-        assert!(!forward_open_path_with(None, |_| Ok(ReplyOk::Bool(false))));
-        assert!(!forward_open_path_with(None, |_| Ok(ReplyOk::Unit)));
-        assert!(!forward_open_path_with(None, |_| {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::ConnectionRefused,
-                "daemon is not running",
-            ))
-        }));
+        assert!(!forward_open_path_with(
+            None,
+            || false,
+            |_| Ok(ReplyOk::Bool(false))
+        ));
+        assert!(!forward_open_path_with(
+            None,
+            || false,
+            |_| Ok(ReplyOk::Unit)
+        ));
+        assert!(!forward_open_path_with(
+            None,
+            || false,
+            |_| {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    "daemon is not running",
+                ))
+            }
+        ));
+    }
+
+    #[test]
+    fn early_dispatch_is_skipped_when_the_recorded_daemon_is_dead() {
+        // A dead recorded daemon cannot be routing for a registered GUI, so the
+        // probe must not run — the connect would only wait out the OS's refusal
+        // delay on the stale control port before `ensure_running` clears it.
+        assert!(!forward_open_path_with(
+            None,
+            || true,
+            |_| -> std::io::Result<ReplyOk> {
+                panic!("the probe must not dispatch when the daemon is dead")
+            },
+        ));
+        assert!(!forward_open_path_with(
+            Some(std::path::Path::new("/work")),
+            || true,
+            |_| -> std::io::Result<ReplyOk> {
+                panic!("the probe must not dispatch when the daemon is dead")
+            },
+        ));
     }
 
     #[test]
     fn early_dispatch_exits_only_after_a_gui_accepts_the_path() {
         let path = std::env::current_dir().unwrap().join("folder with spaces");
         let expected = path.to_str().unwrap().to_owned();
-        let delivered = forward_open_path_with(Some(&path), |actual| {
-            assert_eq!(actual, Some(expected));
-            Ok(ReplyOk::Bool(true))
-        });
+        let delivered = forward_open_path_with(
+            Some(&path),
+            || false,
+            |actual| {
+                assert_eq!(actual, Some(expected));
+                Ok(ReplyOk::Bool(true))
+            },
+        );
 
         assert!(delivered);
-        assert!(!forward_open_path_with(Some(&path), |_| Ok(ReplyOk::Bool(
-            false
-        ))));
-        assert!(!forward_open_path_with(Some(&path), |_| Ok(ReplyOk::Unit)));
-        assert!(!forward_open_path_with(Some(&path), |_| {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::ConnectionRefused,
-                "daemon is not running",
-            ))
-        }));
+        assert!(!forward_open_path_with(
+            Some(&path),
+            || false,
+            |_| Ok(ReplyOk::Bool(false))
+        ));
+        assert!(!forward_open_path_with(
+            Some(&path),
+            || false,
+            |_| Ok(ReplyOk::Unit)
+        ));
+        assert!(!forward_open_path_with(
+            Some(&path),
+            || false,
+            |_| {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    "daemon is not running",
+                ))
+            }
+        ));
     }
 
     #[test]
@@ -909,10 +975,14 @@ mod argument_tests {
             .unwrap()
             .to_owned();
 
-        assert!(forward_open_path_with(Some(relative), |actual| {
-            assert_eq!(actual, Some(expected));
-            Ok(ReplyOk::Bool(true))
-        }));
+        assert!(forward_open_path_with(
+            Some(relative),
+            || false,
+            |actual| {
+                assert_eq!(actual, Some(expected));
+                Ok(ReplyOk::Bool(true))
+            }
+        ));
     }
 
     #[cfg(unix)]
@@ -922,9 +992,11 @@ mod argument_tests {
         use std::os::unix::ffi::OsStringExt as _;
 
         let path = std::env::temp_dir().join(OsString::from_vec(b"tty7-\xff".to_vec()));
-        let delivered = forward_open_path_with(Some(&path), |_| {
-            panic!("a non-UTF-8 path must never be changed and sent over the string protocol")
-        });
+        let delivered = forward_open_path_with(
+            Some(&path),
+            || false,
+            |_| panic!("a non-UTF-8 path must never be changed and sent over the string protocol"),
+        );
 
         assert!(!delivered);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,38 +272,45 @@ fn explorer_menu_action_from(args: &[std::ffi::OsString]) -> Option<bool> {
     })
 }
 
-/// Offers an explicit launch path to an already running local GUI.
+/// Offers an explicit launch request to an already running local GUI.
 ///
 /// The dispatcher is injected so the startup decision can be tested without
 /// opening a real daemon connection. Only an explicit `Bool(true)` means the
-/// path reached a GUI; every other response keeps the current app alive so it
-/// can perform the normal first-window startup.
+/// request reached a GUI; every other response keeps the current app alive so
+/// it can perform the normal first-window startup. A pathless request asks the
+/// GUI to surface itself — restore its most recent workspace, or activate the
+/// window it already has — which is what lets a second launch hand the tray
+/// its window back instead of opening a second process.
 fn forward_open_path_with(
     open_path: Option<&std::path::Path>,
-    dispatch: impl FnOnce(String) -> std::io::Result<tty7_core::daemon::control::ReplyOk>,
+    dispatch: impl FnOnce(Option<String>) -> std::io::Result<tty7_core::daemon::control::ReplyOk>,
 ) -> bool {
     use tty7_core::daemon::control::ReplyOk;
 
-    let Some(path) = open_path else {
-        return false;
-    };
-    let path = if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        match std::env::current_dir() {
-            Ok(current_dir) => current_dir.join(path),
-            Err(error) => {
-                log::debug!("could not resolve the relative GUI open path: {error}");
-                return false;
-            }
-        }
-    };
+    let wire_path = match open_path {
+        None => None,
+        Some(path) => {
+            let path = if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                match std::env::current_dir() {
+                    Ok(current_dir) => current_dir.join(path),
+                    Err(error) => {
+                        log::debug!("could not resolve the relative GUI open path: {error}");
+                        return false;
+                    }
+                }
+            };
 
-    let Some(wire_path) = path.to_str().map(str::to_owned) else {
-        // Keep the native PathBuf in this process. Returning false continues
-        // normal startup, which opens the path without crossing the protocol.
-        log::debug!("the explicit GUI open path is not valid UTF-8; opening it locally");
-        return false;
+            // Keep the native PathBuf in this process. Returning false
+            // continues normal startup, which opens the path without crossing
+            // the protocol.
+            let Some(wire_path) = path.to_str().map(str::to_owned) else {
+                log::debug!("the explicit GUI open path is not valid UTF-8; opening it locally");
+                return false;
+            };
+            Some(wire_path)
+        }
     };
 
     match dispatch(wire_path) {
@@ -336,7 +343,7 @@ fn forward_open_path(open_path: Option<&std::path::Path>) -> bool {
         );
         let client = ControlClient::connect(&hello)?;
         let reply = client.request(ControlRequest::GuiOpen {
-            path: Some(path),
+            path,
             workspace: None,
         });
         client.close();
@@ -534,12 +541,27 @@ fn main() {
     } else {
         crate::daemon::spawn::restart()
     };
+    // A pathless launch that found a GUI already registered hands the request
+    // to it — the GUI may be sitting in the tray with no window — and exits.
+    // The forward above cannot do this: it runs before the daemon exists, and
+    // routing through a daemon that is not up yet would fail on every cold
+    // start. Here the daemon is known to be running, so the probe is cheap and
+    // a `Bool(true)` means a GUI actually received the request.
+    if open_path.is_none() && daemon_result.is_ok() && forward_open_path(None) {
+        return;
+    }
     if let Err(e) = daemon_result {
         log::error!("failed to ensure daemon is running: {e}");
     }
 
     gpui_platform::application()
         .with_assets(Assets)
+        // The window-close path decides whether this process survives: with
+        // the tray icon on, closing the last window retires to the tray, and
+        // without it the close handler quits explicitly. The platform default
+        // would quit on the last window unconditionally, which is exactly the
+        // orphaned-daemon trap the tray is meant to prevent.
+        .with_quit_mode(QuitMode::Explicit)
         .run(move |cx| {
             gpui_component::init(cx);
             register_bundled_fonts(cx);
@@ -838,12 +860,21 @@ mod argument_tests {
     }
 
     #[test]
-    fn no_open_path_never_attempts_early_dispatch() {
-        let delivered = forward_open_path_with(None, |_| {
-            panic!("the dispatcher must not run without an explicit path")
+    fn a_pathless_forward_asks_the_gui_to_surface_and_exits_only_on_bool_true() {
+        let delivered = forward_open_path_with(None, |actual| {
+            assert_eq!(actual, None, "a pathless request carries no wire path");
+            Ok(ReplyOk::Bool(true))
         });
+        assert!(delivered, "a GUI accepted the surface request");
 
-        assert!(!delivered);
+        assert!(!forward_open_path_with(None, |_| Ok(ReplyOk::Bool(false))));
+        assert!(!forward_open_path_with(None, |_| Ok(ReplyOk::Unit)));
+        assert!(!forward_open_path_with(None, |_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::ConnectionRefused,
+                "daemon is not running",
+            ))
+        }));
     }
 
     #[test]
@@ -851,7 +882,7 @@ mod argument_tests {
         let path = std::env::current_dir().unwrap().join("folder with spaces");
         let expected = path.to_str().unwrap().to_owned();
         let delivered = forward_open_path_with(Some(&path), |actual| {
-            assert_eq!(actual, expected);
+            assert_eq!(actual, Some(expected));
             Ok(ReplyOk::Bool(true))
         });
 
@@ -879,7 +910,7 @@ mod argument_tests {
             .to_owned();
 
         assert!(forward_open_path_with(Some(relative), |actual| {
-            assert_eq!(actual, expected);
+            assert_eq!(actual, Some(expected));
             Ok(ReplyOk::Bool(true))
         }));
     }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1246,7 +1246,14 @@ impl Tty7App {
                 // tray: the daemon stays reachable (show / quit-and-stop)
                 // instead of being orphaned behind a dead icon. Without one
                 // the app quits — the only way it stays visible at all.
-                let retire_to_tray = cx.global::<Config>().show_tray_icon;
+                //
+                // The icon has to actually be up, not merely asked for: the
+                // backend can fail for the whole run (a Linux session with no
+                // StatusNotifier host), and retiring into an icon that never
+                // appeared leaves a process with no window and no tray — no
+                // way back in, and the daemon still held.
+                let retire_to_tray =
+                    cx.global::<Config>().show_tray_icon && crate::ui::tray::icon_is_up();
                 if !retire_to_tray {
                     cx.spawn(async move |cx| {
                         let _ = cx.update(|cx| cx.quit());

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1242,10 +1242,17 @@ impl Tty7App {
                 app.update(cx, |app, cx| app.detach_workspace(cx));
             }
             if last_window {
-                cx.spawn(async move |cx| {
-                    let _ = cx.update(|cx| cx.quit());
-                })
-                .detach();
+                // With a tray icon, closing the last window retires to the
+                // tray: the daemon stays reachable (show / quit-and-stop)
+                // instead of being orphaned behind a dead icon. Without one
+                // the app quits — the only way it stays visible at all.
+                let retire_to_tray = cx.global::<Config>().show_tray_icon;
+                if !retire_to_tray {
+                    cx.spawn(async move |cx| {
+                        let _ = cx.update(|cx| cx.quit());
+                    })
+                    .detach();
+                }
             }
             true
         });
@@ -1576,8 +1583,10 @@ impl Tty7App {
                 surface_window(window, cx);
                 self.check_for_updates_now(window, cx);
             }
-            TrayAction::Quit => cx.quit(),
-            TrayAction::QuitStopSessions => self.quit_stop_sessions(window, cx),
+            // One exit path with one meaning: quit the app and stop the server
+            // (after the confirmation that protects running shells). Closing
+            // the window is the keep-everything exit — it retires to the tray.
+            TrayAction::Quit => self.quit_stop_sessions(window, cx),
         }
     }
 
@@ -4383,7 +4392,10 @@ impl Tty7App {
             OpenDocumentation => cx.open_url(DOCS_URL),
             OpenDiscord => cx.open_url(DISCORD_URL),
             ReportIssue => cx.open_url(ISSUES_URL),
-            Quit => cx.quit(),
+            // Same exit as the tray's: confirm, then stop the server with the
+            // app. A bare quit would leave the daemon orphaned behind a dead
+            // tray icon.
+            Quit => self.quit_stop_sessions(window, cx),
             RestartDaemon => self.restart_window_daemon(window, cx),
             ToggleSftp => self.toggle_sftp(window, cx),
             ShowSshForwards => self.show_ssh_forwards(window, cx),
@@ -6818,7 +6830,9 @@ impl Render for Tty7App {
                     }
                     this.editor_save_active(window, cx)
                 }))
-                .on_action(cx.listener(|_, _: &Quit, _, cx| cx.quit()))
+                .on_action(
+                    cx.listener(|this, _: &Quit, window, cx| this.quit_stop_sessions(window, cx)),
+                )
                 .on_action(cx.listener(|this, _: &OpenSshProfiles, window, cx| {
                     this.open_settings_section(SettingsSection::Ssh, window, cx)
                 }))

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -61,7 +61,8 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         L10nKey::QuitStopServerBody => {
             "This quits tty7 and stops the background server — anything still running \
              in your shells is terminated. Your tabs and layout are kept and reopen with \
-             fresh shells next launch. (Plain Quit keeps shells running.)"
+             fresh shells next launch. (Closing the window only retires the app to the \
+             tray; the shells keep running.)"
         }
         L10nKey::QuitAndStop => "Quit and Stop",
         L10nKey::CloseSshConnectionTitle => "Close this SSH connection?",

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -61,7 +61,7 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         L10nKey::Close => "閉じる",
         L10nKey::QuitStopServerTitle => "tty7 を終了してサーバーを停止しますか？",
         L10nKey::QuitStopServerBody => {
-            "tty7 を終了してバックグラウンドサーバーを停止します。シェルで実行中のものはすべて終了します。タブとレイアウトは保持され、次回起動時に新しいシェルで開きます。通常の終了ではシェルは動き続けます。"
+            "tty7 を終了してバックグラウンドサーバーを停止します。シェルで実行中のものはすべて終了します。タブとレイアウトは保持され、次回起動時に新しいシェルで開きます。ウィンドウを閉じただけではアプリはトレイに退避し、シェルは動き続けます。"
         }
         L10nKey::QuitAndStop => "終了して停止",
         L10nKey::CloseSshConnectionTitle => "この SSH 接続を閉じますか？",

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -55,7 +55,7 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         L10nKey::Close => "关闭",
         L10nKey::QuitStopServerTitle => "退出并停止 server？",
         L10nKey::QuitStopServerBody => {
-            "这会退出 tty7 并停止后台 server，所有仍在运行的 shell 都会被终止。你的标签页和布局会被保留，下次启动时以全新的 shell 重新打开。（普通退出会保持 shell 运行。）"
+            "这会退出 tty7 并停止后台 server，所有仍在运行的 shell 都会被终止。你的标签页和布局会被保留，下次启动时以全新的 shell 重新打开。（关闭窗口只会把应用收起到托盘，shell 保持运行。）"
         }
         L10nKey::QuitAndStop => "退出并停止",
         L10nKey::CloseSshConnectionTitle => "关闭这个 SSH 连接？",

--- a/src/ui/tray/mod.rs
+++ b/src/ui/tray/mod.rs
@@ -14,16 +14,17 @@ use std::sync::Mutex;
 use crate::core::cli_agent::AgentStatus;
 use crate::core::config::{Config, NotifyMode};
 use crate::ui::i18n::{L10nKey, t};
-use gpui::App;
+use gpui::{App, AppContext};
 
 const POLL: std::time::Duration = std::time::Duration::from_millis(1000);
 
 /// Handed out to callers that live outside the UI thread — notification click
 /// handlers, which run on a platform callback thread and can only enqueue.
 ///
-/// `init` runs again whenever the window count drops to zero and comes back, so
-/// this has to be replaceable: holding the first channel forever would keep its
-/// (long dead) dispatch loop alive and send later clicks nowhere.
+/// The dispatch loop is created once, for the whole process. A window can be
+/// built and retired many times (the tray keeps the app alive windowless), so
+/// the channel must survive as long as the app does — it does, because the
+/// loop outlives every window.
 static SENDER: Mutex<Option<smol::channel::Sender<TrayAction>>> = Mutex::new(None);
 
 /// A sender for the current tray dispatch loop, if one is running.
@@ -42,7 +43,6 @@ pub(crate) enum TrayAction {
     OpenSettings,
     CheckForUpdates,
     Quit,
-    QuitStopSessions,
 }
 
 pub(crate) fn urgency(status: AgentStatus) -> u8 {
@@ -178,11 +178,9 @@ pub(crate) fn menu_spec(snap: &TraySnapshot) -> Vec<SpecItem> {
     items.push(item("settings", t(L10nKey::AppMenuSettings)));
     items.push(item("updates", t(L10nKey::AppMenuCheckForUpdates)));
     items.push(SpecItem::Separator);
+    // One exit path with one meaning: quit the app and stop the server. The
+    // window-close button is the keep-everything exit — it retires to the tray.
     items.push(item("quit", t(L10nKey::AppMenuQuit)));
-    items.push(item(
-        "quit-stop",
-        crate::ui::i18n::t(crate::ui::i18n::L10nKey::TrayQuitStopServer),
-    ));
     items
 }
 
@@ -192,7 +190,6 @@ pub(crate) fn action_from_id(id: &str) -> Option<TrayAction> {
         "settings" => Some(TrayAction::OpenSettings),
         "updates" => Some(TrayAction::CheckForUpdates),
         "quit" => Some(TrayAction::Quit),
-        "quit-stop" => Some(TrayAction::QuitStopSessions),
         "notify:always" => Some(TrayAction::SetNotifyMode(NotifyMode::Always)),
         "notify:unfocused" => Some(TrayAction::SetNotifyMode(NotifyMode::Unfocused)),
         "notify:never" => Some(TrayAction::SetNotifyMode(NotifyMode::Never)),
@@ -283,7 +280,6 @@ mod tests {
                 t(L10nKey::AppMenuSettings),
                 t(L10nKey::AppMenuCheckForUpdates),
                 t(L10nKey::AppMenuQuit),
-                t(L10nKey::TrayQuitStopServer),
             ]
         );
         assert!(
@@ -330,8 +326,26 @@ fn dispatch(action: TrayAction, cx: &mut App) {
     .or_else(|| WindowRegistry::most_recent(cx));
 
     let Some(workspace) = target else {
-        if matches!(action, TrayAction::Quit) {
-            cx.quit();
+        // No window on screen. The tray is then the app's only presence, so
+        // every action either works windowless or brings a window back first.
+        match action {
+            TrayAction::Quit => {
+                // Nothing to prompt on: the confirmation exists to ask whether
+                // the panes behind a window should end, and there is no window.
+                cx.spawn(async move |cx| {
+                    cx.background_spawn(async { crate::daemon::spawn::stop() })
+                        .await;
+                    let _ = cx.update(|cx| cx.quit());
+                })
+                .detach();
+            }
+            // ShowWindow and the rest: restore the most recent workspace the
+            // way a pathless launch would, then drop the action — the window
+            // that just came back can be asked again.
+            _ => {
+                let restore = crate::ui::windows::restore_target(cx, None);
+                crate::ui::windows::open_at(cx, restore.map(|(id, _)| id), None);
+            }
         }
         return;
     };
@@ -349,6 +363,16 @@ fn dispatch(action: TrayAction, cx: &mut App) {
 }
 
 pub(crate) fn init(cx: &mut App) {
+    // One tray per process. Every window's constructor calls this, and the
+    // tray-persist flow builds and retires windows without the app ever
+    // exiting — a second backend loop here would add a second icon that the
+    // window close cannot remove. The channel and both loops are created
+    // exactly once; later calls must not touch them.
+    static STARTED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    if STARTED.set(()).is_err() {
+        return;
+    }
+
     let (tx, rx) = smol::channel::unbounded::<TrayAction>();
     if let Ok(mut slot) = SENDER.lock() {
         *slot = Some(tx.clone());
@@ -377,6 +401,14 @@ pub(crate) fn init(cx: &mut App) {
                 shown = None;
                 attempts = 0;
                 cooldown = 0;
+                // Closing the last window only keeps the app alive because the
+                // tray is its window. If the icon is turned off while no
+                // window is up (a config edit is the only way there), staying
+                // would leave an invisible process that can never be reached.
+                if cx.update(|cx| crate::ui::windows::WindowRegistry::count(cx)) == 0 {
+                    let _ = cx.update(|cx| cx.quit());
+                    continue;
+                }
                 continue;
             }
             if backend.is_none() && attempts < MAX_ATTEMPTS {

--- a/src/ui/tray/mod.rs
+++ b/src/ui/tray/mod.rs
@@ -27,6 +27,21 @@ const POLL: std::time::Duration = std::time::Duration::from_millis(1000);
 /// loop outlives every window.
 static SENDER: Mutex<Option<smol::channel::Sender<TrayAction>>> = Mutex::new(None);
 
+/// Whether an icon is actually on the bar right now.
+///
+/// `show_tray_icon` is a request, not an outcome: `Backend::create` can fail
+/// for the whole run (a Linux session with no StatusNotifier host is the
+/// ordinary case), and after `MAX_ATTEMPTS` the loop gives up and logs. Asking
+/// the config alone whether closing the last window may retire the app would
+/// then leave a process with no window and no icon — running, unreachable, and
+/// still holding the daemon.
+static ICON_UP: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Whether the app still has a visible presence once its last window closes.
+pub(crate) fn icon_is_up() -> bool {
+    ICON_UP.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// A sender for the current tray dispatch loop, if one is running.
 // Only the platform notification callbacks call this, and those are compiled
 // out of test builds so unit tests never raise a real toast.
@@ -327,11 +342,26 @@ fn dispatch(action: TrayAction, cx: &mut App) {
 
     let Some(workspace) = target else {
         // No window on screen. The tray is then the app's only presence, so
-        // every action either works windowless or brings a window back first.
-        match action {
-            TrayAction::Quit => {
-                // Nothing to prompt on: the confirmation exists to ask whether
-                // the panes behind a window should end, and there is no window.
+        // bring the most recent workspace back the way a pathless launch would
+        // and let the action run against it.
+        //
+        // Quit especially: retiring to the tray leaves every shell running, so
+        // by the time the tray menu is the only way in there can be a whole
+        // session behind it. `quit_stop_sessions` — "anything still running in
+        // your shells is terminated" — is the one thing standing between this
+        // menu item and all of it, and a confirmation needs a window to appear
+        // in. Stopping the server here instead would take the shells with no
+        // way to say no.
+        let restore = crate::ui::windows::restore_target(cx, None);
+        crate::ui::windows::open_at(cx, restore.map(|(id, _)| id), None);
+        match WindowRegistry::most_recent(cx) {
+            Some(restored) => deliver(action, restored, cx),
+            // The window would not open, so nothing can be confirmed in it.
+            // Quit still has to work — a tray whose only exit is inert strands
+            // the app — but every other action wanted the window it failed to
+            // get.
+            None if matches!(action, TrayAction::Quit) => {
+                log::warn!("no window to confirm the quit in; stopping the server anyway");
                 cx.spawn(async move |cx| {
                     cx.background_spawn(async { crate::daemon::spawn::stop() })
                         .await;
@@ -339,16 +369,17 @@ fn dispatch(action: TrayAction, cx: &mut App) {
                 })
                 .detach();
             }
-            // ShowWindow and the rest: restore the most recent workspace the
-            // way a pathless launch would, then drop the action — the window
-            // that just came back can be asked again.
-            _ => {
-                let restore = crate::ui::windows::restore_target(cx, None);
-                crate::ui::windows::open_at(cx, restore.map(|(id, _)| id), None);
-            }
+            None => {}
         }
         return;
     };
+    deliver(action, workspace, cx);
+}
+
+/// Hand an action to the window that owns `workspace`.
+fn deliver(action: TrayAction, workspace: tty7_core::core::session::WorkspaceId, cx: &mut App) {
+    use crate::ui::windows::WindowRegistry;
+
     let (Some(handle), Some(weak)) = (
         WindowRegistry::window_for(cx, workspace),
         WindowRegistry::app_for(cx, workspace),
@@ -401,6 +432,7 @@ pub(crate) fn init(cx: &mut App) {
                 shown = None;
                 attempts = 0;
                 cooldown = 0;
+                ICON_UP.store(false, std::sync::atomic::Ordering::Relaxed);
                 // Closing the last window only keeps the app alive because the
                 // tray is its window. If the icon is turned off while no
                 // window is up (a config edit is the only way there), staying
@@ -418,12 +450,13 @@ pub(crate) fn init(cx: &mut App) {
                 }
                 attempts += 1;
                 backend = Backend::create(tx.clone(), cx).await;
+                ICON_UP.store(backend.is_some(), std::sync::atomic::Ordering::Relaxed);
                 if backend.is_none() {
                     cooldown = RETRY_EVERY;
                     if attempts == MAX_ATTEMPTS {
                         log::warn!(
                             "tray icon unavailable after {MAX_ATTEMPTS} attempts; \
-                             running without one"
+                             running without one — the last window closing now quits"
                         );
                     }
                 }


### PR DESCRIPTION
Two problems shared a root: the daemon outlived every window, and nothing could stop it gracefully. This PR fixes the lifecycle on one side and makes the startup path robust on the other.

## Window lifecycle

- **Tray-persist**: closing the last window now retires the app to the tray instead of quitting (`QuitMode::Explicit`). The tray menu restores the most recent workspace and offers one exit path: **Quit**, which — after the existing confirmation that protects running shells — stops the daemon and exits the app. The redundant "Quit and Stop Server" menu item is gone; the palette and keybinding Quit behave identically. No exit path leaves an orphaned daemon behind a dead tray icon.
- **Pathless handoff**: a pathless launch (e.g. double-clicking `tty7-app`) while a GUI is already registered sends `GuiOpen(None)` to it and exits — the windowed instance activates, the windowless (tray) instance restores its workspace. No second process, no second tray icon.
- **Single tray per process**: the tray subsystem (dispatch loop + icon backend) initializes once; rebuilding a window no longer creates a duplicate icon.

## Cold-start robustness

After a force-killed daemon, stale `daemon.port`/`control.port` files made every cold start pay the OS's loopback refusal delay (up to 2 s on some machines) and, on a reused silent port, a 2 s handshake timeout plus a 6 s graceful-stop poll. Now:

- Liveness connects are bounded to **500 ms** (`CONNECT_TIMEOUT`); the version handshake times out in **1 s**.
- An unresponsive daemon is reaped by its recorded pid (bounded) instead of being polled through a 6 s graceful stop.
- A **dead recorded pid skips the TCP probes entirely** (`recorded_daemon_is_dead`): the GUI's `ensure_running`, the new daemon's endpoint check, and the control-listener occupancy check. The last one also had a latent failure mode: a stale control.port whose port was reused by a silent acceptor would make the new daemon refuse to start its control listener and exit.
- Stale cleanup now also removes the leftover `control.port`.

## Verification

Measured on Windows (cold start, no daemon running):

| Scenario | Before | After |
|---|---|---|
| Clean cold start | 0.6 s | ~0.4 s |
| Stale daemon files after force-kill | 4.5 s | **0.4 s** |
| Stale port reused by a silent acceptor | 8.75 s | **0.36 s** |
| Close window → tray → reopen | app quit, daemon orphaned | tray persists, one icon, window restores |

End-to-end scripted checks cover: stale-file cold start, silent-acceptor
cold start, window-close → tray retirement, second-launch handoff, and
tray-icon uniqueness across the full lifecycle.