### PR TITLE
feat(ssh): reach a saved host from the New Tab button, and read back what you typed

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -4368,6 +4368,21 @@ impl Tty7App {
         cx.notify();
     }
 
+    /// Open the palette already on its address box.
+    ///
+    /// The New Tab menu's *Add Connection…* means "I want a connection", and
+    /// dropping the user in the command list to find the row that means the
+    /// same thing is a step nobody asked for.
+    pub(crate) fn open_ssh_connect_input(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.palette.is_none() {
+            self.toggle_palette(window, cx);
+        }
+        if let Some(palette) = self.palette.clone() {
+            palette.update(cx, |palette, cx| palette.open_on_ssh_connect(window, cx));
+        }
+        cx.notify();
+    }
+
     fn on_palette_event(
         &mut self,
         _view: &Entity<PaletteView>,

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -1459,6 +1459,7 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         L10nKey::CmdCut => "Cut",
         L10nKey::CmdPaste => "Paste",
         L10nKey::CmdSelectAll => "Select All",
+        L10nKey::MenuSshAddConnection => "Add Connection…",
         L10nKey::CmdSshAddConnection => "SSH: Add Connection…",
         L10nKey::CmdSshManageProfiles => "SSH: Manage Profiles…",
         L10nKey::CmdSshReconnect => "SSH: Reconnect",

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -1492,6 +1492,7 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         L10nKey::CmdCut => "切り取り",
         L10nKey::CmdPaste => "貼り付け",
         L10nKey::CmdSelectAll => "すべて選択",
+        L10nKey::MenuSshAddConnection => "接続を追加…",
         L10nKey::CmdSshAddConnection => "SSH: 接続を追加…",
         L10nKey::CmdSshManageProfiles => "SSH: プロファイルを管理…",
         L10nKey::CmdSshReconnect => "SSH: 再接続",

--- a/src/ui/i18n/mod.rs
+++ b/src/ui/i18n/mod.rs
@@ -1185,6 +1185,7 @@ l10n_keys! {
     CmdPaste,
     CmdSelectAll,
     CmdSshAddConnection,
+    MenuSshAddConnection,
     CmdSshManageProfiles,
     CmdSshReconnect,
     CmdSshRemoteFiles,

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -1364,6 +1364,7 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         L10nKey::CmdCut => "剪切",
         L10nKey::CmdPaste => "粘贴",
         L10nKey::CmdSelectAll => "全选",
+        L10nKey::MenuSshAddConnection => "添加连接…",
         L10nKey::CmdSshAddConnection => "SSH：添加连接…",
         L10nKey::CmdSshManageProfiles => "SSH：管理主机配置…",
         L10nKey::CmdSshReconnect => "SSH：重新连接",

--- a/src/ui/palette.rs
+++ b/src/ui/palette.rs
@@ -1145,6 +1145,15 @@ impl PaletteView {
         cx.notify();
     }
 
+    /// Open straight on the address box, for callers that already know the
+    /// user wants a connection and not a command — the New Tab menu's
+    /// *Add Connection…*, which would otherwise land them in the command list
+    /// to find the row that opens this.
+    pub fn open_on_ssh_connect(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.menu = PaletteMenu::SshConnect;
+        self.show_ssh_connect(window, cx);
+    }
+
     fn show_ssh_connect(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let list = Self::build_list_with_delegate(PaletteDelegate::ssh_connect(), window, cx);
         self._sub = cx.subscribe_in(&list, window, Self::on_list_event);

--- a/src/ui/ssh_prompt.rs
+++ b/src/ui/ssh_prompt.rs
@@ -990,10 +990,23 @@ impl Tty7App {
     }
 
     fn render_ssh_input(&self, ix: usize) -> AnyElement {
-        match self.ssh_prompt.inputs.get(ix) {
-            Some(state) => Input::new(state).small().into_any_element(),
-            None => div().into_any_element(),
-        }
+        let Some(state) = self.ssh_prompt.inputs.get(ix) else {
+            return div().into_any_element();
+        };
+        // A masked field gets the eye. Mistyping a long passphrase is the
+        // ordinary way this dialog fails, and a field that cannot be read back
+        // makes the second attempt as blind as the first — with a connection
+        // dropped in between. A field the server asked to have echoed is not
+        // masked and gets no toggle: there is nothing hidden to reveal.
+        let masked = self
+            .ssh_prompt
+            .model
+            .as_ref()
+            .is_some_and(|model| input_is_masked(model, ix));
+        Input::new(state)
+            .small()
+            .when(masked, Input::mask_toggle)
+            .into_any_element()
     }
 
     fn render_ssh_remember(&self, cx: &mut Context<Self>) -> AnyElement {
@@ -1039,6 +1052,22 @@ impl Tty7App {
     }
 }
 
+/// Whether the nth field of this prompt hides what is typed into it.
+///
+/// `InputState` keeps its own `masked` private, so the render side cannot ask
+/// it back — and the render side is what decides whether the field gets the eye
+/// that reveals it. One answer, read twice.
+fn input_is_masked(model: &PromptModel, i: usize) -> bool {
+    match model {
+        PromptModel::Password { .. } | PromptModel::KeyPassphrase { .. } => true,
+        // A server that asked for its prompt to be echoed gets an echoed field.
+        PromptModel::KeyboardInteractive { prompts, .. } => {
+            prompts.get(i).map(|p| !p.echo).unwrap_or(true)
+        }
+        PromptModel::HostKeyUnknown { .. } | PromptModel::HostKeyChanged { .. } => false,
+    }
+}
+
 fn build_inputs(
     model: &PromptModel,
     window: &mut Window,
@@ -1047,13 +1076,7 @@ fn build_inputs(
     let count = model.input_count();
     (0..count)
         .map(|i| {
-            let masked = match model {
-                PromptModel::Password { .. } | PromptModel::KeyPassphrase { .. } => true,
-                PromptModel::KeyboardInteractive { prompts, .. } => {
-                    prompts.get(i).map(|p| !p.echo).unwrap_or(true)
-                }
-                PromptModel::HostKeyUnknown { .. } | PromptModel::HostKeyChanged { .. } => false,
-            };
+            let masked = input_is_masked(model, i);
             cx.new(|cx| InputState::new(window, cx).masked(masked))
         })
         .collect()
@@ -1062,6 +1085,55 @@ fn build_inputs(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The render side decides whether a field gets the eye that reveals it,
+    /// and `InputState` keeps its own `masked` private — so the answer has to
+    /// come from the model both times. A field the server asked to have echoed
+    /// has nothing to reveal, and offering to reveal it would be a control that
+    /// does nothing.
+    #[test]
+    fn only_a_hidden_field_offers_to_be_revealed() {
+        let password = PromptModel::Password {
+            user: "deploy".into(),
+            host: "10.0.0.5".into(),
+            port: 22,
+            rejected: false,
+        };
+        assert!(input_is_masked(&password, 0));
+
+        let passphrase = PromptModel::KeyPassphrase {
+            key_path: "/keys/id_ed25519".into(),
+            comment: String::new(),
+            rejected: false,
+        };
+        assert!(input_is_masked(&passphrase, 0));
+
+        let ki = PromptModel::KeyboardInteractive {
+            name: "Duo".into(),
+            instructions: String::new(),
+            prompts: vec![
+                KiRow {
+                    text: "Password:".into(),
+                    echo: false,
+                },
+                KiRow {
+                    text: "Which device?".into(),
+                    echo: true,
+                },
+            ],
+            endpoint: None,
+            stored_rejected: false,
+        };
+        assert!(input_is_masked(&ki, 0));
+        assert!(
+            !input_is_masked(&ki, 1),
+            "the server asked for this one back"
+        );
+        assert!(
+            input_is_masked(&ki, 9),
+            "a prompt index the server never sent is hidden, not exposed"
+        );
+    }
 
     fn endpoint() -> PromptEndpoint {
         PromptEndpoint {

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -460,6 +460,12 @@ pub(crate) const BUTTON_ICON_SCALE: f32 = 0.75;
 /// gpui-component renders an icon-only `.xsmall()` button as a 20×20 box (18×18
 /// where the chrome overrode it). Grow only the box: the glyph keeps its size,
 /// so the chrome looks unchanged and simply stops being fiddly to hit.
+/// How many saved hosts the New Tab menu offers before it stops and points at
+/// the full list. This is a menu whose first job is the shells at the top; past
+/// a handful of hosts under them neither half is scannable, and *Add
+/// Connection…* reaches every host anyway.
+const NEW_TAB_MENU_HOSTS: usize = 6;
+
 pub(crate) const MIN_TARGET: f32 = 24.;
 
 pub(crate) fn hit_target(button: Button) -> Button {
@@ -1014,6 +1020,28 @@ impl Tty7App {
         let shells = self.shells.shells.clone();
         let default_name = self.default_shell_label(cx);
         let app = cx.entity().downgrade();
+        // The saved hosts this menu offers, most likely first. Every other way
+        // to open one — the palette, the switcher's create form, the settings
+        // list — is somewhere other than the button that means "start
+        // something", which is why reaching a saved host took four clicks
+        // through the workspace switcher (#438).
+        //
+        // Capped, because this is a menu and not a host list: past a handful of
+        // rows the shells at the top stop being findable, and *Other Host…*
+        // leads to the full list anyway.
+        let hosts: Vec<(uuid::Uuid, SharedString, SharedString)> =
+            crate::ui::ssh_connect::ssh_profiles_by_frecency(cx)
+                .into_iter()
+                .take(NEW_TAB_MENU_HOSTS)
+                .map(|p| {
+                    let endpoint = crate::core::ssh_profile::to_connect_string(&p);
+                    let name = match p.name.trim() {
+                        "" => endpoint.clone(),
+                        name => name.to_string(),
+                    };
+                    (p.id, name.into(), endpoint.into())
+                })
+                .collect();
         // Every other tile in this row names itself on hover — Switch
         // Workspace, More, Hide Sidebar. The three New Tab buttons that come
         // through here were the ones left silent.
@@ -1059,6 +1087,47 @@ impl Tty7App {
                     },
                 ));
             }
+
+            menu = menu
+                .separator()
+                .item(PopupMenuItem::label(t(L10nKey::CmdGroupSsh)));
+            for (id, name, endpoint) in &hosts {
+                let (id, connect) = (*id, app.clone());
+                let (name, endpoint) = (name.clone(), endpoint.clone());
+                // The address under the name, the way the palette and the
+                // switcher's host list both show a host: two machines called
+                // `web` are told apart by nothing else.
+                let row = PopupMenuItem::element(move |_window, cx| {
+                    h_flex()
+                        .w_full()
+                        .items_center()
+                        .justify_between()
+                        .gap_3()
+                        .child(name.clone())
+                        .when(name != endpoint, |row| {
+                            row.child(
+                                div()
+                                    .text_color(cx.theme().muted_foreground)
+                                    .child(endpoint.clone()),
+                            )
+                        })
+                });
+                menu = menu.item(row.on_click(move |_, window, cx| {
+                    if let Some(app) = connect.upgrade() {
+                        app.update(cx, |this, cx| this.connect_ssh_profile(id, window, cx));
+                    }
+                }));
+            }
+            let other = app.clone();
+            menu = menu.item(
+                PopupMenuItem::new(t(L10nKey::MenuSshAddConnection)).on_click(
+                    move |_, window, cx| {
+                        if let Some(app) = other.upgrade() {
+                            app.update(cx, |this, cx| this.open_ssh_connect_input(window, cx));
+                        }
+                    },
+                ),
+            );
             menu
         })
     }


### PR DESCRIPTION
Stacked on #641. Two things the SSH path made harder than it is.

## Before / After

| | Before | After |
|---|---|---|
| Open a saved host from the main window | Workspace switcher → New Workspace… → host dropdown → pick → Enter (#438) | New Tab **+** → the host. One click |
| New Tab **+** menu | Nine shells, nothing else | Shells, then an **SSH** section: up to six saved hosts by frecency, each with its address, then *Add Connection…* |
| *Add Connection…* | — | Opens the palette **on its address box** (`user@host [-p 2222 -J jump]`), not in the command list where you then have to find the row that does this |
| Password / passphrase field | No way to see what you typed | 👁 reveal toggle |
| Keyboard-interactive field the server asked to echo | Not masked | Still not masked, and gets **no** toggle — nothing hidden to reveal |

## Why the reveal matters

Mistyping a long passphrase is the ordinary way this dialog fails. Without a reveal, the second attempt is as blind as the first — and there is a dropped connection between them. `Input::mask_toggle` was already in the component library; tty7 simply never asked for it.

## Notes

The host list is capped at six. This is a menu whose first job is the shells at the top; past a handful of hosts under them neither half is scannable, and *Add Connection…* reaches every host anyway.

The menu row shows the address only when it differs from the name, so a host saved without a name does not print its address twice.

## Testing

- `cargo test` — all suites green (1544 / 1159 / 129 / …), `cargo fmt --check` clean.
- New unit test `only_a_hidden_field_offers_to_be_revealed` — pins which prompt fields get the toggle, including the out-of-range index (hidden, not exposed).
- Manual, against a real Ubuntu box (`java@java`):
  - **+** → menu shows `zsh … csh`, separator, `SSH`, `java-box  java@java`, `Add Connection…`.
  - Clicking `java-box` → password sheet for `java@java` directly.
  - Clicking `Add Connection…` → palette opens on `user@host [-p 2222 -J jump]`.
  - Typed into the password field, pressed 👁 → text readable, icon flips to eye-off.
