### PR TITLE
fix(ssh): give a failed one-off connection a way forward, and find a machine before it has a workspace

### DIFF
--- a/docs/remote/port-forwarding.mdx
+++ b/docs/remote/port-forwarding.mdx
@@ -23,6 +23,28 @@ half-configured.
 Each rule takes an optional description — *"what it's for"* — because six months
 later `8080 → 3000` explains nothing.
 
+## Switching a rule off
+
+The switch at the start of a rule decides whether the connection opens it. A
+rule that is off is kept exactly as you wrote it and simply not offered to the
+far side — which is what a forward for a service that is only up part of the
+day needs, instead of deleting the rule and typing it in again twice a day.
+
+The section header counts both: *"2 rules, opened with the connection · 1
+switched off"*.
+
+A live forward has the same switch. In the **Forwards** panel, ⏸ takes the
+listener down and keeps the row — faded, with ▶ beside it. Nothing is retyped
+when it comes back. If the port has been taken in the meantime, the rule stays
+off and says why rather than disappearing.
+
+<Note>
+  A live forward switched off this way comes back on when you switch it on, not
+  when you reconnect — the far side has no such thing as a paused listener, so
+  the rule is being kept by tty7 for this session. For something you want off
+  across sessions, switch the rule off in the profile.
+</Note>
+
 ## Adding one mid-session
 
 *SSH: Port Forwarding* in the command palette opens the **Forwards** panel for

--- a/docs/remote/ssh.mdx
+++ b/docs/remote/ssh.mdx
@@ -15,9 +15,16 @@ instead of a password echoing into your shell.
   <img src="/images/placeholder.svg" alt="Connecting over SSH in tty7" />
 </Frame>
 
-## Four ways to connect
+## Ways to connect
 
 <AccordionGroup>
+  <Accordion title="The New Tab menu">
+    The **+** button's menu lists your saved hosts under the shells, most
+    recently and often used first, each with the address behind its name.
+    Picking one opens the connection in a new tab. *Add Connection…* under them
+    opens the address box for a host you have not saved.
+  </Accordion>
+
   <Accordion title="QuickConnect — type an address">
     Open the palette (<kbd>⌘ P</kbd>) and type an address. IPv6 works with
     brackets.

--- a/docs/remote/workspaces.mdx
+++ b/docs/remote/workspaces.mdx
@@ -22,6 +22,12 @@ Nothing is synced or copied. The repository stays where it is.
     (<kbd>⌘ ⇧ O</kbd>). The form's host dropdown lists *This Computer*, every
     saved SSH profile, your `~/.ssh/config` aliases and, on Windows, every WSL
     distribution — type to filter when the list is long.
+
+    <Tip>
+      Or search for the machine by name in the switcher. One with nothing on it
+      yet appears under **Machines with no workspace yet**, and picking it opens
+      this form with that host already chosen.
+    </Tip>
   </Step>
   <Step title="Pick a machine">
     tty7 connects over the same SSH stack as everything else, so profiles,

--- a/docs/remote/workspaces.mdx
+++ b/docs/remote/workspaces.mdx
@@ -46,6 +46,26 @@ Nothing is synced or copied. The repository stays where it is.
   </Step>
 </Steps>
 
+## Knowing which machine you are on
+
+A window on another machine says so, and keeps saying so. Under the workspace
+name in the tab rail is a dot and the machine's name — green while the link is
+up, amber while it is being made or remade, red once it has given up, with a
+word beside it whenever the state is not the one you would assume:
+
+```
+[F] fable-marten          ⌃⌄
+ ●  devbox · reconnecting
+```
+
+The tab rows below it stay quiet, because the badge above them already answered
+the question. A row only names its own machine when that would *contradict* the
+badge — an SSH pane opened inside a local workspace, or a `wsl` shell beside
+Windows ones.
+
+An empty remote workspace has no rail to carry the badge, so the home screen
+names the machine a new tab would open a shell on.
+
 ## What gets installed
 
 | | |

--- a/src/ui/forwards.rs
+++ b/src/ui/forwards.rs
@@ -182,11 +182,14 @@ impl Tty7App {
             _ => None,
         };
         // A saved connection is editable; a one-off `user@host` is not, and
-        // offering to edit one would open an empty page.
+        // offering to edit one opened Settings on "Nothing selected" — this
+        // comment already said that was the thing to avoid, and the code under
+        // it only checked that the spec's uuid *parsed*. Every connection has
+        // one. Ask the same question `unsaved_ssh_session` asks.
+        let profiles = &cx.global::<crate::core::config::Config>().ssh_profiles;
         let profile = view
             .ssh_spec()
-            .and_then(|s| s.profile_id.clone())
-            .and_then(|id| uuid::Uuid::parse_str(&id).ok());
+            .and_then(|spec| crate::ui::ssh_connect::saved_profile_of(&spec, profiles));
 
         let theme = cx.theme();
 
@@ -251,15 +254,28 @@ impl Tty7App {
                         cx.listener(|this, _, window, cx| this.restart_ssh_session(window, cx)),
                     ),
             )
-            .children(profile.map(|id| {
-                Button::new("ssh-edit-profile")
-                    .label(crate::ui::i18n::t(crate::ui::i18n::L10nKey::SshEditProfile))
+            .child(match profile {
+                // A saved host: the form that opens is the one this connection
+                // was dialled from, so a wrong hostname or password is fixed
+                // where it lives.
+                Some(id) => Button::new("ssh-edit-profile")
+                    .label(t(L10nKey::SshEditProfile))
                     .ghost()
                     .small()
                     .on_click(cx.listener(move |this, _, window, cx| {
                         this.open_ssh_profile_in_settings(id, window, cx)
-                    }))
-            }));
+                    })),
+                // A one-off: there is no host to open, but the address that
+                // failed is worth keeping — the form opens prefilled from the
+                // live spec, which is where the typo gets corrected (#438).
+                None => Button::new("ssh-save-as-host")
+                    .label(t(L10nKey::SshSaveAsHost))
+                    .ghost()
+                    .small()
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        this.save_ssh_session_as_host(window, cx)
+                    })),
+            });
         Some(
             div()
                 .absolute()

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -917,6 +917,7 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         L10nKey::ForwardPanelTitle => "Forwards",
         L10nKey::ForwardDisconnected => "Disconnected",
         L10nKey::ForwardDisconnectedFrom => "Disconnected from {host}",
+        L10nKey::SshSaveAsHost => "Save as Host…",
         L10nKey::SshEditProfile => "Edit connection…",
         L10nKey::ForwardTooltipAdd => "Add forward",
         L10nKey::ForwardTooltipTurnOff => "Switch off — keeps the rule",

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -1340,6 +1340,7 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         L10nKey::SwitcherTabsAfterOpening => "Open this workspace to see its tabs.",
         L10nKey::SwitcherOpenToManage => "Open this workspace to rename or stop it.",
         L10nKey::SwitcherConnectToUse => "Connect to this machine to open a workspace on it.",
+        L10nKey::SwitcherMachinesNoWorkspace => "Machines with no workspace yet",
         L10nKey::SwitcherOrphanPanes => {
             "Background panes — shells still running outside any window:"
         }

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -1373,6 +1373,7 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         L10nKey::SwitcherTabsAfterOpening => "このワークスペースを開くとタブが表示されます",
         L10nKey::SwitcherOpenToManage => "このワークスペースを開くと名前の変更や停止ができます",
         L10nKey::SwitcherConnectToUse => "このマシンに接続するとワークスペースを作成できます",
+        L10nKey::SwitcherMachinesNoWorkspace => "ワークスペースがまだないマシン",
         L10nKey::SwitcherOrphanPanes => {
             "バックグラウンドペイン — どのウィンドウにも属さずに実行中のシェル:"
         }

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -967,6 +967,7 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         L10nKey::ForwardPanelTitle => "ポートフォワード",
         L10nKey::ForwardDisconnected => "切断済み",
         L10nKey::ForwardDisconnectedFrom => "{host} から切断されました",
+        L10nKey::SshSaveAsHost => "ホストとして保存…",
         L10nKey::SshEditProfile => "接続を編集…",
         L10nKey::ForwardTooltipAdd => "フォワードを追加",
         L10nKey::ForwardTooltipTurnOff => "無効にする（ルールは残す）",

--- a/src/ui/i18n/mod.rs
+++ b/src/ui/i18n/mod.rs
@@ -678,6 +678,7 @@ l10n_keys! {
     ForwardDisconnected,
     ForwardDisconnectedFrom,
     SshEditProfile,
+    SshSaveAsHost,
     ForwardTooltipAdd,
     ForwardTooltipRemove,
     ForwardTooltipTurnOff,

--- a/src/ui/i18n/mod.rs
+++ b/src/ui/i18n/mod.rs
@@ -1074,6 +1074,7 @@ l10n_keys! {
     SwitcherOpenToManage,
     SwitcherConnectToUse,
     SwitcherOrphanPanes,
+    SwitcherMachinesNoWorkspace,
     SwitcherTabCount,
     SwitcherTabCountOne,
     SwitcherActiveTab,

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -1251,6 +1251,7 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         L10nKey::SwitcherTabsAfterOpening => "打开这个工作区后才能看到它的标签页。",
         L10nKey::SwitcherOpenToManage => "打开这个工作区后才能重命名或停止它。",
         L10nKey::SwitcherConnectToUse => "连接这台机器后才能在上面新建工作区。",
+        L10nKey::SwitcherMachinesNoWorkspace => "尚无工作区的机器",
         L10nKey::SwitcherOrphanPanes => "后台窗格——仍在运行、但不属于任何窗口的 shell：",
         L10nKey::SwitcherTabCount => "{n} 个标签页",
         L10nKey::SwitcherTabCountOne => "1 个标签页",

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -871,6 +871,7 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         L10nKey::ForwardPanelTitle => "端口转发",
         L10nKey::ForwardDisconnected => "已断开",
         L10nKey::ForwardDisconnectedFrom => "与 {host} 的连接已断开",
+        L10nKey::SshSaveAsHost => "保存为主机…",
         L10nKey::SshEditProfile => "编辑连接…",
         L10nKey::ForwardTooltipAdd => "添加转发",
         L10nKey::ForwardTooltipTurnOff => "停用（保留规则）",

--- a/src/ui/ssh_connect.rs
+++ b/src/ui/ssh_connect.rs
@@ -155,15 +155,7 @@ impl Tty7App {
     ) -> Option<Box<NativeSshSpec>> {
         let spec = self.focused_pane_view(window, cx)?.read(cx).ssh_spec()?;
         let profiles = &cx.global::<Config>().ssh_profiles;
-        // A transient profile is handed a fresh uuid on its way to the daemon,
-        // so an id alone does not mean a host was saved — only one that still
-        // resolves does.
-        let saved = spec
-            .profile_id
-            .as_deref()
-            .and_then(|s| uuid::Uuid::parse_str(s).ok())
-            .is_some_and(|id| profiles.iter().any(|p| p.id == id));
-        (!saved).then_some(spec)
+        saved_profile_of(&spec, profiles).is_none().then_some(spec)
     }
 
     /// Keep the connection in front of you: the form opens on everything the
@@ -242,6 +234,21 @@ impl Tty7App {
             entry.last_used = crate::core::config::unix_now();
         });
     }
+}
+
+/// The saved host a live connection came from, if it still exists.
+///
+/// A transient profile is handed a fresh uuid on its way to the daemon, so
+/// *every* spec carries a `profile_id` and an id alone does not mean anything
+/// was saved. Only one that still resolves does — and the two places that ask
+/// (whether to offer Save Connection as Host, and whether the failure strip's
+/// button edits a host or offers to keep one) have to agree, or an ad-hoc
+/// connection gets an Edit button that opens Settings on nothing.
+pub(crate) fn saved_profile_of(spec: &NativeSshSpec, profiles: &[SshProfile]) -> Option<Uuid> {
+    spec.profile_id
+        .as_deref()
+        .and_then(|s| Uuid::parse_str(s).ok())
+        .filter(|id| profiles.iter().any(|p| p.id == *id))
 }
 
 /// Saved hosts, most likely first: whatever has been connected to often and
@@ -657,6 +664,34 @@ mod tests {
         p.auth = AuthMode::PublicKey;
         let spec = build_native_ssh_spec(&p, &[], &store, true);
         assert_eq!(spec.password, None);
+    }
+
+    /// Both the palette (Save Connection as Host) and the failure strip (Edit
+    /// connection… vs Save as Host…) branch on this. They used to answer it
+    /// separately, and the strip's copy of the test only checked that the uuid
+    /// parsed — which every connection's does — so an ad-hoc `user@host` wore
+    /// an Edit button that opened Settings on "Nothing selected".
+    #[test]
+    fn only_a_uuid_that_still_names_a_host_counts_as_saved() {
+        let store = InMemoryCredentialStore::new();
+        let saved = profile("prod-web", "10.0.0.5", "deploy");
+        let profiles = vec![saved.clone()];
+
+        let spec = build_native_ssh_spec(&saved, &profiles, &store, true);
+        assert_eq!(saved_profile_of(&spec, &profiles), Some(saved.id));
+
+        // What `quick_connect` and the palette's address box build: a profile
+        // that never reached the config, carrying a uuid of its own.
+        let adhoc = profile("", "nosuchhost.invalid", "root");
+        let spec = build_native_ssh_spec(&adhoc, &profiles, &store, true);
+        assert!(
+            spec.profile_id.is_some(),
+            "the spec does carry an id — that is exactly why the id alone is not the test"
+        );
+        assert_eq!(saved_profile_of(&spec, &profiles), None);
+
+        // And a host that was saved and has since been deleted.
+        assert_eq!(saved_profile_of(&spec, &[]), None);
     }
 
     /// The pane wears this until the remote shell titles itself, so a host

--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -32,6 +32,12 @@ const FORM_LIST_H: f32 = 8.5 * (ROW_H + 8.0);
 
 const LEFT_W: f32 = 340.0;
 
+/// How many not-yet-used machines a search offers. This box sits under the
+/// workspace list and is an answer to "the machine you meant is configured but
+/// has nothing on it yet" — a long list of them would push the workspaces the
+/// query actually matched off the screen.
+const MAX_UNLISTED_HOSTS: usize = 5;
+
 pub(crate) const CARD_TOP: f32 = 120.0;
 
 /// Breathing room the card keeps from the window edge, and the height its own
@@ -343,6 +349,17 @@ fn flatten(groups: &[Group], query: &str) -> Vec<Nav> {
             .then_with(|| a.name.cmp(&b.name))
     });
     nav
+}
+
+/// Of the machines a query matched, the ones the workspace list does not
+/// already show — capped, because this box sits under the workspaces the query
+/// actually matched and must not push them off the screen.
+fn hosts_without_workspaces(matched: Vec<HostChoice>, listed: &[String]) -> Vec<HostChoice> {
+    matched
+        .into_iter()
+        .filter(|h| !listed.contains(&h.target.to_string()))
+        .take(MAX_UNLISTED_HOSTS)
+        .collect()
 }
 
 /// One line of the create form's host dropdown.
@@ -1636,7 +1653,8 @@ impl Tty7App {
             let group = &layout.groups[g];
             list = list.child(self.render_row(group, &group.rows[r], picked, Some(at), cx));
         }
-        if layout.nav.is_empty() {
+        let unlisted = self.unlisted_hosts(&sw.text(cx), cx);
+        if layout.nav.is_empty() && unlisted.is_empty() {
             list = list.child(
                 div()
                     .px(px(ROW_PAD))
@@ -1645,6 +1663,9 @@ impl Tty7App {
                     .text_color(cx.theme().muted_foreground)
                     .child(t(L10nKey::SwitcherNoMatch)),
             );
+        }
+        if !unlisted.is_empty() {
+            list = list.child(self.render_unlisted_hosts(unlisted, cx));
         }
         // Orphan panes belong to the machine, not to a workspace, so they are
         // not rows and join no navigation — the bottom of the workspace list
@@ -2005,6 +2026,100 @@ impl Tty7App {
 
     /// The orphan block under the local group (#596): one line per pane no
     /// window holds — id, owner, where it runs — and the way to stop it.
+    /// Machines the query matched that have no workspace yet.
+    ///
+    /// The search box says it looks through "workspaces, tabs, and machines",
+    /// and a machine only became findable once it *had* a workspace — so
+    /// searching for the box you are about to set up found nothing, and the way
+    /// in was New Workspace… and its dropdown, which you had to already know
+    /// about. These rows lead there with the host chosen.
+    ///
+    /// Outside the navigation, like the orphan-pane box under them (#596): they
+    /// are not workspaces, and Enter belongs to the workspace the cursor is on.
+    fn unlisted_hosts(&self, query: &str, cx: &gpui::App) -> Vec<HostChoice> {
+        let query = query.trim();
+        if query.is_empty() {
+            return Vec::new();
+        }
+        let listed: Vec<String> = WorkspaceStore::all(cx)
+            .views
+            .iter()
+            .filter_map(|w| w.host.as_ref().map(|r| r.target.to_string()))
+            .collect();
+        let hosts = remote_connect::available_hosts(cx);
+        hosts_without_workspaces(remote_connect::filter_hosts(&hosts, query), &listed)
+    }
+
+    fn render_unlisted_hosts(
+        &self,
+        hosts: Vec<HostChoice>,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let theme = cx.theme();
+        let sf = rungs(cx);
+        let hover = gpui::rgb(sf.hover);
+        let mut list = v_flex().gap(px(1.));
+        for host in hosts {
+            let label = host.label.clone();
+            let detail = host.detail.clone();
+            let key = gpui::SharedString::from(format!("switcher-host:{}", host.target));
+            list = list.child(
+                h_flex()
+                    .id(key)
+                    .items_center()
+                    .gap(px(6.))
+                    .px(px(6.))
+                    .py(px(3.))
+                    .rounded(px(4.))
+                    .cursor_pointer()
+                    .hover(move |r| r.bg(hover))
+                    .child(
+                        div()
+                            .flex_shrink_0()
+                            .size(px(6.))
+                            .rounded_full()
+                            .bg(gpui::rgb(crate::ui::tab_strip::UNKNOWN_DOT)),
+                    )
+                    .child(
+                        div()
+                            .flex_shrink_0()
+                            .text_xs()
+                            .text_color(theme.foreground)
+                            .child(label),
+                    )
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .truncate()
+                            .text_xs()
+                            .text_color(theme.muted_foreground)
+                            .child(detail),
+                    )
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        this.switcher_to_form(Some(host.clone()), window, cx)
+                    })),
+            );
+        }
+        v_flex()
+            .gap(px(4.))
+            .mx(px(4.))
+            .mt(px(6.))
+            .mb(px(2.))
+            .px(px(10.))
+            .py(px(8.))
+            .rounded(px(6.))
+            .border_1()
+            .border_color(theme.border)
+            .child(
+                div()
+                    .text_xs()
+                    .text_color(theme.muted_foreground)
+                    .child(t(L10nKey::SwitcherMachinesNoWorkspace)),
+            )
+            .child(list)
+    }
+
     fn render_orphan_panes(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
         let Some(switcher) = self.switcher.as_ref() else {
@@ -3247,6 +3362,44 @@ fn glyph_col(w: f32, child: impl IntoElement) -> impl IntoElement {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The search box says it looks through "workspaces, tabs, and machines",
+    /// and a machine only became findable once it had a workspace — so
+    /// searching for the box you were about to set up found nothing. What it
+    /// must *not* do is repeat the machines the list above it is already
+    /// showing.
+    #[test]
+    fn only_the_machines_the_workspace_list_is_not_already_showing() {
+        let host = |alias: &str| HostChoice {
+            target: RemoteTarget::Alias {
+                alias: alias.into(),
+            },
+            label: alias.into(),
+            detail: format!("me@{alias}"),
+        };
+        let listed = vec![
+            RemoteTarget::Alias {
+                alias: "devbox".into(),
+            }
+            .to_string(),
+        ];
+
+        let out = hosts_without_workspaces(vec![host("devbox"), host("gpu")], &listed);
+        assert_eq!(
+            out.iter().map(|h| h.label.as_str()).collect::<Vec<_>>(),
+            vec!["gpu"],
+            "devbox already has a row of its own above this box"
+        );
+
+        let many: Vec<HostChoice> = (0..MAX_UNLISTED_HOSTS + 3)
+            .map(|i| host(&format!("box{i}")))
+            .collect();
+        assert_eq!(
+            hosts_without_workspaces(many, &[]).len(),
+            MAX_UNLISTED_HOSTS,
+            "the box must not push the matched workspaces off the screen"
+        );
+    }
 
     /// A wrong hostname or a stale password used to be fixable only by
     /// finding the same machine again in Settings (#438). The machine is on

--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -2313,8 +2313,18 @@ impl Tty7App {
                                     .child(host_label),
                             )
                             .when(!when_path.is_empty(), |line| {
+                                // `flex_1`, not a bare `min_w_0`: with an auto
+                                // basis this box takes its content width as its
+                                // starting size and then absorbs every pixel
+                                // the row is over — which collapsed it to its
+                                // zero minimum and left a lone "…" where the
+                                // timestamp goes. Rows with *less* to say lost
+                                // more of it: `java-box · …` beside
+                                // `local · ~/repo/025/tty7 ·…`. A zero basis
+                                // that grows into what is left ellipsizes only
+                                // what genuinely does not fit.
                                 line.child(div().flex_shrink_0().child("·"))
-                                    .child(div().min_w_0().truncate().child(when_path))
+                                    .child(div().flex_1().min_w_0().truncate().child(when_path))
                             }),
                     ),
             )


### PR DESCRIPTION
Stacked on #642.


## Before / After

| | Before | After |
|---|---|---|
| A one-off `root@nosuchhost.invalid` fails | Strip offers **Edit connection…** → Settings opens on *"Nothing selected"* | Strip offers **Save as Host…** → the host form, prefilled with the address that failed |
| A saved host fails | **Edit connection…** → that host's form | Unchanged |
| Switcher row for a workspace with no path | `● java-box · …` | `● java-box · yesterday` |
| Switcher row that genuinely overflows | `🖥 local · ~/repo/025/tty7 ·…` | Unchanged — it really does not fit |

## Why the Edit button was wrong

The comment next to it already stated the rule:

> A saved connection is editable; a one-off `user@host` is not, and offering to edit one would open an empty page.

The code under it only checked that `spec.profile_id` **parsed** as a uuid. Every connection has one — `native_spec_from_transient_profile` hands a fresh uuid to anything dialled by hand — so the test was always true. Both callers (the palette's *Save Connection as Host*, and this strip) now go through one `saved_profile_of`, so they cannot disagree again.

Offering *Save as Host…* rather than nothing is the point: someone whose connection just failed on a typo wants to fix the address, and the prefilled form is where that happens.

## Why the row collapsed

`div().min_w_0().truncate()` with no flex basis starts at its content width and, as the only shrinkable item in the line, absorbs the whole overflow — down to its zero minimum. That is why the rows with *less* to say lost more of it. `flex_1` gives it a zero basis that grows into what is left, so CSS ellipsis only eats what genuinely does not fit.

Confirmed by instrumenting the row: `when_path="yesterday"` rendered as `…`.

## Testing

- `cargo test` — all suites green (1545 / 1159 / 129 / …), `cargo fmt --check` clean.
- New unit test `only_a_uuid_that_still_names_a_host_counts_as_saved` — covers the saved host, the ad-hoc spec (asserting it *does* carry an id, which is the whole trap), and a host deleted since.
- Manual:
  - `root@nosuchhost.invalid` → strip shows **Save as Host…**; pressing it opens the form on `root@nosuchhost.invalid` / host `nosuchhost.invalid` / user `root`, ready to fix and Test.
  - Switcher: `hummingbot`, `bold-otter`, `ochre-koala` now read `java-box · yesterday`; `fable-marten` reads `java-box · /home/java · 1 hour ago` in full.

---

## Also here: finding a machine that has no workspace yet

| | Before | After |
|---|---|---|
| Type `gpu` in the switcher, a configured host with nothing on it | *No match* — even though the box says it searches "machines" | **Machines with no workspace yet** → `● gpu  root@35.209.74.136`; clicking it opens New Workspace with `gpu` chosen |
| A machine that already has workspaces | Its rows are in the list | Unchanged — it is not repeated in the box |

Outside the keyboard navigation, like the orphan-pane box it sits beside (#596): these are not workspaces, and Enter belongs to the workspace the cursor is on. Capped at five so it cannot push the matched workspaces off the screen.

Test: `only_the_machines_the_workspace_list_is_not_already_showing`.

## Docs

`docs/remote/` gained the machine badge, the forward switch, the New Tab host menu, and this switcher search — all four shipped across this stack.