### PR TITLE
feat(remote): finish the machine badge, and reach a connection's host and forwards from its tab

### DIFF
--- a/crates/tty7-core/src/daemon/pane.rs
+++ b/crates/tty7-core/src/daemon/pane.rs
@@ -11,6 +11,7 @@ use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system}
 
 use crate::core::kitty_graphics::{GraphicsSniffer, Segment, Sniffed};
 use crate::core::osc::OscTokenizer;
+use crate::daemon::protocol::SshPhase;
 use crate::daemon::protocol::{
     AuthResponse, DaemonMsg, MAX_FRAME, NativeSshSpec, PaneInfo, RemoteContext, RemoteKind,
     ShellSpec, WinSize,
@@ -684,6 +685,13 @@ struct PaneState {
     /// `shell` above, which is the shell-integration state.
     shell_spec: Option<ShellSpec>,
     remote: Option<RemoteContext>,
+    /// The last phase a native ssh connection reported.
+    ///
+    /// Kept so a client that attaches later is told: the phase is an event, and
+    /// a GUI restarted while the session was up got no answer at all — every
+    /// live connection came back wearing the grey "nobody said" dot instead of
+    /// the green one, on a pane the user could type into.
+    ssh_phase: Option<SshPhase>,
     agent: Option<crate::core::cli_agent::CLIAgent>,
     agent_argv: Option<Vec<String>>,
     agent_session: Option<crate::core::cli_agent::AgentSessionState>,
@@ -1330,6 +1338,7 @@ impl DaemonPane {
                 shell: ShellState::default(),
                 shell_spec: spawn.shell.clone(),
                 remote: spawn.remote.clone(),
+                ssh_phase: None,
                 agent: None,
                 agent_session: None,
                 agent_argv: None,
@@ -1549,6 +1558,7 @@ impl DaemonPane {
                     command: None,
                 },
                 remote: carried.remote,
+                ssh_phase: None,
                 agent: carried.agent,
                 agent_session: carried.agent_session,
                 agent_argv: carried.agent_argv,
@@ -1598,6 +1608,7 @@ impl DaemonPane {
             osc_title: None,
             shell: ShellState::default(),
             remote: Some(remote),
+            ssh_phase: None,
             agent: None,
             agent_session: None,
             agent_argv: None,
@@ -1610,7 +1621,14 @@ impl DaemonPane {
         let broker = {
             let state = state.clone();
             crate::daemon::ssh::PromptBroker::new(Box::new(move |msg: DaemonMsg| {
-                match &state.lock().unwrap().subscriber {
+                let mut st = state.lock().unwrap();
+                // Remembered before it is sent, and remembered even when there
+                // is no client listening: the phase a connection reached while
+                // nobody was attached is exactly the one the next client needs.
+                if let DaemonMsg::SshStatus { phase } = &msg {
+                    st.ssh_phase = Some(phase.clone());
+                }
+                match &st.subscriber {
                     Some(sub) => sub.send(msg).is_ok(),
                     None => false,
                 }
@@ -2401,6 +2419,11 @@ fn replay_state(st: &PaneState, subscriber: &Sender<DaemonMsg>) {
     if st.remote.is_some() {
         let _ = subscriber.send(DaemonMsg::RemoteContext(st.remote.clone()));
     }
+    if let Some(phase) = &st.ssh_phase {
+        let _ = subscriber.send(DaemonMsg::SshStatus {
+            phase: phase.clone(),
+        });
+    }
     if st.agent.is_some() {
         let _ = subscriber.send(DaemonMsg::Agent(st.agent));
     }
@@ -3041,6 +3064,66 @@ mod tests {
     use super::*;
     use crate::core::kitty_graphics::ImageDelete;
     use std::path::Path;
+
+    /// A client that attaches after the fact is told what the connection
+    /// reached. The phase is an event, so a GUI restarted while an ssh session
+    /// was up got no answer at all — every live connection came back wearing
+    /// the grey "nobody said" dot on a pane the user could type into.
+    #[test]
+    fn attaching_late_is_told_the_phase_the_connection_reached() {
+        let mut st = PaneState {
+            id: 7,
+            ring: ReplayRing::new(crate::daemon::protocol::WinSize {
+                cols: 80,
+                rows: 24,
+                cell_w: 8,
+                cell_h: 16,
+            }),
+            subscriber: None,
+            subscriber_epoch: 0,
+            observers: Vec::new(),
+            observer_seq: 0,
+            cwd: None,
+            osc_title: None,
+            shell: ShellState::default(),
+            shell_spec: None,
+            remote: Some(RemoteContext {
+                kind: crate::daemon::protocol::RemoteKind::NativeSsh,
+                argv: Vec::new(),
+                target: "java-box".into(),
+            }),
+            ssh_phase: Some(SshPhase::Connected),
+            agent: None,
+            agent_argv: None,
+            agent_session: None,
+            alive: true,
+            exit_code: None,
+        };
+
+        let (tx, rx) = mpsc::channel();
+        replay_state(&st, &tx);
+        drop(tx);
+        let replayed: Vec<DaemonMsg> = rx.into_iter().collect();
+        assert!(
+            replayed.iter().any(|m| matches!(
+                m,
+                DaemonMsg::SshStatus {
+                    phase: SshPhase::Connected
+                }
+            )),
+            "a late client has no other way to learn the connection is up: {replayed:?}"
+        );
+
+        // A pane that never had a connection says nothing about one.
+        st.ssh_phase = None;
+        let (tx, rx) = mpsc::channel();
+        replay_state(&st, &tx);
+        drop(tx);
+        assert!(
+            !rx.into_iter()
+                .any(|m| matches!(m, DaemonMsg::SshStatus { .. }))
+        );
+    }
 
     #[test]
     fn a_shell_that_cannot_run_is_named_once_not_wrapped_four_deep() {
@@ -4154,6 +4237,7 @@ mod tests {
             osc_title: None,
             shell: ShellState::default(),
             remote: None,
+            ssh_phase: None,
             agent: None,
             agent_session: None,
             agent_argv: None,

--- a/docs/remote/port-forwarding.mdx
+++ b/docs/remote/port-forwarding.mdx
@@ -47,8 +47,8 @@ off and says why rather than disappearing.
 
 ## Adding one mid-session
 
-*SSH: Port Forwarding* in the command palette opens the **Forwards** panel for
-the current connection. Add a rule there and it starts immediately; remove it
+*SSH: Port Forwarding* in the command palette, or **Port Forwarding…** in the
+tab's context menu, opens the **Forwards** panel for that connection. Add a rule there and it starts immediately; remove it
 and it stops. These live only as long as the session unless you save them into
 the profile.
 

--- a/docs/remote/ssh.mdx
+++ b/docs/remote/ssh.mdx
@@ -74,6 +74,11 @@ instead of a password echoing into your shell.
 **Defaults** at the top of the list is inherited by every host, so a setting you
 want everywhere is set once.
 
+Right-clicking an SSH tab opens that connection's host form — *Edit
+connection…* for a saved one, *Save as Host…* for an address typed by hand.
+The same pair sits on the strip a dropped connection leaves behind, so a
+hostname or password typed wrong is corrected where you noticed it.
+
 Passwords and key passphrases go in the **OS keychain**, never in
 `config.json` and never on disk in plain text. **Forget Password** in a
 profile's menu removes the stored one.

--- a/docs/remote/workspaces.mdx
+++ b/docs/remote/workspaces.mdx
@@ -70,7 +70,9 @@ badge — an SSH pane opened inside a local workspace, or a `wsl` shell beside
 Windows ones.
 
 An empty remote workspace has no rail to carry the badge, so the home screen
-names the machine a new tab would open a shell on.
+names the machine a new tab would open a shell on. With the tab bar on top the
+badge sits beside the **+**, and a tab chip names its machine under the
+pointer.
 
 ## What gets installed
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -384,7 +384,11 @@ impl Tab {
 
     /// The leaf a tab names itself after — its title and, with it, the home
     /// that title's path is measured against.
-    fn title_leaf(&self, window: Option<&Window>, cx: &App) -> Option<Entity<TerminalView>> {
+    pub(crate) fn title_leaf(
+        &self,
+        window: Option<&Window>,
+        cx: &App,
+    ) -> Option<Entity<TerminalView>> {
         let leaf = match window {
             Some(window) => self
                 .pane

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -6550,11 +6550,16 @@ impl Render for Tty7App {
         let rail = self.sidebar_open(cx);
         let strip = self.tab_strip(!vertical, window, cx);
         let sidebar = rail.then(|| self.tab_sidebar(window, cx));
-        let ssh_status = self
+        let ssh_leaf = self
             .tabs
             .get(self.active)
-            .and_then(|t| t.pane.focused_or_first(window, cx))
-            .and_then(|leaf| self.render_ssh_status_strip(&leaf, cx));
+            .and_then(|t| t.pane.focused_or_first(window, cx));
+        let ssh_status = ssh_leaf
+            .as_ref()
+            .and_then(|leaf| self.render_ssh_status_strip(leaf, cx));
+        let ssh_connecting = ssh_leaf
+            .as_ref()
+            .and_then(|leaf| self.render_ssh_connecting(leaf, cx));
         let body = match self.tabs.get(self.active) {
             None => self.render_home(cx).into_any_element(),
             Some(active_tab) => {
@@ -6611,6 +6616,7 @@ impl Render for Tty7App {
             .when_some(self.render_ssh_prompt_overlay(window, cx), |this, el| {
                 this.child(el)
             })
+            .when_some(ssh_connecting, |this, el| this.child(el))
             .when_some(ssh_status, |this, el| this.child(el))
             .when_some(self.render_remote_workspace_strip(cx), |this, el| {
                 this.child(el)

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -2729,7 +2729,18 @@ impl Tty7App {
     /// The palette asks this to decide whether to offer the command at all, so
     /// the row and what pressing it does cannot drift apart.
     pub(crate) fn forwardable_pane(&self, window: &Window, cx: &App) -> Option<u64> {
-        let leaf = self.tabs.get(self.active)?.detail_pane(window, cx)?;
+        self.forwardable_pane_of(self.active, window, cx)
+    }
+
+    /// The same question about a named tab, for the tab's own context menu:
+    /// right-clicking a background tab has to act on *that* tab's connection.
+    pub(crate) fn forwardable_pane_of(
+        &self,
+        index: usize,
+        window: &Window,
+        cx: &App,
+    ) -> Option<u64> {
+        let leaf = self.tabs.get(index)?.detail_pane(window, cx)?;
         let view = leaf.read(cx);
         crate::ui::right_panel::pane_holds_forwards(view).then_some(view.pane_id)
     }
@@ -2738,6 +2749,16 @@ impl Tty7App {
         let Some(pane_id) = self.forwardable_pane(window, cx) else {
             return;
         };
+        self.open_forwards_for(pane_id, window, cx);
+    }
+
+    /// Put the Forwards section on screen for a pane and open its add form.
+    pub(crate) fn open_forwards_for(
+        &mut self,
+        pane_id: u64,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         self.set_right_panel_tab(crate::core::config::RightPanelTab::Info, cx);
         if self.loopback_panel.form_pane_id != Some(pane_id) {
             self.toggle_managed_forward_form(pane_id, window, cx);

--- a/src/ui/forwards.rs
+++ b/src/ui/forwards.rs
@@ -1,4 +1,7 @@
-use gpui::{AnyElement, Context, Div, Entity, FontWeight, Stateful, div, prelude::*, px, rems};
+use gpui::{
+    AnimationExt as _, AnyElement, Context, Div, Entity, FontWeight, Stateful, div, prelude::*, px,
+    rems,
+};
 use gpui_component::button::{Button, ButtonVariants as _};
 use gpui_component::input::Input;
 use gpui_component::{
@@ -155,6 +158,72 @@ fn row_tile(id: impl Into<gpui::ElementId>, icon: IconName, cx: &mut Context<Tty
 }
 
 impl Tty7App {
+    /// What a native SSH pane shows while the connection is being made.
+    ///
+    /// The pane is a terminal that has printed nothing yet, so until this it
+    /// was a blank rectangle: a host that takes twenty seconds to time out
+    /// looked exactly like one that had already connected and had nothing to
+    /// say. The remote-workspace route has had a spinner and a name for this
+    /// all along (`PendingPane`); the pane route had the dot on the tab and
+    /// nothing else.
+    ///
+    /// Only `Connecting`. `Authenticating` is the phase the prompt sheet is up
+    /// in, and a second thing saying "working on it" behind a dialog asking for
+    /// a password is noise.
+    pub(crate) fn render_ssh_connecting(
+        &self,
+        leaf: &Entity<TerminalView>,
+        cx: &mut Context<Self>,
+    ) -> Option<AnyElement> {
+        use crate::daemon::protocol::SshPhase;
+        let view = leaf.read(cx);
+        if !matches!(view.ssh_phase(), Some(SshPhase::Connecting)) {
+            return None;
+        }
+        let host = view
+            .ssh_spec()
+            .and_then(|s| s.display_name.clone())
+            .or_else(|| view.remote_context().map(|c| c.target))
+            .unwrap_or_default();
+        let theme = cx.theme();
+        let muted = theme.muted_foreground;
+        Some(
+            div()
+                .absolute()
+                .inset_0()
+                .flex()
+                .items_center()
+                .justify_center()
+                .child(
+                    v_flex()
+                        .items_center()
+                        .gap(px(10.))
+                        .child(
+                            Icon::new(IconName::LoaderCircle)
+                                .size(px(18.))
+                                .text_color(muted.opacity(0.75))
+                                .with_animation(
+                                    "ssh-connecting-spin",
+                                    gpui::Animation::new(std::time::Duration::from_millis(900))
+                                        .repeat(),
+                                    |icon, delta| {
+                                        icon.transform(gpui::Transformation::rotate(
+                                            gpui::percentage(delta),
+                                        ))
+                                    },
+                                ),
+                        )
+                        .child(
+                            div()
+                                .text_sm()
+                                .text_color(muted)
+                                .child(t_fmt(L10nKey::PendingConnecting, &[("machine", &host)])),
+                        ),
+                )
+                .into_any_element(),
+        )
+    }
+
     pub(crate) fn render_ssh_status_strip(
         &self,
         leaf: &Entity<TerminalView>,

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -1461,6 +1461,7 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         L10nKey::CmdCut => "Cut",
         L10nKey::CmdPaste => "Paste",
         L10nKey::CmdSelectAll => "Select All",
+        L10nKey::MenuSshPortForwarding => "Port Forwarding…",
         L10nKey::MenuSshAddConnection => "Add Connection…",
         L10nKey::CmdSshAddConnection => "SSH: Add Connection…",
         L10nKey::CmdSshManageProfiles => "SSH: Manage Profiles…",

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -1494,6 +1494,7 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         L10nKey::CmdCut => "切り取り",
         L10nKey::CmdPaste => "貼り付け",
         L10nKey::CmdSelectAll => "すべて選択",
+        L10nKey::MenuSshPortForwarding => "ポート転送…",
         L10nKey::MenuSshAddConnection => "接続を追加…",
         L10nKey::CmdSshAddConnection => "SSH: 接続を追加…",
         L10nKey::CmdSshManageProfiles => "SSH: プロファイルを管理…",

--- a/src/ui/i18n/mod.rs
+++ b/src/ui/i18n/mod.rs
@@ -1188,6 +1188,7 @@ l10n_keys! {
     CmdSelectAll,
     CmdSshAddConnection,
     MenuSshAddConnection,
+    MenuSshPortForwarding,
     CmdSshManageProfiles,
     CmdSshReconnect,
     CmdSshRemoteFiles,

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -1366,6 +1366,7 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         L10nKey::CmdCut => "剪切",
         L10nKey::CmdPaste => "粘贴",
         L10nKey::CmdSelectAll => "全选",
+        L10nKey::MenuSshPortForwarding => "端口转发…",
         L10nKey::MenuSshAddConnection => "添加连接…",
         L10nKey::CmdSshAddConnection => "SSH：添加连接…",
         L10nKey::CmdSshManageProfiles => "SSH：管理主机配置…",

--- a/src/ui/remote_workspace.rs
+++ b/src/ui/remote_workspace.rs
@@ -197,6 +197,7 @@ impl RemoteStatus {
 /// `None` for a local workspace on purpose: a badge shown everywhere means
 /// nothing anywhere, and every surface that asks here is asking "is there
 /// something the reader does not already assume?".
+#[derive(Clone)]
 pub(crate) struct WindowMachine {
     pub label: String,
     pub status: RemoteStatus,

--- a/src/ui/ssh_connect.rs
+++ b/src/ui/ssh_connect.rs
@@ -161,6 +161,27 @@ impl Tty7App {
     /// Keep the connection in front of you: the form opens on everything the
     /// live session was dialled with, so a host proved by hand becomes a saved
     /// one without retyping it (#438).
+    /// What the tab's own context menu offers, for the tab it was opened on
+    /// rather than for whichever pane happens to be focused.
+    ///
+    /// `Some(id)` is a saved host to open; `None` with a spec is a connection
+    /// worth keeping. `None` at all means this tab is not an SSH one.
+    pub(crate) fn tab_ssh_host_action(
+        &self,
+        index: usize,
+        window: &gpui::Window,
+        cx: &gpui::App,
+    ) -> Option<(Option<Uuid>, Box<NativeSshSpec>)> {
+        let spec = self
+            .tabs
+            .get(index)?
+            .title_leaf(Some(window), cx)?
+            .read(cx)
+            .ssh_spec()?;
+        let saved = saved_profile_of(&spec, &cx.global::<Config>().ssh_profiles);
+        Some((saved, spec))
+    }
+
     pub(crate) fn save_ssh_session_as_host(
         &mut self,
         window: &mut gpui::Window,
@@ -169,7 +190,19 @@ impl Tty7App {
         let Some(spec) = self.unsaved_ssh_session(window, cx) else {
             return;
         };
-        let profile = profile_from_live_spec(&spec);
+        self.save_ssh_spec_as_host(&spec, window, cx);
+    }
+
+    /// Open the host form on a live connection, prefilled from what it was
+    /// dialled with. Shared by the palette, the failure strip and the tab menu,
+    /// which reach it from three different pane identities.
+    pub(crate) fn save_ssh_spec_as_host(
+        &mut self,
+        spec: &NativeSshSpec,
+        window: &mut gpui::Window,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        let profile = profile_from_live_spec(spec);
         let jumped = spec.jump.is_some();
         self.open_settings_section(crate::ui::settings::SettingsSection::Ssh, window, cx);
         self.ssh_form_load(&profile, window, cx);

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -207,9 +207,11 @@ impl Tty7App {
             .collect();
 
         let pointer = window.mouse_position();
-        // What the banner under the workspace head already says, so a row can
-        // tell whether naming its own machine would be news or an echo.
-        let window_machine = self.window_machine(cx).map(|m| m.label);
+        // Asked once for the whole frame: the banner under the workspace head
+        // draws from it, and every row reads it to tell whether naming its own
+        // machine would be news or an echo.
+        let machine = self.window_machine(cx);
+        let window_machine = machine.as_ref().map(|m| m.label.clone());
         // The row text is measured against real glyphs before it is elided:
         // `text_sm` is 0.875rem and `text_xs` 0.75rem, resolved here so the
         // measurement and the render use the same sizes and family.
@@ -1044,7 +1046,7 @@ impl Tty7App {
             .pt(px(4.))
             .child(self.workspace_head(cx));
 
-        let machine_banner = self.remote_head_banner(cx);
+        let machine_banner = self.remote_head_banner(machine.clone(), cx);
 
         let chip_inset = crate::ui::app::CONTENT_INSET - 7. + 4.;
         let top_bar = h_flex()
@@ -1206,8 +1208,12 @@ impl Tty7App {
     ///
     /// `None` on a local workspace: a badge that is always there stops being
     /// read.
-    fn remote_head_banner(&self, cx: &mut Context<Self>) -> Option<impl IntoElement + use<>> {
-        let machine = self.window_machine(cx)?;
+    fn remote_head_banner(
+        &self,
+        machine: Option<crate::ui::remote_workspace::WindowMachine>,
+        cx: &mut Context<Self>,
+    ) -> Option<impl IntoElement + use<>> {
+        let machine = machine?;
         let theme = cx.theme();
         let muted = theme.muted_foreground;
         let dot = machine.status.dot(theme);

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -1288,6 +1288,21 @@ impl Tty7App {
                     });
                 }
             }));
+            // Forwards belong to one connection, and this is the connection.
+            // They lived only behind a palette command and a section of the Info
+            // panel, neither of which is where someone looking at the tab would
+            // reach for them (#439).
+            if let Some(pane_id) = this.forwardable_pane_of(index, window, cx) {
+                menu = menu.item(
+                    PopupMenuItem::new(t(L10nKey::MenuSshPortForwarding)).on_click({
+                        let app = app.clone();
+                        move |_, window, cx| {
+                            let _ = app
+                                .update(cx, |this, cx| this.open_forwards_for(pane_id, window, cx));
+                        }
+                    }),
+                );
+            }
         }
 
         let agent_session = this.tab_agent_session(index, window, cx);

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -1035,7 +1035,7 @@ impl Tty7App {
         }
     }
 
-    /// The machine this window is on, for the horizontal tab strip.
+    /// The machine this window is on, for the title bar's strip.
     ///
     /// The rail carries this under the workspace head, and the strip has no
     /// workspace head — so with the tab bar on top a window on another computer
@@ -1044,8 +1044,16 @@ impl Tty7App {
     /// machine reads the same wherever it is shown.
     ///
     /// `None` on a local workspace: a badge that is always there stops being
-    /// read.
+    /// read. And `None` wherever another surface is already carrying it.
     fn strip_machine_badge(&self, cx: &mut Context<Self>) -> Option<impl IntoElement + use<>> {
+        // Only when nothing else is already saying it. The rail carries the
+        // badge under the workspace head whenever it is on screen, and the home
+        // screen carries it when there are no tabs at all — drawing it here too
+        // puts the same badge on screen twice, which is how a badge stops being
+        // read.
+        if self.sidebar_open(cx) || self.tabs.is_empty() {
+            return None;
+        }
         let machine = self.window_machine(cx)?;
         let theme = cx.theme();
         let muted = theme.muted_foreground;
@@ -1259,6 +1267,27 @@ impl Tty7App {
                         }
                     }),
             );
+        }
+
+        // The connection this tab is on, editable from the tab itself. A
+        // hostname or password typed wrong used to be fixable only by finding
+        // the same host again in Settings, and right-clicking the connection —
+        // the gesture that asks "change this" — offered nothing (#438).
+        if let Some((saved, spec)) = this.tab_ssh_host_action(index, window, cx) {
+            let label = match saved {
+                Some(_) => t(L10nKey::SshEditProfile),
+                None => t(L10nKey::SshSaveAsHost),
+            };
+            menu = menu.separator().item(PopupMenuItem::new(label).on_click({
+                let app = app.clone();
+                move |_, window, cx| {
+                    let spec = spec.clone();
+                    let _ = app.update(cx, |this, cx| match saved {
+                        Some(id) => this.open_ssh_profile_in_settings(id, window, cx),
+                        None => this.save_ssh_spec_as_host(&spec, window, cx),
+                    });
+                }
+            }));
         }
 
         let agent_session = this.tab_agent_session(index, window, cx);

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -466,6 +466,19 @@ pub(crate) const BUTTON_ICON_SCALE: f32 = 0.75;
 /// Connection…* reaches every host anyway.
 const NEW_TAB_MENU_HOSTS: usize = 6;
 
+/// What a tab chip says under the pointer: the machine it is on, then the title
+/// it could not fit, joined only when there are both.
+///
+/// The machine leads because it is the half a reader cannot infer from the chip
+/// — the title is at least partly on screen, and the machine is a 6px dot.
+fn chip_tooltip(machine: Option<String>, title: Option<String>) -> Option<SharedString> {
+    match (machine, title) {
+        (None, None) => None,
+        (None, Some(one)) | (Some(one), None) => Some(SharedString::from(one)),
+        (Some(machine), Some(title)) => Some(SharedString::from(format!("{machine} · {title}"))),
+    }
+}
+
 pub(crate) const MIN_TARGET: f32 = 24.;
 
 pub(crate) fn hit_target(button: Button) -> Button {
@@ -974,17 +987,27 @@ impl Tty7App {
         window: Option<&Window>,
         cx: &App,
     ) -> Option<SharedString> {
-        if tab.name.as_ref().is_some_and(|n| !n.trim().is_empty()) {
-            return None;
-        }
-        let (raw, home) = tab.leaf_title_and_home(window, cx);
-        let raw = raw.trim();
-        if raw.is_empty() || raw == self.tab_label(tab, index, window, cx) {
-            return None;
-        }
-        Some(SharedString::from(
-            abbreviate_home(raw, home.as_deref()).into_owned(),
-        ))
+        // A chip has no second line, so a pane on another machine has nothing
+        // but a 6px dot to say so. The rail's rows spell the machine out; here
+        // the pointer is the only place it fits. Leads the tooltip, because it
+        // is the part a reader cannot infer from the chip.
+        let machine = tab
+            .title_leaf(window, cx)
+            .and_then(|leaf| leaf.read(cx).remote_context())
+            .map(|remote| remote.target)
+            .filter(|target| !target.trim().is_empty());
+        let title = match tab.name.as_ref().filter(|n| !n.trim().is_empty()) {
+            Some(_) => None,
+            None => {
+                let (raw, home) = tab.leaf_title_and_home(window, cx);
+                let raw = raw.trim();
+                match raw.is_empty() || raw == self.tab_label(tab, index, window, cx) {
+                    true => None,
+                    false => Some(abbreviate_home(raw, home.as_deref()).into_owned()),
+                }
+            }
+        };
+        chip_tooltip(machine, title)
     }
 
     pub(crate) fn tab_label(
@@ -1010,6 +1033,46 @@ impl Tty7App {
         } else {
             label
         }
+    }
+
+    /// The machine this window is on, for the horizontal tab strip.
+    ///
+    /// The rail carries this under the workspace head, and the strip has no
+    /// workspace head — so with the tab bar on top a window on another computer
+    /// said nothing at all about it, which is the state this badge exists to
+    /// prevent. Same dot-plus-name as the rail's and the switcher's, so one
+    /// machine reads the same wherever it is shown.
+    ///
+    /// `None` on a local workspace: a badge that is always there stops being
+    /// read.
+    fn strip_machine_badge(&self, cx: &mut Context<Self>) -> Option<impl IntoElement + use<>> {
+        let machine = self.window_machine(cx)?;
+        let theme = cx.theme();
+        let muted = theme.muted_foreground;
+        let dot = machine.status.dot(theme);
+        let state = machine.status.short_label();
+        Some(
+            h_flex()
+                .id("strip-machine")
+                .flex_shrink(1.)
+                .min_w_0()
+                .items_center()
+                .gap(px(6.))
+                .pl(px(8.))
+                .text_xs()
+                .text_color(muted)
+                .child(div().flex_shrink_0().size(px(6.)).rounded_full().bg(dot))
+                .child(
+                    div()
+                        .min_w_0()
+                        .truncate()
+                        .child(SharedString::from(machine.label)),
+                )
+                .when_some(state, |row, state| {
+                    row.child(div().flex_shrink_0().child("·"))
+                        .child(div().flex_shrink_0().child(state))
+                }),
+        )
     }
 
     pub(crate) fn attach_new_tab_menu(
@@ -1679,7 +1742,17 @@ impl Tty7App {
             .when_some(left_group, |this, g| this.child(g))
             .child(chips)
             .when(show_chips, move |this| this.child(add_button))
-            .child(div().flex_1().min_w(px(GRAB_HANDLE_W)))
+            // The machine badge rides in the drag slack rather than beside the
+            // chips: it must never take width from the tabs, and there is
+            // normally far more room here than it needs.
+            .child(
+                h_flex()
+                    .flex_1()
+                    .min_w(px(GRAB_HANDLE_W))
+                    .items_center()
+                    .overflow_hidden()
+                    .children(self.strip_machine_badge(cx)),
+            )
             .when_some(right_chrome, |this, chrome| match chrome_band_w {
                 Some(w) => this.child(
                     h_flex()
@@ -1698,6 +1771,22 @@ impl Tty7App {
 mod tests {
     use super::*;
     use gpui::TestAppContext;
+
+    /// A chip has no second line, so a pane on another machine has nothing but
+    /// a 6px dot to say so — the pointer is the only place the machine fits.
+    #[test]
+    fn a_chip_names_its_machine_before_the_title_it_could_not_fit() {
+        let m = || Some("java-box".to_string());
+        let t = || Some("java@java: ~".to_string());
+        assert_eq!(chip_tooltip(None, None), None);
+        assert_eq!(chip_tooltip(m(), None).as_deref(), Some("java-box"));
+        assert_eq!(chip_tooltip(None, t()).as_deref(), Some("java@java: ~"));
+        assert_eq!(
+            chip_tooltip(m(), t()).as_deref(),
+            Some("java-box · java@java: ~"),
+            "the machine leads: it is the half the chip cannot show at all"
+        );
+    }
     use std::path::Path;
     use unicode_segmentation::UnicodeSegmentation;
 


### PR DESCRIPTION
Stacked on #643. Finishes the machine badge from #640: it only ever showed with the tab bar on the left.

## Before / After

| | Before | After |
|---|---|---|
| Remote workspace, tab bar **on top** | Nothing on screen names the machine — the strip has no workspace head to carry the badge | `● java-box` beside the **+**, same dot-plus-name as the rail and the switcher |
| Remote workspace, tab bar on the left | `● java-box` under the workspace name | Unchanged |
| Hovering an SSH tab chip | `java@java: ~` — the title it could not fit | `java-box · java@java: ~` |
| Hovering a local chip | Unchanged | Unchanged |

## Placement

The badge rides in the drag slack **after** the New Tab button, not beside the chips. The chip row's width budget is load-bearing (`visible_chips` measures against it), and a badge that competes with the tabs would push one out. In the slack it takes only room nobody else wanted.

The chip tooltip leads with the machine rather than the title: the title is at least partly on the chip already, and the machine is a 6px dot.

## Testing

- `cargo test` — all suites green (1547 / 1159 / 129 / …), `cargo fmt --check` clean.
- New unit test `a_chip_names_its_machine_before_the_title_it_could_not_fit` — all four combinations of machine × elided-title.
- Manual, tab bar moved to the top, against `java@java`:
  - Remote workspace on java-box → `● java-box` beside the **+**.
  - Local workspace → nothing, as before.
  - Hovering the SSH chip → `java-box · java@java: ~`.

---

## Also here: edit the host from the tab that is connected to it

Closes the last open bullet of #438.

| | Before | After |
|---|---|---|
| Right-click an SSH tab | Rename / Split / Close — nothing about the connection | **Edit connection…** (saved host) or **Save as Host…** (address dialled by hand) |
| Right-click a *background* SSH tab | — | Acts on that tab's connection, not on whichever pane is focused |
| Right-click a local or remote-workspace tab | Unchanged | Unchanged — neither has an SSH spec to open |

> 如果 SSH 主机名或密码错误，不能右键左侧边栏的 SSH 连接修改（修改麻烦）

The form-opening half (`save_ssh_spec_as_host`) is now shared by the palette, the failure strip and this menu, which reach it from three different pane identities.

## And a fix to the badge above

The strip drew the badge whenever the window was remote — including with the rail on screen carrying its own, so a remote workspace with the tab bar on the left showed it twice. It draws only when nothing else is: not with the rail up, and not on an empty workspace where the home screen has it.

Verified: rail up → badge only in the rail; tab bar on top → badge only in the strip; no tabs → badge only on the home screen.

---

## Also here: a connection being made says so

| | Before | After |
|---|---|---|
| Native SSH pane, connecting | A blank white rectangle. A host taking 20s to time out looked exactly like one that had connected and had nothing to print | Centred spinner and *Connecting to 10.255.255.1…* |
| The same pane once it fails | *Disconnected from … · connection timed out · Reconnect · Save as Host…* | Unchanged — the spinner hands over to it |
| While the password sheet is up | — | Nothing extra: `Authenticating` is that phase, and a second "working on it" behind a password dialog is noise |

The remote-workspace route has had this (spinner + machine name, `PendingPane`) all along. The pane route had the tab's dot and nothing else.

Verified against a black-holed address (`me@10.255.255.1`): spinner for the full connect timeout, then the disconnect strip with `connection timed out`.

---

## And: reach a connection's forwards from its own tab

Closes #439.

| | Before | After |
|---|---|---|
| Get to a connection's forwards | *SSH: Port Forwarding* in the palette, or find the Forwards section of the Info panel | Also **Port Forwarding…** in the tab's context menu, beside *Edit connection…* |
| Right-clicking a background SSH tab | — | Opens **that** tab's forwards |
| A local tab | Unchanged | Unchanged |

`show_ssh_forwards` and this share `open_forwards_for`, so the palette route and the menu route cannot land in different states.

---

## And: a client that attaches late is told the phase

| | Before | After |
|---|---|---|
| Restart the GUI with an SSH session up | The tab's dot came back **grey** ("nobody said") on a pane you could type into and get output back from | Green |
| A pane that never had a connection | No `SshStatus` replayed | Unchanged |

`replay_state` catches a new subscriber up on the cwd, the prompt, the remote context and the exit — the ssh phase was the one piece of pane state that was fire-and-forget. The daemon keeps the last phase per pane and records it **even with no client listening**, which is the case that matters: the phase a connection reached while nobody was attached is the one the next client needs.

Test: `attaching_late_is_told_the_phase_the_connection_reached` (tty7-core).
Manual: connect, `kill` the GUI process only, relaunch — session alive, prompt responsive, dot green.