### PR TITLE
Cover the whole window with the SSH password prompt's scrim, and name the machine in a failed reconnect

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -7292,10 +7292,14 @@ pub(crate) fn new_terminal(
         owner,
         font_size,
     };
+    // The same leak the reconnect banner had: this name is read out as
+    // "Connecting to {machine}…" and "Could not reach {machine}", and a
+    // `Profile` target spells itself as its config UUID (#485). The pane's own
+    // notifications already resolve it through the live config.
     let machine = spawn
         .workspace
         .as_ref()
-        .map(|w| w.target.to_string())
+        .map(|w| crate::ui::remote_connect::target_label(cx, &w.target))
         .unwrap_or_else(|| t(L10nKey::AppLocalServerName).to_string());
     let pending = cx.new(|cx| crate::ui::pending_pane::PendingPane::new(machine, spawn, cx));
     cx.subscribe_in(

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -6474,9 +6474,6 @@ impl Render for Tty7App {
             )
             .child(body)
             .when_some(self.pane_landing(window, cx), |this, el| this.child(el))
-            .when_some(self.render_ssh_prompt_overlay(window, cx), |this, el| {
-                this.child(el)
-            })
             .when_some(ssh_status, |this, el| this.child(el))
             .when_some(self.render_remote_workspace_strip(cx), |this, el| {
                 this.child(el)
@@ -6912,6 +6909,13 @@ impl Render for Tty7App {
                 // clipped to the terminal area, which read as "only the
                 // terminal is busy".
                 .when_some(self.render_worktree_prompt_overlay(cx), |this, el| {
+                    this.child(el)
+                })
+                // Same reason, and the ssh prompt has more claim to it than any
+                // of them: nothing in the window can proceed until the password
+                // is answered, so the scrim has to cover the whole window and
+                // not stop at the terminal area.
+                .when_some(self.render_ssh_prompt_overlay(window, cx), |this, el| {
                     this.child(el)
                 })
                 .children(self.render_switcher(window, cx))

--- a/src/ui/remote_workspace.rs
+++ b/src/ui/remote_workspace.rs
@@ -1773,7 +1773,11 @@ fn client_id_for(cx: &gpui::App, host: HostId, store_key: &str) -> Option<Worksp
 }
 
 fn launch_attempt(cx: &mut gpui::App, host: HostId, target: RemoteTarget) {
-    let label = target.to_string();
+    // Not `target.to_string()`: a `Profile` target spells itself as its config
+    // UUID, and this label is what the failure the strip shows names the
+    // machine (#485). The reconnect banner beside it already reads the live
+    // config for the same name, so the two disagreed mid-sentence.
+    let label = remote_connect::target_label(cx, &target);
     let header = match remote_connect::control_route(&target, cx) {
         Ok(header) => header,
         Err(e) => {
@@ -1833,7 +1837,7 @@ fn finish_attempt(
     target: &RemoteTarget,
     outcome: Result<(remote_connect::Connected, Vec<String>), String>,
 ) {
-    let label = target.to_string();
+    let label = remote_connect::target_label(cx, target);
     match outcome {
         Ok((connected, sent)) => {
             let restarted = server_restarted(cx, host, &connected.host);

--- a/src/ui/ssh_prompt.rs
+++ b/src/ui/ssh_prompt.rs
@@ -689,7 +689,11 @@ impl Tty7App {
                 .flex_col()
                 .items_center()
                 .justify_start()
-                .pt(px(48.))
+                // Window-level now, so the old 48px — measured from the top of
+                // the terminal area — would ride up under the title bar. The
+                // same drop the switcher, the palette and the worktree prompt
+                // take.
+                .pt(px(crate::ui::switcher::CARD_TOP))
                 .child(stack)
                 .into_any_element(),
         )


### PR DESCRIPTION
Two fixes to what an SSH connection shows while it is failing: the password prompt now dims the whole window, and a failed reconnect names the machine instead of a config UUID.

| | Before | After |
|---|---|---|
| Password prompt scrim | Stopped at the terminal area — the title bar and tab strip stayed lit, so the prompt read as "only the terminal is busy" | Covers the whole window, like the switcher, the command palette and the worktree prompt |
| Password prompt position | 48px below the top of the terminal area | 120px below the top of the window (`CARD_TOP`), aligned with the other window-level cards |
| Reconnect failure for a profile target | `Reconnecting to java-box… — last failure: could not reach 51d32f65-e669-496b-8f7d-e09cb4991cb6: Broken pipe` | `…could not reach java-box: Broken pipe` |
| Reconnect failure for a deleted profile | Bare UUID | The deleted-profile placeholder, never the UUID (#485) |

## Why

Both are the same class of bug — a detail that leaks out of the layer it belongs to.

The prompt was parented to `body_area`, which is the box below the title bar, so `inset_0` could never reach the chrome. The worktree prompt was hoisted to the window root for this exact reason and left a comment saying so; the SSH prompt was the one that got missed.

The label came from `RemoteTarget`'s `Display`, and `RemoteTarget::Profile` carries nothing but a config UUID — the human name lives in `Config::ssh_profiles`, which `tty7-core` cannot see. The strip's own half of the sentence resolves the name through the live config, so a single line named the same machine two different ways. `remote_connect::target_label` already does that resolution and was added for this in #485; the reconnect path just never called it.

## Testing

- `cargo build -p tty7`, `cargo fmt --check` clean.
- Both symptoms were reported from a manual run of an isolated dev instance (`--config-dir`), on a profile-backed host whose connection dropped mid-session. The fixed build has not been re-checked by hand yet.
- No new tests: both changes are render-tree placement and a call-site swap to a function that already has its own coverage.
