### PR TITLE
Restyle the in-app notification to sit in tty7's own visual language

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "gpui-component"
 version = "0.5.2"
-source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#e48db6d4eb49528958cb70983f9cde6478930a28"
+source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#00c9a7d3927f461ed35725a64b4eaac2a4ecd23b"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -3386,7 +3386,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-assets"
 version = "0.5.1"
-source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#e48db6d4eb49528958cb70983f9cde6478930a28"
+source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#00c9a7d3927f461ed35725a64b4eaac2a4ecd23b"
 dependencies = [
  "anyhow",
  "gpui",
@@ -3400,7 +3400,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-macros"
 version = "0.5.1"
-source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#e48db6d4eb49528958cb70983f9cde6478930a28"
+source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#00c9a7d3927f461ed35725a64b4eaac2a4ecd23b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "gpui-component"
 version = "0.5.2"
-source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#2264ff991da93bddfaa0780b5fc070d0ed0a36a5"
+source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#e48db6d4eb49528958cb70983f9cde6478930a28"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -3386,7 +3386,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-assets"
 version = "0.5.1"
-source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#2264ff991da93bddfaa0780b5fc070d0ed0a36a5"
+source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#e48db6d4eb49528958cb70983f9cde6478930a28"
 dependencies = [
  "anyhow",
  "gpui",
@@ -3400,7 +3400,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-macros"
 version = "0.5.1"
-source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#2264ff991da93bddfaa0780b5fc070d0ed0a36a5"
+source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#e48db6d4eb49528958cb70983f9cde6478930a28"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Restyles the in-app notification so it reads as something the OS put on screen rather than a web dialog bolted onto the UI. All the work is in the `gpui-component` fork; this PR is the lock bump that picks it up.

The settings page has no bordered, hard-shadowed box anywhere in it — lists group by whitespace, hierarchy comes from type size and grey. The notification was the one element still built like a Bootstrap alert.

## Layout

| | Before | After |
|---|---|---|
| Status icon | `absolute`, hardcoded `top: 18px`; text column reserved room with `pl_6` | Sibling in the row, in a box one `text_sm` line tall pinned to the top |
| Icon on a wrapped message | Stayed at 18px — visibly off the first line, and CJK wraps early | Centred on the first line at any line count |
| Close button | `absolute` at `top_1 right_1`, sitting on the corner radius | Sibling at the end of the row, mirroring the icon |
| Action button | `mr_3p5` to clear the absolutely positioned close button | No margin needed — the close button is a sibling now |

## Surface

| | Before | After |
|---|---|---|
| Border | 1px drawn border, both themes | Light: hairline shadow (1px spread, no blur). Dark: keeps the real border |
| Shadow | `shadow_md`, then `shadow_xl` | Two soft layers — wide and faint for the lift, tight to seat the edge |
| Radius | `radius_lg` (8px) | 12px |
| Padding | 14 / 16 | 16 / 18 |
| Width | 448px | 400px |

A dark theme keeps the drawn border on purpose: its surface sits close to the app behind it, and a black shadow on a dark ground is invisible, so nothing else would separate the two.

## Type

| | Before | After |
|---|---|---|
| Title | `text_sm` semibold | `text_sm` medium |
| Message under a title | `text_sm`, same ink as the title, no gap | 13px, muted, 4px below the title |
| Message with no title | `text_sm` | Unchanged — full size, full contrast |
| Status icon | 16px | 14px |

Colour alone is a weak rank: two runs at the same size on adjacent lines still read as one paragraph with the back half faded. Size is what says "this is the detail".

The no-title case is deliberately left alone — most tty7 call sites are `window.push_notification(text, cx)`, which sets only a message. There it *is* the text, and shrinking and greying the only thing on the card would be pure loss.

## Why the fork and not a wrapper here

`Notification` implements `Styled` and its render calls `refine_style`, so width, radius, shadow and padding *could* have been overridden from tty7. The layout could not: the icon's absolute positioning, the close button's placement, and the title/message type ranking are all internal. Doing half the change here and half there would have split one visual decision across two repos, and every one of ~30 call sites would have had to opt in.

## Also included

`e31b77b fix(list): make set_query run the search it promises` — unrelated, landed on the fork's `tty7` branch from another change while these commits were in flight.

## Testing

- `cargo check -p gpui-component` after each fork commit.
- `cargo test -p gpui-component notification` — 4 existing tests pass. They cover dismissal/id logic; none of this is layout, which has no assertions in this codebase.
- Manual: isolated dev instance (`--config-dir /tmp/t7v`), Settings → SSH → import from `~/.ssh/config`, which produces a success notification with both a title and a wrapped three-line message. Verified icon-to-first-line alignment, the close button clear of the radius, and the title/message ranking. Light theme only — the dark branch of the border/shadow split is unverified by eye.
- Every build was checked with `strings` against the linked `gpui-component` rev before launching, because 43 worktrees share this repo's `target/` and a stale `tty7-core` artifact from another worktree can make `cargo build` report `Finished` while silently linking old code.
