### PR TITLE
fix(new-tab): keep the SSH menu inside a menu's shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -309,7 +309,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2098,7 +2098,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2136,7 +2136,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.8.9",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -2388,7 +2388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "gpui-component"
 version = "0.5.2"
-source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#00c9a7d3927f461ed35725a64b4eaac2a4ecd23b"
+source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#809203d5f2519c29b7fd47b4cd6cd06d0005d1aa"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -3386,7 +3386,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-assets"
 version = "0.5.1"
-source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#00c9a7d3927f461ed35725a64b4eaac2a4ecd23b"
+source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#809203d5f2519c29b7fd47b4cd6cd06d0005d1aa"
 dependencies = [
  "anyhow",
  "gpui",
@@ -3400,7 +3400,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-macros"
 version = "0.5.1"
-source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#00c9a7d3927f461ed35725a64b4eaac2a4ecd23b"
+source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#809203d5f2519c29b7fd47b4cd6cd06d0005d1aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5196,7 +5196,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5252,7 +5252,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.20",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5475,7 +5475,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6894,7 +6894,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7605,7 +7605,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8383,7 +8383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8509,7 +8509,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8911,7 +8911,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9377,7 +9377,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.20",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9886,7 +9886,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10730,7 +10730,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -11481,7 +11481,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -309,7 +309,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2098,7 +2098,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2136,7 +2136,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -2388,7 +2388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5196,7 +5196,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5252,7 +5252,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5475,7 +5475,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6894,7 +6894,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7605,7 +7605,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8383,7 +8383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8509,7 +8509,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8911,7 +8911,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9377,7 +9377,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9886,7 +9886,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10730,7 +10730,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11481,7 +11481,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -1,7 +1,7 @@
 use gpui::{
     Animation, AnimationExt as _, AnyElement, App, Axis, Bounds, Context, FontWeight, MouseButton,
     MouseDownEvent, Pixels, SharedString, Window, canvas, deferred, div, ease_out_quint,
-    linear_color_stop, linear_gradient, prelude::*, px,
+    linear_color_stop, linear_gradient, prelude::*, px, relative,
 };
 use gpui_component::button::{Button, ButtonCustomVariant, ButtonVariants as _};
 use gpui_component::input::Input;
@@ -513,6 +513,19 @@ pub(crate) fn chrome_tile_sized(
 /// closes the section is where the rest are.
 const MENU_HOSTS: usize = 6;
 
+/// How wide the New Tab menu is allowed to get.
+const MENU_W: Pixels = px(360.);
+
+/// How tall, before it starts scrolling.
+///
+/// Enough for the menu's own full hand — the nine shells a stock macOS box
+/// reports, both headings, [`MENU_HOSTS`] hosts and the two rows that close the
+/// list, at the 26px a row occupies — so the shape everyone actually sees
+/// arrives whole. Past that (a pile of custom shells) it scrolls, and it is
+/// capped again against the window in [`NewTabMenu::build`], since a menu taller
+/// than what it hangs off is worse than one that scrolls.
+const MENU_H: Pixels = px(560.);
+
 /// What the row closing the SSH section types into the palette for you.
 ///
 /// Every saved host is a palette command titled `SSH: {name}`
@@ -557,14 +570,28 @@ struct NewTabMenu {
 }
 
 impl NewTabMenu {
-    fn build(&self, menu: PopupMenu) -> PopupMenu {
+    fn build(&self, menu: PopupMenu, window: &Window) -> PopupMenu {
+        // Whatever [`MENU_H`] asks for, a menu still has to fit the window it
+        // hangs off — on a short one the list gives way, not the window.
+        let ceiling = MENU_H.min(window.window_bounds().get_bounds().size.height * 0.8);
         let mut menu = menu
             .min_w(px(240.))
+            // A menu is a list of names, not a place to read a full address.
+            // Left to itself the panel widens to its longest row — one saved
+            // host with a descriptive name and a long `user@host` drags every
+            // other row out with it and the menu stops looking like chrome.
+            .max_w(MENU_W)
             // Shells are whatever this machine has plus whatever the user
             // added by hand, so the row count has no ceiling. Past the height
             // of the window an un-scrollable menu simply loses its last rows —
             // and the last rows here are the SSH section.
             .scrollable(true)
+            // Only the overflow case should scroll, and the default ceiling is
+            // too low to tell the two apart: a stock macOS box has nine shells,
+            // which with both headings, the hosts and the two closing rows
+            // already runs past `PopupMenu`'s built-in 450px. The menu would
+            // arrive scrolled on every machine, with `Local` cut off above.
+            .max_h(ceiling)
             .item(PopupMenuItem::label(t(L10nKey::TabMenuLocalShells)));
         for (label, spec) in &self.shells {
             let spec = spec.clone();
@@ -645,12 +672,13 @@ impl NewTabMenu {
         }));
 
         // The one place ⌥ is spelled out. Nothing else in the app teaches it,
-        // and a modifier nobody is told about is a feature nobody has.
-        menu.item(PopupMenuItem::separator())
-            .item(PopupMenuItem::label(t_fmt(
-                L10nKey::TabMenuSplitHint,
-                &[("key", split_modifier())],
-            )))
+        // and a modifier nobody is told about is a feature nobody has. No rule
+        // above it: a separator divides two lists of things to pick, and this
+        // is a footnote about the list it follows, not a section of its own.
+        menu.item(PopupMenuItem::label(t_fmt(
+            L10nKey::TabMenuSplitHint,
+            &[("key", split_modifier())],
+        )))
     }
 }
 
@@ -686,9 +714,13 @@ fn menu_hosts(
 
 /// A menu row that names a thing on the left and says what it is on the right.
 ///
-/// Both halves are cut rather than allowed to push: a menu is 500px wide at
-/// the most, and a descriptive host name next to a long `user@host:port` will
-/// ask for more than that. The name keeps whatever the endpoint leaves.
+/// Both halves are cut rather than allowed to push: the panel stops at
+/// [`MENU_W`], and a descriptive host name next to a long `user@host:port`
+/// asks for more than that. Which half gives way is the whole point — the name
+/// is what the reader is picking by, so the endpoint is capped at half the row
+/// and elides first, and the name takes everything left over. Sized the other
+/// way round (name growing from nothing, endpoint at its natural width) a long
+/// address squeezes the name down to `..` and the row names nothing at all.
 fn menu_row(label: SharedString, note: SharedString, cx: &gpui::App) -> impl IntoElement + use<> {
     h_flex()
         .w_full()
@@ -698,7 +730,8 @@ fn menu_row(label: SharedString, note: SharedString, cx: &gpui::App) -> impl Int
         .child(div().flex_1().min_w_0().truncate().child(label))
         .child(
             div()
-                .min_w_0()
+                .flex_shrink_0()
+                .max_w(relative(0.5))
                 .truncate()
                 .text_color(cx.theme().muted_foreground)
                 .child(note),
@@ -1235,11 +1268,13 @@ impl Tty7App {
             .tooltip(chord_hint(t(L10nKey::AppMenuNewTab), "NewTab", cx))
             // Built when the menu opens, not when the strip draws: this
             // closure runs once per press, and again after each dismissal.
-            .dropdown_menu(move |menu, _window, cx| {
+            .dropdown_menu(move |menu, window, cx| {
                 let Some(this) = app.upgrade() else {
                     return menu;
                 };
-                this.read(cx).new_tab_menu_rows(app.clone(), cx).build(menu)
+                this.read(cx)
+                    .new_tab_menu_rows(app.clone(), cx)
+                    .build(menu, window)
             })
     }
 

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -573,7 +573,15 @@ impl NewTabMenu {
     fn build(&self, menu: PopupMenu, window: &Window) -> PopupMenu {
         // Whatever [`MENU_H`] asks for, a menu still has to fit the window it
         // hangs off — on a short one the list gives way, not the window.
-        let ceiling = MENU_H.min(window.window_bounds().get_bounds().size.height * 0.8);
+        //
+        // Measured off the viewport, not `window_bounds()`: that one answers
+        // "how should this window be reopened after it is closed", so on macOS
+        // a fullscreen window reports the small bounds it would restore to,
+        // not the screen it currently fills. A terminal spends much of its
+        // life fullscreen, and reading that would cap the menu at 80% of a
+        // window nobody is looking at — putting back the scrollbar and the
+        // cut-off `Local` this whole change is here to remove.
+        let ceiling = MENU_H.min(window.viewport_size().height * 0.8);
         let mut menu = menu
             .min_w(px(240.))
             // A menu is a list of names, not a place to read a full address.
@@ -633,13 +641,14 @@ impl NewTabMenu {
         for (id, name, endpoint) in &self.hosts {
             let (id, name, endpoint) = (*id, name.clone(), endpoint.clone());
             let app = self.app.clone();
-            let row = if endpoint.is_empty() {
-                PopupMenuItem::new(name.clone())
-            } else {
-                PopupMenuItem::element(move |_window, cx| {
-                    menu_row(name.clone(), endpoint.clone(), cx)
-                })
-            };
+            // Every host row is a custom element, note or not: a plain item
+            // renders its label as bare text with nothing to elide against,
+            // and a host saved on its address alone is *named* `user@host:port`
+            // — the longest string in the menu, on the row least able to cut
+            // it. [`menu_row`] drops the right half when there is no note.
+            let row = PopupMenuItem::element(move |_window, cx| {
+                menu_row(name.clone(), endpoint.clone(), cx)
+            });
             menu = menu.item(row.on_click(move |_, window, cx| {
                 let at = SpawnWhere::from_modifiers(window.modifiers());
                 if let Some(app) = app.upgrade() {
@@ -721,21 +730,28 @@ fn menu_hosts(
 /// and elides first, and the name takes everything left over. Sized the other
 /// way round (name growing from nothing, endpoint at its natural width) a long
 /// address squeezes the name down to `..` and the row names nothing at all.
+///
+/// An empty note drops the right half entirely rather than leaving a zero-width
+/// child to hold the `gap_3` open — the name is then free to use the full row,
+/// still eliding at the panel edge.
 fn menu_row(label: SharedString, note: SharedString, cx: &gpui::App) -> impl IntoElement + use<> {
+    let muted = cx.theme().muted_foreground;
     h_flex()
         .w_full()
         .items_center()
         .justify_between()
         .gap_3()
         .child(div().flex_1().min_w_0().truncate().child(label))
-        .child(
-            div()
-                .flex_shrink_0()
-                .max_w(relative(0.5))
-                .truncate()
-                .text_color(cx.theme().muted_foreground)
-                .child(note),
-        )
+        .when(!note.is_empty(), |this| {
+            this.child(
+                div()
+                    .flex_shrink_0()
+                    .max_w(relative(0.5))
+                    .truncate()
+                    .text_color(muted)
+                    .child(note),
+            )
+        })
 }
 
 /// The words behind the status dot's colour.


### PR DESCRIPTION
Follow-up to #647: the saved-SSH-hosts section outgrew the shape a menu is supposed to have. Four fixes here, plus the `gpui-component` bump that three of them needed.

| | Before | After |
|---|---|---|
| A long host name / endpoint | Widens the panel to `PopupMenu`'s 500px fallback, dragging every other row out with it | Panel stops at 360px |
| A row too long for the panel | Clipped mid glyph at the panel edge — `truncate()` never fired | Elides with `…` |
| Which half gives way | The name, squeezed to `..`, while the endpoint kept its natural width | The endpoint, capped at half the row; the name takes the rest |
| A host saved on its address alone | Named `user@host:port` with no note, so it took the plain-item path — bare text, nothing to elide against | A custom row like every other host; `menu_row` drops its right half when the note is empty |
| Default menu on a stock macOS box | Arrives scrolled, `Local` cut off above — nine shells + two headings + six hosts + two closing rows run past the built-in 450px ceiling | Arrives whole; ceiling is 560px, and capped again at 80% of the viewport |
| Scrollbar on a menu that fits | Always painted | Only when the menu really is too tall |
| Above `Hold ⌥ to split` | A separator | Nothing |

## Why the scrollbar was always there

Not "the content overflowed". `PopupMenu` put its 5px inset on the scrolling box itself, and a scroll container's padding counts towards its scrollable content but not towards its viewport. So the content measured exactly 10px taller than the container no matter how few items were in it, and `Scrollbar`'s `if scroll_area_size <= container_size { skip }` was never true:

```
scroll_area=532px  container=522px   ← this menu, 10px = its own p(5.)
scroll_area=782px  container=782px   ← a list with no padding, correctly skipped
```

This was not specific to the New Tab menu — **every scrollable `PopupMenu` in the app was painting a bar it didn't need**. Fixed upstream in the fork by moving the vertical half of the inset outside the scrolling box, which leaves the two measurements agreeing. Total inset is unchanged, so nothing moves visually.

## Why the ceiling is measured off the viewport

`window.window_bounds()` answers "how should this window be reopened after it is closed", not "how big is it now": on macOS a fullscreen window reports `Fullscreen(fullscreen_restore_bounds)` — the small window it would restore to. A terminal spends much of its life fullscreen, and capping the menu at 80% of *that* would put the scrollbar and the cut-off `Local` straight back. `viewport_size()` is the current content box, and is what every other window-relative size in the app (`switcher`, `tab_sidebar`, `right_panel`, `settings`, `scm::graph`) already measures against.

## gpui-component bump

`00c9a7d` → `809203d` ([l0ng-ai/gpui-component@809203d](https://github.com/l0ng-ai/gpui-component/commit/809203d5f2519c29b7fd47b4cd6cd06d0005d1aa)), three fixes in `PopupMenu`:

- **Scrollbar on menus that fit** — the padding/viewport mismatch above.
- **Custom rows could not elide** — `PopupMenuItem::ElementItem` wrapped the row in a flex child at its automatic minimum (the width of its own content), so a row built to truncate grew past the panel's `max_w` and got clipped instead. `min_w_0()` lets it shrink.
- **Labels had no padding of their own** — a label carries no `item_height` the way a row does, so it is only as tall as its text and sat flush against the panel edge when it was the last item.

`Cargo.lock` moves only the three `source` lines that bump asks for; `cargo check --locked` accepts it.

## Testing

- `cargo test -p tty7 --bin tty7-app` — 1542 passed, 0 failed.
- `cargo fmt --check`, `cargo check --locked -p tty7` — clean.
- Manual, in an isolated dev instance (`--config-dir /tmp/t7dev`) seeded with 14 synthetic SSH profiles covering the edge cases: a name and endpoint both long enough to overflow, a profile with no name of its own, a profile whose name equals its host, and enough hosts to exceed `MENU_HOSTS`. Checked the New Tab menu on the tab strip at each step — truncation, which half elides, the panel width, the absence of a scrollbar, and top/bottom padding symmetry.
