### PR TITLE
fix(daemon): keep a lingering daemon findable and reapable after quit-and-stop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9862,6 +9862,7 @@ dependencies = [
 name = "tty7-server"
 version = "26.8.3"
 dependencies = [
+ "libc",
  "tempfile",
  "tty7-core",
 ]

--- a/crates/tty7-core/src/daemon/server.rs
+++ b/crates/tty7-core/src/daemon/server.rs
@@ -633,7 +633,7 @@ fn serve_sigterm(registry: Arc<Registry>) {
                 store_scrollback_now(&registry);
                 registry.drain_and_kill();
                 on_shutdown();
-                std::process::exit(0);
+                exit_now();
             }
         })
         .ok();
@@ -646,7 +646,32 @@ fn on_shutdown() {
     transport::remove_stale_endpoint();
     #[cfg(windows)]
     crate::host::server::remove_control_endpoint();
-    crate::daemon::pidfile::remove();
+    // The pidfile stays. Once the endpoint above is unlinked it is the only
+    // name anything has for this process, and the process is not gone yet —
+    // a stalled exit after this point used to leave a daemon holding the
+    // singleton lock with no pidfile, which `spawn::stop` and
+    // `ensure_running` could then never find or reap: every later launch
+    // stood down against a server serving nobody (#653). A pidfile that
+    // outlives a clean exit is already handled — `recorded_daemon_is_dead`
+    // reads a dead pid as stale, and `reap_recorded_daemon` deletes the file
+    // once the process is confirmed gone.
+}
+
+/// Ends the daemon immediately, skipping libc `exit`'s atexit handlers and
+/// static destructors. Those run while this process's other threads — the
+/// accept loop, the control listeners — are still live, and a finalizer that
+/// blocks on anything one of them holds never returns: the daemon then
+/// lingers with its endpoint already unlinked but the singleton lock still
+/// held (#653). Everything that must reach disk is flushed explicitly in
+/// `on_shutdown`, so nothing is owed to the handlers being skipped.
+fn exit_now() -> ! {
+    log::logger().flush();
+    #[cfg(unix)]
+    unsafe {
+        libc::_exit(0)
+    }
+    #[cfg(not(unix))]
+    std::process::exit(0)
 }
 
 fn handle_conn(stream: Stream, registry: Arc<Registry>) -> anyhow::Result<()> {
@@ -804,7 +829,7 @@ fn handle_conn(stream: Stream, registry: Arc<Registry>) -> anyhow::Result<()> {
                 std::time::Duration::from_secs(3),
             );
             on_shutdown();
-            std::process::exit(0);
+            exit_now();
         }
 
         ClientMsg::Kill { pane_id } => {

--- a/crates/tty7-core/src/daemon/spawn.rs
+++ b/crates/tty7-core/src/daemon/spawn.rs
@@ -480,10 +480,12 @@ pub fn hand_off() -> anyhow::Result<()> {
 pub fn stop() {
     use std::io::Write as _;
 
-    // Read the pid before asking the daemon to die: a clean shutdown removes
-    // the pidfile, and the endpoint disappearing is not the same event as the
-    // process releasing its image — the gap between them is exactly where an
-    // installer starts replacing files that are still locked.
+    // Read the pid before asking the daemon to die: the endpoint disappearing
+    // is not the same event as the process releasing its image — the gap
+    // between them is exactly where an installer starts replacing files that
+    // are still locked — and an old build's shutdown still deletes the pidfile
+    // before the process is gone, so this is the last moment the pid is
+    // guaranteed readable.
     let recorded = pidfile::read().filter(|&pid| pid > 4 && pid != std::process::id());
 
     if let Ok(mut stream) = transport::connect() {

--- a/crates/tty7-core/src/daemon/spawn.rs
+++ b/crates/tty7-core/src/daemon/spawn.rs
@@ -273,7 +273,7 @@ pub fn ensure_running() -> anyhow::Result<()> {
     }
 
     if stale {
-        reap_recorded_daemon();
+        reap_recorded_daemon(None);
 
         if transport::endpoint_exists() {
             transport::remove_stale_endpoint();
@@ -502,7 +502,13 @@ pub fn stop() {
         log::warn!("daemon pid {pid} released its endpoint but has not exited yet");
     }
 
-    reap_recorded_daemon();
+    // With the pid read at the top, not from the pidfile: a shutdown that got
+    // as far as its cleanup deleted nothing we rely on here, but a build that
+    // still removes the pidfile mid-shutdown — or one whose exit stalled after
+    // the cleanup — would otherwise leave the reap with no pid to act on, and
+    // the survivor holding the singleton lock against every later launch
+    // (#653).
+    reap_recorded_daemon(recorded);
 
     if transport::endpoint_exists() {
         transport::remove_stale_endpoint();
@@ -534,16 +540,25 @@ fn wait_for_recorded_exit(_pid: u32, _timeout: Duration) -> bool {
     true
 }
 
+/// `recorded` is a pid the caller captured before asking the daemon to die;
+/// the pidfile is only the fallback, because a shutdown that stalled after its
+/// cleanup may have already deleted it.
 #[cfg(any(target_os = "macos", target_os = "linux"))]
-fn reap_recorded_daemon() {
-    let Some(pid) = pidfile::read() else { return };
+fn reap_recorded_daemon(recorded: Option<u32>) {
+    let Some(pid) = recorded.or_else(pidfile::read) else {
+        return;
+    };
     if pid <= 1 || pid == std::process::id() {
         pidfile::remove();
         return;
     }
     if process_matches_daemon_exe(pid as libc::pid_t) {
         log::warn!("reaping unreachable daemon (pid {pid}); its sessions will be hung up");
-        reap_process(pid as libc::pid_t);
+        if !reap_process(pid as libc::pid_t) {
+            // The pid is the only handle left on the survivor; keep the file
+            // so the next attempt still has someone to reap.
+            return;
+        }
     }
     pidfile::remove();
 }
@@ -555,14 +570,17 @@ fn process_matches_daemon_exe(pid: libc::pid_t) -> bool {
         .is_some_and(|name| is_reapable_daemon_name(&name))
 }
 
+/// Whether the process is gone by the end.
 #[cfg(any(target_os = "macos", target_os = "linux"))]
-fn reap_process(pid: libc::pid_t) {
+fn reap_process(pid: libc::pid_t) -> bool {
     if signal_and_await_exit(pid, libc::SIGTERM, REAP_TERM_TIMEOUT) {
-        return;
+        return true;
     }
-    if !signal_and_await_exit(pid, libc::SIGKILL, REAP_KILL_TIMEOUT) {
-        log::error!("daemon pid {pid} survived SIGKILL; leaving it behind");
+    if signal_and_await_exit(pid, libc::SIGKILL, REAP_KILL_TIMEOUT) {
+        return true;
     }
+    log::error!("daemon pid {pid} survived SIGKILL; leaving it behind");
+    false
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -577,10 +595,12 @@ fn process_alive(pid: libc::pid_t) -> bool {
 }
 
 #[cfg(windows)]
-fn reap_recorded_daemon() {
+fn reap_recorded_daemon(recorded: Option<u32>) {
     use crate::daemon::winproc;
 
-    let Some(pid) = pidfile::read() else { return };
+    let Some(pid) = recorded.or_else(pidfile::read) else {
+        return;
+    };
     if pid <= 4 || pid == std::process::id() {
         pidfile::remove();
         return;
@@ -691,7 +711,7 @@ fn wait_until_images_unlocked(dir: &Path, deadline: Instant) -> Result<(), Strin
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
-fn reap_recorded_daemon() {}
+fn reap_recorded_daemon(_recorded: Option<u32>) {}
 
 fn spawn_detached() -> anyhow::Result<()> {
     let exe = std::env::current_exe()

--- a/crates/tty7-server/Cargo.toml
+++ b/crates/tty7-server/Cargo.toml
@@ -26,5 +26,9 @@ tty7-core = { path = "../tty7-core" }
 # Sandboxes for the suite: an empty directory per case, removed on drop. The
 # server is on this machine, so a local temp dir is a path in its namespace.
 tempfile = "3"
+# `tests/daemon_stop.rs` probes and, on failure, kills the daemon it spawned;
+# a pid needs `kill(2)`, which `Child` cannot express once ownership has moved
+# to the thread collecting the exit.
+libc = "0.2"
 [lints]
 workspace = true

--- a/crates/tty7-server/tests/daemon_stop.rs
+++ b/crates/tty7-server/tests/daemon_stop.rs
@@ -125,17 +125,31 @@ fn stop_reaps_a_lingering_daemon_even_after_the_pidfile_vanishes() {
 
     // The #653 state, as stop() meets it: the endpoint is gone before stop()
     // can ask for a shutdown, and the pidfile disappears while stop() is
-    // still waiting on the process.
+    // still waiting on the process. The delete must land inside stop()'s
+    // wait on the still-alive process (PROCESS_EXIT_TIMEOUT in spawn.rs),
+    // which the elapsed assertion below pins.
+    const SWEEP_DELAY: Duration = Duration::from_secs(1);
     std::fs::remove_file(dir.path().join("daemon.sock")).unwrap();
     let pidfile = dir.path().join("daemon.pid");
     let sweeper = std::thread::spawn(move || {
-        std::thread::sleep(Duration::from_secs(1));
-        let _ = std::fs::remove_file(pidfile);
+        std::thread::sleep(SWEEP_DELAY);
+        std::fs::remove_file(pidfile).is_ok()
     });
 
+    let stop_started = Instant::now();
     tty7_core::daemon::spawn::stop();
 
-    sweeper.join().unwrap();
+    assert!(
+        stop_started.elapsed() >= SWEEP_DELAY,
+        "stop() returned before the sweeper's delete — the mid-stop pidfile \
+         removal this test exists to exercise never happened; lower SWEEP_DELAY \
+         below spawn.rs's PROCESS_EXIT_TIMEOUT"
+    );
+    assert!(
+        sweeper.join().unwrap(),
+        "the sweeper found no pidfile to delete — stop() removed it early, so \
+         the vanishing-pidfile ordering was not exercised"
+    );
     let deadline = Instant::now() + Duration::from_secs(2);
     while unsafe { libc::kill(pid as libc::pid_t, 0) } == 0 {
         if Instant::now() >= deadline {

--- a/crates/tty7-server/tests/daemon_stop.rs
+++ b/crates/tty7-server/tests/daemon_stop.rs
@@ -1,0 +1,151 @@
+//! Guards for #653: a daemon that lingers after unlinking its endpoint must
+//! stay findable and reapable, or its singleton lock makes every later launch
+//! stand down and time out red with no way back short of `pkill`.
+//!
+//! Unix-only: both tests drive the daemon through unix sockets and signals.
+
+#![cfg(unix)]
+
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use tty7_core::client::PaneClient;
+use tty7_core::daemon::protocol::ClientMsg;
+
+const READY_WITHIN: Duration = Duration::from_secs(30);
+const EXIT_WITHIN: Duration = Duration::from_secs(10);
+
+fn spawn_daemon(dir: &Path) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_tty7-server"))
+        .arg("--daemon")
+        .arg("--config-dir")
+        .arg(dir)
+        .env("TTY7_DATA_DIR", dir)
+        .env("TTY7_CONTROL_SOCK", dir.join("control.sock"))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("start tty7-server --daemon")
+}
+
+fn await_ready(dir: &Path) {
+    let endpoint = dir.join("daemon.sock");
+    let deadline = Instant::now() + READY_WITHIN;
+    while PaneClient::at(&endpoint).version().is_err() || !dir.join("daemon.pid").exists() {
+        assert!(
+            Instant::now() < deadline,
+            "tty7-server did not open its endpoint within {READY_WITHIN:?}"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn send_shutdown(endpoint: &Path) {
+    use std::io::Write as _;
+    let mut stream =
+        std::os::unix::net::UnixStream::connect(endpoint).expect("connect to the daemon");
+    ClientMsg::Shutdown
+        .encode(&mut stream)
+        .expect("send Shutdown");
+    stream.flush().expect("flush Shutdown");
+}
+
+fn await_exit(child: &mut Child) -> std::process::ExitStatus {
+    let deadline = Instant::now() + EXIT_WITHIN;
+    loop {
+        if let Some(status) = child.try_wait().expect("query the daemon's state") {
+            return status;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("the daemon did not exit within {EXIT_WITHIN:?} of Shutdown");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// The pidfile must outlive the daemon's own cleanup: once `daemon.sock` is
+/// unlinked it is the only name anything has for the process, and an exit
+/// that stalls after the cleanup (#653) is findable through it — deleting it
+/// there is what turned a lingering process into a permanent lockout.
+#[test]
+fn a_clean_shutdown_keeps_the_pidfile_until_the_process_is_gone() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let mut child = spawn_daemon(dir.path());
+    await_ready(dir.path());
+    let pid = child.id().to_string();
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("daemon.pid"))
+            .unwrap()
+            .trim(),
+        pid,
+        "the pidfile names the running daemon"
+    );
+
+    send_shutdown(&dir.path().join("daemon.sock"));
+    let status = await_exit(&mut child);
+
+    assert!(status.success(), "clean shutdown exits cleanly: {status:?}");
+    assert!(
+        !dir.path().join("daemon.sock").exists(),
+        "shutdown unlinks the endpoint"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("daemon.pid"))
+            .unwrap()
+            .trim(),
+        pid,
+        "the pidfile survives the daemon's cleanup; the reap in spawn::stop \
+         and ensure_running deletes it once the process is confirmed gone"
+    );
+}
+
+/// `spawn::stop` must reap a daemon that stopped listening but never exited,
+/// even when the pidfile vanishes under it mid-stop — the ordering an old
+/// build's shutdown produces when it wipes its files and then stalls (#653).
+/// The pid captured at the top of `stop` is what the reap has to act on.
+#[test]
+fn stop_reaps_a_lingering_daemon_even_after_the_pidfile_vanishes() {
+    let dir = tempfile::TempDir::new().unwrap();
+    tty7_core::core::config::set_config_dir(dir.path().to_path_buf());
+    let child = spawn_daemon(dir.path());
+    let pid = child.id();
+    await_ready(dir.path());
+
+    // Collect the child the moment it dies: outside tests the daemon is
+    // nobody's child, and a zombie would read as alive to the reap's
+    // liveness poll.
+    let waiter = std::thread::spawn(move || {
+        let mut child = child;
+        child.wait()
+    });
+
+    // The #653 state, as stop() meets it: the endpoint is gone before stop()
+    // can ask for a shutdown, and the pidfile disappears while stop() is
+    // still waiting on the process.
+    std::fs::remove_file(dir.path().join("daemon.sock")).unwrap();
+    let pidfile = dir.path().join("daemon.pid");
+    let sweeper = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_secs(1));
+        let _ = std::fs::remove_file(pidfile);
+    });
+
+    tty7_core::daemon::spawn::stop();
+
+    sweeper.join().unwrap();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while unsafe { libc::kill(pid as libc::pid_t, 0) } == 0 {
+        if Instant::now() >= deadline {
+            unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+            panic!("stop() left the daemon (pid {pid}) holding the singleton lock");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    waiter
+        .join()
+        .unwrap()
+        .expect("collect the reaped daemon's exit");
+}


### PR DESCRIPTION
Makes a daemon that lingers after "Quit and Stop" findable and reapable, instead of permanently locking out every later launch with `daemon did not start listening ... within 3s`.

Fixes #653.

| | Before | After |
|---|---|---|
| Daemon's shutdown cleanup | Unlinks `daemon.sock` **and deletes `daemon.pid`**, then runs libc `exit()` | Unlinks `daemon.sock`, keeps `daemon.pid`, exits via `_exit(2)` |
| Daemon whose exit stalls after cleanup | Invisible: holds the singleton lock with no name on disk; every new daemon stands down, GUI shows the 3s red error forever | Named by the surviving pidfile; the next `stop()`/`ensure_running` reaps it (SIGTERM → SIGKILL) and a fresh daemon starts |
| `spawn::stop()` when the process outlives its endpoint | Logs a warning, then re-reads the pidfile the shutdown just deleted — reaps nothing | Reaps with the pid it captured before asking the daemon to die (also covers an old-build daemon that still wipes its pidfile mid-stop) |
| Process that survives even SIGKILL | Pidfile deleted anyway — no handle left | Pidfile kept so the next attempt still has someone to reap |

## Why

`std::process::exit(0)` runs atexit handlers and static destructors beside dozens of still-live threads (accept loop, control listeners). A finalizer that blocks on anything one of them holds never returns — leaving a process that answers `tty7 server status` on `control.sock`, holds an fd on the already-unlinked `daemon.sock`, and holds the `daemon.lock` flock. With the pidfile gone, nothing could find it: every launch spawned a daemon that saw `Claim::Taken`, exited silently, and the GUI timed out red. Only `pkill` recovered.

The recovery machinery already existed and worked — reproduced locally: the same zombie state heals in ~100ms once a pidfile names the process. The shutdown ordering was simply deleting that name before the process was actually gone. Everything owed to disk is flushed explicitly in `on_shutdown`, so `_exit(2)` skips nothing that matters.

```mermaid
sequenceDiagram
    participant GUI as GUI (quit-and-stop)
    participant D as daemon
    participant N as next launch
    GUI->>D: Shutdown
    D->>D: store scrollback, drain panes
    D->>D: unlink daemon.sock (pidfile now kept)
    D--xD: exit stalls (atexit) — before: process lost
    Note over D: after: _exit(2), no atexit window
    GUI->>D: reap by pid captured at stop() entry
    N->>D: ensure_running: pidfile names survivor → reap
    N->>N: fresh daemon binds, window opens
```

## Testing

- New `crates/tty7-server/tests/daemon_stop.rs` against a real `tty7-server --daemon`:
  - `a_clean_shutdown_keeps_the_pidfile_until_the_process_is_gone` — pins that the daemon's own cleanup no longer deletes the pidfile.
  - `stop_reaps_a_lingering_daemon_even_after_the_pidfile_vanishes` — endpoint gone, pidfile swept away mid-`stop()` (the old build's ordering); `stop()` must still reap via the captured pid.
  - Red/green verified: both tests fail against the previous implementation, pass with this one.
- Full `tty7-server` suite (12 test binaries) and `tty7-core` daemon unit tests (592) pass; `rustfmt` clean; `tty7` (GUI) and `tty7-cli` compile.
- Issue state reproduced end-to-end beforehand in an isolated config dir: daemon alive with unlinked socket + held lock + no pidfile → exact `within 3s` error on every retry; restoring only the pidfile healed it in ~100ms, which is the path this PR guarantees.

`libc` is added to `tty7-server` as a **dev-dependency** only (the test kills the daemon it spawned by pid); `[dependencies]` still contains only `tty7-core`.
