### PR TITLE
feat(sftp): open remote text files in the built-in editor

### DIFF
--- a/crates/tty7-core/src/daemon/protocol.rs
+++ b/crates/tty7-core/src/daemon/protocol.rs
@@ -347,9 +347,11 @@ pub enum SftpOpResult {
     Stat(SftpEntry),
     Link(String),
     Error(String),
-    /// Reply to [`SftpOp::ReadFile`]: the bytes plus the stat they were read
-    /// under, in one round trip — the editor needs the mtime alongside the
-    /// body to notice later external changes.
+    /// Reply to [`SftpOp::ReadFile`]: the bytes, plus the stat they were
+    /// actually read under. The stat costs nothing — the size check before
+    /// the read has it in hand either way — and it is the only description of
+    /// the body that cannot disagree with it, which a separate `Stat` round
+    /// trip either side of the read can.
     File {
         entry: SftpEntry,
         #[serde(with = "crate::host::b64")]

--- a/crates/tty7-core/src/daemon/protocol.rs
+++ b/crates/tty7-core/src/daemon/protocol.rs
@@ -294,15 +294,50 @@ pub struct SftpEntry {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum SftpOp {
-    Stat { path: String },
-    Mkdir { path: String },
-    CreateFile { path: String },
-    RemoveFile { path: String },
-    RemoveDir { path: String },
-    Rename { from: String, to: String },
-    Chmod { path: String, mode: u32 },
-    Readlink { path: String },
-    Realpath { path: String },
+    Stat {
+        path: String,
+    },
+    Mkdir {
+        path: String,
+    },
+    CreateFile {
+        path: String,
+    },
+    RemoveFile {
+        path: String,
+    },
+    RemoveDir {
+        path: String,
+    },
+    Rename {
+        from: String,
+        to: String,
+    },
+    Chmod {
+        path: String,
+        mode: u32,
+    },
+    Readlink {
+        path: String,
+    },
+    Realpath {
+        path: String,
+    },
+    /// Whole-file read, for the built-in editor. `max_bytes` is the reader's
+    /// own ceiling; a file larger than it answers with an error instead of a
+    /// truncated body that would later be saved back short.
+    ReadFile {
+        path: String,
+        max_bytes: u64,
+    },
+    /// Whole-file write, in place (truncate + write, no temp-and-rename): the
+    /// editor saves over a file the user already has open, and replacing the
+    /// inode would silently drop its mode and ownership.
+    WriteFile {
+        path: String,
+        #[serde(with = "crate::host::b64")]
+        bytes: Vec<u8>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -312,6 +347,14 @@ pub enum SftpOpResult {
     Stat(SftpEntry),
     Link(String),
     Error(String),
+    /// Reply to [`SftpOp::ReadFile`]: the bytes plus the stat they were read
+    /// under, in one round trip — the editor needs the mtime alongside the
+    /// body to notice later external changes.
+    File {
+        entry: SftpEntry,
+        #[serde(with = "crate::host::b64")]
+        bytes: Vec<u8>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1572,6 +1615,20 @@ mod tests {
                 pane_id: 4,
                 op: SftpOp::Realpath { path: ".".into() },
             },
+            ClientMsg::SftpOp {
+                pane_id: 4,
+                op: SftpOp::ReadFile {
+                    path: "/etc/nginx/nginx.conf".into(),
+                    max_bytes: 4 * 1024 * 1024,
+                },
+            },
+            ClientMsg::SftpOp {
+                pane_id: 4,
+                op: SftpOp::WriteFile {
+                    path: "/home/deploy/笔记.md".into(),
+                    bytes: vec![0x00, 0xff, b'h', b'i'],
+                },
+            },
             ClientMsg::SftpTransferStart(SftpTransferSpec {
                 pane_id: 4,
                 kind: SftpTransferKind::Upload,
@@ -1741,6 +1798,17 @@ mod tests {
                 permissions: 0o100644,
                 target_is_dir: false,
             })),
+            DaemonMsg::SftpOpResult(SftpOpResult::File {
+                entry: SftpEntry {
+                    name: "nginx.conf".into(),
+                    kind: SftpEntryKind::File,
+                    size: 4,
+                    mtime: 1_700_000_000,
+                    permissions: 0o100644,
+                    target_is_dir: false,
+                },
+                bytes: vec![0x00, 0xff, 0x80, b'!'],
+            }),
             DaemonMsg::SftpTransferStarted { job_id: 3 },
             DaemonMsg::SftpTransferProgress(vec![SftpJobProgress {
                 job_id: 3,

--- a/crates/tty7-core/src/daemon/ssh/sftp.rs
+++ b/crates/tty7-core/src/daemon/ssh/sftp.rs
@@ -531,6 +531,68 @@ async fn run_op(sftp: &SftpSession, op: &SftpOp) -> Result<SftpOpResult, String>
                 .map_err(|e| format!("{e}"))?;
             SftpOpResult::Link(resolved)
         }
+        SftpOp::ReadFile { path, max_bytes } => {
+            let attrs = sftp
+                .metadata(path.clone())
+                .await
+                .map_err(|e| format!("{e}"))?;
+            if attrs.is_dir() {
+                return Err("is a directory".to_string());
+            }
+            // Checked before the read, not after: a body clipped at the limit
+            // would round-trip through the editor and be saved back short.
+            let size = attrs.size.unwrap_or(0);
+            if size > *max_bytes {
+                return Err(format!(
+                    "file is {size} bytes, larger than the {max_bytes}-byte limit"
+                ));
+            }
+            let mut file = sftp.open(path.clone()).await.map_err(|e| format!("{e}"))?;
+            let mut bytes = Vec::with_capacity(size.min(*max_bytes) as usize);
+            let mut buf = vec![0u8; CHUNK];
+            loop {
+                let n = file.read(&mut buf).await.map_err(|e| format!("{e}"))?;
+                if n == 0 {
+                    break;
+                }
+                bytes.extend_from_slice(&buf[..n]);
+                // The size the stat reported is a moment old; the file may
+                // have grown since. The limit holds either way.
+                if bytes.len() as u64 > *max_bytes {
+                    return Err(format!(
+                        "file grew past the {max_bytes}-byte limit mid-read"
+                    ));
+                }
+            }
+            SftpOpResult::File {
+                entry: entry_from_attrs(&remote_basename(path), &attrs),
+                bytes,
+            }
+        }
+        SftpOp::WriteFile { path, bytes } => {
+            // In place on purpose — truncate and rewrite the same inode. The
+            // temp-and-rename dance the transfer path does would hand the file
+            // fresh default permissions and ownership, and this op overwrites
+            // a file the user just had open in the editor, so its identity is
+            // worth more than crash-atomicity here.
+            let flags = OpenFlags::WRITE | OpenFlags::CREATE | OpenFlags::TRUNCATE;
+            let mut file = sftp
+                .open_with_flags(path.clone(), flags)
+                .await
+                .map_err(|e| format!("{e}"))?;
+            for chunk in bytes.chunks(CHUNK) {
+                file.write_all(chunk).await.map_err(|e| format!("{e}"))?;
+            }
+            file.flush().await.map_err(|e| format!("{e}"))?;
+            file.shutdown().await.map_err(|e| format!("{e}"))?;
+            // The fresh stat is the editor's baseline for spotting external
+            // changes; without it every save would read as a conflict.
+            let attrs = sftp
+                .metadata(path.clone())
+                .await
+                .map_err(|e| format!("written, but stat after failed: {e}"))?;
+            SftpOpResult::Stat(entry_from_attrs(&remote_basename(path), &attrs))
+        }
     })
 }
 

--- a/docs/remote/sftp.mdx
+++ b/docs/remote/sftp.mdx
@@ -33,7 +33,7 @@ for those.
 
 | Direction | How |
 |---|---|
-| Download | Right-click → **Download**, or drag a file out of the panel into Finder or Explorer |
+| Download | Right-click → **Download** |
 | Upload | **Upload…**, or drag files into the panel |
 
 Uploads are written under a temporary name and renamed into place at the end, so

--- a/docs/remote/sftp.mdx
+++ b/docs/remote/sftp.mdx
@@ -17,15 +17,23 @@ The panel opens on the remote home directory. **Go to Shell Directory** in the
 overflow menu jumps it to wherever the pane's shell currently is, which is
 usually where you actually want to be.
 
-Right-click a row for **Open**, **Follow Symlink**, **Rename**, **chmod…**, and
-delete. The overflow menu adds **New Folder**, **New File**, **Upload…**, and
-**Refresh**.
+Right-click a row for **Edit** (**Open** on a directory), **Download**,
+**Follow Symlink**, **Rename**, **chmod…**, and delete. The overflow menu adds
+**New Folder**, **New File**, **Upload…**, and **Refresh**.
+
+## Editing
+
+Click a text file and it opens in the [built-in
+editor](/window/side-panel), the same gesture as the local file tree; saving
+writes straight back over the same connection. Files the editor cannot hold —
+binary, or over its 4 MB limit — say so instead; right-click → **Download**
+for those.
 
 ## Transferring
 
 | Direction | How |
 |---|---|
-| Download | Drag a file out of the panel into Finder or Explorer |
+| Download | Right-click → **Download**, or drag a file out of the panel into Finder or Explorer |
 | Upload | **Upload…**, or drag files into the panel |
 
 Uploads are written under a temporary name and renamed into place at the end, so

--- a/src/terminal/git_data.rs
+++ b/src/terminal/git_data.rs
@@ -885,7 +885,11 @@ impl Tty7App {
             return None;
         }
         let open = code.active_file()?;
-        let host = self.spawn_host(cx);
+        // The file's host, not the window's. They are the same for everything
+        // the tree can open, but a buffer read over SFTP carries a path from
+        // another machine, and pairing it with this one's host would resolve
+        // it against a local repository that merely shares the path.
+        let host = open.host.id();
         let root = cx
             .try_global::<crate::terminal::git_status::GitStatusCache>()?
             .repo_root_for(host, open.path.parent()?)?;

--- a/src/ui/code_editor.rs
+++ b/src/ui/code_editor.rs
@@ -14,7 +14,8 @@ use gpui_component::{
 };
 
 use crate::ui::app::Tty7App;
-use crate::ui::host_ops::{HostOps, MTime, SharedHost, WatchSub};
+use crate::ui::host_ops::{HostId, HostOps, MTime, SharedHost, WatchSub};
+use crate::ui::host_registry::HostRegistry;
 use crate::ui::i18n::{L10nKey, t, t_fmt};
 
 const MAX_FILE_BYTES: u64 = 4 * 1024 * 1024;
@@ -23,6 +24,10 @@ const RELOAD_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(20
 
 pub(crate) struct OpenFile {
     pub(crate) path: PathBuf,
+    /// The machine `path` lives on. Saves, reloads and duplicate detection
+    /// all key on it: an SFTP file and a local file can share the string
+    /// `/etc/hosts` without being the same file.
+    pub(crate) host: HostId,
     pub(crate) input: Entity<InputState>,
     pub(crate) dirty: bool,
     disk_mtime: Option<MTime>,
@@ -286,11 +291,18 @@ impl Tty7App {
     }
 
     fn editor_rebuild_watcher(&mut self, cx: &mut Context<Self>) {
+        // Only files on the host the watch itself runs on. A path from
+        // another machine — an SFTP file, say — does not exist under that
+        // watcher's feet, and hosts without watching (SFTP again) fall back
+        // to the save-time conflict check instead.
+        let watch_host = self.spawn_host(cx);
         let files: HashSet<PathBuf> = self
             .tabs
             .iter()
             .filter_map(|t| t.code.as_deref())
-            .flat_map(|c| c.files.iter().map(|f| f.path.clone()))
+            .flat_map(|c| c.files.iter())
+            .filter(|f| f.host == watch_host)
+            .map(|f| f.path.clone())
             .collect();
         let dirs: HashSet<PathBuf> = files
             .iter()
@@ -471,16 +483,29 @@ impl Tty7App {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let Some(host) = self.active_host(cx) else {
+            return;
+        };
+        self.editor_open_on_host(host, path, window, cx);
+    }
+
+    /// [`Self::open_file_in_editor`] against an explicit host — the SFTP
+    /// browser's files live on a host that is never the active one.
+    pub(crate) fn editor_open_on_host(
+        &mut self,
+        host: SharedHost,
+        path: &Path,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if self.tabs.get(self.active).is_none() {
             return;
         }
         self.raise_code_overlay();
-        if self.editor_activate_open(path, window, cx) {
+        if self.editor_activate_open(host.id(), path, window, cx) {
             return;
         }
-        let Some(host) = self.active_host(cx) else {
-            return;
-        };
+        let host_id = host.id();
         let p = path.to_path_buf();
         let requested = p.clone();
         HostOps::run_in(
@@ -532,7 +557,7 @@ impl Tty7App {
             },
             move |app, opened, window, cx| match opened {
                 Ok((path, text, mtime)) => {
-                    app.editor_install_file(path.clone(), text, mtime, window, cx);
+                    app.editor_install_file(host_id, path.clone(), text, mtime, window, cx);
                     // Against `requested`, not `path`: the host canonicalised
                     // it on the way through, and a link that named a symlink
                     // would otherwise lose the line it asked for.
@@ -545,6 +570,7 @@ impl Tty7App {
 
     fn editor_activate_open(
         &mut self,
+        host: HostId,
         path: &Path,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -552,7 +578,11 @@ impl Tty7App {
         let Some(code) = self.tab_code_mut() else {
             return false;
         };
-        let Some(ix) = code.files.iter().position(|f| f.path == *path) else {
+        let Some(ix) = code
+            .files
+            .iter()
+            .position(|f| f.host == host && f.path == *path)
+        else {
             return false;
         };
         code.visible = true;
@@ -567,13 +597,14 @@ impl Tty7App {
 
     fn editor_install_file(
         &mut self,
+        host: HostId,
         path: PathBuf,
         text: String,
         mtime: Option<MTime>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.editor_activate_open(&path, window, cx) {
+        if self.editor_activate_open(host, &path, window, cx) {
             return;
         }
         if self.tabs.get(self.active).is_none() {
@@ -604,7 +635,7 @@ impl Tty7App {
                         .iter_mut()
                         .filter_map(|t| t.code.as_deref_mut())
                         .flat_map(|c| c.files.iter_mut())
-                        .find(|f| f.path == path)
+                        .find(|f| f.host == host && f.path == path)
                     else {
                         return;
                     };
@@ -624,6 +655,7 @@ impl Tty7App {
             0,
             OpenFile {
                 path,
+                host,
                 input,
                 dirty: false,
                 disk_mtime: mtime,
@@ -732,7 +764,13 @@ impl Tty7App {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let Some(host) = self.active_host(cx) else {
+        // The file's own host, not the active one: the buffer keeps pointing
+        // at the machine it was read from, however the focus has moved since.
+        let Some(host) = self
+            .editor_file_mut(id)
+            .map(|f| f.host)
+            .and_then(|host| HostRegistry::lookup(cx, host))
+        else {
             return;
         };
         let Some(f) = self.editor_file_mut(id) else {
@@ -927,6 +965,7 @@ impl Tty7App {
         let Some(host) = self.active_host(cx) else {
             return;
         };
+        let host_id = host.id();
         let p = path.to_path_buf();
         let landed = p.clone();
         HostOps::run_in(
@@ -935,13 +974,14 @@ impl Tty7App {
             cx,
             move |h| h.stat(&p).ok().and_then(|m| m.mtime),
             move |app, mtime, window, cx| {
-                app.editor_apply_external_change(&landed, mtime, window, cx)
+                app.editor_apply_external_change(host_id, &landed, mtime, window, cx)
             },
         );
     }
 
     fn editor_apply_external_change(
         &mut self,
+        host: HostId,
         path: &Path,
         mtime: Option<MTime>,
         window: &mut Window,
@@ -954,7 +994,7 @@ impl Tty7App {
                 continue;
             };
             for (ix, f) in code.files.iter_mut().enumerate() {
-                if f.path != *path {
+                if f.host != host || f.path != *path {
                     continue;
                 }
                 match classify_external_change(f.saving.is_some(), f.dirty, f.disk_mtime, mtime) {
@@ -991,10 +1031,11 @@ impl Tty7App {
             return;
         };
         let target = f.path.clone();
+        let file_host = f.host;
         let id = f.input.entity_id();
         f.reload_seq = f.reload_seq.wrapping_add(1);
         let seq = f.reload_seq;
-        let Some(host) = self.active_host(cx) else {
+        let Some(host) = HostRegistry::lookup(cx, file_host) else {
             return;
         };
         HostOps::run_in(

--- a/src/ui/code_editor.rs
+++ b/src/ui/code_editor.rs
@@ -294,8 +294,14 @@ impl Tty7App {
     fn editor_rebuild_watcher(&mut self, cx: &mut Context<Self>) {
         // Only files on the host the watch itself runs on. A path from
         // another machine — an SFTP file, say — does not exist under that
-        // watcher's feet, and hosts without watching (SFTP again) fall back
-        // to the save-time conflict check instead.
+        // watcher's feet, and would either miss or, worse, match a local file
+        // that happens to share its name.
+        //
+        // A host that cannot watch therefore gets no external-change
+        // detection at all: an SFTP buffer will not notice the file changing
+        // underneath it, and saving overwrites whatever is there. Catching
+        // that at save time needs a "keep mine" that survives to the next
+        // save, which the conflict banner does not have yet.
         let watch_host = self.spawn_host(cx);
         let files: HashSet<PathBuf> = self
             .tabs

--- a/src/ui/code_editor.rs
+++ b/src/ui/code_editor.rs
@@ -15,7 +15,6 @@ use gpui_component::{
 
 use crate::ui::app::Tty7App;
 use crate::ui::host_ops::{HostId, HostOps, MTime, SharedHost, WatchSub};
-use crate::ui::host_registry::HostRegistry;
 use crate::ui::i18n::{L10nKey, t, t_fmt};
 
 const MAX_FILE_BYTES: u64 = 4 * 1024 * 1024;
@@ -24,10 +23,12 @@ const RELOAD_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(20
 
 pub(crate) struct OpenFile {
     pub(crate) path: PathBuf,
-    /// The machine `path` lives on. Saves, reloads and duplicate detection
-    /// all key on it: an SFTP file and a local file can share the string
-    /// `/etc/hosts` without being the same file.
-    pub(crate) host: HostId,
+    /// The machine `path` lives on, held rather than looked up. Saves,
+    /// reloads and duplicate detection all key on its id — an SFTP file and a
+    /// local file can share the string `/etc/hosts` without being the same
+    /// file — and saving goes straight through this handle, so a buffer stays
+    /// saveable however the window's own machine has changed underneath it.
+    pub(crate) host: SharedHost,
     pub(crate) input: Entity<InputState>,
     pub(crate) dirty: bool,
     disk_mtime: Option<MTime>,
@@ -301,7 +302,7 @@ impl Tty7App {
             .iter()
             .filter_map(|t| t.code.as_deref())
             .flat_map(|c| c.files.iter())
-            .filter(|f| f.host == watch_host)
+            .filter(|f| f.host.id() == watch_host)
             .map(|f| f.path.clone())
             .collect();
         let dirs: HashSet<PathBuf> = files
@@ -443,6 +444,7 @@ impl Tty7App {
     /// than throwing the cursor somewhere it was never meant to go.
     fn apply_pending_cursor(
         &mut self,
+        host: HostId,
         requested: &Path,
         opened: &Path,
         window: &mut Window,
@@ -461,10 +463,11 @@ impl Tty7App {
         let Some((_, line, column)) = self.editor.pending_cursor.take() else {
             return;
         };
-        let Some(file) = self
-            .tab_code()
-            .and_then(|c| c.files.iter().find(|f| f.path == *opened))
-        else {
+        let Some(file) = self.tab_code().and_then(|c| {
+            c.files
+                .iter()
+                .find(|f| f.host.id() == host && f.path == *opened)
+        }) else {
             return;
         };
         let input = file.input.clone();
@@ -509,7 +512,7 @@ impl Tty7App {
         let p = path.to_path_buf();
         let requested = p.clone();
         HostOps::run_in(
-            host,
+            host.clone(),
             window,
             cx,
             move |h| -> Result<(PathBuf, String, Option<MTime>), String> {
@@ -557,11 +560,11 @@ impl Tty7App {
             },
             move |app, opened, window, cx| match opened {
                 Ok((path, text, mtime)) => {
-                    app.editor_install_file(host_id, path.clone(), text, mtime, window, cx);
+                    app.editor_install_file(host, path.clone(), text, mtime, window, cx);
                     // Against `requested`, not `path`: the host canonicalised
                     // it on the way through, and a link that named a symlink
                     // would otherwise lose the line it asked for.
-                    app.apply_pending_cursor(&requested, &path, window, cx);
+                    app.apply_pending_cursor(host_id, &requested, &path, window, cx);
                 }
                 Err(message) => window.push_notification(message, cx),
             },
@@ -581,7 +584,7 @@ impl Tty7App {
         let Some(ix) = code
             .files
             .iter()
-            .position(|f| f.host == host && f.path == *path)
+            .position(|f| f.host.id() == host && f.path == *path)
         else {
             return false;
         };
@@ -590,21 +593,22 @@ impl Tty7App {
         code.files.insert(0, f);
         code.active = 0;
         self.focus_editor(window, cx);
-        self.apply_pending_cursor(path, path, window, cx);
+        self.apply_pending_cursor(host, path, path, window, cx);
         cx.notify();
         true
     }
 
     fn editor_install_file(
         &mut self,
-        host: HostId,
+        host: SharedHost,
         path: PathBuf,
         text: String,
         mtime: Option<MTime>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.editor_activate_open(host, &path, window, cx) {
+        let host_id = host.id();
+        if self.editor_activate_open(host_id, &path, window, cx) {
             return;
         }
         if self.tabs.get(self.active).is_none() {
@@ -635,7 +639,7 @@ impl Tty7App {
                         .iter_mut()
                         .filter_map(|t| t.code.as_deref_mut())
                         .flat_map(|c| c.files.iter_mut())
-                        .find(|f| f.host == host && f.path == path)
+                        .find(|f| f.host.id() == host_id && f.path == path)
                     else {
                         return;
                     };
@@ -766,11 +770,7 @@ impl Tty7App {
     ) {
         // The file's own host, not the active one: the buffer keeps pointing
         // at the machine it was read from, however the focus has moved since.
-        let Some(host) = self
-            .editor_file_mut(id)
-            .map(|f| f.host)
-            .and_then(|host| HostRegistry::lookup(cx, host))
-        else {
+        let Some(host) = self.editor_file_mut(id).map(|f| f.host.clone()) else {
             return;
         };
         let Some(f) = self.editor_file_mut(id) else {
@@ -994,7 +994,7 @@ impl Tty7App {
                 continue;
             };
             for (ix, f) in code.files.iter_mut().enumerate() {
-                if f.host != host || f.path != *path {
+                if f.host.id() != host || f.path != *path {
                     continue;
                 }
                 match classify_external_change(f.saving.is_some(), f.dirty, f.disk_mtime, mtime) {
@@ -1031,13 +1031,10 @@ impl Tty7App {
             return;
         };
         let target = f.path.clone();
-        let file_host = f.host;
+        let host = f.host.clone();
         let id = f.input.entity_id();
         f.reload_seq = f.reload_seq.wrapping_add(1);
         let seq = f.reload_seq;
-        let Some(host) = HostRegistry::lookup(cx, file_host) else {
-            return;
-        };
         HostOps::run_in(
             host,
             window,
@@ -1226,6 +1223,10 @@ impl Tty7App {
     }
 
     fn render_code_status_bar(&self, _window: &Window, cx: &mut Context<Self>) -> gpui::Div {
+        // The roots below belong to this window's own machine. A file read
+        // over SFTP is on another one, where they mean nothing, so it shows
+        // its own full path rather than borrowing the local repo's name.
+        let tree_host = self.spawn_host(cx);
         let code = self.tab_code();
         let muted = cx.theme().muted_foreground;
         let path_text: Option<SharedString> = code.map(|c| {
@@ -1236,6 +1237,7 @@ impl Tty7App {
                 .map(|n| n.to_string_lossy().to_string())
                 .unwrap_or_default();
             match c.active_file() {
+                Some(f) if f.host.id() != tree_host => f.path.display().to_string().into(),
                 Some(f) => {
                     let rel = c
                         .roots

--- a/src/ui/file_tree.rs
+++ b/src/ui/file_tree.rs
@@ -1774,9 +1774,12 @@ impl Tty7App {
         }
 
         let sf = cx.global::<crate::ui::presets::Surfaces>().popover;
-        let dirty = self
-            .tab_code()
-            .is_some_and(|c| c.files.iter().any(|f| f.dirty && f.path == *path));
+        let tree_host = self.spawn_host(cx);
+        let dirty = self.tab_code().is_some_and(|c| {
+            c.files
+                .iter()
+                .any(|f| f.dirty && f.host == tree_host && f.path == *path)
+        });
 
         let renaming = matches!(
             &self.file_tree.editing,

--- a/src/ui/file_tree.rs
+++ b/src/ui/file_tree.rs
@@ -1778,7 +1778,7 @@ impl Tty7App {
         let dirty = self.tab_code().is_some_and(|c| {
             c.files
                 .iter()
-                .any(|f| f.dirty && f.host == tree_host && f.path == *path)
+                .any(|f| f.dirty && f.host.id() == tree_host && f.path == *path)
         });
 
         let renaming = matches!(

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -896,6 +896,7 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         L10nKey::SftpLoading => "Loading…",
         L10nKey::SftpEmptyDirectory => "Empty directory.",
         L10nKey::SftpContextOpen => "Open",
+        L10nKey::SftpContextEdit => "Edit",
         L10nKey::SftpContextFollowSymlink => "Follow Symlink",
         L10nKey::SftpContextRename => "Rename",
         L10nKey::SftpContextChmod => "chmod…",

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -945,6 +945,7 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         L10nKey::SftpLoading => "読み込み中…",
         L10nKey::SftpEmptyDirectory => "空のディレクトリです",
         L10nKey::SftpContextOpen => "開く",
+        L10nKey::SftpContextEdit => "編集",
         L10nKey::SftpContextFollowSymlink => "シンボリックリンクを辿る",
         L10nKey::SftpContextRename => "名前を変更",
         L10nKey::SftpContextChmod => "chmod…",

--- a/src/ui/i18n/mod.rs
+++ b/src/ui/i18n/mod.rs
@@ -657,6 +657,7 @@ l10n_keys! {
     SftpLoading,
     SftpEmptyDirectory,
     SftpContextOpen,
+    SftpContextEdit,
     SftpContextFollowSymlink,
     SftpContextRename,
     SftpContextChmod,

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -851,6 +851,7 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         L10nKey::SftpLoading => "加载中…",
         L10nKey::SftpEmptyDirectory => "空文件夹。",
         L10nKey::SftpContextOpen => "打开",
+        L10nKey::SftpContextEdit => "编辑",
         L10nKey::SftpContextFollowSymlink => "跟随符号链接",
         L10nKey::SftpContextRename => "重命名",
         L10nKey::SftpContextChmod => "权限…",

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -33,6 +33,7 @@ pub mod scm;
 pub mod scrollbar;
 pub mod settings;
 pub mod sftp;
+pub mod sftp_host;
 pub mod ssh_connect;
 pub mod ssh_prompt;
 pub mod switcher;

--- a/src/ui/sftp.rs
+++ b/src/ui/sftp.rs
@@ -601,26 +601,25 @@ impl Tty7App {
         let target = remote_join(&self.sftp_panel.cwd, &entry.name);
         if is_dir_like(&entry) {
             self.sftp_navigate(target, cx);
-        } else if let Some(host) = self.sftp_editor_host(cx) {
+        } else if let Some(host) = self.sftp_editor_host() {
             self.editor_open_on_host(host, Path::new(&target), window, cx);
         }
     }
 
-    /// The [`Host`] the editor reads and saves this pane's files through,
-    /// registered so saves can find it again long after the panel has moved
-    /// on. Rebuilt on every call: the host is stateless apart from its route,
-    /// and re-inserting is what keeps a re-opened pane's route fresh.
+    /// The [`Host`] the editor reads and saves this pane's files through.
+    ///
+    /// Handed to the editor rather than filed in `HostRegistry`: that table
+    /// means "a machine this window has a link to", and its entries are
+    /// listed as machines and swept when no workspace is left holding one.
+    /// An SFTP channel borrowed from a pane is neither, so the buffer holds
+    /// the host itself and stays saveable for as long as it is open.
     ///
     /// [`Host`]: crate::ui::host_ops::Host
-    fn sftp_editor_host(
-        &mut self,
-        cx: &mut Context<Self>,
-    ) -> Option<crate::ui::host_ops::SharedHost> {
+    fn sftp_editor_host(&self) -> Option<crate::ui::host_ops::SharedHost> {
         self.sftp_panel.open_pane_id?;
-        let host: crate::ui::host_ops::SharedHost =
-            std::sync::Arc::new(crate::ui::sftp_host::SftpHost::new(self.sftp_route()));
-        crate::ui::host_registry::HostRegistry::insert(cx, host.clone());
-        Some(host)
+        Some(std::sync::Arc::new(crate::ui::sftp_host::SftpHost::new(
+            self.sftp_route(),
+        )))
     }
 
     pub(crate) fn sftp_download_entry(&mut self, entry: SftpEntry, cx: &mut Context<Self>) {

--- a/src/ui/sftp.rs
+++ b/src/ui/sftp.rs
@@ -58,6 +58,20 @@ impl SftpRoute {
         Self { pane_id, workspace }
     }
 
+    /// What makes this route *this* route, for a [`HostId`]. Keyed by pane —
+    /// two panes into the same server are two routes, because every op is
+    /// addressed to a pane's SSH connection — and by workspace, because a
+    /// workspace pane's id was minted by the far daemon and can collide with
+    /// a local one.
+    ///
+    /// [`HostId`]: crate::ui::host_registry::HostId
+    pub(crate) fn connection_key(&self) -> String {
+        match &self.workspace {
+            Some(ws) => format!("sftp:{}:{}", ws.workspace, self.pane_id),
+            None => format!("sftp:{}", self.pane_id),
+        }
+    }
+
     fn workspace_op(
         &self,
         op: crate::daemon::protocol::WorkspaceOp,
@@ -572,19 +586,41 @@ impl Tty7App {
         cx.notify();
     }
 
-    /// The double-click gesture and the row menu's first item both land here.
-    /// They used to differ: double-click ran a directory-only handler, so
-    /// double-clicking a file — the gesture every file browser answers by
-    /// opening it — did nothing at all, with no cursor change or message to
-    /// say why. A download is visible in the transfers tray and cancellable
-    /// from it, so the worst case is a click you can take back.
-    pub(crate) fn sftp_open_entry(&mut self, entry: SftpEntry, cx: &mut Context<Self>) {
+    /// A click on a row and the row menu's first item both land here.
+    /// A directory opens in place; a file opens in the built-in editor, the
+    /// way it already does on a local or remote-workspace tree (#656). What
+    /// the editor cannot hold — binary, oversized — gets the same toast the
+    /// local tree gives it; a single click must never start a transfer, so
+    /// downloading lives in the row menu and nowhere else.
+    pub(crate) fn sftp_open_entry(
+        &mut self,
+        entry: SftpEntry,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         let target = remote_join(&self.sftp_panel.cwd, &entry.name);
         if is_dir_like(&entry) {
             self.sftp_navigate(target, cx);
-        } else {
-            self.sftp_download_entry(entry, cx);
+        } else if let Some(host) = self.sftp_editor_host(cx) {
+            self.editor_open_on_host(host, Path::new(&target), window, cx);
         }
+    }
+
+    /// The [`Host`] the editor reads and saves this pane's files through,
+    /// registered so saves can find it again long after the panel has moved
+    /// on. Rebuilt on every call: the host is stateless apart from its route,
+    /// and re-inserting is what keeps a re-opened pane's route fresh.
+    ///
+    /// [`Host`]: crate::ui::host_ops::Host
+    fn sftp_editor_host(
+        &mut self,
+        cx: &mut Context<Self>,
+    ) -> Option<crate::ui::host_ops::SharedHost> {
+        self.sftp_panel.open_pane_id?;
+        let host: crate::ui::host_ops::SharedHost =
+            std::sync::Arc::new(crate::ui::sftp_host::SftpHost::new(self.sftp_route()));
+        crate::ui::host_registry::HostRegistry::insert(cx, host.clone());
+        Some(host)
     }
 
     pub(crate) fn sftp_download_entry(&mut self, entry: SftpEntry, cx: &mut Context<Self>) {
@@ -1502,8 +1538,14 @@ impl Tty7App {
             .rounded(cx.theme().radius)
             .cursor_pointer()
             .hover(|s| s.bg(list_hover))
-            .on_double_click(
-                cx.listener(move |this, _, _w, cx| this.sftp_open_entry(open_entry.clone(), cx)),
+            // Single click, the same gesture the local file tree answers —
+            // this panel used to demand a double click because its open
+            // action was a download, and that caution outlived the download.
+            .on_mouse_down(
+                gpui::MouseButton::Left,
+                cx.listener(move |this, _, window, cx| {
+                    this.sftp_open_entry(open_entry.clone(), window, cx)
+                }),
             )
             .child(
                 Icon::new(icon)
@@ -1540,16 +1582,29 @@ impl Tty7App {
         let primary_label = if dir_like {
             t(L10nKey::SftpContextOpen)
         } else {
-            t(L10nKey::Download)
+            t(L10nKey::SftpContextEdit)
         };
         menu = menu.item(PopupMenuItem::new(primary_label).on_click({
             let app = app.clone();
             let entry = entry.clone();
-            move |_, _window, cx| {
+            move |_, window, cx| {
                 let entry = entry.clone();
-                let _ = app.update(cx, |this, cx| this.sftp_open_entry(entry, cx));
+                let _ = app.update(cx, |this, cx| this.sftp_open_entry(entry, window, cx));
             }
         }));
+
+        // Editing is the double-click now, but a copy in ~/Downloads is still
+        // a thing people come to this menu for.
+        if !dir_like {
+            menu = menu.item(PopupMenuItem::new(t(L10nKey::Download)).on_click({
+                let app = app.clone();
+                let entry = entry.clone();
+                move |_, _window, cx| {
+                    let entry = entry.clone();
+                    let _ = app.update(cx, |this, cx| this.sftp_download_entry(entry, cx));
+                }
+            }));
+        }
 
         if is_symlink {
             menu = menu.item(

--- a/src/ui/sftp_host.rs
+++ b/src/ui/sftp_host.rs
@@ -1,0 +1,314 @@
+//! The SFTP browser's file access, shaped like a [`Host`].
+//!
+//! The built-in editor speaks `Host` and nothing else — that is how it opens
+//! and saves files on the local machine and over a remote workspace. An SSH
+//! pane's files come over SFTP instead, which had no `Host`, so double-click
+//! could only download (#656). This adapter closes that gap: the file
+//! operations map one-to-one onto [`SftpOp`]s, and everything a bare SFTP
+//! channel cannot do — git, search, shells, watching — says so honestly
+//! instead of pretending.
+//!
+//! Calls block on a daemon round trip, so they must stay off the UI thread;
+//! `HostOps` already guarantees that for every `Host`.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use tty7_core::host::ShellInventory;
+
+use crate::daemon::protocol::{SftpEntry, SftpEntryKind, SftpOp, SftpOpResult};
+use crate::daemon::ssh::sftp::remote_parent;
+use crate::ui::host_ops::{Entry, Host, HostId, MTime, Meta, Output, SearchHit, WatchSub};
+use crate::ui::sftp::SftpRoute;
+
+pub(crate) struct SftpHost {
+    id: HostId,
+    route: SftpRoute,
+}
+
+impl SftpHost {
+    pub(crate) fn new(route: SftpRoute) -> Self {
+        let id = HostId::from_connection_key(&route.connection_key());
+        SftpHost { id, route }
+    }
+
+    fn op(&self, op: SftpOp) -> io::Result<SftpOpResult> {
+        match self.route.op(op) {
+            SftpOpResult::Error(e) => Err(sftp_io(e)),
+            other => Ok(other),
+        }
+    }
+}
+
+fn rpath(p: &Path) -> String {
+    p.to_string_lossy().into_owned()
+}
+
+/// An SFTP error is a string by the time it crosses the daemon socket. The
+/// editor's error toasts speak in `io::ErrorKind`, so the two failures a
+/// person can act on are picked back out of the text; everything else stays
+/// verbatim.
+fn sftp_io(msg: String) -> io::Error {
+    let lower = msg.to_lowercase();
+    let kind = if lower.contains("no such file") {
+        io::ErrorKind::NotFound
+    } else if lower.contains("permission denied") {
+        io::ErrorKind::PermissionDenied
+    } else {
+        io::ErrorKind::Other
+    };
+    io::Error::new(kind, msg)
+}
+
+fn unsupported(what: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Unsupported,
+        format!("{what} is not available over SFTP"),
+    )
+}
+
+fn unexpected(op: &str) -> io::Error {
+    io::Error::other(format!("unexpected SFTP reply to {op}"))
+}
+
+fn meta_from_entry(e: &SftpEntry) -> Meta {
+    Meta {
+        is_dir: matches!(e.kind, SftpEntryKind::Dir),
+        is_symlink: matches!(e.kind, SftpEntryKind::Symlink),
+        len: e.size,
+        // An absent mtime comes across as 0; epoch-0 files are a curiosity,
+        // "no answer" is what 0 actually means here.
+        mtime: (e.mtime != 0).then_some(MTime {
+            secs: e.mtime as i64,
+            nanos: 0,
+        }),
+        readonly: false,
+    }
+}
+
+impl Host for SftpHost {
+    fn id(&self) -> HostId {
+        self.id
+    }
+
+    fn separator(&self) -> char {
+        '/'
+    }
+
+    fn is_absolute(&self, p: &Path) -> bool {
+        p.to_string_lossy().starts_with('/')
+    }
+
+    fn read_dir(&self, dir: &Path, _root: Option<&Path>) -> io::Result<Vec<Entry>> {
+        let entries = self.route.list(&rpath(dir)).map_err(sftp_io)?;
+        Ok(entries
+            .iter()
+            .map(|e| Entry {
+                name: e.name.clone(),
+                is_dir: matches!(e.kind, SftpEntryKind::Dir)
+                    || (matches!(e.kind, SftpEntryKind::Symlink) && e.target_is_dir),
+                is_symlink: matches!(e.kind, SftpEntryKind::Symlink),
+                ignored: false,
+            })
+            .collect())
+    }
+
+    fn stat(&self, p: &Path) -> io::Result<Meta> {
+        match self.op(SftpOp::Stat { path: rpath(p) })? {
+            SftpOpResult::Stat(entry) => Ok(meta_from_entry(&entry)),
+            _ => Err(unexpected("Stat")),
+        }
+    }
+
+    fn read_file(&self, p: &Path, max_bytes: u64) -> io::Result<Vec<u8>> {
+        match self.op(SftpOp::ReadFile {
+            path: rpath(p),
+            max_bytes,
+        })? {
+            SftpOpResult::File { bytes, .. } => Ok(bytes),
+            _ => Err(unexpected("ReadFile")),
+        }
+    }
+
+    fn canonicalize(&self, p: &Path) -> io::Result<PathBuf> {
+        match self.op(SftpOp::Realpath { path: rpath(p) })? {
+            SftpOpResult::Link(resolved) => Ok(PathBuf::from(resolved)),
+            _ => Err(unexpected("Realpath")),
+        }
+    }
+
+    fn search(
+        &self,
+        _roots: &[PathBuf],
+        _query: &str,
+        _limit: usize,
+        _max_dirs: usize,
+        _show_hidden: bool,
+    ) -> io::Result<Vec<SearchHit>> {
+        Err(unsupported("search"))
+    }
+
+    fn write_file(&self, p: &Path, bytes: &[u8]) -> io::Result<Meta> {
+        match self.op(SftpOp::WriteFile {
+            path: rpath(p),
+            bytes: bytes.to_vec(),
+        })? {
+            SftpOpResult::Stat(entry) => Ok(meta_from_entry(&entry)),
+            _ => Err(unexpected("WriteFile")),
+        }
+    }
+
+    fn create_file_new(&self, p: &Path) -> io::Result<()> {
+        self.op(SftpOp::CreateFile { path: rpath(p) })?;
+        Ok(())
+    }
+
+    fn create_dir(&self, p: &Path, recursive: bool) -> io::Result<()> {
+        let path = rpath(p);
+        if !recursive {
+            self.op(SftpOp::Mkdir { path })?;
+            return Ok(());
+        }
+        // SFTP mkdir has no `-p`; walk down from the root, tolerating every
+        // prefix that already exists, then let a stat of the full path be the
+        // judge of whether the walk actually arrived.
+        let mut prefixes = vec![path.clone()];
+        let mut cursor = path.clone();
+        loop {
+            let parent = remote_parent(&cursor);
+            if parent == cursor || parent == "/" {
+                break;
+            }
+            prefixes.push(parent.clone());
+            cursor = parent;
+        }
+        for prefix in prefixes.into_iter().rev() {
+            let _ = self.op(SftpOp::Mkdir { path: prefix });
+        }
+        if self.stat(p)?.is_dir {
+            Ok(())
+        } else {
+            Err(io::Error::other(format!("{path} is not a directory")))
+        }
+    }
+
+    fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
+        self.op(SftpOp::Rename {
+            from: rpath(from),
+            to: rpath(to),
+        })?;
+        Ok(())
+    }
+
+    fn remove(&self, p: &Path, recursive: bool) -> io::Result<()> {
+        // Unlink first. It is the right call for files and for symlinks —
+        // including a symlink to a directory, which stat would follow and a
+        // stat-then-recurse would wrongly descend into. Only something unlink
+        // cannot take down, a real directory, moves on to the next question.
+        let file_err = match self.op(SftpOp::RemoveFile { path: rpath(p) }) {
+            Ok(_) => return Ok(()),
+            Err(e) => e,
+        };
+        match self.stat(p) {
+            Ok(meta) if meta.is_dir => {
+                if !recursive {
+                    return Err(unsupported("non-recursive directory removal"));
+                }
+                self.op(SftpOp::RemoveDir { path: rpath(p) })?;
+                Ok(())
+            }
+            _ => Err(file_err),
+        }
+    }
+
+    fn repo_root(&self, _p: &Path) -> io::Result<Option<PathBuf>> {
+        Ok(None)
+    }
+
+    fn git(&self, _cwd: &Path, _args: &[&str]) -> io::Result<Output> {
+        Err(unsupported("git"))
+    }
+
+    fn shells(&self) -> io::Result<ShellInventory> {
+        Err(unsupported("shell discovery"))
+    }
+
+    fn watch(&self, _dirs: &[PathBuf]) -> io::Result<WatchSub> {
+        Err(unsupported("file watching"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_host_id_is_stable_and_never_local() {
+        let a = SftpHost::new(SftpRoute::new(4, None));
+        let b = SftpHost::new(SftpRoute::new(4, None));
+        let c = SftpHost::new(SftpRoute::new(5, None));
+        assert_eq!(a.id(), b.id());
+        assert_ne!(a.id(), c.id());
+        assert!(!a.id().is_local());
+    }
+
+    #[test]
+    fn meta_mapping_reads_kind_size_and_mtime() {
+        let m = meta_from_entry(&SftpEntry {
+            name: "notes.md".into(),
+            kind: SftpEntryKind::File,
+            size: 42,
+            mtime: 1_700_000_000,
+            permissions: 0o100644,
+            target_is_dir: false,
+        });
+        assert!(!m.is_dir);
+        assert!(!m.is_symlink);
+        assert_eq!(m.len, 42);
+        assert_eq!(
+            m.mtime,
+            Some(MTime {
+                secs: 1_700_000_000,
+                nanos: 0
+            })
+        );
+
+        let dir = meta_from_entry(&SftpEntry {
+            name: "src".into(),
+            kind: SftpEntryKind::Dir,
+            size: 4096,
+            mtime: 0,
+            permissions: 0o40755,
+            target_is_dir: false,
+        });
+        assert!(dir.is_dir);
+        assert_eq!(dir.mtime, None, "an absent mtime crosses the wire as 0");
+    }
+
+    #[test]
+    fn actionable_failures_get_their_io_kind_back() {
+        assert_eq!(
+            sftp_io("2: No such file or directory".into()).kind(),
+            io::ErrorKind::NotFound
+        );
+        assert_eq!(
+            sftp_io("3: Permission denied".into()).kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        let other = sftp_io("I/O: broken pipe".into());
+        assert_eq!(other.kind(), io::ErrorKind::Other);
+        assert_eq!(other.to_string(), "I/O: broken pipe");
+    }
+
+    #[test]
+    fn paths_are_posix_regardless_of_the_local_platform() {
+        let host = SftpHost::new(SftpRoute::new(1, None));
+        assert_eq!(host.separator(), '/');
+        assert!(host.is_absolute(Path::new("/home/deploy")));
+        assert!(!host.is_absolute(Path::new("relative/path")));
+        assert_eq!(
+            host.join(Path::new("/home/deploy"), "notes.md"),
+            PathBuf::from("/home/deploy/notes.md")
+        );
+    }
+}


### PR DESCRIPTION
Closes #656.

Text files in the SSH Files panel now open in the built-in editor, and saving writes straight back over the pane's own SFTP channel — the same edit-in-place the Files panel already offers locally and over a remote workspace.

| | Before | After |
|---|---|---|
| Click a file in the SSH Files panel | Nothing (double-click required) | Opens it in the built-in editor |
| Double-click a text file | Downloads to `~/Downloads` | Opens it in the built-in editor (first click already did) |
| Save an opened remote file | n/a | Cmd-S writes back over the same SFTP connection, in place — mode and ownership preserved |
| Click a directory | Nothing (double-click required) | Enters it — same single-click gesture as the local file tree |
| Click a binary or >4 MB file | Downloads | Toast explaining it can't be edited, same as the local tree; no accidental transfer from a single click |
| Download a file | Double-click | Context menu → **Download** (row menu's first item is now **Edit**) |

## How

The editor only speaks `Host`, which had two implementations: `LocalHost` and `RemoteHost` (tty7-server). This adds a third, `SftpHost`, backed by the pane's existing SFTP route, so the whole open/save/conflict path is reused rather than duplicated:

- **Protocol**: `SftpOp::ReadFile { path, max_bytes }` / `SftpOp::WriteFile { path, bytes }` and `SftpOpResult::File { entry, bytes }`, bytes as base64. One round trip returns the body plus the stat the editor keys external-change detection on. Both routes are covered automatically: the local daemon and the remote-workspace proxy dispatch through the same `run_op`.
- **Daemon**: `ReadFile` rejects oversized files before the read (and mid-read, if the file grew) so a truncated body can never be saved back short. `WriteFile` truncates and rewrites in place instead of temp-and-rename — it overwrites a file the user has open, and replacing the inode would silently drop its mode and ownership.
- **Editor**: `OpenFile` now records the `HostId` it was read from; save, reload, duplicate detection and the dirty marker key on `(host, path)` instead of the active host. Without this, saving an SFTP file after switching focus would have written to a same-named local path. The external-change watcher only tracks files on the host it runs on; SFTP files (no watch support) fall back to the save-time conflict check.
- **Panel**: rows respond to a single left click, aligning the gesture with the local file tree. The double-click requirement was protection for an open action that used to be a download; that action is gone, so the guard went with it.

```mermaid
flowchart LR
    subgraph editor [Built-in editor]
        open[open / save / reload]
    end
    open -->|Host trait| LH[LocalHost]
    open -->|Host trait| RH[RemoteHost<br/>tty7-server]
    open -->|Host trait| SH[SftpHost *new*]
    SH -->|SftpOp ReadFile / WriteFile| route[SftpRoute]
    route -->|local pane| daemon[daemon SftpManager]
    route -->|workspace pane| ws[workspace proxy] --> daemon
    daemon -->|SFTP subsystem| remote[(remote machine)]
```

Old daemons or workspace servers that predate the new ops answer them with an error toast; nothing hangs or crashes.

## Testing

- Protocol round-trips for the new ops and result variant (`daemon::protocol` tests).
- `SftpHost` unit tests: host-id stability, POSIX path handling, meta/mtime mapping, io-kind classification of SFTP error strings.
- Full suites green: tty7 1546 passed, tty7-core 1160 passed; `cargo fmt --check` clean.
- Manual acceptance in an isolated dev instance against a real SSH host: click-to-edit, Cmd-S round trip (`cat` on the remote confirmed content, `ls -l` confirmed permissions), directory navigation, binary/oversized toast, context-menu download.
