### PR TITLE
fix(sidebar): give the workspace head a width that always resolves

### DIFF
--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -990,13 +990,17 @@ impl Tty7App {
                 ),
             );
         // The tile inside asks for `w_full`, and a percentage is only a width
-        // while every box above it has one. This row had none of its own — it
-        // borrowed the column's by cross-axis stretch — so on any pass that
-        // sizes the column from its content the chain resolves against nothing
-        // and the tile falls back to hugging the workspace name. Declaring the
-        // width here anchors it to the rail, which is a fixed `w(px(width))`.
+        // while some box above it has a real one. This row used to have none of
+        // its own and borrowed the column's by cross-axis stretch, which did not
+        // always hold; `w_full` here swapped that for a second percentage, and a
+        // row whose width is `Percent` is no longer `auto`, so it lost stretch
+        // as well — on the passes that size the column from its content there
+        // was still nothing to resolve against and the tile fell back to hugging
+        // the workspace name. Hand the row real pixels: the rail is
+        // `w(px(width))` and layout is border-box, so its content is one pixel
+        // narrower than that because of the right border.
         let workspace_head = h_flex()
-            .w_full()
+            .w(px(width - 1.))
             .flex_shrink_0()
             .px(px(crate::ui::app::CONTENT_INSET - 7.))
             .pt(px(4.))


### PR DESCRIPTION
Make the sidebar's workspace switcher fill the rail every time instead of intermittently shrinking to hug the workspace name.

| | Before | After |
|---|---|---|
| Workspace tile in the sidebar head | Usually spans the rail, but on some layout passes collapses to just the avatar + name + chevron | Always spans the rail |
| Width of the row holding it | `w_full` — a percentage with nothing definite above it to resolve against | `w(px(width - 1.))` — the rail's own width, minus its right border |

## Why

`w_full` is `width: 100%`, and a percentage is only a width while some box above it has a real one. The row holding the tile originally had no width of its own and borrowed the column's by cross-axis stretch, which did not always hold. 2b6eab5 replaced that with `w_full` on the row — but a row whose width is `Percent` is no longer `auto`, so it lost stretch as well. On the passes that size the column from its content, neither path supplied a width, the percentage resolved to nothing, and the tile fell back to hugging its content.

The rail itself is already a definite `w(px(width))`, so the row can simply take those pixels. Layout is border-box and the rail draws a 1px right border, so the column's content is one pixel narrower than `width`. With a definite value at the top, every `w_full` below it resolves on every pass.

## Testing

- `cargo build -p tty7`, `cargo fmt --check` clean; `cargo test -p tty7 sidebar` green (13 tests).
- Manual acceptance in an isolated dev instance (`--config-dir /tmp/t7dev`): resized the sidebar, collapsed and reopened it, switched and created workspaces, opened extra tabs, and reopened the window — the tile spans the rail throughout.
