### PR TITLE
ci: pin the GITHUB_TOKEN to read-only in the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Every job here checks out, builds, tests and greps — none of them write
+# anything back to the repo, so the token needs nothing but read. The repository
+# default is already `read`, but that is a settings toggle anyone with admin can
+# flip; declaring it in the file is what actually pins it, and it is what
+# CodeQL's `actions/missing-workflow-permissions` asks for.
+permissions:
+  contents: read
+
 # A superseded PR run is dead weight the moment the next push lands, and a run
 # left going is not free: the account's concurrent-job budget is shared, and
 # macOS slots are the scarce ones. A zombie Windows job (see the `Test` step's


### PR DESCRIPTION
Declare `permissions: contents: read` at the top of `ci.yml`, clearing all five open CodeQL `actions/missing-workflow-permissions` alerts in one block.

| | Before | After |
|---|---|---|
| `GITHUB_TOKEN` scope in `ci.yml` | Inherited from the repository default | Pinned to `contents: read` in the file |
| CodeQL alerts #1, #2, #3, #5, #6 | Open (medium) | Resolved |
| `nightly.yml` / `release.yml` | Already declare `contents: write` | Unchanged |

## Why

All five jobs in `ci.yml` (`fmt`, `host-boundary`, `build`, `server-musl`, `server-macos`) only check out, build, test and grep — none of them write anything back to the repo, so a top-level block covers every job without a per-job override.

The repository default workflow permission is already `read`, so this changes no behavior today. The point is that the default is an admin-flippable settings toggle: declaring it in the workflow is what actually pins it, and it is what the CodeQL rule asks for.

## Testing

- `.github/workflows/ci.yml` parses and still exposes the same five jobs.
- CI on this PR is itself the check: every required job runs under the new read-only token.
