### PR TITLE
feat(cli): restart the server in place by default, keeping sessions

### DIFF
--- a/crates/tty7-cli/src/cli.rs
+++ b/crates/tty7-cli/src/cli.rs
@@ -506,8 +506,11 @@ pub enum ServerCmd {
     #[command(about = "Stop the server; sessions end")]
     Stop,
 
-    #[command(about = "Stop, then start")]
-    Restart,
+    #[command(about = "Restart in place; sessions keep running (--hard: stop, then start)")]
+    Restart {
+        #[arg(long, help = "Stop, then start — every session ends")]
+        hard: bool,
+    },
 
     #[command(about = "Version, uptime, panes, links")]
     Status,
@@ -801,7 +804,7 @@ mod tests {
         for (verb, want) in [
             ("start", ServerCmd::Start),
             ("stop", ServerCmd::Stop),
-            ("restart", ServerCmd::Restart),
+            ("restart", ServerCmd::Restart { hard: false }),
             ("status", ServerCmd::Status),
             ("logs", ServerCmd::Logs),
         ] {
@@ -815,6 +818,10 @@ mod tests {
                 "server {verb} parsed as the wrong verb"
             );
         }
+        assert!(matches!(
+            parse(&["tty7", "server", "restart", "--hard"]).command,
+            Some(Command::Server(ServerCmd::Restart { hard: true }))
+        ));
     }
 
     #[test]

--- a/crates/tty7-cli/src/commands.rs
+++ b/crates/tty7-cli/src/commands.rs
@@ -105,8 +105,10 @@ pub fn execute(cli: Cli, ctx: &Context, backend: &mut dyn Backend) -> Result<Out
         Some(Command::Server(ServerCmd::Stop)) => {
             local_server(machine.as_deref(), "stop", crate::server::stop)
         }
-        Some(Command::Server(ServerCmd::Restart)) => {
-            local_server(machine.as_deref(), "restart", crate::server::restart)
+        Some(Command::Server(ServerCmd::Restart { hard })) => {
+            local_server(machine.as_deref(), "restart", || {
+                crate::server::restart(hard)
+            })
         }
         Some(Command::Server(ServerCmd::Logs)) => {
             local_server(machine.as_deref(), "logs", crate::server::logs)
@@ -118,7 +120,7 @@ pub fn execute(cli: Cli, ctx: &Context, backend: &mut dyn Backend) -> Result<Out
 fn local_server(
     machine: Option<&str>,
     verb: &str,
-    act: fn() -> Result<Outcome>,
+    act: impl FnOnce() -> Result<Outcome>,
 ) -> Result<Outcome> {
     if let Some(machine) = machine {
         bail!(

--- a/crates/tty7-cli/src/server.rs
+++ b/crates/tty7-cli/src/server.rs
@@ -137,12 +137,29 @@ pub fn restart(hard: bool) -> Result<Outcome> {
     }
     // Either `--hard`, or a daemon that cannot replace itself in place —
     // Windows, or a build from before the handoff existed. Stopping is the
-    // only restart that daemon has.
+    // only restart that daemon has — and the report has to own that, because
+    // the default restart's promise is sessions kept.
     spawn::stop();
     if running() {
         bail!("the server did not shut down on request");
     }
-    start()
+    let how = if hard {
+        "stopped and started"
+    } else {
+        "stopped and started (this server cannot restart in place)"
+    };
+    match start()? {
+        Outcome::Report(r) => report(
+            format!("{how}; sessions ended; {}", r.human),
+            json!({
+                "restarted": true,
+                "in_place": false,
+                "sessions_kept": false,
+                "start": r.json,
+            }),
+        ),
+        other => Ok(other),
+    }
 }
 
 /// The daemon execs the tty7-server binary found by [`server_exe`]: same pid,
@@ -199,8 +216,20 @@ fn restart_in_place(
              `tty7 server restart --hard` stops and starts it instead; sessions end"
         );
     }
-    // It went down mid-handoff, and its sessions with it; what is left to
-    // restore is a serving endpoint.
+    // The endpoint is silent, but the seat still tells "becoming the new
+    // image" apart from "died": the singleton lock survives the exec, so a
+    // held seat is the handed-off daemon still coming up, carrying every
+    // session. `start` would grant it one second of grace and then reap it —
+    // ending exactly the sessions this command promised to keep.
+    if tty7_core::daemon::singleton::holder_pid().is_some() {
+        bail!(
+            "the server took the handoff but has not started answering within \
+             {START_TIMEOUT:?} — it still holds the server seat, so its sessions may yet \
+             survive; give it a moment and check `tty7 server status`"
+        );
+    }
+    // The seat is free: it went down mid-handoff, and its sessions with it;
+    // what is left to restore is a serving endpoint.
     match start()? {
         Outcome::Report(r) => report(
             format!(

--- a/crates/tty7-cli/src/server.rs
+++ b/crates/tty7-cli/src/server.rs
@@ -6,6 +6,7 @@ use anyhow::{Result, bail};
 use serde_json::json;
 use tty7_core::client::PaneClient;
 use tty7_core::core::config;
+use tty7_core::daemon::protocol::FEATURE_HANDOFF;
 use tty7_core::daemon::spawn;
 
 use crate::commands::{Outcome, Report};
@@ -126,14 +127,95 @@ pub fn stop() -> Result<Outcome> {
     report("stopped", json!({ "stopped": true }))
 }
 
-pub fn restart() -> Result<Outcome> {
+pub fn restart(hard: bool) -> Result<Outcome> {
+    let client = PaneClient::local();
+    let Ok(old) = client.version() else {
+        return start();
+    };
+    if !hard && old.has_feature(FEATURE_HANDOFF) {
+        return restart_in_place(&client, &old);
+    }
+    // Either `--hard`, or a daemon that cannot replace itself in place —
+    // Windows, or a build from before the handoff existed. Stopping is the
+    // only restart that daemon has.
+    spawn::stop();
     if running() {
-        spawn::stop();
-        if running() {
-            bail!("the server did not shut down on request");
-        }
+        bail!("the server did not shut down on request");
     }
     start()
+}
+
+/// The daemon execs the tty7-server binary found by [`server_exe`]: same pid,
+/// same ptys, every session kept. The socket closing is the handoff being
+/// taken; the proof it *worked* is the version endpoint answering with a new
+/// `instance`, because that value is minted once per process image.
+fn restart_in_place(
+    client: &PaneClient,
+    old: &tty7_core::daemon::protocol::DaemonVersion,
+) -> Result<Outcome> {
+    let exe = server_exe()?;
+    client.hand_off(&exe).map_err(|e| {
+        anyhow::anyhow!(
+            "the server refused to restart in place and was left running: {e} — \
+             `tty7 server restart --hard` stops and starts it instead; sessions end"
+        )
+    })?;
+    let deadline = Instant::now() + START_TIMEOUT;
+    loop {
+        if let Ok(new) = client.version()
+            && new.instance != old.instance
+        {
+            let human = if new.build == old.build {
+                format!(
+                    "restarted in place (build {}); sessions kept running",
+                    new.build
+                )
+            } else {
+                format!(
+                    "restarted in place (build {} -> {}); sessions kept running",
+                    old.build, new.build
+                )
+            };
+            return report(
+                human,
+                json!({
+                    "restarted": true,
+                    "in_place": true,
+                    "build": new.build,
+                    "sessions_kept": true,
+                }),
+            );
+        }
+        if Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+    if client.version().is_ok() {
+        // Still the old instance answering: the handoff was accepted but the
+        // exec never landed. The daemon is intact, and so are its sessions.
+        bail!(
+            "the server took the handoff but is still running its old image — \
+             `tty7 server restart --hard` stops and starts it instead; sessions end"
+        );
+    }
+    // It went down mid-handoff, and its sessions with it; what is left to
+    // restore is a serving endpoint.
+    match start()? {
+        Outcome::Report(r) => report(
+            format!(
+                "the server went away during the handoff, ending its sessions; {}",
+                r.human
+            ),
+            json!({
+                "restarted": true,
+                "in_place": false,
+                "sessions_kept": false,
+                "start": r.json,
+            }),
+        ),
+        other => Ok(other),
+    }
 }
 
 pub fn logs() -> Result<Outcome> {


### PR DESCRIPTION
Makes `tty7 server restart` restart the daemon in place (execve handoff) by default, so sessions keep running — aligning it with the GUI's Restart Server. The killing restart now requires an explicit `--hard`.

| | Before | After |
|---|---|---|
| `tty7 server restart` | Stop + start; every session ends | Handoff: daemon execs the `tty7-server` binary in place — same pid, same ptys, sessions keep running |
| `tty7 server restart --hard` | (did not exist) | Stop + start; every session ends |
| Daemon without handoff (Windows, pre-handoff builds) | Stop + start | Unchanged: stop + start, the only restart such a daemon has |
| Handoff refused / exec never lands | — | Error suggesting `--hard`; daemon and sessions left untouched |
| Daemon dies mid-handoff | — | Fresh start, report says sessions ended |
| Help text | `Stop, then start` | `Restart in place; sessions keep running (--hard: stop, then start)` |

## Why

The GUI's Restart Server and the CLI's `server restart` shared a name but had opposite side effects: the GUI hands the daemon off to a new image and keeps every pane, the CLI killed them all. The most dangerous semantics sat on the most intuitive command. The default is now the safe one; destroying sessions takes an explicit flag.

Success of the in-place restart is judged by the daemon's per-process `instance` id changing, not by build strings — the CLI and server binaries can legitimately be on different versions.

```mermaid
flowchart TD
    R["tty7 server restart"] --> V{daemon running?}
    V -- no --> S[start]
    V -- yes --> H{"--hard? / no handoff feature?"}
    H -- "handoff supported, not --hard" --> X["PaneClient::hand_off(tty7-server)"]
    H -- "--hard or unsupported" --> K[stop + start<br/>sessions end]
    X --> P{new instance answers?}
    P -- yes --> OK[same pid, sessions kept]
    P -- "old instance still serving" --> E[error: suggest --hard<br/>daemon untouched]
    P -- "endpoint gone" --> S2[fresh start<br/>report sessions ended]
```

## Testing

- `cargo test -p tty7-cli`: 129 unit tests + 13 e2e pass, including a new parse assertion for `--hard`.
- Manual, against an isolated server in a scratch config dir:
  - `restart`: daemon pid unchanged, uptime reset (new image), pane's shell survived; reports `restarted in place (build 26.8.3); sessions kept running`.
  - `restart --hard`: new pid, pane gone, shell dead.
