### PR TITLE
fix(terminal): stop hidden panes from repainting the whole window

### DIFF
--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -4,9 +4,9 @@ use alacritty_terminal::index::{Column, Direction, Line, Point, Side};
 use alacritty_terminal::selection::{Selection, SelectionType};
 use alacritty_terminal::term::TermMode;
 use gpui::{
-    App, ClipboardEntry, ClipboardItem, Context, ExternalPaths, FocusHandle, Focusable, Font,
-    KeyDownEvent, Modifiers, MouseButton, MouseDownEvent, Pixels, ScrollDelta, ScrollWheelEvent,
-    WeakEntity, Window, actions, div, prelude::*, px,
+    App, ClipboardEntry, ClipboardItem, Context, EntityId, ExternalPaths, FocusHandle, Focusable,
+    Font, KeyDownEvent, Modifiers, MouseButton, MouseDownEvent, Pixels, ScrollDelta,
+    ScrollWheelEvent, WeakEntity, Window, actions, div, prelude::*, px,
 };
 use gpui_component::kbd::Kbd;
 use gpui_component::menu::{ContextMenuExt, PopupMenuItem};
@@ -35,6 +35,33 @@ use crate::ui::i18n::{L10nKey, t, t_fmt};
 
 const GRID_PAD_X: f32 = 8.;
 const GRID_PAD_Y: f32 = 4.;
+
+/// Which panes are on screen right now, readable without touching the entity
+/// map. The chrome (tab strip, sidebar, switcher) reads every pane entity
+/// while the window draws, so gpui tracks them all and `notify()` from a
+/// hidden pane still dirties the window — this flag is the out-of-band answer
+/// the output pump consults instead. `Tty7App::render` declares it each frame
+/// for its own tabs; a pane nobody has declared yet counts as displayed, so a
+/// missed path can only cost extra repaints, never a frozen grid.
+fn displayed_registry() -> &'static std::sync::Mutex<
+    std::collections::HashMap<EntityId, std::sync::Arc<std::sync::atomic::AtomicBool>>,
+> {
+    static R: std::sync::OnceLock<
+        std::sync::Mutex<
+            std::collections::HashMap<EntityId, std::sync::Arc<std::sync::atomic::AtomicBool>>,
+        >,
+    > = std::sync::OnceLock::new();
+    R.get_or_init(Default::default)
+}
+
+pub fn declare_displayed(panes: impl IntoIterator<Item = (EntityId, bool)>) {
+    let map = displayed_registry().lock().unwrap();
+    for (id, on) in panes {
+        if let Some(flag) = map.get(&id) {
+            flag.store(on, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+}
 
 actions!(
     terminal,
@@ -160,6 +187,9 @@ pub struct TerminalView {
     /// "preparation failed" — see [`staging_cache`].
     remote_clipboard_dir: Option<String>,
     pub focus_handle: FocusHandle,
+    /// See [`displayed_registry`]. Shared with the registry so the app can
+    /// flip it during a draw without an entity access.
+    displayed: std::sync::Arc<std::sync::atomic::AtomicBool>,
     pub font: Font,
     pub font_bold: Option<Font>,
     pub font_italic: Option<Font>,
@@ -1110,6 +1140,12 @@ impl TerminalView {
                 while let Ok(ev) = events.try_recv() {
                     batch.push(ev);
                 }
+                // Output reaches the screen through `handle_event`'s
+                // `notify()`, which gpui scopes to windows currently
+                // rendering this view. A pane in a background tab must stay
+                // out of the frame loop entirely: refreshing the window
+                // directly from here pinned the visible tab at full frame
+                // rate whenever any hidden pane was producing output.
                 let res = this.update(cx, |view, cx| {
                     let mut woke = false;
                     for ev in batch.drain(..) {
@@ -1118,14 +1154,9 @@ impl TerminalView {
                         }
                         view.handle_event(ev, cx);
                     }
-                    woke
                 });
-                let woke = match res {
-                    Ok(woke) => woke,
-                    Err(_) => break,
-                };
-                if woke {
-                    let _ = this.update_in(cx, |_, window, _| window.refresh());
+                if res.is_err() {
+                    break;
                 }
             }
         })
@@ -1190,7 +1221,15 @@ impl TerminalView {
         })
         .detach();
 
-        cx.on_release_in(window, |view, window, cx| {
+        let displayed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let entity_id = cx.entity().entity_id();
+        displayed_registry()
+            .lock()
+            .unwrap()
+            .insert(entity_id, displayed.clone());
+
+        cx.on_release_in(window, move |view, window, cx| {
+            displayed_registry().lock().unwrap().remove(&entity_id);
             view.terminal.detach_link();
             for image in view.terminal.images().take_for_release() {
                 cx.drop_image(image, Some(window));
@@ -1221,6 +1260,7 @@ impl TerminalView {
             ssh_spec: None,
             remote_clipboard_dir: None,
             focus_handle,
+            displayed,
             font,
             font_bold,
             font_italic,
@@ -1652,7 +1692,13 @@ impl TerminalView {
             AlacEvent::Wakeup => {
                 // The grid moved under whatever the search bar last measured.
                 self.note_output_under_search(cx);
-                cx.notify();
+                // Only a pane that is on screen repaints on output. The
+                // chrome's per-frame entity reads keep every pane in the
+                // window's tracked set, so an ungated notify from a
+                // background tab would dirty the window at output rate.
+                if self.displayed.load(std::sync::atomic::Ordering::Relaxed) {
+                    cx.notify();
+                }
             }
             AlacEvent::Title(title) => self.set_title_when_settled(title, cx),
             AlacEvent::ResetTitle => self.set_title_when_settled(self.default_title.clone(), cx),

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -43,24 +43,43 @@ const GRID_PAD_Y: f32 = 4.;
 /// the output pump consults instead. `Tty7App::render` declares it each frame
 /// for its own tabs; a pane nobody has declared yet counts as displayed, so a
 /// missed path can only cost extra repaints, never a frozen grid.
-fn displayed_registry() -> &'static std::sync::Mutex<
-    std::collections::HashMap<EntityId, std::sync::Arc<std::sync::atomic::AtomicBool>>,
-> {
-    static R: std::sync::OnceLock<
-        std::sync::Mutex<
-            std::collections::HashMap<EntityId, std::sync::Arc<std::sync::atomic::AtomicBool>>,
-        >,
-    > = std::sync::OnceLock::new();
-    R.get_or_init(Default::default)
-}
+///
+/// A gpui `Global` rather than a `static`: entity ids are only unique within
+/// one `App`, and parallel `#[gpui::test]` apps mint colliding ids — a
+/// process-wide map would let one test's declarations flip another's flags.
+/// In the shipped binary there is exactly one `App`, so the two are the same.
+#[derive(Default)]
+struct DisplayedRegistry(
+    std::sync::Mutex<
+        std::collections::HashMap<EntityId, std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    >,
+);
 
-pub fn declare_displayed(panes: impl IntoIterator<Item = (EntityId, bool)>) {
-    let map = displayed_registry().lock().unwrap();
+impl gpui::Global for DisplayedRegistry {}
+
+pub fn declare_displayed(cx: &App, panes: impl IntoIterator<Item = (EntityId, bool)>) {
+    // No registry means no pane has ever been built in this app.
+    let Some(registry) = cx.try_global::<DisplayedRegistry>() else {
+        return;
+    };
+    let map = registry.0.lock().unwrap();
     for (id, on) in panes {
         if let Some(flag) = map.get(&id) {
             flag.store(on, std::sync::atomic::Ordering::Relaxed);
         }
     }
+}
+
+/// What the registry holds for `id`: `None` when the pane never registered
+/// (or already released), otherwise the flag the output gate would consult.
+#[cfg(all(test, unix))]
+pub(crate) fn displayed_for_test(cx: &App, id: EntityId) -> Option<bool> {
+    cx.try_global::<DisplayedRegistry>()?
+        .0
+        .lock()
+        .unwrap()
+        .get(&id)
+        .map(|flag| flag.load(std::sync::atomic::Ordering::Relaxed))
 }
 
 actions!(
@@ -1223,13 +1242,16 @@ impl TerminalView {
 
         let displayed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
         let entity_id = cx.entity().entity_id();
-        displayed_registry()
+        cx.default_global::<DisplayedRegistry>()
+            .0
             .lock()
             .unwrap()
             .insert(entity_id, displayed.clone());
 
         cx.on_release_in(window, move |view, window, cx| {
-            displayed_registry().lock().unwrap().remove(&entity_id);
+            if let Some(registry) = cx.try_global::<DisplayedRegistry>() {
+                registry.0.lock().unwrap().remove(&entity_id);
+            }
             view.terminal.detach_link();
             for image in view.terminal.images().take_for_release() {
                 cx.drop_image(image, Some(window));

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -3927,6 +3927,24 @@ impl Tty7App {
     /// Stamps whichever tab is active right now. Called once per frame rather
     /// than from the ten places that assign `self.active` — it is idempotent,
     /// so the stamp only advances on the first frame after a switch.
+    /// Declare to the pane registry which terminals are on screen this
+    /// frame: the active tab's, nobody else's. Stated per frame rather than
+    /// maintained at every tab operation, the way `scm_sync_watchers` is.
+    /// Entity ids only — reading the entities here would put them into the
+    /// window's tracked set, which is exactly what the registry routes
+    /// around.
+    fn declare_displayed_panes(&self) {
+        let active = self.active;
+        crate::terminal::view::declare_displayed(self.tabs.iter().enumerate().flat_map(
+            |(i, tab)| {
+                tab.pane
+                    .leaves()
+                    .into_iter()
+                    .filter_map(move |slot| Some((slot.terminal()?.entity_id(), i == active)))
+            },
+        ));
+    }
+
     pub(crate) fn touch_active_tab(&self) {
         let Some(tab) = self.tabs.get(self.active) else {
             return;
@@ -6825,6 +6843,7 @@ impl Render for Tty7App {
         window.set_rem_size(px(cx.global::<Config>().ui_font_size));
         self.claim_pending_tab(window, cx);
         self.touch_active_tab();
+        self.declare_displayed_panes();
         self.scm_sync_watchers(window, cx);
         if cx.has_active_drag() {
             crate::ui::reorder::clear_pending(&self.reorder);

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -3924,27 +3924,28 @@ impl Tty7App {
         self.activate(index, window, cx);
     }
 
-    /// Stamps whichever tab is active right now. Called once per frame rather
-    /// than from the ten places that assign `self.active` — it is idempotent,
-    /// so the stamp only advances on the first frame after a switch.
     /// Declare to the pane registry which terminals are on screen this
     /// frame: the active tab's, nobody else's. Stated per frame rather than
     /// maintained at every tab operation, the way `scm_sync_watchers` is.
     /// Entity ids only — reading the entities here would put them into the
     /// window's tracked set, which is exactly what the registry routes
     /// around.
-    fn declare_displayed_panes(&self) {
+    fn declare_displayed_panes(&self, cx: &App) {
         let active = self.active;
-        crate::terminal::view::declare_displayed(self.tabs.iter().enumerate().flat_map(
-            |(i, tab)| {
+        crate::terminal::view::declare_displayed(
+            cx,
+            self.tabs.iter().enumerate().flat_map(|(i, tab)| {
                 tab.pane
                     .leaves()
                     .into_iter()
                     .filter_map(move |slot| Some((slot.terminal()?.entity_id(), i == active)))
-            },
-        ));
+            }),
+        );
     }
 
+    /// Stamps whichever tab is active right now. Called once per frame rather
+    /// than from the ten places that assign `self.active` — it is idempotent,
+    /// so the stamp only advances on the first frame after a switch.
     pub(crate) fn touch_active_tab(&self) {
         let Some(tab) = self.tabs.get(self.active) else {
             return;
@@ -6843,7 +6844,7 @@ impl Render for Tty7App {
         window.set_rem_size(px(cx.global::<Config>().ui_font_size));
         self.claim_pending_tab(window, cx);
         self.touch_active_tab();
-        self.declare_displayed_panes();
+        self.declare_displayed_panes(cx);
         self.scm_sync_watchers(window, cx);
         if cx.has_active_drag() {
             crate::ui::reorder::clear_pending(&self.reorder);
@@ -9540,6 +9541,110 @@ mod rename_gpui_tests {
             assert!(app.renaming.is_some());
             app.close_tab_inner(0, true, window, cx);
             assert!(app.renaming.is_none(), "losing its own tab closes the box");
+        });
+    }
+}
+
+// The output gate: a pane repaints on PTY output only while it is on screen.
+// `Tty7App::render` declares the active tab's panes displayed each frame and
+// everything else hidden; a pane nobody has declared — or whose id nobody
+// registered — must err toward displayed, because the failure direction that
+// matters is a visible pane that stops repainting.
+#[cfg(all(test, unix))]
+mod displayed_gpui_tests {
+    use gpui::TestAppContext;
+
+    use crate::terminal::view::{declare_displayed, displayed_for_test, quiet_test_pane};
+    use crate::ui::app::test_window::harness_with_tabs;
+
+    fn pane_id(app: &super::Tty7App, tab: usize) -> gpui::EntityId {
+        app.tabs[tab]
+            .pane
+            .first_leaf()
+            .expect("tab has a pane")
+            .entity_id()
+    }
+
+    #[gpui::test]
+    fn the_output_gate_follows_the_active_tab(cx: &mut TestAppContext) {
+        let (app, mut vcx, _streams) = harness_with_tabs(cx, 2);
+
+        app.update_in(&mut vcx, |app, window, cx| {
+            let (front, back) = (pane_id(app, 0), pane_id(app, 1));
+
+            app.declare_displayed_panes(cx);
+            assert_eq!(
+                displayed_for_test(cx, front),
+                Some(true),
+                "the active tab's pane repaints on output"
+            );
+            assert_eq!(
+                displayed_for_test(cx, back),
+                Some(false),
+                "a background tab's pane stays out of the frame loop"
+            );
+
+            app.activate(1, window, cx);
+            app.declare_displayed_panes(cx);
+            assert_eq!(displayed_for_test(cx, front), Some(false));
+            assert_eq!(
+                displayed_for_test(cx, back),
+                Some(true),
+                "switching tabs hands the frame loop to the new tab"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn a_pane_nobody_declared_counts_as_displayed(cx: &mut TestAppContext) {
+        let (app, mut vcx, _streams) = harness_with_tabs(cx, 1);
+
+        let _orphan = app.update_in(&mut vcx, |app, window, cx| {
+            // A pane that exists but sits in no tab — the shape of every
+            // "path that never declares": it registers as displayed and a
+            // declaration pass over the app's own tabs leaves it alone.
+            let (view, stream) = quiet_test_pane(99, window, cx);
+            let orphan = view.entity_id();
+            assert_eq!(
+                displayed_for_test(cx, orphan),
+                Some(true),
+                "a fresh pane defaults to displayed"
+            );
+
+            app.declare_displayed_panes(cx);
+            assert_eq!(
+                displayed_for_test(cx, orphan),
+                Some(true),
+                "declaring only speaks about panes the app holds"
+            );
+
+            // An id nobody registered is declared into the void, not
+            // inserted: the registry only ever holds live panes' flags.
+            let ghost = gpui::EntityId::from(u64::MAX);
+            declare_displayed(cx, [(ghost, false)]);
+            assert_eq!(displayed_for_test(cx, ghost), None);
+
+            (view, stream)
+        });
+    }
+
+    #[gpui::test]
+    fn a_released_pane_leaves_the_registry(cx: &mut TestAppContext) {
+        let (app, mut vcx, _streams) = harness_with_tabs(cx, 2);
+
+        let back = app.update_in(&mut vcx, |app, _window, _cx| {
+            let back = pane_id(app, 1);
+            app.tabs.remove(1);
+            back
+        });
+        vcx.background_executor.run_until_parked();
+
+        app.update_in(&mut vcx, |_, _, cx| {
+            assert_eq!(
+                displayed_for_test(cx, back),
+                None,
+                "a closed pane's flag does not outlive it"
+            );
         });
     }
 }


### PR DESCRIPTION
Output from panes in background tabs no longer repaints the whole window — the many-terminals lag fix.

| | Before | After |
|---|---|---|
| 30 tabs, 29 producing output in background tabs | Window pinned at 60 renders/s, GUI process ~45% CPU, nothing visible changing | ~20 renders/s (the visible pane's own output rate), background wakeups (~520/s) suppressed |
| Same 30 tabs, all quiet | 60 renders/s persisted while any pane had recently spoken | A few renders/s, ~5% CPU |
| Drag-selecting / typing while background panes are chatty | Competes with a full-window repaint per output batch | Frame loop belongs to the visible tab |
| Visible pane output, splits, zoom, tab switch, titles from hidden panes | — | Unchanged: both split halves live, background tab fresh on switch, OSC titles still update the chip |

## Why

Two stacked causes, found with `TTY7_PROFILE=1` and a 20-lines/s shell in N tabs:

1. Every pane's PTY pump ended each batch with an unconditional `window.refresh()`. `update_in` resolves to the pane's window even when the pane is in a background tab, and `refresh()` sets the `refreshing` flag that bypasses element reuse for the entire window — so one chatty hidden pane repainted everything at its output rate.
2. Deleting the refresh alone changed nothing, because gpui's `notify()` filter is based on entities *read* during the last draw, and the tab strip reads every pane's title/agent state each frame. Every pane in every tab is therefore "tracked", and a hidden pane's `cx.notify()` dirtied the window anyway.

The fix removes the refresh and gates the high-frequency `Wakeup` notify on a per-pane `displayed` flag that lives outside the entity map (`Arc<AtomicBool>` in a registry keyed by entity id). `Tty7App::render` declares it each frame — every leaf of the active tab true, everything else false — in the same stated-not-remembered style as `scm_sync_watchers`. Flags default to displayed and registration is dropped on release, so a path that never declares can only cost extra repaints, never a frozen grid. Low-frequency events (title, exit, clipboard) keep notifying unconditionally so tab chips update from hidden panes.

```mermaid
flowchart LR
    subgraph pump [PTY pump, per pane]
        B[batch of AlacEvents] --> H[handle_event]
    end
    H -- "Wakeup" --> G{displayed?}
    G -- "yes (active tab)" --> N[cx.notify → repaint]
    G -- "no (background tab)" --> S[suppressed]
    H -- "Title / Exit / …" --> N
    R[Tty7App::render] -- "declares each frame:
active tab leaves = true, rest = false" --> G
```

## Testing

- `cargo test` green.
- Measured with `TTY7_PROFILE=1` on an isolated dev instance (config-dir + own daemon), 30 tabs each running a single-process 20-lines/s printer: renders/s and CPU as in the table above; suppressed wakeups counted with temporary instrumentation (~520/s dropped, visible pane's ~18/s passed).
- Acceptance pass on a stock-zsh dev instance: typing/echo; vertical split with both halves printing to completion; background-tab output arriving complete on switch-back; OSC title change from a hidden pane; `exit` closing a split half; 12s-idle-then-output repainting immediately (the freeze case the old `window.refresh()` guarded against); 30s steady-output soak without a stall.
