### PR TITLE
fix(daemon): find and reap a seat-holding daemon that lost both its names

### DIFF
--- a/crates/tty7-cli/src/server.rs
+++ b/crates/tty7-cli/src/server.rs
@@ -40,6 +40,10 @@ pub fn start() -> Result<Outcome> {
             json!({ "started": false, "running": true }),
         );
     }
+    // Nobody answered, so whatever is recorded or still holding the server
+    // seat is a stranded process (#667) — left alone it would make the spawn
+    // below stand down and time out with nothing to show for it.
+    spawn::reap_stranded();
     let exe = server_exe()?;
     let mut cmd = Command::new(&exe);
     cmd.arg("--daemon");
@@ -72,9 +76,13 @@ pub fn start() -> Result<Outcome> {
                 }
                 Err(_) => "its state could not be checked, so it was left alone",
             };
+            // A spawn that exited cleanly did so because it stood down
+            // against a seat holder — without naming it, the message points
+            // at nothing anyone can act on (#667).
             bail!(
-                "{} (pid {pid}) did not open its endpoints within {START_TIMEOUT:?} — {fate}",
-                exe.display()
+                "{} (pid {pid}) did not open its endpoints within {START_TIMEOUT:?} — {fate}{}",
+                exe.display(),
+                spawn::seat_holder_note()
             );
         }
         std::thread::sleep(POLL_INTERVAL);
@@ -87,9 +95,28 @@ pub fn start() -> Result<Outcome> {
 
 pub fn stop() -> Result<Outcome> {
     if !running() {
+        // Answering nothing is not the same as being gone: a stranded server
+        // (#667) still holds the seat, and stop is the verb people reach for
+        // to clear it. Only a free seat means there is truly nothing to stop.
+        let Some(stranded) = tty7_core::daemon::singleton::holder_pid() else {
+            return report(
+                "the server is not running",
+                json!({ "stopped": false, "running": false }),
+            );
+        };
+        spawn::stop();
+        // Compared against the pid, not mere occupancy: a fresh daemon may
+        // legitimately claim the freed seat in this very window, and it is
+        // not the thing this command failed to stop.
+        if tty7_core::daemon::singleton::holder_pid() == Some(stranded) {
+            bail!(
+                "the stranded server could not be reaped{}",
+                spawn::seat_holder_note()
+            );
+        }
         return report(
-            "the server is not running",
-            json!({ "stopped": false, "running": false }),
+            format!("stopped a stranded server (pid {stranded})"),
+            json!({ "stopped": true, "stranded": true, "pid": stranded }),
         );
     }
     spawn::stop();

--- a/crates/tty7-core/src/daemon/singleton.rs
+++ b/crates/tty7-core/src/daemon/singleton.rs
@@ -104,6 +104,10 @@ pub unsafe fn adopt(fd: std::os::fd::RawFd) -> Singleton {
     }
     let file = unsafe { <File as std::os::fd::FromRawFd>::from_raw_fd(fd) };
     note_held(&file);
+    // The exec kept the pid, so this rewrites the same number — done anyway,
+    // so the recorded pid stays an invariant of holding the seat rather than
+    // a property of how the seat was acquired.
+    record_holder_pid(&file);
     Singleton { _file: file }
 }
 
@@ -118,11 +122,121 @@ pub fn claim() -> Claim {
     match open_exclusive(&path) {
         Ok(Some(file)) => {
             note_held(&file);
+            record_holder_pid(&file);
             Claim::Held(Singleton { _file: file })
         }
         Ok(None) => Claim::Taken,
         Err(e) => Claim::Unavailable(format!("{} could not be locked: {e}", path.display())),
     }
+}
+
+/// Writes this process's pid into the lock file it holds.
+///
+/// The lock file is the one name for the server that nothing ever deletes, so
+/// the pid in it is the handle of last resort: a daemon that unlinked its
+/// endpoint and lost its pidfile (#667) is otherwise unfindable — `flock` can
+/// say the seat is taken but not by whom — and every later launch stands down
+/// against a process nobody can name or reap.
+fn record_holder_pid(file: &File) {
+    use std::io::{Seek as _, Write as _};
+
+    let mut f = file;
+    let write = file
+        .set_len(0)
+        .and_then(|()| f.seek(std::io::SeekFrom::Start(0)))
+        .and_then(|_| f.write_all(std::process::id().to_string().as_bytes()))
+        .and_then(|()| f.sync_data());
+    if let Err(e) = write {
+        log::warn!("could not record this server's pid in its lock file: {e}");
+    }
+}
+
+/// The pid of the process currently holding this config dir's server seat, or
+/// `None` when the seat is free (or was never held by a build that records
+/// pids). For the reap paths: when the pidfile is gone, this is the only way
+/// left to name the survivor.
+///
+/// Probing takes the lock for a moment when it turns out to be free, so a
+/// server claiming in exactly that window is told `Taken` and stands down.
+/// On the reap paths a spawn follows and serves instead, so the outcome is
+/// the same either way; on the error-message paths nothing follows, and a
+/// claimant colliding with the probe would be lost — accepted, because that
+/// claimant is a stray arriving microseconds after its launcher already gave
+/// up a multi-second wait on it.
+#[cfg(unix)]
+pub fn holder_pid() -> Option<u32> {
+    use std::os::unix::io::AsRawFd as _;
+
+    let path = lock_path()?;
+    // No `create`: a lock file that does not exist has never had a holder.
+    let file = File::options().read(true).open(&path).ok()?;
+    loop {
+        // LOCK_SH is enough to conflict with a holder's LOCK_EX while keeping
+        // the probe as weak as possible.
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_SH | libc::LOCK_NB) } == 0 {
+            unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+            return None;
+        }
+        match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::EWOULDBLOCK) => break,
+            Some(libc::EINTR) => continue,
+            _ => return None,
+        }
+    }
+    // Read only once the seat is known to be held: the content then names the
+    // holder, because every holder writes its pid the moment it claims. A
+    // pre-recording build holding the seat left older content or none; the
+    // caller's identity check on the pid is what keeps a stale number from
+    // reaping an innocent process.
+    let contents = std::fs::read_to_string(&path).ok()?;
+    contents.trim().parse::<u32>().ok().filter(|&pid| pid > 1)
+}
+
+/// Truncates the recorded pid — only when nobody holds the seat.
+///
+/// For the reap, after it confirms the recorded process is gone: the content
+/// would otherwise keep naming the dead holder forever, and a later
+/// pre-recording build holding the seat over it would make that number — by
+/// then possibly reused for an unrelated process — read as the holder. A
+/// claim that lands before this does wins the flock, and the truncation is
+/// skipped rather than erasing the new holder's record.
+///
+/// Like [`holder_pid`]'s probe, this holds the lock for a moment, so a claim
+/// colliding with it is told `Taken` — accepted for the same reason: every
+/// caller is a reap that has just confirmed the seat's holder dead, and a
+/// spawn follows on each of those paths.
+#[cfg(unix)]
+pub fn clear_record_if_free() {
+    use std::os::unix::io::AsRawFd as _;
+
+    let Some(path) = lock_path() else { return };
+    let Ok(file) = File::options().write(true).open(&path) else {
+        return;
+    };
+    loop {
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+            let _ = file.set_len(0);
+            unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+            return;
+        }
+        match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::EINTR) => continue,
+            _ => return,
+        }
+    }
+}
+
+#[cfg(not(unix))]
+pub fn clear_record_if_free() {}
+
+#[cfg(not(unix))]
+pub fn holder_pid() -> Option<u32> {
+    // The Windows seat is `share_mode(0)`: while it is held the file cannot
+    // even be opened to read a pid out of. The Windows reap therefore still
+    // has only the pidfile to act on — a seat-holding survivor whose pidfile
+    // is gone stays unfindable there, so the #667 recovery is unix-only for
+    // now.
+    None
 }
 
 /// `Ok(Some(file))` when the lock is ours, `Ok(None)` when someone else holds
@@ -283,6 +397,77 @@ mod tests {
             matches!(again, Claim::Held(_)),
             "the seat comes back once the last reference to it is gone, got {again:?}"
         );
+    }
+
+    /// The pid in the lock file is the reap's handle of last resort (#667):
+    /// held means it names the holder, free means it names nobody.
+    #[cfg(unix)]
+    #[test]
+    fn the_held_seat_names_its_holder_and_a_free_seat_names_nobody() {
+        let (dir, _guard) = pin_dir("holder-pid");
+        let seat = match claim_within(PATIENCE) {
+            Claim::Held(s) => s,
+            other => panic!("the claim must be granted, got {other:?}"),
+        };
+        assert_eq!(
+            std::fs::read_to_string(dir.join("daemon.lock"))
+                .unwrap()
+                .trim(),
+            std::process::id().to_string(),
+            "claiming records the holder's pid in the lock file"
+        );
+        assert_eq!(
+            holder_pid(),
+            Some(std::process::id()),
+            "while the seat is held, the probe names the holder"
+        );
+        drop(seat);
+        // A forked neighbour can keep the released seat referenced for a
+        // moment (see `claim_within`); what matters is that the answer
+        // becomes "nobody", not the microsecond it does.
+        let deadline = std::time::Instant::now() + PATIENCE;
+        while holder_pid().is_some() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "a released seat must stop naming a holder"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
+    /// Clearing the record is fenced by the seat itself: a live holder's pid
+    /// must survive it, a dead holder's must not — stale content is what
+    /// could one day send a reap after a reused pid.
+    #[cfg(unix)]
+    #[test]
+    fn clearing_the_record_spares_a_live_holder_and_erases_a_dead_one() {
+        let (dir, _guard) = pin_dir("clear-record");
+        let path = dir.join("daemon.lock");
+        let seat = match claim_within(PATIENCE) {
+            Claim::Held(s) => s,
+            other => panic!("the claim must be granted, got {other:?}"),
+        };
+        clear_record_if_free();
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap().trim(),
+            std::process::id().to_string(),
+            "a held seat's record must survive the clear"
+        );
+        drop(seat);
+        // A forked neighbour can keep the seat referenced briefly; keep
+        // asking until the clear lands.
+        let deadline = std::time::Instant::now() + PATIENCE;
+        loop {
+            clear_record_if_free();
+            if std::fs::read_to_string(&path).unwrap().is_empty() {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "a free seat's stale record must be cleared"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
     }
 
     #[test]

--- a/crates/tty7-core/src/daemon/spawn.rs
+++ b/crates/tty7-core/src/daemon/spawn.rs
@@ -273,17 +273,7 @@ pub fn ensure_running() -> anyhow::Result<()> {
     }
 
     if stale {
-        reap_recorded_daemon(None);
-
-        if transport::endpoint_exists() {
-            transport::remove_stale_endpoint();
-        }
-        // The daemon's control listener probes control.port for a live
-        // predecessor before binding; a stale file would cost it the same
-        // refused-connect delay the probe above just skipped. The recorded
-        // daemon is known dead here, so the file cannot be live.
-        #[cfg(windows)]
-        crate::host::server::remove_control_endpoint();
+        reap_stranded();
     }
 
     // While an installer is replacing the installation, spawning a daemon
@@ -321,13 +311,108 @@ pub fn ensure_running() -> anyhow::Result<()> {
         }
         if Instant::now() >= deadline {
             anyhow::bail!(
-                "daemon did not start listening at {} within {:?}",
+                "daemon did not start listening at {} within {:?}{}",
                 transport::endpoint_display(),
-                STARTUP_TIMEOUT
+                STARTUP_TIMEOUT,
+                seat_holder_note()
             );
         }
         std::thread::sleep(POLL_INTERVAL);
     }
+}
+
+/// Clears whatever is left of a server a connect probe already failed to
+/// reach: reaps the recorded (or seat-holding, #667) process and removes the
+/// endpoint files a fresh spawn would otherwise stand down against or pay a
+/// refusal delay on.
+///
+/// A healthy server is the caller's to detect first — everything here acts on
+/// the premise that nobody answered.
+pub fn reap_stranded() {
+    // A seat holder mid-handoff or mid-startup — claimed, not yet listening —
+    // looks exactly like a stranded one from out here, and it may be carrying
+    // every live session across an exec. Give it a moment to open its
+    // endpoint before concluding it never will; a genuinely stranded holder
+    // costs this wait once and then gets reaped.
+    //
+    // Health is an *answered handshake*, never a bare connect: a wedged
+    // daemon's listener still completes connections out of the kernel's
+    // backlog, and callers on the Unresponsive path have already proven that
+    // connecting says nothing. A holder that connects but will not answer is
+    // the reap's subject, not its exception — waiting out the rest of the
+    // grace on it would only delay what its silence already decided.
+
+    if crate::daemon::singleton::holder_pid().is_some() {
+        let deadline = Instant::now() + STRANDED_GRACE;
+        while Instant::now() < deadline {
+            if let Ok(mut stream) = transport::connect() {
+                match query_daemon_version(&mut stream) {
+                    VersionProbe::Speaks(_) | VersionProbe::Legacy => return,
+                    VersionProbe::Unresponsive => break,
+                }
+            }
+            std::thread::sleep(POLL_INTERVAL);
+        }
+    }
+
+    reap_recorded_daemon(None);
+
+    if transport::endpoint_exists() {
+        transport::remove_stale_endpoint();
+    }
+    // The daemon's control listener probes control.port for a live
+    // predecessor before binding; a stale file would cost it the same
+    // refused-connect delay the reap above just made unnecessary.
+    #[cfg(windows)]
+    crate::host::server::remove_control_endpoint();
+}
+
+/// How long a seat holder that is not answering yet gets to be a daemon
+/// mid-handoff or mid-startup rather than a stranded one.
+const STRANDED_GRACE: Duration = Duration::from_secs(1);
+
+/// Names the process still holding the server seat, for the startup-timeout
+/// errors: a spawned daemon that stood down against a survivor used to time
+/// out with a message that pointed at nothing (#667). Empty when the seat is
+/// free — the timeout is then genuinely about a slow or crashed start.
+///
+/// The kill advice is identity-gated: the recorded pid can outlive the
+/// process it named (a pre-recording build holding the seat over an older
+/// number), and an ungated message would be telling the user to kill
+/// whatever process the OS reuses that pid for.
+pub fn seat_holder_note() -> String {
+    let Some(pid) = crate::daemon::singleton::holder_pid() else {
+        return String::new();
+    };
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        if !process_alive(pid as libc::pid_t) {
+            return format!(
+                "; the server seat is still held, but its recorded pid {pid} is no longer \
+                 alive — find the holder of daemon.lock before killing anything"
+            );
+        }
+        return match process_identity(pid as libc::pid_t) {
+            ProcessIdentity::OurDaemon => format!(
+                "; the server seat is still held by pid {pid}, which could not be reaped — \
+                 `kill {pid}` and retry"
+            ),
+            ProcessIdentity::Foreign => format!(
+                "; the server seat is still held, but its recorded pid {pid} now names an \
+                 unrelated process — find the holder of daemon.lock before killing anything"
+            ),
+            // Alive, seat held, executable unreadable: most likely this *is*
+            // the stranded server — saying otherwise would talk the user out
+            // of the one action that frees the seat.
+            ProcessIdentity::Unknown => format!(
+                "; the server seat is still held by pid {pid}, whose executable can no \
+                 longer be read — likely a stranded server; check it with `ps -p {pid}` \
+                 before killing it"
+            ),
+        };
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    format!("; the server seat is still held (recorded pid {pid})")
 }
 
 fn query_daemon_version(stream: &mut transport::Stream) -> VersionProbe {
@@ -468,9 +553,10 @@ pub fn hand_off() -> anyhow::Result<()> {
         }
         if Instant::now() >= deadline {
             anyhow::bail!(
-                "the daemon did not start listening again at {} within {:?}",
+                "the daemon did not start listening again at {} within {:?}{}",
                 transport::endpoint_display(),
-                STARTUP_TIMEOUT
+                STARTUP_TIMEOUT,
+                seat_holder_note()
             );
         }
         std::thread::sleep(POLL_INTERVAL);
@@ -485,12 +571,18 @@ pub fn stop() {
     // between them is exactly where an installer starts replacing files that
     // are still locked — and an old build's shutdown still deletes the pidfile
     // before the process is gone, so this is the last moment the pid is
-    // guaranteed readable.
-    let recorded = pidfile::read().filter(|&pid| pid > 4 && pid != std::process::id());
+    // guaranteed readable. When the pidfile is already gone (#667), the pid
+    // recorded in the singleton lock file is the remaining name for a
+    // survivor that is still holding the seat.
+    let recorded = pidfile::read()
+        .or_else(crate::daemon::singleton::holder_pid)
+        .filter(|&pid| pid > 4 && pid != std::process::id());
 
+    let mut asked = false;
     if let Ok(mut stream) = transport::connect() {
         if ClientMsg::Shutdown.encode(&mut stream).is_ok() {
             let _ = stream.flush();
+            asked = true;
             let deadline = Instant::now() + SHUTDOWN_TIMEOUT;
             while Instant::now() < deadline && transport::connect().is_ok() {
                 std::thread::sleep(POLL_INTERVAL);
@@ -498,7 +590,13 @@ pub fn stop() {
         }
     }
 
-    if let Some(pid) = recorded
+    // Only a shutdown that was actually delivered earns this wait: it is the
+    // time a daemon that stopped listening gets to finish releasing its
+    // image. A daemon nobody could even connect to was never asked to die —
+    // waiting on it is five seconds spent watching a survivor not move
+    // (#667); the reap below has its own graceful SIGTERM window.
+    if asked
+        && let Some(pid) = recorded
         && !wait_for_recorded_exit(pid, PROCESS_EXIT_TIMEOUT)
     {
         log::warn!("daemon pid {pid} released its endpoint but has not exited yet");
@@ -543,33 +641,115 @@ fn wait_for_recorded_exit(_pid: u32, _timeout: Duration) -> bool {
 }
 
 /// `recorded` is a pid the caller captured before asking the daemon to die;
-/// the pidfile is only the fallback, because a shutdown that stalled after its
-/// cleanup may have already deleted it.
+/// the pidfile is the first fallback, because a shutdown that stalled after
+/// its cleanup may have already deleted it — and the pid in the singleton
+/// lock file is the last one, for the #667 state where the pidfile is gone
+/// entirely but a survivor still holds the seat.
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 fn reap_recorded_daemon(recorded: Option<u32>) {
-    let Some(pid) = recorded.or_else(pidfile::read) else {
+    let Some(pid) = recorded
+        .or_else(pidfile::read)
+        .or_else(crate::daemon::singleton::holder_pid)
+    else {
         return;
     };
     if pid <= 1 || pid == std::process::id() {
-        pidfile::remove();
+        clear_daemon_records();
         return;
     }
-    if process_matches_daemon_exe(pid as libc::pid_t) {
-        log::warn!("reaping unreachable daemon (pid {pid}); its sessions will be hung up");
-        if !reap_process(pid as libc::pid_t) {
-            // The pid is the only handle left on the survivor; keep the file
-            // so the next attempt still has someone to reap.
+    if !process_alive(pid as libc::pid_t) {
+        clear_daemon_records();
+        return;
+    }
+    match process_identity(pid as libc::pid_t) {
+        ProcessIdentity::OurDaemon => {
+            log::warn!("reaping unreachable daemon (pid {pid}); its sessions will be hung up");
+            if !reap_process(pid as libc::pid_t) {
+                // The pid is the only handle left on the survivor; keep the
+                // file so the next attempt still has someone to reap.
+                return;
+            }
+        }
+        // The recorded pid now belongs to some unrelated program: the record
+        // is stale, not the process.
+        ProcessIdentity::Foreign => {}
+        ProcessIdentity::Unknown => {
+            // Alive but unnameable. Deleting the record here is what used to
+            // strand the machine (#667): the pid is the only handle on
+            // whatever this is, so it must outlive this attempt.
+            log::warn!(
+                "recorded daemon pid {pid} is alive but its executable cannot be identified; \
+                 keeping its record and leaving it alone"
+            );
             return;
         }
     }
+    clear_daemon_records();
+}
+
+/// Clears both records of a daemon the reap has confirmed dealt with — the
+/// pidfile, and the pid in the lock file (which is only touched if the seat
+/// is actually free; see `clear_record_if_free`).
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn clear_daemon_records() {
     pidfile::remove();
+    crate::daemon::singleton::clear_record_if_free();
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
-fn process_matches_daemon_exe(pid: libc::pid_t) -> bool {
-    process_path(pid)
+enum ProcessIdentity {
+    /// Named like a daemon of ours: safe to reap.
+    OurDaemon,
+    /// Named like something else: the recorded pid has been reused.
+    Foreign,
+    /// Alive, but neither its executable path nor its comm name is readable.
+    Unknown,
+}
+
+/// What the process behind `pid` is, judged by name — by executable path
+/// first, and by the kernel's comm name when the path is unreadable.
+///
+/// The path is unreadable in exactly the case the reap exists for: on macOS
+/// `proc_pidpath` fails outright for a live process whose binary has been
+/// deleted, which is every daemon still running through an update that
+/// replaced the installation. The comm name is recorded at `exec` time and
+/// survives the deletion on both platforms.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn process_identity(pid: libc::pid_t) -> ProcessIdentity {
+    let named = process_path(pid)
         .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
-        .is_some_and(|name| is_reapable_daemon_name(&name))
+        .or_else(|| process_comm(pid));
+    match named {
+        Some(name) if is_reapable_daemon_name(&name) => ProcessIdentity::OurDaemon,
+        Some(_) => ProcessIdentity::Foreign,
+        None => ProcessIdentity::Unknown,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn process_comm(pid: libc::pid_t) -> Option<String> {
+    if pid <= 0 {
+        return None;
+    }
+    // 2 * MAXCOMLEN, the buffer libproc's own callers use; proc_name refuses
+    // anything smaller.
+    let mut buf = [0u8; 64];
+    let len =
+        unsafe { libc::proc_name(pid, buf.as_mut_ptr() as *mut libc::c_void, buf.len() as u32) };
+    if len <= 0 {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&buf[..len as usize]).into_owned())
+}
+
+#[cfg(target_os = "linux")]
+fn process_comm(pid: libc::pid_t) -> Option<String> {
+    if pid <= 0 {
+        return None;
+    }
+    let comm = std::fs::read_to_string(format!("/proc/{pid}/comm")).ok()?;
+    let comm = comm.trim();
+    (!comm.is_empty()).then(|| comm.to_string())
 }
 
 /// Whether the process is gone by the end.
@@ -591,9 +771,53 @@ fn signal_and_await_exit(pid: libc::pid_t, sig: libc::c_int, timeout: Duration) 
     wait_for_recorded_exit(pid as u32, timeout)
 }
 
+/// Whether `pid` is a process that still exists — where a zombie does not
+/// count. A zombie answers `kill(pid, 0)` like the living, but it holds no
+/// lock, no endpoint and no image, and no signal can end it: counting it
+/// alive made the reap SIGTERM-then-SIGKILL a corpse for the full eight
+/// seconds of both timeouts before giving up on it. The GUI never waits on
+/// the daemons it spawns, so a crashed daemon *is* a zombie of a long-lived
+/// GUI, not a rare state.
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 fn process_alive(pid: libc::pid_t) -> bool {
-    unsafe { libc::kill(pid, 0) == 0 }
+    let exists = unsafe { libc::kill(pid, 0) == 0 };
+    exists && !is_zombie(pid)
+}
+
+#[cfg(target_os = "macos")]
+fn is_zombie(pid: libc::pid_t) -> bool {
+    let mut info: libc::proc_bsdinfo = unsafe { std::mem::zeroed() };
+    let size = std::mem::size_of::<libc::proc_bsdinfo>() as libc::c_int;
+    let got = unsafe {
+        libc::proc_pidinfo(
+            pid,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            &mut info as *mut _ as *mut libc::c_void,
+            size,
+        )
+    };
+    if got == size {
+        return info.pbi_status == libc::SZOMB;
+    }
+    // Measured, not assumed: for a zombie this call fails outright while
+    // `kill(pid, 0)` still succeeds — unlike a live process with a deleted
+    // executable, whose state (though not its path) stays readable. A pid we
+    // may signal but cannot introspect is a corpse.
+    true
+}
+
+#[cfg(target_os = "linux")]
+fn is_zombie(pid: libc::pid_t) -> bool {
+    let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+        // Readable state is the same boundary as on macOS: signalable but
+        // not introspectable is a corpse, not a daemon.
+        return true;
+    };
+    // The state field follows the comm's closing paren — the comm itself may
+    // contain spaces and parens.
+    stat.rsplit_once(')')
+        .is_some_and(|(_, rest)| rest.trim_start().starts_with('Z'))
 }
 
 #[cfg(windows)]
@@ -820,7 +1044,22 @@ fn process_path(pid: libc::pid_t) -> Option<PathBuf> {
     if pid <= 0 {
         return None;
     }
-    std::fs::read_link(format!("/proc/{pid}/exe")).ok()
+    let path = std::fs::read_link(format!("/proc/{pid}/exe")).ok()?;
+    Some(PathBuf::from(strip_deleted_marker(
+        path.to_string_lossy().into_owned(),
+    )))
+}
+
+/// A deleted executable's `/proc/<pid>/exe` reads as "/path/name (deleted)".
+/// The marker is the kernel's, not part of the name — left in place it made a
+/// replaced daemon read as foreign, which dropped its record without reaping
+/// it (#667).
+#[cfg(any(target_os = "linux", test))]
+fn strip_deleted_marker(path: String) -> String {
+    match path.strip_suffix(" (deleted)") {
+        Some(stripped) => stripped.to_string(),
+        None => path,
+    }
 }
 
 #[cfg(unix)]
@@ -1124,6 +1363,68 @@ mod exe_name_tests {
         assert!(is_reapable_daemon_name("TTY7"));
     }
 
+    /// The kernel's " (deleted)" marker on a replaced executable is not part
+    /// of its name; treating it as one made an updated-under daemon read as
+    /// foreign, which dropped its record without reaping it (#667).
+    #[test]
+    fn the_deleted_marker_is_not_part_of_a_process_name() {
+        assert_eq!(
+            strip_deleted_marker("/opt/tty7/tty7-server (deleted)".into()),
+            "/opt/tty7/tty7-server"
+        );
+        assert_eq!(
+            strip_deleted_marker("/opt/tty7/tty7-server".into()),
+            "/opt/tty7/tty7-server"
+        );
+        // Only the trailing marker is the kernel's.
+        assert_eq!(
+            strip_deleted_marker("/tmp/x (deleted)/tty7-server".into()),
+            "/tmp/x (deleted)/tty7-server"
+        );
+    }
+
+    /// A zombie answers `kill(pid, 0)` like the living but holds nothing and
+    /// cannot be signalled dead; counting it alive made the reap spend both
+    /// kill timeouts on a corpse. The GUI never waits on the daemons it
+    /// spawns, so this is the ordinary afterlife of a crashed daemon.
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[test]
+    fn a_zombie_is_not_an_alive_process() {
+        let mut child = std::process::Command::new("true")
+            .spawn()
+            .expect("spawn true");
+        let pid = child.id() as libc::pid_t;
+        // It has exited; nobody has waited: a zombie, once the exit lands.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !is_zombie(pid) {
+            assert!(
+                Instant::now() < deadline,
+                "the unwaited child must read as a zombie"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            unsafe { libc::kill(pid, 0) == 0 },
+            "a zombie still answers signal 0 — that is the trap"
+        );
+        assert!(
+            !process_alive(pid),
+            "a corpse is not a process the reap can act on"
+        );
+        let _ = child.wait();
+    }
+
+    /// The comm fallback is what identifies a daemon whose executable path is
+    /// unreadable — on macOS `proc_pidpath` fails outright once the binary is
+    /// deleted. This process is alive and its own comm must resolve.
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[test]
+    fn a_live_process_resolves_its_own_comm_name() {
+        let comm = process_comm(std::process::id() as libc::pid_t)
+            .expect("this process is alive; its comm name must be readable");
+        assert!(!comm.is_empty());
+    }
+
     #[test]
     fn strip_exe_suffix_only_strips_a_trailing_exe() {
         assert_eq!(strip_exe_suffix("tty7-app.exe"), "tty7-app");
@@ -1216,8 +1517,9 @@ mod tests {
             std::thread::sleep(Duration::from_millis(10));
         }
         assert!(
-            !process_matches_daemon_exe(pid),
-            "sleep must not match any daemon name; matching here would mean the reap could kill it"
+            matches!(process_identity(pid), ProcessIdentity::Foreign),
+            "sleep must read as a foreign process — OurDaemon would mean the reap \
+             could kill it, Unknown would mean its record is never cleared"
         );
 
         let _ = child.kill();

--- a/crates/tty7-server/tests/daemon_reap.rs
+++ b/crates/tty7-server/tests/daemon_reap.rs
@@ -1,0 +1,307 @@
+//! Guards for #667: a daemon can survive with its endpoint unlinked and its
+//! pidfile gone, holding the singleton seat against every later launch. The
+//! reap must still find it — through the pid recorded in the lock file — and
+//! must still recognise it when its executable has been deleted under it,
+//! which is what every update that replaces the installation does.
+//!
+//! Unix-only: both tests drive the daemon through unix sockets and signals.
+//! One process-wide config dir (`set_config_dir` is first-wins), so the tests
+//! serialize on a mutex and each cleans up the daemon it started.
+
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use tty7_core::client::PaneClient;
+
+const READY_WITHIN: Duration = Duration::from_secs(30);
+const DEAD_WITHIN: Duration = Duration::from_secs(5);
+
+/// The one config dir every test here shares, pinned into `tty7_core` on
+/// first use. `set_config_dir` is first-wins for the whole process, so a
+/// per-test directory would silently leave later tests reaping in the first
+/// test's directory.
+fn pinned_dir() -> &'static Path {
+    static DIR: OnceLock<PathBuf> = OnceLock::new();
+    DIR.get_or_init(|| {
+        sweep_dead_runs();
+        let dir = std::env::temp_dir().join(format!("tty7-reap-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create the shared config dir");
+        tty7_core::core::config::set_config_dir(dir.clone());
+        dir
+    })
+}
+
+/// Removes `tty7-reap-<pid>` directories whose creating test run is gone —
+/// the pid in the name keeps concurrent runs apart, and is also what says a
+/// leftover is safe to delete.
+fn sweep_dead_runs() {
+    let Ok(entries) = std::fs::read_dir(std::env::temp_dir()) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(pid) = name
+            .to_str()
+            .and_then(|n| n.strip_prefix("tty7-reap-"))
+            .and_then(|pid| pid.parse::<libc::pid_t>().ok())
+            .filter(|&pid| pid > 0)
+        else {
+            continue;
+        };
+        let gone = unsafe { libc::kill(pid, 0) } != 0
+            && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH);
+        if gone {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
+}
+
+fn serialized() -> std::sync::MutexGuard<'static, ()> {
+    static GATE: Mutex<()> = Mutex::new(());
+    GATE.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+fn clear_stale_files(dir: &Path) {
+    for name in ["daemon.sock", "daemon.pid", "control.sock"] {
+        let _ = std::fs::remove_file(dir.join(name));
+    }
+}
+
+fn spawn_daemon_from(exe: &Path, dir: &Path) -> Child {
+    Command::new(exe)
+        .arg("--daemon")
+        .arg("--config-dir")
+        .arg(dir)
+        .env("TTY7_DATA_DIR", dir)
+        .env("TTY7_CONTROL_SOCK", dir.join("control.sock"))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("start tty7-server --daemon")
+}
+
+fn await_ready(dir: &Path) {
+    let endpoint = dir.join("daemon.sock");
+    let deadline = Instant::now() + READY_WITHIN;
+    while PaneClient::at(&endpoint).version().is_err() || !dir.join("daemon.pid").exists() {
+        assert!(
+            Instant::now() < deadline,
+            "tty7-server did not open its endpoint within {READY_WITHIN:?}"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Collects the child the moment it dies: outside tests the daemon is
+/// nobody's child, and a zombie would read as alive to the reap's liveness
+/// poll — and to this test's.
+fn collect_on_exit(
+    child: Child,
+) -> std::thread::JoinHandle<std::io::Result<std::process::ExitStatus>> {
+    std::thread::spawn(move || {
+        let mut child = child;
+        child.wait()
+    })
+}
+
+fn assert_dies(pid: u32, what: &str) {
+    let deadline = Instant::now() + DEAD_WITHIN;
+    while unsafe { libc::kill(pid as libc::pid_t, 0) } == 0 {
+        if Instant::now() >= deadline {
+            unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+            panic!("{what}: the daemon (pid {pid}) is still holding the seat");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// The #667 state itself: endpoint unlinked, pidfile gone, the seat still
+/// held by a live daemon. `stop` must find the survivor through the pid the
+/// lock file records and reap it — and a fresh daemon must then be able to
+/// take the seat.
+#[test]
+fn a_seat_holder_with_no_pidfile_is_still_found_and_reaped() {
+    let _gate = serialized();
+    let dir = pinned_dir();
+    clear_stale_files(dir);
+
+    let child = spawn_daemon_from(Path::new(env!("CARGO_BIN_EXE_tty7-server")), dir);
+    let pid = child.id();
+    await_ready(dir);
+    assert_eq!(
+        std::fs::read_to_string(dir.join("daemon.lock"))
+            .unwrap()
+            .trim(),
+        pid.to_string(),
+        "the lock file names the daemon holding the seat"
+    );
+    let waiter = collect_on_exit(child);
+
+    // What #667 reports after quit-and-stop: both names for the process are
+    // gone; only the seat (and the pid recorded in it) remains.
+    std::fs::remove_file(dir.join("daemon.sock")).unwrap();
+    std::fs::remove_file(dir.join("daemon.pid")).unwrap();
+
+    tty7_core::daemon::spawn::stop();
+
+    assert_dies(pid, "stop() with no pidfile");
+    waiter
+        .join()
+        .unwrap()
+        .expect("collect the reaped daemon's exit");
+
+    // The user-visible acceptance: the next launch gets the seat instead of
+    // standing down and timing out red.
+    let second = spawn_daemon_from(Path::new(env!("CARGO_BIN_EXE_tty7-server")), dir);
+    let second_pid = second.id();
+    await_ready(dir);
+    let waiter = collect_on_exit(second);
+    tty7_core::daemon::spawn::stop();
+    assert_dies(second_pid, "cleanup stop");
+    waiter.join().unwrap().expect("collect the second daemon");
+}
+
+/// `reap_stranded` is the road the GUI's `ensure_running` and `tty7 server
+/// start` take into the #667 state; it must clear the survivor the same way
+/// `stop` does — after granting the grace a daemon mid-handoff would need.
+#[test]
+fn reap_stranded_clears_a_seat_holder_with_no_pidfile() {
+    let _gate = serialized();
+    let dir = pinned_dir();
+    clear_stale_files(dir);
+
+    let child = spawn_daemon_from(Path::new(env!("CARGO_BIN_EXE_tty7-server")), dir);
+    let pid = child.id();
+    await_ready(dir);
+    let waiter = collect_on_exit(child);
+
+    std::fs::remove_file(dir.join("daemon.sock")).unwrap();
+    std::fs::remove_file(dir.join("daemon.pid")).unwrap();
+
+    tty7_core::daemon::spawn::reap_stranded();
+
+    assert_dies(pid, "reap_stranded() with no pidfile");
+    waiter
+        .join()
+        .unwrap()
+        .expect("collect the reaped daemon's exit");
+    assert_eq!(
+        std::fs::read_to_string(dir.join("daemon.lock")).unwrap(),
+        "",
+        "a confirmed reap clears the dead holder's record from the lock file"
+    );
+}
+
+/// The grace's other half: a holder that answers the handshake is healthy —
+/// mid-startup, mid-handoff, or simply fine — and `reap_stranded` must leave
+/// it completely alone. This is the guard against the reap ending a daemon
+/// that is carrying every live session across an exec.
+#[test]
+fn a_holder_that_answers_the_handshake_is_left_alone() {
+    let _gate = serialized();
+    let dir = pinned_dir();
+    clear_stale_files(dir);
+
+    let child = spawn_daemon_from(Path::new(env!("CARGO_BIN_EXE_tty7-server")), dir);
+    let pid = child.id();
+    await_ready(dir);
+    let waiter = collect_on_exit(child);
+
+    tty7_core::daemon::spawn::reap_stranded();
+
+    assert!(
+        unsafe { libc::kill(pid as libc::pid_t, 0) } == 0,
+        "a healthy daemon must survive reap_stranded untouched"
+    );
+    assert!(
+        PaneClient::at(&dir.join("daemon.sock")).version().is_ok(),
+        "and still be serving on its endpoint"
+    );
+
+    tty7_core::daemon::spawn::stop();
+    assert_dies(pid, "cleanup stop");
+    waiter.join().unwrap().expect("collect the daemon");
+}
+
+/// The startup grace must not excuse a holder that merely *connects*: a
+/// wedged daemon's listener still completes connections out of the kernel's
+/// backlog while answering nothing. Health is an answered handshake — a
+/// live, connectable, silent holder is exactly what the reap is for.
+#[test]
+fn a_connectable_holder_that_answers_nothing_is_still_reaped() {
+    let _gate = serialized();
+    let dir = pinned_dir();
+    clear_stale_files(dir);
+
+    let child = spawn_daemon_from(Path::new(env!("CARGO_BIN_EXE_tty7-server")), dir);
+    let pid = child.id();
+    await_ready(dir);
+    let waiter = collect_on_exit(child);
+
+    // Frozen mid-service: the kernel keeps completing connections on its
+    // listener, the process answers nothing — the closest reproducible stand-
+    // in for a daemon wedged in its main loop.
+    assert_eq!(
+        unsafe { libc::kill(pid as libc::pid_t, libc::SIGSTOP) },
+        0,
+        "freeze the daemon"
+    );
+    assert!(
+        std::os::unix::net::UnixStream::connect(dir.join("daemon.sock")).is_ok(),
+        "a frozen daemon's endpoint still connects — that is the trap"
+    );
+
+    tty7_core::daemon::spawn::reap_stranded();
+
+    assert_dies(pid, "reap_stranded() against a connectable, silent holder");
+    waiter
+        .join()
+        .unwrap()
+        .expect("collect the reaped daemon's exit");
+}
+
+/// A daemon whose executable was deleted under it — every update that
+/// replaces the installation — must still read as ours. `proc_pidpath` fails
+/// outright for such a process on macOS, and treating that as "not our
+/// daemon" dropped the pidfile without reaping anyone: the other road into
+/// the #667 lockout.
+#[test]
+fn a_daemon_running_from_a_deleted_executable_is_still_ours_to_reap() {
+    let _gate = serialized();
+    let dir = pinned_dir();
+    clear_stale_files(dir);
+
+    let bin_dir = dir.join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    let copied = bin_dir.join("tty7-server");
+    std::fs::copy(env!("CARGO_BIN_EXE_tty7-server"), &copied).unwrap();
+
+    let child = spawn_daemon_from(&copied, dir);
+    let pid = child.id();
+    await_ready(dir);
+    let waiter = collect_on_exit(child);
+
+    std::fs::remove_file(&copied).unwrap();
+    // Unlinked so stop() cannot simply ask for a shutdown: the reap's
+    // identity check is the code under test, and it only runs against a
+    // process that would not die politely. The pidfile stays — the pid
+    // source here is the ordinary one; what is broken is the executable.
+    std::fs::remove_file(dir.join("daemon.sock")).unwrap();
+
+    tty7_core::daemon::spawn::stop();
+
+    assert_dies(pid, "stop() with the executable deleted");
+    waiter
+        .join()
+        .unwrap()
+        .expect("collect the reaped daemon's exit");
+    assert!(
+        !dir.join("daemon.pid").exists(),
+        "a confirmed reap clears the pidfile"
+    );
+}

--- a/crates/tty7-server/tests/daemon_stop.rs
+++ b/crates/tty7-server/tests/daemon_stop.rs
@@ -103,12 +103,17 @@ fn a_clean_shutdown_keeps_the_pidfile_until_the_process_is_gone() {
     );
 }
 
-/// `spawn::stop` must reap a daemon that stopped listening but never exited,
-/// even when the pidfile vanishes under it mid-stop — the ordering an old
-/// build's shutdown produces when it wipes its files and then stalls (#653).
-/// The pid captured at the top of `stop` is what the reap has to act on.
+/// `spawn::stop` must reap a daemon that stopped listening but never exited
+/// (#653) — and without the shutdown wait: only a shutdown that was actually
+/// delivered earns `PROCESS_EXIT_TIMEOUT`, the time an *asked* daemon gets
+/// to finish exiting. To a survivor stop() could not even connect to, that
+/// wait was five seconds of watching nothing move (#667); the reap's own
+/// SIGTERM window is all the grace such a process gets.
+///
+/// (The companion ordering — the pidfile already gone when the reap needs a
+/// pid — is pinned by the `daemon_reap` suite through the seat record.)
 #[test]
-fn stop_reaps_a_lingering_daemon_even_after_the_pidfile_vanishes() {
+fn stop_reaps_an_unreachable_daemon_without_the_shutdown_wait() {
     let dir = tempfile::TempDir::new().unwrap();
     tty7_core::core::config::set_config_dir(dir.path().to_path_buf());
     let child = spawn_daemon(dir.path());
@@ -124,31 +129,19 @@ fn stop_reaps_a_lingering_daemon_even_after_the_pidfile_vanishes() {
     });
 
     // The #653 state, as stop() meets it: the endpoint is gone before stop()
-    // can ask for a shutdown, and the pidfile disappears while stop() is
-    // still waiting on the process. The delete must land inside stop()'s
-    // wait on the still-alive process (PROCESS_EXIT_TIMEOUT in spawn.rs),
-    // which the elapsed assertion below pins.
-    const SWEEP_DELAY: Duration = Duration::from_secs(1);
+    // can ask for a shutdown, and the process lives on.
     std::fs::remove_file(dir.path().join("daemon.sock")).unwrap();
-    let pidfile = dir.path().join("daemon.pid");
-    let sweeper = std::thread::spawn(move || {
-        std::thread::sleep(SWEEP_DELAY);
-        std::fs::remove_file(pidfile).is_ok()
-    });
 
     let stop_started = Instant::now();
     tty7_core::daemon::spawn::stop();
 
+    // Well under spawn.rs's PROCESS_EXIT_TIMEOUT (5s): a stop() that pays
+    // that wait for a shutdown it never delivered has regressed.
     assert!(
-        stop_started.elapsed() >= SWEEP_DELAY,
-        "stop() returned before the sweeper's delete — the mid-stop pidfile \
-         removal this test exists to exercise never happened; lower SWEEP_DELAY \
-         below spawn.rs's PROCESS_EXIT_TIMEOUT"
-    );
-    assert!(
-        sweeper.join().unwrap(),
-        "the sweeper found no pidfile to delete — stop() removed it early, so \
-         the vanishing-pidfile ordering was not exercised"
+        stop_started.elapsed() < Duration::from_secs(4),
+        "stop() spent {:?} on a daemon it never reached — the exit wait must \
+         be earned by a delivered shutdown",
+        stop_started.elapsed()
     );
     let deadline = Instant::now() + Duration::from_secs(2);
     while unsafe { libc::kill(pid as libc::pid_t, 0) } == 0 {


### PR DESCRIPTION
Fixes #667: a daemon that survives quit-and-stop with its endpoint unlinked and its pidfile gone still holds the singleton seat, and nothing on the machine could find it, kill it, or start a replacement — every launch timed out red until a manual `kill`.

| | Before | After |
|---|---|---|
| Reopen the app in the #667 state | New daemon stands down on `Claim::Taken`, GUI errors "daemon did not start listening within 3s", forever | The reap finds the survivor through the pid recorded in `daemon.lock`, kills it, and the fresh daemon takes the seat |
| `tty7 server stop` when nobody answers | "the server is not running" — the seat holder is left untouched | Reaps the stranded holder and reports `stopped a stranded server (pid X)`; "not running" only when the seat is actually free |
| `tty7 server start` against a stranded seat | Spawn stands down, 10s timeout, error points at nothing | Clears the stranded holder first (`spawn::reap_stranded`, shared with the GUI's `ensure_running`), then starts |
| Daemon whose binary was deleted (every nightly update) | `proc_pidpath` fails → reap deletes the pidfile **without killing anyone** — the road into #667 | Identity falls back to the kernel's comm name (`proc_name` / `/proc/pid/comm`, recorded at exec, immune to deletion); Linux's ` (deleted)` marker is stripped |
| Live process the reap cannot identify | Record deleted, process left alive (stranded) | Record kept — the pid is the only handle left on the survivor |
| Zombie recorded as the daemon | Counted alive: SIGTERM + SIGKILL a corpse for the full 8s of both timeouts | Reads as dead (`proc_pidinfo` / `/proc/stat` state); record cleared immediately |
| `stop()` against a daemon it could not even connect to | Waits `PROCESS_EXIT_TIMEOUT` (5s) for a shutdown it never delivered | The wait is earned by a delivered shutdown; otherwise straight to the reap's own graceful SIGTERM window |
| Startup-timeout error text | Names nothing actionable | Names the seat-holding pid; `kill` advice only when the pid verifiably is our daemon |

Health checks during recovery are an **answered handshake, never a bare connect** — a wedged daemon's listener still completes connections out of the kernel's backlog — and a seat holder that answers is left completely alone, so a daemon mid-handoff (carrying every live session across an exec) is never reaped by mistake.

```mermaid
flowchart TD
    A[nobody answers on daemon.sock] --> B{seat held?<br/>flock probe on daemon.lock}
    B -- free --> S[spawn fresh daemon]
    B -- held --> G{answers handshake<br/>within 1s grace?}
    G -- yes --> OK[healthy: leave it alone]
    G -- no --> P{pid known?<br/>pidfile, else lock record}
    P -- no --> S
    P -- yes --> I{alive + named<br/>tty7-app / tty7-server / comm?}
    I -- "dead / foreign" --> C[clear stale records] --> S
    I -- ours --> K[SIGTERM, then SIGKILL] --> C
    I -- unidentifiable --> W[keep the record,<br/>touch nothing]
```

The pid is written into `daemon.lock` at claim time (and rewritten on handoff adoption). The lock file is never deleted and holding the flock is the definition of being the server, so while the seat is held its content names the holder. A confirmed reap truncates the record — only under a momentarily-free seat, so a fresh claimant's record is never erased. On-disk format is compatible both ways: old builds never read the content, new builds treat empty/garbage content as "no record" and degrade to the old behavior. No protocol or dialect bump.

Known limits, stated in code: the recovery is unix-only (the Windows seat is `share_mode(0)`, unreadable while held), and daemons stranded by pre-fix builds wrote no pid — those still need one manual `kill`, which the error text now at least points at.

## Testing

- New integration suite `daemon_reap.rs` (5 tests, real daemons): seat-holder-with-no-pidfile reaped via the lock record and the seat retaken; deleted-executable daemon still identified and reaped; `reap_stranded` recovery path incl. record cleanup; a connectable-but-silent holder still reaped (SIGSTOP-frozen daemon); a handshake-answering holder left untouched.
- New unit tests: lock file names its holder / free seat names nobody; clear-record spares a live holder and erases a dead one; zombie is not alive; comm resolution; ` (deleted)` stripping.
- Every guard was **mutation-verified**: with the fallback / handshake criterion / grace / wait-gate removed, the corresponding test goes red.
- Zombie probe semantics (`proc_pidinfo` failing for a zombie that still answers signal 0) and `proc_pidpath` failing for deleted executables were measured on macOS, not assumed.
- Manual end-to-end on macOS: reproduced the exact #667 state (sock + pidfile gone, seat held), then `tty7 server start` recovered in one command and `tty7 server stop` reaped the survivor in 73ms; clean-state `stop` stays a fast no-op.
- Full runs green: 598 `daemon::` unit tests, `daemon_reap` + `daemon_stop` integration, tty7-cli suite, `cargo fmt --check`.
