### PR TITLE
fix(windows): normalize path separators before reveal and copy

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -4241,22 +4241,29 @@ impl Tty7App {
         cx.notify();
     }
 
-    pub(crate) fn tab_cwd(
-        &self,
-        index: usize,
-        window: &Window,
-        cx: &App,
-    ) -> Option<std::path::PathBuf> {
-        self.tabs
-            .get(index)?
-            .pane
-            .focused_or_first(window, cx)
-            .and_then(|leaf| leaf.read(cx).cwd())
+    /// A tab's working directory, spelled for the clipboard.
+    ///
+    /// A cwd on this machine is re-spelled with this OS's separators, because
+    /// what goes on the clipboard is meant to be pasted into a shell and a
+    /// mixed-separator path is not one Windows will take. A remote pane's cwd
+    /// keeps the spelling its own machine uses — it is already native over
+    /// there. Both "Copy working directory" entry points (the app-menu action
+    /// and the tab context menu) come through here so the two cannot drift.
+    pub(crate) fn tab_cwd_text(&self, index: usize, window: &Window, cx: &App) -> Option<String> {
+        let leaf = self.tabs.get(index)?.pane.focused_or_first(window, cx)?;
+        let view = leaf.read(cx);
+        let cwd = view.cwd()?;
+        Some(match view.local_cwd().is_some() {
+            true => crate::ui::path_display::native_separators(&cwd)
+                .display()
+                .to_string(),
+            false => cwd.display().to_string(),
+        })
     }
 
     pub(crate) fn copy_active_cwd(&mut self, window: &Window, cx: &mut Context<Self>) {
-        if let Some(cwd) = self.tab_cwd(self.active, window, cx) {
-            cx.write_to_clipboard(gpui::ClipboardItem::new_string(cwd.display().to_string()));
+        if let Some(text) = self.tab_cwd_text(self.active, window, cx) {
+            cx.write_to_clipboard(gpui::ClipboardItem::new_string(text));
         }
     }
 

--- a/src/ui/file_tree.rs
+++ b/src/ui/file_tree.rs
@@ -2050,13 +2050,18 @@ impl Tty7App {
 
         menu = menu.separator().item(
             PopupMenuItem::new(t(L10nKey::FileTreeContextCopyPath)).on_click({
-                let p = p.clone();
+                // Only a path on this machine gets re-spelled: a remote
+                // host's paths are already native over there, and giving
+                // them this OS's separators would copy something that names
+                // nothing on either machine.
+                let text = match paths_are_local {
+                    true => crate::ui::path_display::native_separators(&p)
+                        .display()
+                        .to_string(),
+                    false => p.display().to_string(),
+                };
                 move |_, _window, cx| {
-                    cx.write_to_clipboard(gpui::ClipboardItem::new_string(
-                        crate::ui::path_display::native_separators(&p)
-                            .display()
-                            .to_string(),
-                    ));
+                    cx.write_to_clipboard(gpui::ClipboardItem::new_string(text.clone()));
                 }
             }),
         );

--- a/src/ui/file_tree.rs
+++ b/src/ui/file_tree.rs
@@ -2052,7 +2052,11 @@ impl Tty7App {
             PopupMenuItem::new(t(L10nKey::FileTreeContextCopyPath)).on_click({
                 let p = p.clone();
                 move |_, _window, cx| {
-                    cx.write_to_clipboard(gpui::ClipboardItem::new_string(p.display().to_string()));
+                    cx.write_to_clipboard(gpui::ClipboardItem::new_string(
+                        crate::ui::path_display::native_separators(&p)
+                            .display()
+                            .to_string(),
+                    ));
                 }
             }),
         );
@@ -2061,7 +2065,7 @@ impl Tty7App {
                 PopupMenuItem::new(crate::ui::right_panel::reveal_label()).on_click({
                     let p = p.clone();
                     move |_, _window, cx| {
-                        cx.reveal_path(&p);
+                        cx.reveal_path(&crate::ui::path_display::native_separators(&p));
                     }
                 }),
             );

--- a/src/ui/path_display.rs
+++ b/src/ui/path_display.rs
@@ -69,21 +69,55 @@ fn normalized(s: &str) -> String {
         .to_ascii_lowercase()
 }
 
-/// Normalizes a path's separators to what the local OS expects. On Windows the
-/// shell's `IShellFolder::ParseDisplayName` bails out with `E_INVALIDARG` on a
-/// mixed-separator path — a forward-slash prefix joined with backslash
-/// entries. The forward slashes get in from two routes: the shell's PWD
-/// (OSC 7 from Git Bash / MSYS bash reports `/`, and that string survives
-/// `Path::ancestors()` when the file tree walks up to find `.git`), and
-/// `git rev-parse --show-toplevel` from Git for Windows (MSYS2), which always
-/// prints `/` regardless of the calling shell. `reveal_path` swallows that
-/// failure (it only logs), so handing it native separators is what makes
+/// Re-spells a path on **this** machine with the separators this OS expects.
+///
+/// On Windows the shell's `IShellFolder::ParseDisplayName` bails out with
+/// `E_INVALIDARG` on a mixed-separator path — a forward-slash prefix joined
+/// with backslash entries. The forward slashes get in from two routes: the
+/// shell's PWD (OSC 7 from Git Bash / MSYS bash reports `/`, and that string
+/// survives `Path::ancestors()` when the file tree walks up to find `.git`),
+/// and `git rev-parse --show-toplevel` from Git for Windows (MSYS2), which
+/// always prints `/` regardless of the calling shell. `reveal_path` swallows
+/// that failure (it only logs), so handing it native separators is what makes
 /// "open folder" actually open.
+///
+/// **Only for paths on the machine this window runs on.** A remote host's
+/// `/home/u/src` is already native over there; re-spelling it would put a
+/// path on the clipboard that names nothing on either machine. Every caller
+/// sits behind a locality check for that reason.
+///
+/// The rewrite runs on the path's own UTF-16 code units, not on a
+/// `to_string_lossy` copy of them. A Windows filename may hold unpaired
+/// surrogates, which `to_string_lossy` turns into `U+FFFD` — the returned
+/// path would then silently name a *different* file, and reveal would open
+/// nothing without reporting why. `/` and `\` are ASCII, so a code unit
+/// equal to one of them is that character and never half of a surrogate
+/// pair, which is what makes the swap safe to do one unit at a time.
+#[cfg(windows)]
 pub(crate) fn native_separators(path: &Path) -> Cow<'_, Path> {
-    #[cfg(windows)]
-    if path.as_os_str().to_string_lossy().contains('/') {
-        return Cow::Owned(path.as_os_str().to_string_lossy().replace('/', "\\").into());
+    use std::ffi::OsString;
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+    const SLASH: u16 = b'/' as u16;
+    const BACKSLASH: u16 = b'\\' as u16;
+
+    let os = path.as_os_str();
+    // Nothing to fix — including every UNC (`\\wsl$\…`, `\\?\…`) and
+    // already-native path — hands the caller's own path straight back.
+    if !os.encode_wide().any(|unit| unit == SLASH) {
+        return Cow::Borrowed(path);
     }
+    let wide: Vec<u16> = os
+        .encode_wide()
+        .map(|unit| if unit == SLASH { BACKSLASH } else { unit })
+        .collect();
+    Cow::Owned(PathBuf::from(OsString::from_wide(&wide)))
+}
+
+/// Off Windows the OS separator is already `/`, and a backslash in a path is
+/// an ordinary filename character — there is nothing to re-spell.
+#[cfg(not(windows))]
+pub(crate) fn native_separators(path: &Path) -> Cow<'_, Path> {
     Cow::Borrowed(path)
 }
 
@@ -232,14 +266,49 @@ mod tests {
         // A UNC path (`\\wsl$\…`, `\\?\…`) or an already-native path has no
         // `/`, so it passes through borrowed — the replace is a no-op and
         // must not allocate, nor touch the leading `\\`.
-        for p in ["\\\\wsl$\\Ubuntu\\home", "\\\\?\\C:\\code", "C:\\code\\tty7"] {
+        for p in [
+            "\\\\wsl$\\Ubuntu\\home",
+            "\\\\?\\C:\\code",
+            "C:\\code\\tty7",
+        ] {
             let got = native_separators(Path::new(p));
             assert_eq!(got.as_ref(), Path::new(p), "{p:?}");
-            assert!(
-                matches!(got, Cow::Borrowed(_)),
-                "{p:?} should not allocate"
-            );
+            assert!(matches!(got, Cow::Borrowed(_)), "{p:?} should not allocate");
         }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn native_separators_keeps_a_name_a_string_cannot_hold() {
+        use std::ffi::OsString;
+        use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+        // `0xD800` is a lone high surrogate — legal in an NTFS name, and not
+        // representable in a Rust `str`. Rewriting through
+        // `to_string_lossy` would swap it for `U+FFFD` and hand back a path
+        // naming a *different* file; because `reveal_path` only logs its
+        // failures, that reads to the user as the same silent no-op this fix
+        // is here to remove. Working on the UTF-16 units keeps the name.
+        let raw: Vec<u16> = "C:/a"
+            .encode_utf16()
+            .chain([0xD800])
+            .chain("/b".encode_utf16())
+            .collect();
+        let path = PathBuf::from(OsString::from_wide(&raw));
+        let want: Vec<u16> = "C:\\a"
+            .encode_utf16()
+            .chain([0xD800])
+            .chain("\\b".encode_utf16())
+            .collect();
+        assert_eq!(
+            native_separators(&path)
+                .as_os_str()
+                .encode_wide()
+                .collect::<Vec<_>>(),
+            want
+        );
+        // The round-trip this replaced really did destroy it.
+        assert!(path.to_string_lossy().contains('\u{FFFD}'));
     }
 
     #[cfg(not(windows))]

--- a/src/ui/path_display.rs
+++ b/src/ui/path_display.rs
@@ -69,6 +69,24 @@ fn normalized(s: &str) -> String {
         .to_ascii_lowercase()
 }
 
+/// Normalizes a path's separators to what the local OS expects. On Windows the
+/// shell's `IShellFolder::ParseDisplayName` bails out with `E_INVALIDARG` on a
+/// mixed-separator path — a forward-slash prefix joined with backslash
+/// entries. The forward slashes get in from two routes: the shell's PWD
+/// (OSC 7 from Git Bash / MSYS bash reports `/`, and that string survives
+/// `Path::ancestors()` when the file tree walks up to find `.git`), and
+/// `git rev-parse --show-toplevel` from Git for Windows (MSYS2), which always
+/// prints `/` regardless of the calling shell. `reveal_path` swallows that
+/// failure (it only logs), so handing it native separators is what makes
+/// "open folder" actually open.
+pub(crate) fn native_separators(path: &Path) -> Cow<'_, Path> {
+    #[cfg(windows)]
+    if path.as_os_str().to_string_lossy().contains('/') {
+        return Cow::Owned(path.as_os_str().to_string_lossy().replace('/', "\\").into());
+    }
+    Cow::Borrowed(path)
+}
+
 /// Shortens `path` to start from `~` when it is (inside) `home` — the home
 /// directory of the machine `path` is on, not of this one.
 ///
@@ -180,5 +198,59 @@ mod tests {
         // component before or after the home prefix cannot move it.
         assert_eq!(abbreviate_under("/home/日本/work", "/home/日本"), "~/work");
         assert_eq!(abbreviate_under("/home/xa/日本語", "/home/xa"), "~/日本語");
+    }
+
+    #[test]
+    fn native_separators_passes_through_a_path_with_nothing_to_fix() {
+        // No forward slashes → nothing to rewrite, and no allocation: the
+        // borrowed path is the caller's, handed back untouched.
+        assert!(matches!(
+            native_separators(Path::new("README.md")),
+            Cow::Borrowed(_)
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn native_separators_rewrites_forward_slashes_to_backslashes_on_windows() {
+        // The bug: a repo root from `git rev-parse` (forward slashes) joined
+        // with backslash-joined entries yields a mixed path, which
+        // `ParseDisplayName` rejects. Every `/` must become `\`.
+        assert_eq!(
+            native_separators(Path::new("D:/code/tty7\\skills")),
+            Path::new("D:\\code\\tty7\\skills")
+        );
+        assert_eq!(
+            native_separators(Path::new("D:/code/tty7")),
+            Path::new("D:\\code\\tty7")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn native_separators_leaves_unc_and_backslash_paths_alone() {
+        // A UNC path (`\\wsl$\…`, `\\?\…`) or an already-native path has no
+        // `/`, so it passes through borrowed — the replace is a no-op and
+        // must not allocate, nor touch the leading `\\`.
+        for p in ["\\\\wsl$\\Ubuntu\\home", "\\\\?\\C:\\code", "C:\\code\\tty7"] {
+            let got = native_separators(Path::new(p));
+            assert_eq!(got.as_ref(), Path::new(p), "{p:?}");
+            assert!(
+                matches!(got, Cow::Borrowed(_)),
+                "{p:?} should not allocate"
+            );
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn native_separators_is_a_no_op_off_windows() {
+        // On Unix the OS separator is `/`; a path that happens to contain
+        // backslashes is legitimate and must be left alone.
+        for p in ["/home/u/tty7", "C:\\Users\\dev", "mixed/path\\here"] {
+            let got = native_separators(Path::new(p));
+            assert_eq!(got.as_ref(), Path::new(p), "{p:?}");
+            assert!(matches!(got, Cow::Borrowed(_)));
+        }
     }
 }

--- a/src/ui/right_panel.rs
+++ b/src/ui/right_panel.rs
@@ -681,19 +681,24 @@ impl Tty7App {
                 );
                 if let Some(cwd) = view.effective_cwd() {
                     let home = view.display_home(cx);
+                    // Whether this pane's paths are this machine's decides
+                    // both tiles: reveal only means anything on the machine
+                    // the file manager can see, and only a local path may be
+                    // re-spelled with this OS's separators — a remote one is
+                    // already native where it lives.
+                    let local = view.local_cwd().is_some();
                     rows.push(InfoRow {
                         label: t(L10nKey::PanelCwd),
                         value: InfoValue::Path(compact_path(&cwd, home.as_deref())),
                         // The compacted `~/…` spelling is for reading; what
                         // goes on the clipboard is the path a shell can use.
-                        copy: Some(
-                            crate::ui::path_display::native_separators(&cwd)
+                        copy: Some(match local {
+                            true => crate::ui::path_display::native_separators(&cwd)
                                 .display()
                                 .to_string(),
-                        ),
-                        // Reveal only means anything when the path is on the
-                        // machine the file manager can see.
-                        reveal: view.local_cwd().is_some().then(|| cwd.clone()),
+                            false => cwd.display().to_string(),
+                        }),
+                        reveal: local.then(|| cwd.clone()),
                     });
                 }
                 let shell = match view.shell_spec().map(|s| s.program.clone()) {

--- a/src/ui/right_panel.rs
+++ b/src/ui/right_panel.rs
@@ -686,7 +686,11 @@ impl Tty7App {
                         value: InfoValue::Path(compact_path(&cwd, home.as_deref())),
                         // The compacted `~/…` spelling is for reading; what
                         // goes on the clipboard is the path a shell can use.
-                        copy: Some(cwd.display().to_string()),
+                        copy: Some(
+                            crate::ui::path_display::native_separators(&cwd)
+                                .display()
+                                .to_string(),
+                        ),
                         // Reveal only means anything when the path is on the
                         // machine the file manager can see.
                         reveal: view.local_cwd().is_some().then(|| cwd.clone()),
@@ -970,7 +974,9 @@ impl Tty7App {
                     reveal_label(),
                     cx,
                 )
-                .on_click(move |_, _window, cx| cx.reveal_path(&cwd)),
+                .on_click(move |_, _window, cx| {
+                    cx.reveal_path(&crate::ui::path_display::native_separators(&cwd))
+                }),
             );
         }
         if let Some(text) = row.copy {

--- a/src/ui/scm/panel.rs
+++ b/src/ui/scm/panel.rs
@@ -1665,13 +1665,17 @@ impl Tty7App {
             .separator()
             .item(
                 PopupMenuItem::new(t(L10nKey::FileTreeContextCopyPath)).on_click({
-                    let absolute = absolute.clone();
+                    // Same locality rule as Reveal below: a remote
+                    // repository's paths belong to its own filesystem and
+                    // are left spelled the way that machine spells them.
+                    let text = match repo.host == HostId::LOCAL {
+                        true => crate::ui::path_display::native_separators(&absolute)
+                            .display()
+                            .to_string(),
+                        false => absolute.display().to_string(),
+                    };
                     move |_, _window, cx| {
-                        cx.write_to_clipboard(gpui::ClipboardItem::new_string(
-                            crate::ui::path_display::native_separators(&absolute)
-                                .display()
-                                .to_string(),
-                        ));
+                        cx.write_to_clipboard(gpui::ClipboardItem::new_string(text.clone()));
                     }
                 }),
             );

--- a/src/ui/scm/panel.rs
+++ b/src/ui/scm/panel.rs
@@ -1668,7 +1668,9 @@ impl Tty7App {
                     let absolute = absolute.clone();
                     move |_, _window, cx| {
                         cx.write_to_clipboard(gpui::ClipboardItem::new_string(
-                            absolute.display().to_string(),
+                            crate::ui::path_display::native_separators(&absolute)
+                                .display()
+                                .to_string(),
                         ));
                     }
                 }),
@@ -1680,7 +1682,9 @@ impl Tty7App {
             menu = menu.item(
                 PopupMenuItem::new(crate::ui::right_panel::reveal_label()).on_click({
                     let absolute = absolute.clone();
-                    move |_, _window, cx| cx.reveal_path(&absolute)
+                    move |_, _window, cx| {
+                        cx.reveal_path(&crate::ui::path_display::native_separators(&absolute))
+                    }
                 }),
             );
         }

--- a/src/ui/sftp.rs
+++ b/src/ui/sftp.rs
@@ -1047,7 +1047,8 @@ impl Tty7App {
     }
 
     pub(crate) fn sftp_reveal_download(&self, local: String, cx: &mut Context<Self>) {
-        cx.reveal_path(Path::new(&local));
+        let local = Path::new(&local);
+        cx.reveal_path(&crate::ui::path_display::native_separators(local));
     }
 
     fn sftp_poll_jobs(&mut self, cx: &mut Context<Self>) {

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -1321,7 +1321,7 @@ impl Tty7App {
         };
         let this = entity.read(cx);
         let tab_count = this.tabs.len();
-        let cwd = this.tab_cwd(index, window, cx);
+        let cwd = this.tab_cwd_text(index, window, cx);
         let has_cwd = cwd.is_some();
         let mut menu = menu.min_w(px(200.));
 
@@ -1439,10 +1439,8 @@ impl Tty7App {
                 .action(Box::new(CopyWorkingDirectory))
                 .disabled(!has_cwd)
                 .on_click(move |_, _window, cx| {
-                    if let Some(cwd) = cwd.as_ref() {
-                        cx.write_to_clipboard(gpui::ClipboardItem::new_string(
-                            cwd.display().to_string(),
-                        ));
+                    if let Some(text) = cwd.as_ref() {
+                        cx.write_to_clipboard(gpui::ClipboardItem::new_string(text.clone()));
                     }
                 }),
         );


### PR DESCRIPTION
`reveal_path` ("open folder") and copy-to-clipboard on Windows were handed raw paths whose separators `IShellFolder::ParseDisplayName` could not resolve, so opening a folder did nothing and copied paths were not what a shell would type.

A mixed-separator path — a forward-slash prefix joined with backslash entries — reaches `reveal_path` through two routes:

  - **The shell's PWD.** OSC 7 from Git Bash / MSYS bash reports the directory with `/`, and that string survives `Path::ancestors()` when the file tree walks up to find `.git`. So the file-tree root keeps the forward slashes, while the `read_dir` entries underneath come back in native form (backslash).
  - **`git rev-parse --show-toplevel`.** Git for Windows (MSYS2) prints `/` regardless of the calling shell (pwsh included). Both the SCM panel's `scm_repo_root` (`src/ui/scm/panel.rs`) and the worktree creation in `tty7-core` use it, so the root they hand downstream is `/`-prefixed and joins against backslash-joined entries to form paths like `D:/code/tty7\skills`.

Windows' `IShellFolder::ParseDisplayName` rejects that with `E_INVALIDARG` (0x80070057). gpui's `reveal_path` swallows the error (it only logs), so "open folder" silently no-ops. The same mixed-separator strings also make copy-to-clipboard produce paths the user has to retype before a shell will accept them.

## Changes

Add `native_separators(path) -> Cow<Path>` to `src/ui/path_display.rs`:

- On Windows, if the path contains `/`, rewrite every `/` to `\`.
- Otherwise (UNC `\\wsl$\…`, `\\?\…`, already-native path, non-Windows) return `Cow::Borrowed(path)` — **no allocation**.

The rewrite runs on the path's own UTF-16 code units (`OsStrExt::encode_wide` → `OsString::from_wide`), not on a `to_string_lossy` copy. A Windows filename may hold unpaired surrogates, which `to_string_lossy` replaces with `U+FFFD`; a path rebuilt from that names a *different* file, and because `reveal_path` only logs its failures that reads to the user as exactly the silent no-op this PR is removing. `/` and `\` are ASCII, so a code unit equal to either is that character and never half of a surrogate pair — which is what makes the swap safe one unit at a time.

`Cow<'_, Path>` rather than a `String`: `reveal_path` wants a `&Path` and gets one without a lossy step, and the borrowed arm keeps the common case allocation-free.

### Only local paths get re-spelled

`native_separators` answers "how does **this** machine spell a path", so it may only be applied to a path on this machine. A remote host's `/home/u/src` is already native over there; giving it this OS's separators would put `\home\u\src` on the clipboard, which names nothing on either machine. Every call site therefore sits behind the same locality check its Reveal neighbour already used — `paths_are_local` in the file tree, `repo.host == HostId::LOCAL` in the SCM panel, `local_cwd().is_some()` for a pane's cwd.

| Call site | Before | After |
|---|---|---|
| File tree: "Copy path" | Raw separators | Normalized when `paths_are_local` |
| File tree: "Reveal" (open folder) | `reveal_path` got the mixed path, failed silently | Normalized, opens |
| SCM panel: copy path / reveal | Same failure | Normalized when the repo is on `HostId::LOCAL` |
| Info panel cwd: copy / reveal | `copy: cwd.display()`, bare `reveal_path(&cwd)` | Both normalized when the pane's paths are local |
| "Copy working directory" (app menu + tab context menu) | Two inline copies, neither normalized | Both go through `tab_cwd_text`, normalized when local |
| SFTP download → reveal | `reveal_path` got the raw local path | Normalized, opens |

The two "Copy working directory" entries had each spelled the path their own way; folding them into one helper is what stops them drifting apart again.

## Testing

Unit tests in `src/ui/path_display.rs`:

- `native_separators_passes_through_a_path_with_nothing_to_fix` — no `/` → `Cow::Borrowed`, no allocation.
- `native_separators_rewrites_forward_slashes_to_backslashes_on_windows` — `D:/code/tty7\skills` and `D:/code/tty7` both normalized.
- `native_separators_leaves_unc_and_backslash_paths_alone` (windows) — UNC / `\\?\…` / already-native paths pass through borrowed.
- `native_separators_keeps_a_name_a_string_cannot_hold` (windows) — a lone `0xD800` high surrogate survives the rewrite, and the test also asserts the `to_string_lossy` round-trip this replaced really did destroy it.
- `native_separators_is_a_no_op_off_windows` (non-windows) — Unix and backslash-containing paths untouched.

`cargo fmt --all --check` clean. The `#[cfg(windows)]` tests are the Windows CI job's to run.

## Follow-up: the entry points are left as they are

This fix normalizes at the leaves — reveal and clipboard copy — not where the forward slashes enter. That is deliberate, and it does leave work behind: the file-tree root, the dirs handed to `host.watch` (`src/terminal/git_data.rs:944`), the root passed to `git worktree add` (`crates/tty7-core/src/core/worktree.rs`), and the `starts_with` comparison at `worktree.rs:74` all still hold mixed-separator paths, so prefix checks and dedup can still be wrong there — just not user-visible yet.

Normalizing at the entry points is a separate change because both of them are the wrong shape for a `cfg!(windows)` rewrite:

- **`git rev-parse --show-toplevel` (6 sites).** `crates/tty7-core/src/core/git/mod.rs:38` (`probe`), `git/status.rs:835` (`probe_status`), `git/diff.rs:426` (`probe_diff`), `worktree.rs:66` (`managed`), `worktree.rs:111` (`repo_dir`), `src/ui/scm/panel.rs:1147` (`scm_repo_root`) — plus `src/terminal/git_data.rs:1141` for `--git-dir`/`--git-common-dir`. Every one takes `&dyn Host`, and `RemoteHost::git` ships the command to `tty7-server` on another machine. Normalizing there by `cfg!(windows)` would mangle a Linux server's `/home/u/repo` into `\home\u\repo` whenever the *client* is Windows. The right primitive is the host-aware `host.separator()` (what `default_join` already uses), which is a different helper and means auditing all six sites — they also carry three different trim strategies and one is missing `--path-format=absolute`. That is a refactor with its own test surface, not part of this bug fix.
- **OSC 7.** One decode site, `parse_osc7` in `crates/tty7-core/src/daemon/pane.rs:2950`, but it is in the daemon and its result is wire-visible: `PaneState.cwd` → `DaemonMsg::Cwd`, the `ObservedFacts.cwd` / `PaneFacts.cwd` deltas, and `PaneInfo.cwd` on the control API. The forward-slash spelling is also deliberate today — the shell snippet at `daemon/shell_integration.rs:278` emits `pwd -W` output on purpose and `shell_integration.rs:2466` asserts `C:/Users/thoma/repo` survives the round trip. Changing it changes a daemon contract and its guard test, and needs its own compatibility story across client/daemon versions.

The leaves are, in fact, the one place `cfg!(windows)` is the correct question to ask: reveal and copy are guarded to local paths, so the target machine is known to be this one. Pushing normalization up the stack means switching to a host-aware separator first — worth doing, in a change scoped to it.
