### PR TITLE
fix(restart): fail a silent Attach, and hold the tabs a rebuild could not put up (#673)

### DIFF
--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -29,5 +29,5 @@ mod typeahead;
 pub mod view;
 
 pub(crate) use remote::notify_desktop;
-pub use remote::{PaneRoute, PaneWorkspace, RemoteTerminal};
+pub use remote::{PaneRoute, PaneWorkspace, RemoteTerminal, attach_unanswered};
 pub use size::TermSize;

--- a/src/terminal/remote.rs
+++ b/src/terminal/remote.rs
@@ -219,6 +219,10 @@ pub struct RemoteTerminal {
     /// flag under the term lock before every grid mutation, so once it is set
     /// the abandoned thread can only exit, never write.
     reader_quit: Arc<AtomicBool>,
+    /// Set by the first `Input` the link refused, so the loss is said once
+    /// rather than once per keystroke. Cleared when a relink installs a link
+    /// that has not refused anything yet.
+    input_lost: AtomicBool,
 }
 
 /// The workspace id a spawn carries, so the pane's shell gets `$TTY7_WS` and a
@@ -405,7 +409,36 @@ impl RemoteTerminal {
         let win = win_size(size, cell_w, cell_h);
 
         ClientMsg::Attach { pane_id, size: win }.encode(&mut stream)?;
-        let buffered = attach_reply_prefix(&mut stream, pane_id, attach_reply_wait(route))?;
+        let buffered = match attach_reply_prefix(&mut stream, pane_id, attach_reply_wait(route)) {
+            Ok(buffered) => buffered,
+            Err(e) if route.is_local() && attach_unanswered(&e) => {
+                // Silence on the attach socket has two readings, and only one
+                // of them is safe to act on. Ask the daemon on a fresh
+                // connection: if it answers `Version` there, it is up and
+                // serving, and the attach connection is one it will never
+                // serve — a socket some process holds open, or one from a
+                // listener no longer drained — so the verdict stands and the
+                // caller spawns fresh. If it does not answer there either, it
+                // is not serving anyone yet — mid-restart, mid-handoff — and
+                // a fresh pane spawned now would land on a live one the moment
+                // it comes up (its history carried across, its agent session
+                // resumed twice). There is no third path from a synchronous
+                // UI-thread call, so the attach still fails, but says which
+                // silence it was: the log line someone reads while diagnosing
+                // an orphaned shell must not claim the pane was gone.
+                //
+                // Only local routes probe: a remote attach already waits 15 s
+                // and a second routed connection is a second bridge process.
+                if local_daemon_answers() {
+                    return Err(e);
+                }
+                return Err(e.context(
+                    "the daemon answered nothing on a fresh connection either — it is not \
+                     serving yet (restarting?), so this pane may still be alive",
+                ));
+            }
+            Err(e) => return Err(e),
+        };
         let mut term = Self::from_stream_with(stream, size, buffered)?;
         term.route = route.clone();
         Ok(term)
@@ -480,6 +513,7 @@ impl RemoteTerminal {
         }
         self.reader_thread = Some(reader);
         self.reader_quit = quit;
+        self.input_lost.store(false, Ordering::SeqCst);
         self.route = route.clone();
         self.synced_size = false;
         self.resize(size, cell_w, cell_h);
@@ -577,6 +611,7 @@ impl RemoteTerminal {
             proxy,
             reader_thread: Some(reader_thread),
             reader_quit,
+            input_lost: AtomicBool::new(false),
         })
     }
 
@@ -1094,9 +1129,40 @@ impl RemoteTerminal {
         if bytes.is_empty() {
             return;
         }
-        if let Ok(mut writer) = self.writer.lock() {
-            let _ = ClientMsg::Input(bytes.into_owned()).encode(&mut *writer);
+        let Ok(mut writer) = self.writer.lock() else {
+            return;
+        };
+        if let Err(e) = ClientMsg::Input(bytes.into_owned()).encode(&mut *writer) {
+            drop(writer);
+            self.note_input_lost(&e);
         }
+    }
+
+    /// The link refused an `Input`. Every keystroke after the first would say
+    /// the same thing, so this side says it once; and unless the reader has
+    /// been retired for a relink or a release, the pane is marked exited the
+    /// way the reader marks it on EOF — it is the same socket, noticed from the
+    /// writing side first — so the window shows the pane as gone instead of
+    /// taking input into it that nothing will ever read. The reader still
+    /// raises its own `Exit` when it finds the same socket closed; the handler
+    /// is idempotent, so a link that is genuinely gone may be reported twice.
+    ///
+    /// This is hardening for a *closed* link, not the cure for #673: a socket
+    /// some process holds open and never reads accepts writes into its send
+    /// buffer, so they succeed and vanish until the buffer fills, and nothing
+    /// here fires. What stops that pane existing at all is `attach_on`
+    /// refusing to call a silent `Attach` attached.
+    fn note_input_lost(&self, err: &std::io::Error) {
+        if self.input_lost.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        log::warn!("the daemon link stopped taking this pane's input: {err}");
+        if self.reader_quit.load(Ordering::SeqCst) {
+            return;
+        }
+        self.exited_flag.store(true, Ordering::SeqCst);
+        self.proxy.send_event(AlacEvent::Wakeup);
+        self.proxy.send_event(AlacEvent::Exit);
     }
 
     /// Whether the daemon behind this pane echoes a `DaemonMsg::Size` into the
@@ -1646,6 +1712,21 @@ fn daemon_not_listening(err: &anyhow::Error) -> bool {
     })
 }
 
+/// How long an `Attach` may stay silent before it is called unanswered.
+///
+/// Only a silent connection ever pays this: a dead pane answers `Error` at
+/// once and a live one answers `Size` at once, so the budget is not a cost in
+/// the common case. What bounds it is the caller — a local restore attaches
+/// synchronously on the UI thread, one pane after another, so N silent panes
+/// hold the window still for N times this. What argues for more is the other
+/// side of the same silence: a daemon merely slow to serve — an execve handoff
+/// keeps the listener and its backlog across the exec, and a fresh daemon is
+/// adopting panes and seeding ids before it can take an `Attach` — would have
+/// served this connection a moment later, and calling it unanswered spawns a
+/// fresh pane over a live one, carries the live pane's history onto it and
+/// starts an agent resume against a session the old process still holds. The
+/// [`AttachUnanswered`] verdict is confirmed against that case in `attach_on`
+/// rather than by waiting longer here.
 fn attach_reply_wait(route: &PaneRoute) -> std::time::Duration {
     match route.is_local() {
         true => std::time::Duration::from_secs(2),
@@ -1653,6 +1734,48 @@ fn attach_reply_wait(route: &PaneRoute) -> std::time::Duration {
     }
 }
 
+/// An `Attach` that produced no bytes within its wait — nobody served the
+/// connection. Distinct from a refusal (`Error` frame) and from a hangup so
+/// the caller can say the true thing: the pane may well still exist.
+#[derive(Debug)]
+struct AttachUnanswered {
+    pane_id: u64,
+    wait: std::time::Duration,
+}
+
+impl std::fmt::Display for AttachUnanswered {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "the daemon did not answer Attach for pane {} within {:?} (an attached pane replays \
+             its screen at once, so nobody is serving this connection)",
+            self.pane_id, self.wait
+        )
+    }
+}
+
+impl std::error::Error for AttachUnanswered {}
+
+/// Whether `err` is an `Attach` that went unanswered, as opposed to refused or
+/// hung up on. The pane behind an unanswered attach may still be alive.
+pub fn attach_unanswered(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.downcast_ref::<AttachUnanswered>().is_some())
+}
+
+/// Reads far enough into the daemon's answer to an `Attach` to classify it, and
+/// hands back every byte read so the reader thread loses none of the replay.
+///
+/// Silence is a verdict, not a quiet pane. A daemon that attached replays the
+/// pane's ring before it reads a byte of our input, and the ring always holds
+/// a segment, so the first frame on a good attach is a `Size` — a quiet pane
+/// still sends that. An `Attach` that produced nothing within `wait` is one
+/// nobody is serving: a daemon still mid-restart, a socket held open by a
+/// process that will never read it. Taken for success it gave the window a
+/// pane drawn as restored whose every keystroke went into that socket — no
+/// fresh shell, no restored-screen banner, no agent resume, and Ctrl-C did
+/// nothing (#673). Taken for the failure it is, the caller spawns fresh and
+/// asks for the old screen back.
 fn attach_reply_prefix(
     stream: &mut Stream,
     pane_id: u64,
@@ -1684,6 +1807,9 @@ fn attach_reply_prefix(
         kind = crate::daemon::protocol::peek_frame_kind(&buffered);
     }
     let _ = stream.set_read_timeout(None);
+    if buffered.is_empty() {
+        return Err(anyhow::Error::new(AttachUnanswered { pane_id, wait }));
+    }
     if !kind.is_some_and(crate::daemon::protocol::is_error_kind) {
         return Ok(buffered);
     }
@@ -2153,6 +2279,30 @@ fn connect() -> anyhow::Result<Stream> {
             transport::endpoint_display()
         ))
     })
+}
+
+/// Whether the local daemon answers `Version` on a fresh connection right now.
+///
+/// The one question a silent `Attach` leaves open — is the daemon serving and
+/// this socket orphaned, or is nobody serving yet? A daemon answers `Version`
+/// before it touches any state, so this is the cheapest thing it can say. One
+/// second is the same budget `spawn` gives the same handshake; a healthy
+/// daemon answers in microseconds.
+fn local_daemon_answers() -> bool {
+    use std::io::Write as _;
+
+    let Ok(mut stream) = transport::connect() else {
+        return false;
+    };
+    let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(1)));
+    if ClientMsg::Version
+        .encode(&mut stream)
+        .and_then(|()| stream.flush())
+        .is_err()
+    {
+        return false;
+    }
+    matches!(DaemonMsg::read(&mut stream), Ok(DaemonMsg::Version(_)))
 }
 
 fn connect_routed(route: &PaneRoute) -> anyhow::Result<Stream> {
@@ -2760,6 +2910,61 @@ mod tests {
         );
     }
 
+    /// #673: a daemon that attached replays the pane's ring at once, and the
+    /// ring always holds a segment, so even a pane that has printed nothing
+    /// answers with a `Size`. A connection that stays silent for the whole wait
+    /// is therefore one nobody is serving — read as success, it became a pane
+    /// the window drew as restored while every keystroke, Ctrl-C included,
+    /// went into a socket nothing drained.
+    #[test]
+    fn an_attach_nobody_answers_is_not_an_attach() {
+        let (mut client_side, _daemon_side) = UnixStream::pair().unwrap();
+        let wait = std::time::Duration::from_millis(200);
+        let err = attach_reply_prefix(&mut client_side, 7, wait)
+            .expect_err("silence for the whole wait must not pass for an attached pane");
+        assert!(
+            format!("{err:#}").contains("did not answer"),
+            "the failure has to say the daemon never answered, not that the pane is gone: {err:#}"
+        );
+        assert!(
+            attach_unanswered(&err),
+            "silence is its own verdict, told apart from a refusal or a hangup"
+        );
+        // A refusal is not it: the pane really is gone then, and the caller
+        // may say so.
+        let (mut client_side, mut daemon_side) = UnixStream::pair().unwrap();
+        DaemonMsg::Error("no such pane 7".into())
+            .encode(&mut daemon_side)
+            .unwrap();
+        daemon_side.flush().unwrap();
+        let refused = attach_reply_prefix(&mut client_side, 7, wait).expect_err("refused");
+        assert!(!attach_unanswered(&refused));
+    }
+
+    /// The other side of the rule above: the frame a quiet pane does send is
+    /// enough. Nothing else is required of the daemon for the attach to stand.
+    #[test]
+    fn a_size_frame_alone_is_a_live_attach() {
+        let (mut client_side, mut daemon_side) = UnixStream::pair().unwrap();
+        DaemonMsg::Size(WinSize {
+            cols: 80,
+            rows: 24,
+            cell_w: 8,
+            cell_h: 17,
+        })
+        .encode(&mut daemon_side)
+        .unwrap();
+        daemon_side.flush().unwrap();
+
+        let buffered =
+            attach_reply_prefix(&mut client_side, 7, std::time::Duration::from_millis(200))
+                .expect("the daemon's first frame is the attach ack");
+        assert!(
+            !buffered.is_empty(),
+            "the Size frame was read to classify the reply; it must reach the reader"
+        );
+    }
+
     #[test]
     fn a_local_attach_does_not_wait_as_long_as_a_remote_one() {
         let local = attach_reply_wait(&PaneRoute::Local);
@@ -3149,6 +3354,62 @@ mod tests {
             ClientMsg::Input(bytes) => assert_eq!(bytes, b"echo hi\r"),
             other => panic!("expected Input, got {other:?}"),
         }
+    }
+
+    /// Input the link refuses used to vanish: `write` threw the error away, so a
+    /// pane whose daemon had stopped reading kept taking keystrokes into
+    /// nothing. The refusal now marks the pane exited by the reader's own signal
+    /// — only our sending half is shut here, so the reader is still parked on
+    /// an open receiving half and the writing side is the one that finds out.
+    /// (Shutting the peer's receiving half instead is not portable: Linux
+    /// answers the next write with EPIPE, macOS buffers it.)
+    #[test]
+    fn a_write_the_link_refuses_marks_the_pane_gone_once() {
+        crate::core::config::pin_test_config_dir();
+        let (client_side, _daemon_side) = UnixStream::pair().unwrap();
+        let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
+        term.writer
+            .lock()
+            .unwrap()
+            .shutdown(std::net::Shutdown::Write)
+            .unwrap();
+
+        term.write(b"echo hi\r".to_vec());
+        assert!(
+            term.exited_flag.load(Ordering::SeqCst),
+            "a refused Input is the link gone, and the pane has to say so"
+        );
+        let mut exits = 0;
+        while let Ok(ev) = term.events.try_recv() {
+            exits += usize::from(matches!(ev, AlacEvent::Exit));
+        }
+        assert_eq!(
+            exits, 1,
+            "reported through the same event the reader raises on EOF"
+        );
+
+        term.write(b"echo again\r".to_vec());
+        while let Ok(ev) = term.events.try_recv() {
+            exits += usize::from(matches!(ev, AlacEvent::Exit));
+        }
+        assert_eq!(exits, 1, "said once, not once per keystroke");
+    }
+
+    /// A link retired for a relink refuses writes too — `stop_reader` shuts it
+    /// down — and that must not read as the pane dying under the swap, for the
+    /// same reason the retired reader exits silently.
+    #[test]
+    fn a_write_on_a_retired_link_does_not_mark_the_pane_gone() {
+        crate::core::config::pin_test_config_dir();
+        let (client_side, _daemon_side) = UnixStream::pair().unwrap();
+        let mut term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
+        term.stop_reader();
+
+        term.write(b"echo hi\r".to_vec());
+        assert!(
+            !term.exited_flag.load(Ordering::SeqCst),
+            "the pane is being relinked or released, not dying"
+        );
     }
 
     #[test]

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -1008,6 +1008,13 @@ impl TerminalView {
         let attached = match restore_pane {
             Some(id) => match RemoteTerminal::attach_on(&route, TermSize::new(80, 24), 8, 17, id) {
                 Ok(terminal) => Some((terminal, id, None)),
+                Err(e) if crate::terminal::attach_unanswered(&e) => {
+                    // Not "gone": nobody answered, which a daemon still coming
+                    // up also does. Whoever finds an orphaned shell later
+                    // reads this line.
+                    log::warn!("attach to pane {id} went unanswered ({e:#}); spawning fresh");
+                    None
+                }
                 Err(e) => {
                     log::info!("pane {id} is gone on its machine ({e:#}); spawning fresh");
                     None

--- a/src/ui/tree_sync.rs
+++ b/src/ui/tree_sync.rs
@@ -873,6 +873,19 @@ struct WsState {
     /// Rewritten by every attempt, and only ever read while `rehydrate` is
     /// outstanding, so it always describes the debt currently standing.
     owed_over: Vec<TabId>,
+    /// The tabs the last rebuild was handed and could not put up — on the
+    /// machine and in the mirror, but not on screen, because no pane in them
+    /// would start (`tabs_from_session` drops such a tab, and says so).
+    ///
+    /// Held out of every diff, the way a tab still connecting is: the window
+    /// cannot speak for them, and its licence to prune must not read their
+    /// absence as the user closing them. A rebuild that put up some of its tabs
+    /// earned the licence — it did put a layout up — and used it to `TabClose`
+    /// exactly the tabs it had failed to rebuild, deleting them off the machine,
+    /// panes and all (#672). Rewritten by the next rebuild, which either puts
+    /// them up or fails them again; a tab the machine drops meanwhile drops
+    /// out here too, so nothing stays held for a tab nobody has.
+    not_rebuilt: Vec<TabId>,
     /// How many pulls in a row this window has owed, which paces the retry.
     ///
     /// Counts consecutive failures, so it is cleared by anything that ends the
@@ -926,6 +939,7 @@ impl Default for WsState {
             epoch: 0,
             rehydrate: None,
             owed_over: Vec::new(),
+            not_rebuilt: Vec::new(),
             rehydrate_attempts: 0,
             then_open: None,
             chosen_name: None,
@@ -957,7 +971,7 @@ pub(crate) fn sync_window(app: &Tty7App, cx: &mut App) {
         return;
     }
     adopt_tab_ids(app, cx);
-    let (desired, desired_active, held) = desired_tabs(app, cx);
+    let (desired, desired_active, mut held) = desired_tabs(app, cx);
     let machine_ws = tree_workspace_id(cx, client_ws);
 
     let state = cx
@@ -979,6 +993,13 @@ pub(crate) fn sync_window(app: &Tty7App, cx: &mut App) {
             } else {
                 SyncScope::Additive
             };
+            // The tabs the last rebuild could not put up are the machine's to
+            // keep: not on screen, so `desired` cannot speak for them, and held
+            // so their absence is not read as a close.
+            state
+                .not_rebuilt
+                .retain(|id| mirror.tabs.iter().any(|t| t.id == *id));
+            held.extend(state.not_rebuilt.iter().copied());
             let ops = diff(machine_ws, mirror, &desired, desired_active, scope, &held);
             if !ops.is_empty() {
                 let (tabs, active) = (mirror.tabs.clone(), mirror.active);
@@ -2073,30 +2094,99 @@ fn settle_hydration(
         return false;
     };
     let wanted = session.tabs.len();
+    // `tree_id` is not serialized, so only a session built from the tree
+    // carries one on every tab (which is what reaches here today). The guard
+    // below counts the tabs asked for, not the ids found: a session with tabs
+    // and no ids must not read as "nothing was wanted".
+    let wanted_ids: Vec<TabId> = session.tabs.iter().filter_map(|t| t.tree_id).collect();
+    debug_assert_eq!(
+        wanted_ids.len(),
+        wanted,
+        "a session rebuilt from the tree names every tab it holds"
+    );
     log::info!("rebuilding {wanted} tab(s) of workspace {client_ws} from its machine's tree");
     let _ = handle.update(cx, move |_, window, cx| {
         app.update(cx, |app, cx| {
             app.adopt_workspace(client_ws, session, window, cx)
         });
     });
+    let showing = tabs_on_screen(cx, client_ws);
+    settle_rebuild(cx, client_ws, wanted, &wanted_ids, &showing);
+    true
+}
 
-    // Informed *after* the rebuild, and only if the rebuild produced something.
-    //
-    // The licence means "this window knows what belongs in this workspace", and
-    // `switch_workspace` / `detach_workspace` read it as permission to delete a
-    // workspace that has no tabs — from the machine tree and from the store
-    // both. Granting it before the rebuild handed that permission to a window
-    // whose rebuild had not happened yet, and a rebuild can produce nothing:
-    // `tabs_from_session` drops any tab whose panes all fail to start, which is
-    // what every tab does when the pane socket is unreachable. The window then
-    // sat there, empty and authoritative, and the next switch deleted a
-    // workspace with ten live tabs in it.
-    //
-    // Emptiness that came from a failure has to stay indistinguishable from not
-    // knowing, because that is what it is.
-    let rebuilt = crate::ui::windows::WindowRegistry::app_for(cx, client_ws)
-        .and_then(|app| app.upgrade())
-        .is_some_and(|app| !app.read(cx).tabs.is_empty());
+/// What a rebuild leaves the window entitled to say, from how many tabs the
+/// tree asked it to put up (`wanted`), which ids those were (`wanted_ids`),
+/// and the tabs it is showing now (`showing`).
+///
+/// Informed *after* the rebuild, and only if the rebuild produced something.
+///
+/// The licence means "this window knows what belongs in this workspace", and
+/// `switch_workspace` / `detach_workspace` read it as permission to delete a
+/// workspace that has no tabs — from the machine tree and from the store
+/// both. Granting it before the rebuild handed that permission to a window
+/// whose rebuild had not happened yet, and a rebuild can produce nothing:
+/// `tabs_from_session` drops any tab whose panes all fail to start, which is
+/// what every tab does when the pane socket is unreachable. The window then
+/// sat there, empty and authoritative, and the next switch deleted a
+/// workspace with ten live tabs in it.
+///
+/// Emptiness that came from a failure has to stay indistinguishable from not
+/// knowing, because that is what it is.
+///
+/// A rebuild that produced *some* of its tabs is the same failure, one tab at
+/// a time, and the licence it does earn — it put a layout up, and closes and
+/// splits in it must reach the machine — cannot be allowed to speak for the
+/// tabs it did not: at `SyncScope::Full` every mirror tab missing from the
+/// window is a `TabClose`, and the tabs missing were exactly the ones that
+/// failed to rebuild, so the sync deleted them off the machine, panes and all
+/// (#672). They are held instead (`not_rebuilt`), out of the diff's reach until
+/// a later rebuild puts them up or the machine lets them go.
+///
+/// Holding has a cost the caller should know: `diff` stops before its
+/// reorder pass and the active-tab op whenever anything is held, so while
+/// this set stands the window's tab order and active tab do not reach the
+/// machine — a restart restores the order and focus from before the drag.
+/// And nothing retries a held tab: the set is rewritten only by the next
+/// `settle_rebuild`, which runs only from a hydration that rebuilds, and a
+/// re-prime or an `Adopt::IfEmpty` hydrate on a populated window never gets
+/// there. A tab that fails to rebuild stays held, and holds the ordering
+/// with it, until the next restart. That state was already reachable — a
+/// pane whose remote spawn failed stays connecting for the same span, held
+/// the same way — so this widens a standing hole rather than opening one; a
+/// retry, or a way to close a held tab from the window, is separate work.
+///
+/// The none-rebuilt guard reads the *count* asked for, not the ids found:
+/// `tree_id` is not serialized, so a session that reached here from disk
+/// would name no ids at all, and "no ids" must not read as "no tabs wanted"
+/// — that would grant the licence to a window that rebuilt nothing, which is
+/// #672 again.
+fn settle_rebuild(
+    cx: &mut App,
+    client_ws: WorkspaceId,
+    wanted: usize,
+    wanted_ids: &[TabId],
+    showing: &[TabId],
+) {
+    let not_rebuilt: Vec<TabId> = wanted_ids
+        .iter()
+        .copied()
+        .filter(|id| !showing.contains(id))
+        .collect();
+    if !not_rebuilt.is_empty() && !showing.is_empty() {
+        log::warn!(
+            "workspace {client_ws}: {} of its {wanted} tab(s) could not be rebuilt; they stay on \
+             the machine, held out of this window's sync (tab order and active tab are not \
+             synced while a tab is held)",
+            not_rebuilt.len()
+        );
+    }
+    let rebuilt = !showing.is_empty();
+    cx.default_global::<TreeSync>()
+        .windows
+        .entry(client_ws)
+        .or_default()
+        .not_rebuilt = not_rebuilt;
     if rebuilt || wanted == 0 {
         mark_window_informed(cx, client_ws);
     } else {
@@ -2105,7 +2195,6 @@ fn settle_hydration(
              window uninformed so the layout is not mistaken for an empty workspace"
         );
     }
-    true
 }
 
 /// Someone else removed this workspace from its machine — `tty7 ws rm`, or
@@ -3525,6 +3614,153 @@ mod tests {
                 .informed = true;
             hydrate_window_from_tree(cx, ws);
             assert!(cx.default_global::<TreeSync>().windows[&ws].informed);
+        });
+    }
+
+    /// #672's residual: a rebuild that put up some of the tabs the tree asked
+    /// for and dropped the rest (`tabs_from_session` drops a tab none of whose
+    /// panes would start). It earns the licence — it did put a layout up — and
+    /// the tabs it dropped are not tabs the user closed, so they must be held
+    /// out of the diff rather than the licence withheld from the whole window.
+    #[gpui::test]
+    fn a_partial_rebuild_holds_the_tabs_it_could_not_put_up(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let ws = WorkspaceId::new();
+            let (put_up, failed) = (TabId::new(), TabId::new());
+            let settled = |cx: &mut App| {
+                let state = &cx.default_global::<TreeSync>().windows[&ws];
+                (state.informed, state.not_rebuilt.clone())
+            };
+
+            settle_rebuild(cx, ws, 2, &[put_up, failed], &[put_up]);
+            assert_eq!(
+                settled(cx),
+                (true, vec![failed]),
+                "the window speaks for the tab it put up, and holds the one it could not"
+            );
+
+            settle_rebuild(cx, ws, 2, &[put_up, failed], &[put_up, failed]);
+            assert_eq!(
+                settled(cx),
+                (true, vec![]),
+                "a later rebuild that puts them all up holds nothing back"
+            );
+
+            cx.default_global::<TreeSync>()
+                .windows
+                .get_mut(&ws)
+                .unwrap()
+                .informed = false;
+            settle_rebuild(cx, ws, 2, &[put_up, failed], &[]);
+            assert_eq!(
+                settled(cx),
+                (false, vec![put_up, failed]),
+                "a rebuild that produced nothing still does not get to speak for the workspace"
+            );
+
+            settle_rebuild(cx, ws, 0, &[], &[]);
+            assert_eq!(
+                settled(cx),
+                (true, vec![]),
+                "an empty tree rebuilt into an empty window is the one case that is genuinely empty"
+            );
+
+            // A session with tabs but no ids — what a disk-loaded session
+            // looks like, since `tree_id` is not serialized — that rebuilt
+            // nothing. "No ids" must not read as "no tabs wanted".
+            cx.default_global::<TreeSync>()
+                .windows
+                .get_mut(&ws)
+                .unwrap()
+                .informed = false;
+            settle_rebuild(cx, ws, 2, &[], &[]);
+            assert_eq!(
+                settled(cx),
+                (false, vec![]),
+                "the guard counts the tabs asked for, not the ids found"
+            );
+        });
+    }
+
+    /// The consequence, on the sync that follows: the mirror holds both tabs,
+    /// the window shows one, and the one it could not put up must not come out
+    /// of a `Full` diff as `TabClose` — that op deleted from the machine exactly
+    /// the tabs a restart had failed to bring back, panes and all (#672).
+    #[cfg(unix)]
+    #[gpui::test]
+    fn the_next_sync_leaves_a_tab_the_rebuild_could_not_put_up_on_the_machine(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let (app, mut vcx, _pane_stream) = crate::ui::app::test_window::harness_with_pane(cx);
+        let (put_up, failed) = (TabId::new(), TabId::new());
+        app.update_in(&mut vcx, |app, _, cx| {
+            let view = crate::core::session::WindowView::default();
+            let ws = view.id;
+            WorkspaceStore::install_for_test(
+                cx,
+                crate::core::session::WindowViews {
+                    views: vec![view],
+                    active: Some(ws),
+                },
+            );
+            app.workspace = ws;
+            app.tabs[0].tree_id.set(put_up);
+            {
+                let state = cx
+                    .default_global::<TreeSync>()
+                    .windows
+                    .entry(ws)
+                    .or_default();
+                state.sync = SyncPhase::Primed(WsMirror {
+                    tabs: vec![
+                        TreeTab {
+                            id: put_up,
+                            name: None,
+                            sidebar_group: None,
+                            root: PaneNode::Leaf { pane: 1 },
+                        },
+                        TreeTab {
+                            id: failed,
+                            name: None,
+                            sidebar_group: None,
+                            root: PaneNode::Leaf { pane: 2 },
+                        },
+                    ],
+                    active: Some(put_up),
+                });
+                // Keeps whatever the sync queues where the test can read it:
+                // with no link, `pump` would otherwise clear the queue and drop
+                // the mirror on its way to a re-pull.
+                state.inflight = true;
+            }
+            settle_rebuild(cx, ws, 2, &[put_up, failed], &[put_up]);
+            assert!(
+                cx.default_global::<TreeSync>().windows[&ws].informed,
+                "the shape the damage needs: a window licensed to prune, over a mirror \
+                 holding a tab it is not showing"
+            );
+
+            sync_window(app, cx);
+
+            let state = &cx.default_global::<TreeSync>().windows[&ws];
+            assert!(
+                !state
+                    .queue
+                    .iter()
+                    .any(|op| matches!(op, ControlRequest::TabClose { .. })),
+                "the tab that failed to come back is not one the user closed: {:?}",
+                state.queue
+            );
+            match &state.sync {
+                SyncPhase::Primed(mirror) => assert_eq!(
+                    mirror.tabs.iter().map(|t| t.id).collect::<Vec<_>>(),
+                    vec![put_up, failed],
+                    "and it stays on the machine for the next rebuild to put up"
+                ),
+                SyncPhase::Unprimed { .. } => {
+                    panic!("the sync must not have thrown the mirror away")
+                }
+            }
         });
     }
 


### PR DESCRIPTION
Fixes #673. Also closes what is left of #672 at HEAD (the rest was #554 and #579).

## The bug

A restart on nightly 26.8.4 came back with every restored coding-agent pane locked: Ctrl-Z printed its suspended message and never returned to a shell, Ctrl-C did nothing, no keystroke reached anything. Both this and #672's empty workspace are the same mistake — a restart's rebuild reporting a success it did not have.

**The locked panes are an `Attach` the client took on trust.** `attach_reply_prefix` reads far enough into the daemon's reply to tell an `Error` frame from a replay, and a read that timed out with *nothing* in the buffer fell through to the success branch: silence was read as "a quiet pane". But a quiet pane is never silent. `attach_subscriber` replays the pane's ring before the daemon reads a byte of our input, the ring always holds a segment, and every daemon build there has been queues a `Size` first — a pane that has printed nothing still answers with its geometry. So an `Attach` that produced no bytes in the whole wait is one nobody is serving: a daemon still mid-restart, or a socket some process holds open and will never read. Taken for an attach, it made `spawn_shell_terminal_in` report `restored = true` — the flag that skips the fresh spawn, the restored-screen banner and the agent's `--resume` — and `write` threw every encode error away, so Ctrl-C and Ctrl-Z went into that socket and vanished.

**The tabs that did not come back** are the rebuild's licence outrunning what it rebuilt. `tabs_from_session` drops any tab none of whose panes would start; `settle_hydration` then marked the window `informed` as long as *some* tab rebuilt, while the mirror still listed every tab. The next `sync_window` ran at `SyncScope::Full`, whose `diff` emits `TabClose` for every mirror tab not in `desired` — exactly the tabs that had failed to rebuild. A partial rebuild deleted from the machine the tabs it could not put up, panes and all.

## The fix

Zero bytes within the wait is now the failure it is, and the caller falls through to the path it already had for a pane that is gone — a fresh shell under the old screen, with the resume typed. Nothing changes on the wire. Trade-off stated plainly: a *slow* but real attach now costs a fresh shell over its screen and an orphaned shell in the daemon (the orphan sweep reports it), where before it cost a pane nobody could type into. `write` also stops swallowing a refused `Input`: logged once, and unless the reader was retired for a relink the pane is marked exited by the reader's own signal, so the window shows it as gone.

The un-rebuilt tabs are **held** rather than the licence withheld: `settle_rebuild` records the wanted ids the window is not showing, and `sync_window` carries them into `held`, whose contract in `diff` is already "mirror tabs the window cannot speak for — close nothing, don't reorder around them". Withholding the licence would take `TabClose` away from the whole window for as long as the failure stands (a tab whose shell is no longer on the machine fails every restart), resurrecting every close the user made in the meantime. The set is rewritten by the next rebuild and pruned against the mirror on every sync. The none-rebuilt guard is unchanged.

## Tests

`cargo test -p tty7` 1573 passed, `-p tty7-core` 1154 passed. New in `remote.rs`: `an_attach_nobody_answers_is_not_an_attach`, `a_size_frame_alone_is_a_live_attach`, `a_write_the_link_refuses_marks_the_pane_gone_once`, `a_write_on_a_retired_link_does_not_mark_the_pane_gone`. New in `tree_sync.rs`: `a_partial_rebuild_holds_the_tabs_it_could_not_put_up` and `the_next_sync_leaves_a_tab_the_rebuild_could_not_put_up_on_the_machine` (verified to fail with the `held.extend` line removed). Not reproduced live: the macOS mid-handoff race that makes the daemon silent for >2 s — the client fix is correct regardless of its cause.
