### PR TITLE
fix(linux): stop the compositor framing a window that draws its own title bar (#679)

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -293,6 +293,27 @@ pub(crate) fn title_bar_hug_offset() -> f32 {
     }
 }
 
+/// The bounds to remember for reopening this window at the same place.
+///
+/// The value goes back in through `WindowOptions::window_bounds`, which every
+/// backend reads as the *outer* rectangle, so outer is what to save — except
+/// on Wayland under client-side decorations, where the outer rectangle is the
+/// surface, shadow included, and the compositor's first sized configure adds
+/// the inset back onto whatever was asked for (`compute_outer_size`). Saving
+/// outer there grows the window by twice the shadow on every launch (the bug
+/// Zed fixed in ca9cee85e1); saving inner pre-deflates by exactly what the
+/// configure re-inflates, and the geometry holds still. X11 never re-inflates:
+/// it creates the window at the requested rectangle verbatim and its
+/// `inner_window_bounds` also shifts the origin by the inset, so saving inner
+/// there would shrink the window and walk it down-right by the shadow on
+/// every launch. macOS and Windows report no inset, so the two are the same.
+fn window_bounds_to_remember(window: &Window, cx: &App) -> Bounds<Pixels> {
+    match cx.compositor_name() {
+        "Wayland" => window.inner_window_bounds().get_bounds(),
+        _ => window.window_bounds().get_bounds(),
+    }
+}
+
 pub(crate) const WINDOW_MARK_SIZE: f32 = 20.;
 
 pub(crate) fn title_bar_drag(
@@ -1298,7 +1319,7 @@ impl Tty7App {
             settings: None,
             ssh_prompt: crate::ui::ssh_prompt::SshPromptState::new(cx),
             close_prompt_open: false,
-            window_bounds: window.window_bounds().get_bounds(),
+            window_bounds: window_bounds_to_remember(window, cx),
             workspace,
             workspace_rename: None,
             window_title: std::cell::RefCell::new(String::new()),
@@ -1322,8 +1343,8 @@ impl Tty7App {
         })
         .detach();
 
-        cx.observe_window_bounds(window, |this, window, _cx| {
-            this.window_bounds = window.window_bounds().get_bounds();
+        cx.observe_window_bounds(window, |this, window, cx| {
+            this.window_bounds = window_bounds_to_remember(window, cx);
         })
         .detach();
 
@@ -3817,6 +3838,11 @@ impl Tty7App {
         let vertical = matches!(cx.global::<Config>().tab_bar_position, TabBarPosition::Left)
             && !self.tabs.is_empty();
         let viewport = window.viewport_size();
+        // The pointer and the viewport are in the window's outer coordinates;
+        // under client-side decorations the content — title bar included —
+        // sits inside the frame padding, so the strip's band starts there and
+        // not at the window's corner. Zero padding everywhere else.
+        let pad = gpui_component::window_paddings(window);
         // The band each surface claims, read off the tabs it drew rather than
         // measured as an element of its own: the chips and the rows are the
         // only part of either surface a drop has anything to say about, and a
@@ -3833,8 +3859,8 @@ impl Tty7App {
                 .reduce(Pixels::max)?;
             Some(match axis {
                 Axis::Horizontal => Bounds {
-                    origin: point(px(0.), px(0.)),
-                    size: size(viewport.width, px(TITLE_BAR_HEIGHT)),
+                    origin: point(pad.left, pad.top),
+                    size: size(viewport.width - pad.left - pad.right, px(TITLE_BAR_HEIGHT)),
                 },
                 Axis::Vertical => Bounds {
                     origin: point(left, top - px(BAND_REACH)),

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    App, Axis, Bounds, Context, Entity, Focusable, Pixels, PromptLevel, Subscription, Window, div,
-    img, point, prelude::*, px, size,
+    App, Axis, Bounds, Context, Edges, Entity, Focusable, Pixels, PromptLevel, Size, Subscription,
+    Window, div, img, point, prelude::*, px, size,
 };
 use gpui_component::color_picker::{ColorPickerEvent, ColorPickerState};
 use gpui_component::input::{InputEvent, InputState};
@@ -295,22 +295,45 @@ pub(crate) fn title_bar_hug_offset() -> f32 {
 
 /// The bounds to remember for reopening this window at the same place.
 ///
-/// The value goes back in through `WindowOptions::window_bounds`, which every
-/// backend reads as the *outer* rectangle, so outer is what to save — except
-/// on Wayland under client-side decorations, where the outer rectangle is the
-/// surface, shadow included, and the compositor's first sized configure adds
-/// the inset back onto whatever was asked for (`compute_outer_size`). Saving
-/// outer there grows the window by twice the shadow on every launch (the bug
-/// Zed fixed in ca9cee85e1); saving inner pre-deflates by exactly what the
-/// configure re-inflates, and the geometry holds still. X11 never re-inflates:
-/// it creates the window at the requested rectangle verbatim and its
-/// `inner_window_bounds` also shifts the origin by the inset, so saving inner
-/// there would shrink the window and walk it down-right by the shadow on
-/// every launch. macOS and Windows report no inset, so the two are the same.
-fn window_bounds_to_remember(window: &Window, cx: &App) -> Bounds<Pixels> {
-    match cx.compositor_name() {
-        "Wayland" => window.inner_window_bounds().get_bounds(),
-        _ => window.window_bounds().get_bounds(),
+/// Under client-side decorations the window's *outer* rectangle is the whole
+/// surface, shadow included, and both Linux backends put the shadow back on
+/// their own once the window is up: Wayland's first sized configure adds the
+/// inset to whatever geometry was asked for (`compute_outer_size`), and on X11
+/// the inset travels as `_GTK_FRAME_EXTENTS`, which a window manager only
+/// advertises — and gpui only turns CSD on for — when it honours those extents
+/// by keeping the *visible* frame put. Save the outer rectangle either way and
+/// it comes back twice the shadow larger every launch; that is the bug Zed
+/// fixed in ca9cee85e1 ("linux: Fix non-maximized Zed windows growing larger
+/// across sessions", #22301), whose own measurements were taken on X11.
+///
+/// So save the inner rectangle, exactly as Zed does, on every platform. It is
+/// the visible frame, which is what the backends re-inflate back to, and it
+/// costs nothing elsewhere: `inner_window_bounds` defaults to `window_bounds`
+/// on the `PlatformWindow` trait, and neither the macOS nor the Windows backend
+/// nor gpui's `TestWindow` overrides it. On X11 without a compositor the same
+/// holds for a different reason — `window_decorations()` answers `Server`, the
+/// window border never calls `set_client_inset`, and the insets stay zero.
+fn window_bounds_to_remember(window: &Window) -> Bounds<Pixels> {
+    window.inner_window_bounds().get_bounds()
+}
+
+/// The band the tab strip claims for a drop, in the window's outer coordinates.
+///
+/// The strip is the top of the *content*, and under client-side decorations the
+/// content sits inside the frame padding while `viewport` still measures the
+/// whole surface, shadow included — so the band starts at the padding and stops
+/// at the far edge of the frame, one padding in from each side. Anything else
+/// leaves the outermost chips outside the zone that is supposed to contain
+/// them. `window_paddings` answers `Edges::all(0)` under server-side
+/// decorations, which is every platform but Linux CSD, so off Linux this stays
+/// the full-width rectangle from the window's corner it has always been.
+fn strip_band(viewport: Size<Pixels>, pad: Edges<Pixels>) -> Bounds<Pixels> {
+    Bounds {
+        origin: point(pad.left, pad.top),
+        size: size(
+            (viewport.width - pad.left - pad.right).max(px(0.)),
+            px(TITLE_BAR_HEIGHT),
+        ),
     }
 }
 
@@ -1319,7 +1342,7 @@ impl Tty7App {
             settings: None,
             ssh_prompt: crate::ui::ssh_prompt::SshPromptState::new(cx),
             close_prompt_open: false,
-            window_bounds: window_bounds_to_remember(window, cx),
+            window_bounds: window_bounds_to_remember(window),
             workspace,
             workspace_rename: None,
             window_title: std::cell::RefCell::new(String::new()),
@@ -1343,8 +1366,8 @@ impl Tty7App {
         })
         .detach();
 
-        cx.observe_window_bounds(window, |this, window, cx| {
-            this.window_bounds = window_bounds_to_remember(window, cx);
+        cx.observe_window_bounds(window, |this, window, _cx| {
+            this.window_bounds = window_bounds_to_remember(window);
         })
         .detach();
 
@@ -3827,6 +3850,8 @@ impl Tty7App {
     /// Which gap between tabs the pointer is in, as the tab a newcomer would
     /// be inserted before and the caret marking it — on the strip, or on the
     /// sidebar, whichever the pointer is over.
+    ///
+    /// `viewport` and the pointer are both in the window's outer coordinates.
     fn detach_slot(&self, window: &Window, cx: &App) -> Option<(usize, Bounds<Pixels>)> {
         /// How far above its first row the sidebar's band starts, so the gap
         /// over that row is inside it.
@@ -3838,10 +3863,6 @@ impl Tty7App {
         let vertical = matches!(cx.global::<Config>().tab_bar_position, TabBarPosition::Left)
             && !self.tabs.is_empty();
         let viewport = window.viewport_size();
-        // The pointer and the viewport are in the window's outer coordinates;
-        // under client-side decorations the content — title bar included —
-        // sits inside the frame padding, so the strip's band starts there and
-        // not at the window's corner. Zero padding everywhere else.
         let pad = gpui_component::window_paddings(window);
         // The band each surface claims, read off the tabs it drew rather than
         // measured as an element of its own: the chips and the rows are the
@@ -3858,10 +3879,7 @@ impl Tty7App {
                 .map(|(_, b)| b.origin.x + b.size.width)
                 .reduce(Pixels::max)?;
             Some(match axis {
-                Axis::Horizontal => Bounds {
-                    origin: point(pad.left, pad.top),
-                    size: size(viewport.width - pad.left - pad.right, px(TITLE_BAR_HEIGHT)),
-                },
+                Axis::Horizontal => strip_band(viewport, pad),
                 Axis::Vertical => Bounds {
                     origin: point(left, top - px(BAND_REACH)),
                     size: size(
@@ -8645,14 +8663,54 @@ mod window_drag_tests {
 #[cfg(test)]
 mod tests {
     use super::{
-        CloseReason, DOCUMENT_MIN_W, TERMINAL_MIN_W, TabAgentSession, clear_window_override_values,
-        close_prompt, document_column_px, join_shell_args, leaf_shares_the_window_daemon,
-        mru_order, pane_free_for, parse_ssh_connect_input, parse_ssh_option_words, side_panel_max,
-        split_shell_args, wd_path_saveable,
+        CloseReason, DOCUMENT_MIN_W, TERMINAL_MIN_W, TITLE_BAR_HEIGHT, TabAgentSession,
+        clear_window_override_values, close_prompt, document_column_px, join_shell_args,
+        leaf_shares_the_window_daemon, mru_order, pane_free_for, parse_ssh_connect_input,
+        parse_ssh_option_words, side_panel_max, split_shell_args, strip_band, wd_path_saveable,
     };
+    use gpui::{Edges, point, px, size};
 
     const SIDEBAR_MIN: f32 = crate::ui::tab_sidebar::MIN_SIDEBAR_WIDTH;
     const PANEL_MIN: f32 = crate::ui::right_panel::MIN_WIDTH;
+
+    /// #679: the band now starts at the frame padding rather than at the
+    /// window's corner, and off Linux CSD there is no padding to start at —
+    /// `window_paddings` answers `Edges::all(0)` under server-side decorations,
+    /// which is what macOS, Windows and a bare X session all report.
+    #[test]
+    fn an_undecorated_frame_leaves_the_strips_drop_band_where_it_was() {
+        let band = strip_band(size(px(1200.), px(800.)), Edges::all(px(0.)));
+        assert_eq!(band.origin, point(px(0.), px(0.)));
+        assert_eq!(band.size, size(px(1200.), px(TITLE_BAR_HEIGHT)));
+    }
+
+    /// The viewport measures the whole surface, shadow included, so the band
+    /// has to lose one padding at each end — not one twice over, and not none.
+    /// Getting it wrong puts the outermost chips outside the band drawn to hold
+    /// them, and a drop on them reads as a drop on nothing.
+    #[test]
+    fn a_client_side_frame_pulls_the_drop_band_in_by_the_shadow_on_both_sides() {
+        let viewport = size(px(1200.), px(800.));
+        let pad = Edges::all(px(12.));
+        let band = strip_band(viewport, pad);
+
+        assert_eq!(band.origin, point(pad.left, pad.top));
+        assert_eq!(
+            band.origin.x + band.size.width,
+            viewport.width - pad.right,
+            "the band must reach the far edge of the frame, not of the surface"
+        );
+        assert_eq!(band.size.height, px(TITLE_BAR_HEIGHT));
+    }
+
+    /// A surface narrower than its own shadow is only reachable mid-resize, but
+    /// a negative width would make `Bounds::contains` answer for a rectangle
+    /// that is inside out.
+    #[test]
+    fn a_drop_band_narrower_than_its_frame_collapses_instead_of_inverting() {
+        let band = strip_band(size(px(10.), px(800.)), Edges::all(px(12.)));
+        assert_eq!(band.size.width, px(0.));
+    }
 
     /// Two panels that each cap themselves at half the window leave the
     /// terminal nothing when both are open, so the cap is what is left after

--- a/src/ui/windows.rs
+++ b/src/ui/windows.rs
@@ -1,6 +1,7 @@
 use gpui::{
     AnyWindowHandle, App, AppContext as _, BorrowAppContext as _, Bounds, Global, Styled as _,
-    TitlebarOptions, WeakEntity, Window, WindowBounds, WindowOptions, point, px, size,
+    TitlebarOptions, WeakEntity, Window, WindowBounds, WindowDecorations, WindowOptions, point, px,
+    size,
 };
 use gpui_component::{Root, TitleBar};
 
@@ -708,6 +709,12 @@ fn window_options(cx: &mut App, workspace: Option<WorkspaceId>) -> WindowOptions
             traffic_light_position: Some(crate::ui::theme::traffic_light_position()),
             ..TitleBar::title_bar_options()
         }),
+        // The title bar above is tty7's own, so the compositor must not add a
+        // second one: left unset, gpui asks Wayland for server-side
+        // decorations (#679). Only the Linux backends read this — macOS and
+        // Windows ignore the request — and X11 falls back to the window
+        // manager's frame on its own when no compositor is running.
+        window_decorations: Some(WindowDecorations::Client),
         window_background: crate::ui::theme::background_appearance(cx),
         window_min_size: Some(size(px(MIN_SIZE.0), px(MIN_SIZE.1))),
         ..Default::default()
@@ -811,6 +818,25 @@ mod tests {
         let b = bounds_at(100., 100.);
         assert_eq!(cascade(b, 5).origin, b.origin);
         assert_eq!(cascade(b, 6).origin, cascade(b, 1).origin);
+    }
+
+    #[gpui::test]
+    fn a_window_asks_the_compositor_for_client_side_decorations(cx: &mut gpui::TestAppContext) {
+        // #679: tty7 draws its own title bar, so the request must say so —
+        // gpui's default asks Wayland for a server-side frame on top of it.
+        cx.update(|cx| {
+            WindowRegistry::init(cx);
+            let mut config = Config::default();
+            config.remember_window_size = false;
+            cx.set_global(config);
+
+            let options = window_options(cx, None);
+            assert_eq!(options.window_decorations, Some(WindowDecorations::Client));
+            assert!(
+                options.titlebar.is_some_and(|t| t.appears_transparent),
+                "the in-app title bar is what the client-side request stands in for"
+            );
+        });
     }
 
     #[gpui::test]


### PR DESCRIPTION
Fixes #679 — the diagnosis in the report is exactly right.

## The bug

tty7 paints its own title bar through gpui-component's `TitleBar`, and the `WindowOptions` it opens with say as much (`appears_transparent`) — but say nothing about decorations. gpui reads a missing `window_decorations` as `WindowDecorations::Server` (`window.rs`: `request_decorations(window_decorations.unwrap_or(WindowDecorations::Server))`) and, on Wayland, sends `zxdg_toplevel_decoration_v1.set_mode(server_side)`, so a compositor that honours it draws a second title bar and border around the one the app already has.

## The fix

`window_options()` now asks for `WindowDecorations::Client`. Nothing new has to be painted for it — gpui-component's `Root` already wraps the window in `window_border()`, `bordered` defaults to `true`, and tty7 never calls `.bordered(false)` at any of its `Root::new` sites. Under `Decorations::Client` that border draws the 1px frame, the 12px shadow (Linux only; `SHADOW_SIZE` is `px(0.)` elsewhere), the resize hit bands and their cursors, starts the resize from its own `on_mouse_down`, and reports the inset through `set_client_inset`. Under `Decorations::Server` it degrades to a plain `div`. The request was the only piece missing. Right-click-for-window-menu lives in `TitleBar`, already gated on `is_linux && is_client_decorated`, and turns on with the same request.

The field is set without a `cfg`. `request_decorations` is an empty default on the `PlatformWindow` trait, and the only overrides in the pinned gpui are the Wayland, X11 and web backends — macOS and Windows never see it, and `window_decorations()` keeps answering `Decorations::Server` there. X11 turns the request into `_MOTIF_WM_HINTS` and falls back to server-side on its own when no compositor is present, so a bare X session still gets a window-manager frame; a reparenting WM under a compositor, which today is told in the same hints to decorate, gets the same fix as Wayland.

### Remembered bounds

Client-side decorations bring one follow-on Zed hit too: `ca9cee85e1` ("linux: Fix non-maximized Zed windows growing larger across sessions", #22301). The bounds tty7 remembers go back in through `WindowOptions::window_bounds`, which every backend reads as the **outer** rectangle — the whole surface, shadow included, under CSD. Both Linux backends put the shadow back on once the window is up, so reopening at the outer rectangle grows the window by twice the inset per launch:

- **Wayland** re-inflates in gpui itself: the first sized configure runs `compute_outer_size(state.inset(), …)`, which adds the inset back onto whatever geometry was asked for.
- **X11** re-inflates through the window manager. gpui only enables CSD there when a compositor is present *and* the WM advertises `_GTK_FRAME_EXTENTS` (`client_side_decorations_supported`), and a WM that advertises that atom honours it by keeping the *visible* frame put and treating the extents as shadow outside it. Zed's numbers in `ca9cee85e1` were all taken on X11 — +20px per session before, stable after.

So a `window_bounds_to_remember()` helper saves `inner_window_bounds()`, unconditionally, exactly as Zed still does at the pinned rev. It is a no-op wherever there is no inset to strip: `inner_window_bounds` defaults to `window_bounds` on the trait and neither the macOS nor the Windows backend nor gpui's `TestWindow` overrides it, and on X11 without a compositor `window_decorations()` answers `Server`, so the window border never calls `set_client_inset` and `last_insets` stays `[0, 0, 0, 0]`. Maximized and fullscreen are identical in both rectangles on both backends. `WindowState` round-trips unchanged.

*(The first revision of this PR split Wayland from X11 here, saving outer on X11 on the reading that it creates the window at the requested rectangle verbatim. Second commit undoes that: the citation's own measurements are the counter-example.)*

### Drop band

The one place that hardcoded the window's corner has to follow the frame: the pane-to-tab-strip drop band was a rectangle from `(0, 0)` spanning the full viewport width, which under CSD is the 12px shadow strip plus the top 28px of the 40px title bar — the bar's bottom 12px fell outside it — and which runs one shadow past the frame at each end. It now comes from a `strip_band(viewport, pad)` helper fed by `gpui_component::window_paddings(window)` — start at the padding, lose one padding at each end. `window_paddings` answers `Edges::all(0)` under `Decorations::Server`, and gpui's default `window_decorations()` is `Server` with no macOS or Windows override, so this is a no-op off Linux CSD. It clamps at zero: a surface narrower than its own shadow is only reachable mid-resize, but a negative width would hand `Bounds::contains` a rectangle that is inside out.

## Tests

`cargo test -p tty7 --bin tty7-app`: 1603 passed. Rebased onto `2cdc26f3`.

- `a_window_asks_the_compositor_for_client_side_decorations` — calls the real `window_options()`, asserts `Some(Client)` and the transparent title bar it stands in for.
- `an_undecorated_frame_leaves_the_strips_drop_band_where_it_was` — no padding, band unmoved from the corner.
- `a_client_side_frame_pulls_the_drop_band_in_by_the_shadow_on_both_sides` — the band's far edge lands on the frame, not on the surface.
- `a_drop_band_narrower_than_its_frame_collapses_instead_of_inverting`.

`window_bounds_to_remember` is deliberately untested: gpui's `TestWindow` overrides neither `inner_window_bounds` nor the decorations, so inner and outer are one rectangle in every test and any assertion would only restate the call.

## Not verified

There is no Linux session here, so everything below was read out of the pinned gpui (`d99a40a5`) and gpui-component (`070d1a2`) rather than run:

- Whether the reporter's compositor honours the mode switch at all — `xdg-decoration-unstable-v1` lets it refuse.
- How the 12px shadow and the 1px `window_border` colour read against the shipped themes.
- The edges of a maximized or tiled window, and where gpui-component drops the padding on the tiled sides.
- One quit-and-relaunch on X11 under a compositor, to watch the remembered geometry actually hold.
- FreeBSD runs the same backends with gpui-component's `SHADOW_SIZE` at zero; unexercised.

A look from someone on GNOME or KDE would be welcome.

