### PR TITLE
ci(macos): assert every Mach-O in the bundle is the arch it ships as (#687)

### DIFF
--- a/.github/scripts/bundle-macos.sh
+++ b/.github/scripts/bundle-macos.sh
@@ -9,6 +9,10 @@
 #     -> hardened-runtime signature, then notarize + staple. Passes Gatekeeper.
 #   * Otherwise -> adhoc signature, same as before. Fine for local dev, but the
 #     OS will quarantine it on other machines.
+#
+# Before either artifact is packaged, every Mach-O inside the bundle is
+# asserted to be a thin <arch-label> binary (the sweep below), so a wrong-arch
+# or universal file fails the build here instead of shipping.
 set -euo pipefail
 
 TARGET="$1"
@@ -198,6 +202,88 @@ else
     echo "⚠️  no Developer ID secrets — adhoc signing (won't pass Gatekeeper on other machines)"
     codesign --force --deep --sign - "$APP"
 fi
+
+# ---- Architecture sweep ----------------------------------------------------
+# Everything the bundle ships has to be the thin slice its filename claims. A
+# macOS 26 user read "contains Intel parts" off the Apple Silicon bundle (#687).
+# The published bundles turned out clean — every Mach-O in them thin arm64 —
+# but nothing here had ever checked: assert-macho.sh only ever pointed at the
+# standalone tty7-server asset, so a helper built without --target, a dylib
+# dragged in from the runner, or a universal binary would have shipped, and been
+# found by a user rather than by this script.
+#
+# After the signing block, because assert-macho.sh also insists on a code
+# signature, and after both postures so one pass covers Developer ID and adhoc
+# alike. Before the zip and the DMG, so a bundle that fails here never becomes
+# an artifact — and before the `mv` below, after which dist/tty7.app no longer
+# exists. For a Developer ID build that puts it after notarization, which
+# spends a few minutes of notary time on a bundle that was never going to ship;
+# cheap next to carrying a second copy of this block inside each branch.
+BUNDLE_FAIL=0
+ASSERT_MACHO="$(dirname "$0")/assert-macho.sh"
+BUNDLED_BINS=(tty7-app tty7)
+if [[ "$PACKAGE_UPDATE_ZIP" != "0" ]]; then
+    BUNDLED_BINS+=(tty7-updater)
+fi
+# First the binaries we staged ourselves, held to the full standard the server
+# asset is: the right arch, links nothing macOS does not ship, carries a
+# signature. This also leaves every shipped binary's load commands in the
+# release log, which is where the next report like #687 gets answered from.
+for bin in "${BUNDLED_BINS[@]}"; do
+    bash "$ASSERT_MACHO" "$APP/Contents/MacOS/$bin" "$ARCH" || BUNDLE_FAIL=1
+done
+
+# Then the whole bundle, for whatever that list did not know to look at: walk
+# every file, let `file` say which are Mach-O of any kind — executable, dylib,
+# bundle — and have `lipo` name the slices in each. The answer has to be
+# exactly "$ARCH". Any other name is the wrong build; two names is a universal
+# binary, which is what the report described and what nothing in this pipeline
+# should ever produce.
+#
+# `file` detects and `lipo -archs` judges, rather than reading the arch out of
+# `file`'s prose: Apple's build says "64-bit executable arm64" where upstream
+# libmagic says "64-bit arm64 executable, flags:<...>", and a parser written
+# against one misreads the other. lipo's slice names are the same on every
+# macOS, and it is the tool that would have made a fat binary in the first
+# place. Captured into variables, never piped into `grep -q` — see
+# assert-macho.sh for the pipefail race. Process substitution rather than
+# `find | while`, so the counters survive the loop.
+echo "--- Mach-O sweep of $APP, expecting ${ARCH} ---"
+SWEEP_SEEN=0
+while IFS= read -r -d '' f; do
+    KIND="$(file -b "$f")"
+    [[ "$KIND" == *"Mach-O"* ]] || continue
+    SWEEP_SEEN=$((SWEEP_SEEN + 1))
+    # Multi-line for a universal file (one line per slice); the first line is
+    # the verdict.
+    KIND="${KIND%%$'\n'*}"
+    if ! ARCHS="$(lipo -archs "$f" 2>&1)"; then
+        echo "::error::lipo could not read $f ($KIND): $ARCHS"
+        BUNDLE_FAIL=1
+        continue
+    fi
+    case "$ARCHS" in
+        "$ARCH")
+            echo "${ARCHS}  $f  ($KIND)" ;;
+        *" "*)
+            echo "::error::$f is a universal binary carrying [${ARCHS}]; this bundle ships ${ARCH} only"
+            BUNDLE_FAIL=1 ;;
+        *)
+            echo "::error::$f is ${ARCHS}, not ${ARCH} ($KIND)"
+            BUNDLE_FAIL=1 ;;
+    esac
+done < <(find "$APP" -type f -print0)
+# A sweep that sees fewer Mach-Os than the binaries copied in above is not
+# looking at the bundle — a changed `file` wording, an empty find — and must not
+# pass as "nothing wrong found".
+if (( SWEEP_SEEN < ${#BUNDLED_BINS[@]} )); then
+    echo "::error::the sweep found ${SWEEP_SEEN} Mach-O file(s) in $APP, fewer than the ${#BUNDLED_BINS[@]} staged above — it is not seeing the bundle"
+    BUNDLE_FAIL=1
+fi
+if [[ "$BUNDLE_FAIL" -ne 0 ]]; then
+    exit 1
+fi
+echo "✅ every Mach-O in $APP is a thin ${ARCH} binary (${SWEEP_SEEN} checked)"
 
 # The in-app updater needs the signed, notarized .app itself rather than a disk
 # image that requires Finder interaction. The helper re-reads the full embedded


### PR DESCRIPTION
For #687 — not a fix for the report as filed, because the published bundles are clean (details on the issue), but the guard that would have caught it had they not been.

## What's missing today

`assert-macho.sh` knows how to say "this is a 64-bit Mach-O for `<arch>`, it links only what macOS ships, and it is signed", and since #605 it has said it — about the standalone `tty7-server` asset, and only that. It has never been pointed at anything inside the `.app`. A helper built without `--target` on an Intel runner, a dylib dragged in from `/opt/homebrew`, a universal binary from a toolchain that decided to be helpful: each would have zipped, notarized and shipped, and the first check would have been a user's Finder. `nightly.yml`'s verify step checks presence, version and signature — not architecture.

## The change

One block in `bundle-macos.sh`, where `release.yml` and `nightly.yml` both build the bundle, so one implementation covers both channels. After the signing block (`assert-macho.sh` insists on a signature; one pass covers Developer ID and adhoc), before the update zip and the DMG (a failing bundle never becomes an artifact), before the `mv` that dissolves `dist/tty7.app`. Two layers: the staged binaries (`tty7-app`, `tty7`, and `tty7-updater` when packaged) each through `assert-macho.sh` at the full standard the server asset is held to — which also leaves every shipped binary's load commands in the release log, where the next report of this kind gets answered from; then a `find` sweep of every file, `file` to detect any Mach-O (executable, dylib, bundle), `lipo -archs` to judge — the answer must be exactly the matrix arch; two names is a universal binary. `lipo` judges rather than a parse of `file`'s prose because Apple's `file` and upstream libmagic word the arch differently. A count guard fails the sweep if it saw fewer Mach-Os than were staged, so a wording change can't turn it into a silent pass.

## Validation

`bash -n` and shellcheck 0.10 clean. Two local harnesses: one extracts the sweep block verbatim and runs it with stubbed `file`/`lipo` against fake bundles (20/20: clean arm64/x86_64 pass; wrong-arch updater, universal app, stray x86_64 dylib, nested arm64e bundle, lipo failure, paths with spaces all fail naming the offender; empty bundle trips the count guard); the other runs the whole real script in adhoc posture with the toolchain stubbed and confirms no zip/DMG is produced on failure. Not run on macOS — specifically unconfirmed that `lipo` is on PATH on the runner (it ships with the same CLT as `otool`, which the script already calls bare).

## Review

Run on macOS 26.3 with the real Xcode CLT `file`/`lipo`, so the caveat above is settled.

The harness was re-derived rather than taken on faith, and against real bundles — Mach-Os built with `clang` (`-arch arm64` / `x86_64` / `arm64e`, `lipo -create` for a fat one, a truncated header for a Mach-O `lipo` cannot read) instead of stubbed tools. 21/21, and 21/21 again with `/bin/bash` 3.2 running the block, which is the system bash on the runner images: clean arm64, clean x86_64 and clean-without-updater pass; wrong-arch updater, universal `tty7-app`, stray x86_64 dylib in `Resources`, nested arm64e helper bundle, `lipo` exiting nonzero, and a wrong-arch file under both a path with a space and a path with a newline each fail naming the offender, with all three offenders reported when there are three; empty bundle, absent bundle, resources-only bundle, one Mach-O fewer than staged, and a stubbed `file` that no longer says "Mach-O" all trip the count guard.

End-to-end, the real script in adhoc posture with `ditto`/`hdiutil` stubbed: clean bundle produces the zip and the DMG; a bundle with an x86_64 updater exits 1 with `dist/` still holding nothing but `tty7.app` — no zip, no DMG, and the `mv` never reached, which is the placement claim checked against the file rather than the prose. `bash -n` and shellcheck 0.11 are clean; `-o all` adds only SC2250 style noise shared with the rest of the file, plus SC2312 on the `find` whose return value the count guard is precisely what covers.

`lipo` on the runner: `/usr/bin/lipo` and `/usr/bin/otool` are the same Xcode CLT shims, and `assert-macho.sh` already calls `otool` and `file` bare in `ci.yml`'s `server-macos` job on the hosted images. Assumed present, no fallback added.

Two things the block leans on, checked rather than assumed. `codesign --force --deep --sign -` does reach `Contents/MacOS/tty7` and `tty7-updater` — on x86_64, where the linker leaves them bare, as well as on arm64 where it ad-hoc signs them itself — so `assert-macho.sh`'s signature requirement holds in the adhoc posture and not only under Developer ID. And the shipping binaries link nothing outside `/usr/lib` and `/System/Library` (`tty7-app` reaches `GSS.framework`, which is under `/System/Library`), so pointing `assert-macho.sh` at them does not fail a release on the dependency rule. Both channels are covered: `release.yml` and `nightly.yml` invoke the script identically, with the same `arm64` / `x86_64` labels, which are the names `lipo -archs` prints.