### PR TITLE
fix(ci): judge a Mach-O's signature by codesign's exit status

### DIFF
--- a/.github/scripts/assert-macho.sh
+++ b/.github/scripts/assert-macho.sh
@@ -66,8 +66,22 @@ fi
 # Rosetta shell (`uname -sm` = "Darwin x86_64"), and that is not a machine to
 # hand an unsigned binary to on a guess. The workflow signs it; this catches the
 # day it stops.
-SIGNING=$(codesign -dv "$BIN" 2>&1 || true)
-if [[ "$SIGNING" != *"Signature="* ]]; then
+# The verdict is `codesign -dv`'s exit status, not a word in its output. It
+# spells the signature line differently per posture — `Signature=adhoc` for an
+# ad-hoc or linker signature, `Signature size=8968` for a Developer ID one with
+# a timestamp — so the `*"Signature="*` this used to match held only for ad-hoc.
+# While the script pointed at the standalone tty7-server, which is ad-hoc
+# signed, that was invisible; #692 pointed it at the bundle's binaries as well,
+# and those are Developer ID signed whenever the signing secrets are present.
+# Pull requests do not see the secrets, so every PR run took the ad-hoc branch
+# and passed, and the first build that signed for real — the nightly — failed
+# on all three binaries with `Signature size=` in the very output it printed as
+# proof they were unsigned.
+#
+# Exit status has no such split: 0 for anything signed, 1 with `code object is
+# not signed at all` for anything not. The output is still captured so the
+# failure message can carry it.
+if ! SIGNING=$(codesign -dv "$BIN" 2>&1); then
   echo "::error::$BIN carries no code signature — arm64 macOS will refuse to run it"
   echo "$SIGNING"
   fail=1


### PR DESCRIPTION
The nightly build failed on macOS for both architectures, on all three
binaries in the bundle, with:

```
##[error]dist/tty7.app/Contents/MacOS/tty7-app carries no code signature
CodeDirectory v=20500 size=634395 flags=0x10000(runtime) ...
Signature size=8968
TeamIdentifier=...
```

The binaries were signed, notarized and stapled — the step above the
failure says so. The assertion was wrong.

## The bug

`assert-macho.sh` decided whether a binary was signed by looking for the
literal `Signature=` in `codesign -dv` output. That word is spelled two
ways:

| posture | `codesign -dv` says | old check |
|---|---|---|
| ad-hoc / linker-signed | `Signature=adhoc` | passes |
| Developer ID + `--timestamp` | `Signature size=8968` | **fails** |

`Signature size=` does not contain `Signature=`.

## Why CI never caught it

While the script pointed only at the standalone `tty7-server` asset —
ad-hoc signed — the gap was invisible. #692 pointed it at the bundle's
`tty7-app`, `tty7` and `tty7-updater` too, and those take the Developer ID
branch whenever the signing secrets are present.

Pull requests do not see the secrets, so every PR run bundles with
`codesign --force --deep --sign -` and takes the ad-hoc branch. The first
build that signs for real is the nightly, which is where this surfaced —
a PR-green change that could only fail after merge.

## The fix

Judge by exit status instead of by wording. It has no such split, and
nothing about it depends on how a future `codesign` phrases its output:

| posture | exit status |
|---|---|
| ad-hoc | 0 |
| Developer ID | 0 |
| unsigned | 1, `code object is not signed at all` |

Verified locally against all three: a linker-signed `target/debug/tty7`, a
Developer ID binary copied out of the installed `tty7.app`, and that same
binary put through `codesign --remove-signature`. Developer ID and ad-hoc
pass; the unsigned one is still rejected. Under the old check the
Developer ID binary failed, reproducing CI exactly.

The output is still captured, so a real failure still prints what
`codesign` said.

No release has shipped an unsigned binary as a result of this — the check
is too strict, not too loose, and a failing `build` job stops `publish`
from running at all.