### PR TITLE
Address a tab by the bare id --json prints, and stop the skill sending workers in headless

### DIFF
--- a/crates/tty7-cli/src/address.rs
+++ b/crates/tty7-cli/src/address.rs
@@ -60,19 +60,28 @@ pub fn parse_pane(s: &str) -> Result<u64> {
 }
 
 pub fn parse_tab(s: &str) -> Result<TabAddress> {
-    let body = s
-        .strip_prefix('@')
-        .ok_or_else(|| anyhow!("'{s}' is not a tab address — tabs look like @7"))?;
+    // The `@` is optional, for the reason it is optional on a pane (#538): every
+    // `--json` payload spells tabs bare, so the id `tty7 tab new --json` just
+    // handed back has to address the tab it created. Demanding the sigil made
+    // the one id you are certain of the one shape the CLI refused.
+    let body = s.strip_prefix('@').unwrap_or(s);
+    let not_an_address =
+        || anyhow!("'{s}' is not a tab address — @7 as numbered by `tty7 ls`, or a full tab id");
     if body.is_empty() {
-        bail!("'{s}' is not a tab address — tabs look like @7");
+        return Err(not_an_address());
     }
-    if let Ok(n) = body.parse::<u64>() {
-        return Ok(TabAddress::Ordinal(n));
+    // Digits and nothing else. `u64::from_str` also takes a leading `+`, and
+    // with the `@` gone that would read `+5` as tab 5 rather than as a typo.
+    if body.bytes().all(|b| b.is_ascii_digit()) {
+        return body
+            .parse()
+            .map(TabAddress::Ordinal)
+            .map_err(|_| not_an_address());
     }
     if looks_like_uuid(body) {
         return Ok(TabAddress::Id(body.to_string()));
     }
-    bail!("'{s}' is not a tab address — @7 as numbered by `tty7 ls`, or @<full tab id>");
+    Err(not_an_address())
 }
 
 fn looks_like_uuid(s: &str) -> bool {
@@ -161,6 +170,34 @@ mod tests {
         // people into "%${TTY7_PANE#%}" contortions (#538).
         assert_eq!(parse_pane("42").unwrap(), 42);
         assert_eq!(parse_pane("%42").unwrap(), 42);
+    }
+
+    #[test]
+    fn a_bare_tab_id_addresses_the_same_tab_as_the_marked_one() {
+        // Every `--json` payload spells tabs bare, and the id `tty7 tab new`
+        // hands back is the one tab you are certain of — refusing it there made
+        // naming a tab you just created impossible without counting `@N` again.
+        let id = "0d4e1a54-0000-4000-8000-000000000003";
+        assert_eq!(parse_tab(id).unwrap(), TabAddress::Id(id.into()));
+        assert_eq!(
+            parse_tab(&format!("@{id}")).unwrap(),
+            TabAddress::Id(id.into())
+        );
+        assert_eq!(parse_tab("7").unwrap(), TabAddress::Ordinal(7));
+        assert_eq!(parse_tab("@7").unwrap(), TabAddress::Ordinal(7));
+    }
+
+    #[test]
+    fn a_tab_ordinal_is_digits_and_nothing_else() {
+        // Same guard as the pane one, and it matters for the same reason now
+        // that the sigil is optional on both.
+        for not_a_tab in ["+5", "@+5", "-5", " 5", "5 ", "", "@", "5.0", "build"] {
+            assert!(
+                parse_tab(not_a_tab).is_err(),
+                "'{not_a_tab}' must not read as a tab address"
+            );
+        }
+        assert!(parse_tab("99999999999999999999999").is_err());
     }
 
     #[test]

--- a/skills/tty7/SKILL.md
+++ b/skills/tty7/SKILL.md
@@ -62,10 +62,17 @@ Reach for tty7 when one of these is true:
 |---|---|---|
 | `%42` | a pane | yes — a pane keeps its id for its whole life |
 | `@7` | a tab, numbered across the **whole machine** in tree order | **no** — it shifts whenever a workspace or tab appears or disappears |
+| `@<full tab UUID>` | that same tab, by id | yes |
 | `api` / `76698a44` / a full UUID | a workspace, by name, by unique id prefix, or by id | yes |
 
 Re-resolve `@N` right before you use it; never cache one across a step that
-creates or removes a tab. Pane ids and workspace ids are safe to remember.
+creates or removes a tab. Pane ids, tab ids and workspace ids are safe to
+remember — so when you create a tab and mean to address it again later, keep the
+id `tty7 tab new --json` hands back rather than counting `@N` a second time.
+
+The sigils are optional wherever an address is expected: `%42` and `42` are the
+same pane, `@7` and `7` the same tab. Ids copied out of `--json` paste straight
+back in.
 
 Omitting the address inside a tty7 shell means "this pane" / "this workspace".
 An explicit address always wins over the environment.
@@ -126,6 +133,22 @@ waiting is `tty7 wait`.
 For keystrokes rather than characters — Ctrl-C, Escape, the arrow keys — use
 `--key` (see [Answering a prompt](#answering-a-prompt)). Typing `^C` as text
 does nothing; it arrives as two characters.
+
+**A brand-new pane can swallow the Enter.** A shell still working through its
+startup files — a prompt framework, `fastfetch`, anything that paints on login —
+takes the text you send but loses the carriage return that follows it, and the
+command just sits on the prompt line unexecuted. Nothing reports this: the
+`send` succeeded, and the pane looks like a worker that has not got going yet.
+So after sending the first command into a pane you just created, read the screen
+back and check it actually left the prompt:
+
+```bash
+tty7 capture "$PANE" --plain | tail -3   # command still sitting on the prompt?
+tty7 send "$PANE" --enter                # then give it the Enter it lost
+```
+
+Cheaper than diagnosing it later, and only the first `send` into a fresh pane
+needs the check.
 
 ## Reading a pane
 
@@ -197,6 +220,11 @@ If you want the process tree itself — "what is running in there", "which port 
 this pane serving" — that is `tty7 procs %83`: indented by depth, `*` on the
 foreground process, then the ports those processes are listening on.
 
+It is not the way to check on a coding agent, though. `procs` reports
+`nothing running in this pane` for a pane with a busy agent in it, so reading it
+as "the worker died" is wrong. Ask `tty7 agents` about those, or see
+[When a worker never moves](#when-a-worker-never-moves).
+
 ## Handing work to another agent
 
 Everything above also works when the thing in the pane is a coding agent, and
@@ -206,7 +234,7 @@ process tree:
 
 ```bash
 PANE=$(tty7 split --v)
-tty7 send "$PANE" 'claude -p "add tests for the parser"' --enter
+tty7 send "$PANE" 'claude --dangerously-skip-permissions "add tests for the parser"' --enter
 tty7 wait "$PANE" --until waiting,done --changed --timeout 900
 tty7 capture "$PANE" --plain | tail -40
 tty7 pane close "$PANE"
@@ -215,6 +243,27 @@ tty7 pane close "$PANE"
 Five steps: give it a pane, hand it the task, sleep until it needs you or
 finishes, read what happened, clean up. The third is the one worth
 understanding.
+
+### Give the worker its interactive mode
+
+Hand the task as an argument, **not** with `-p`. Both run one turn and stop, so
+the difference is not what the worker does — it is what anybody can see while it
+does it.
+
+Interactive is the mode that draws a TUI, so the pane fills with the worker's
+reasoning and tool calls as they happen. That is visible to the user in their
+tty7 window, and it is what `capture --plain` reads back. `-p` is the piped
+mode: it draws nothing, streams its answer to stdout when the turn ends, and
+until then the pane's screen stays **empty** — `capture --plain` on it returns
+nothing at all, which reads exactly like a worker that hung. Putting a `-p`
+worker in a pane throws away the only reason it is in a pane.
+
+Interactive also leaves the session alive at the prompt, so you can `send` a
+follow-up into the same context. A `-p` worker is gone after its one turn.
+
+Reach for `-p` only when you want the answer as a string and nobody needs to
+watch — and then prefer `tty7 run` or the Bash tool, which is what that shape
+is for.
 
 ### What the states mean
 
@@ -292,6 +341,20 @@ worker is fine, it just has no way to say so. `tty7 agents` names the agent when
 it can see the gap, and `tty7 doctor` reports where every agent's hooks stand.
 Hooks are installed from the GUI's **Settings → Agents**; tell the user rather
 than trying to install them yourself.
+
+Before concluding anything, check whether it is moving. Those same hooks emit an
+OSC 777 line on every tool call, and `capture` **without** `--plain` shows them —
+one of the few times the raw bytes beat the rendered screen:
+
+```bash
+tty7 capture "$PANE" | grep -c 'tool-complete'   # rising = alive and working
+```
+
+That is also the answer when a worker's screen looks empty: a `-p` worker paints
+nothing until its turn ends, so `capture --plain` is blank the whole way through
+while the event stream underneath is busy. Two things that do *not* answer this
+question: `tty7 procs`, which reports nothing running for a pane with a live
+agent in it, and the absence of output on a `--plain` capture.
 
 ## Looking around
 


### PR DESCRIPTION
Removes two pieces of friction found while running four agent workers in tty7 tabs: a tab id that the CLI itself printed could not be used as an address, and the skill told you to run those workers in the one mode that renders nothing.

## `parse_tab` — the `@` is now optional

| | Before | After |
|---|---|---|
| `tty7 tab rename <uuid> build` | `'<uuid>' is not a tab address — tabs look like @7` | renames the tab |
| `tty7 tab rename @<uuid> build` | renames the tab | unchanged |
| `tty7 tab close 7` | rejected | closes `@7` |
| `tty7 tab close @7` | closes `@7` | unchanged |
| `tty7 tab rename +5 x` | rejected | still rejected |

`tty7 tab new --json` hands back `{"tab":"<uuid>","pane":N}`, and every other `--json` payload spells tabs bare too — so the id a caller is *most* certain of was the one shape the address parser turned away. Naming a tab you had just created meant going back to `tab ls` and counting `@N`, which is the unstable address, precisely to avoid the stable one.

`parse_pane` already made `%` optional for this exact reason in #538; this brings tabs in line. The digits-only guard from that change is kept and extended to tabs: with the sigil gone, `u64::from_str` would otherwise read `+5` as tab 5 rather than as a typo.

## Skill — stop telling workers to run headless

| | Before | After |
|---|---|---|
| Worked example | `claude -p "add tests for the parser"` | `claude --dangerously-skip-permissions "add tests for the parser"` |
| Sigils in the address table | `%42` / `@7` only | notes both are optional, and that a tab has a stable UUID address |
| A fresh pane eating the Enter | undocumented | documented, with the check and the fix |
| `tty7 procs` on an agent pane | described as "what is running in there" | flagged: it reports nothing running for a live agent |
| "Is this worker alive?" | undocumented | `capture` without `--plain`, count `tool-complete` in the OSC 777 stream |

`-p` is the piped mode: it paints nothing, so the pane stays blank for the whole turn and `capture --plain` reads back empty — indistinguishable from a worker that hung. Interactive mode draws the TUI, which is visible in the user's window and is what `capture --plain` can actually read; it also leaves the session at the prompt so a follow-up can be sent into the same context.

The other three entries are failure modes hit in one session: one of four workers silently kept its command sitting on the prompt line because the shell was still running its startup files when the Enter arrived, and `procs` plus a blank `--plain` capture then made all four look dead while they were working normally.

## Testing

- `cargo test -p tty7-cli` — 131 passed. Two new unit tests: `a_bare_tab_id_addresses_the_same_tab_as_the_marked_one` (bare and `@`-prefixed forms agree, for both a UUID and an ordinal) and `a_tab_ordinal_is_digits_and_nothing_else` (`+5`, `@+5`, `-5`, whitespace, `5.0`, `build`, empty, bare `@`, and an ordinal past `u64` all still rejected).
- `cargo fmt --check` clean; `cargo clippy -p tty7-cli --all-targets` adds no new warnings.
- End to end against a live server with the built binary: `tab new --json` → `tab rename <bare uuid> probe-bare-uuid` → confirmed the new name in `tab ls --json` → cleaned the pane up.
