### PR TITLE
fix(tabs): follow focused pane agent badges

### DIFF
--- a/crates/tty7-core/src/core/cli_agent.rs
+++ b/crates/tty7-core/src/core/cli_agent.rs
@@ -519,6 +519,39 @@ impl CLIAgent {
         None
     }
 
+    /// Identity from an interpreter's *image path*, not from argv.
+    ///
+    /// ToolHelp often shows only `node.exe`. The install directory still
+    /// names the agent (`…\cursor-agent\…\node.exe`, `…\@openai\codex\…`).
+    /// A home-folder or project directory named `claude` / `pi` / `amp`
+    /// must not count: those aliases are too short to trust as an
+    /// arbitrary path segment. Only a hyphenated alias or a scoped npm
+    /// package (`@openai/codex`) is distinctive enough.
+    pub fn detect_from_image_path_with(
+        path: &std::path::Path,
+        custom: &HashMap<String, String>,
+    ) -> Option<CLIAgent> {
+        let components: Vec<String> = path
+            .iter()
+            .map(|c| c.to_string_lossy().to_ascii_lowercase())
+            .collect();
+
+        for (i, component) in components.iter().enumerate() {
+            let stem = base_stem(component);
+            let prev = i.checked_sub(1).map(|j| components[j].as_str());
+            if !image_path_component_is_distinctive(stem, prev) {
+                continue;
+            }
+            if let Some(agent) = Self::match_token(stem) {
+                return Some(agent);
+            }
+            if let Some(agent) = custom.get(stem).and_then(|slug| CLIAgent::from_slug(slug)) {
+                return Some(agent);
+            }
+        }
+        None
+    }
+
     pub fn detect_from_command_with(
         command: &str,
         custom: &HashMap<String, String>,
@@ -574,6 +607,10 @@ fn base_stem(token: &str) -> &str {
         }
     }
     name
+}
+
+fn image_path_component_is_distinctive(stem: &str, prev: Option<&str>) -> bool {
+    stem.contains('-') || prev.is_some_and(|p| p.starts_with('@'))
 }
 
 fn is_interpreter(stem: &str) -> bool {
@@ -790,6 +827,51 @@ mod tests {
         assert_eq!(
             CLIAgent::detect_from_argv(&argv(&["FOO=1", "BAR=baz", "claude"])),
             Some(CLIAgent::Claude)
+        );
+    }
+
+    #[test]
+    fn an_interpreter_image_path_only_matches_a_distinctive_install_prefix() {
+        use std::path::Path;
+
+        assert_eq!(
+            CLIAgent::detect_from_image_path_with(
+                Path::new(r"C:\Users\me\AppData\Local\cursor-agent\versions\current\node.exe"),
+                &HashMap::new(),
+            ),
+            Some(CLIAgent::Cursor)
+        );
+        assert_eq!(
+            CLIAgent::detect_from_image_path_with(
+                Path::new(
+                    r"C:\Users\me\AppData\Roaming\npm\node_modules\@openai\codex\vendor\node.exe"
+                ),
+                &HashMap::new(),
+            ),
+            Some(CLIAgent::Codex),
+            "a scoped npm package is an install prefix, not a folder name"
+        );
+        assert_eq!(
+            CLIAgent::detect_from_image_path_with(
+                Path::new(r"C:\Users\claude\AppData\Local\fnm\node.exe"),
+                &HashMap::new(),
+            ),
+            None,
+            "a home-directory name must not count as the agent"
+        );
+        assert_eq!(
+            CLIAgent::detect_from_image_path_with(
+                Path::new(r"C:\Users\me\pi\node.exe"),
+                &HashMap::new(),
+            ),
+            None
+        );
+        assert_eq!(
+            CLIAgent::detect_from_image_path_with(
+                Path::new(r"/Users/amp/.nvm/versions/node/v22.0.0/bin/node"),
+                &HashMap::new(),
+            ),
+            None
         );
     }
 

--- a/crates/tty7-core/src/core/config.rs
+++ b/crates/tty7-core/src/core/config.rs
@@ -206,6 +206,12 @@ pub struct Config {
     pub sidebar_grouping: SidebarGrouping,
     #[serde(default = "default_true")]
     pub sidebar_diff_preview: bool,
+    /// Custom sidebar group titles, keyed by the group's root path — `""`
+    /// stands for the Scratch group. A group without an entry keeps the name
+    /// derived from its path, and an entry is removed (not blanked) when the
+    /// user commits an empty rename, so the derived name comes back.
+    #[serde(default)]
+    pub sidebar_group_names: HashMap<String, String>,
     #[serde(default, deserialize_with = "de_lenient")]
     pub notify_on_command_finish: NotifyMode,
     pub check_for_updates: bool,
@@ -605,6 +611,7 @@ impl Default for Config {
             scm_graph_expanded: false,
             sidebar_grouping: SidebarGrouping::Repo,
             sidebar_diff_preview: true,
+            sidebar_group_names: HashMap::new(),
             notify_on_command_finish: NotifyMode::Unfocused,
             check_for_updates: true,
             update_channel: UpdateChannel::default(),
@@ -1294,6 +1301,39 @@ mod tests {
         assert!(json.contains("\"sidebar_diff_preview\":false"), "persisted");
         let back: Config = serde_json::from_str(&json).unwrap();
         assert!(!back.sidebar_diff_preview);
+    }
+
+    #[test]
+    fn sidebar_group_names_round_trip_and_default_empty() {
+        let mut cfg = Config::default();
+        assert!(cfg.sidebar_group_names.is_empty());
+
+        // A Windows group key is the shape this actually stores on the
+        // platform the sidebar groups are keyed by path on, and its
+        // backslashes are the one part of the key that JSON has to escape.
+        let win = r"D:\gh-prj\tty7";
+        cfg.sidebar_group_names.insert(win.into(), "mine".into());
+        cfg.sidebar_group_names
+            .insert(String::new(), "inbox".into());
+        let text = serde_json::to_string(&cfg).unwrap();
+        assert!(
+            text.contains(r#""D:\\gh-prj\\tty7":"mine""#),
+            "the backslashes are escaped, not dropped: {text}"
+        );
+        let back: Config = serde_json::from_str(&text).unwrap();
+        assert_eq!(
+            back.sidebar_group_names.get(win).map(String::as_str),
+            Some("mine")
+        );
+        assert_eq!(
+            back.sidebar_group_names.get("").map(String::as_str),
+            Some("inbox"),
+            "the scratch group's custom title persists under the \"\" key"
+        );
+
+        // A config predating the key parses to the default empty map.
+        let old: Config = serde_json::from_str("{}").unwrap();
+        assert!(old.sidebar_group_names.is_empty());
     }
 
     #[test]

--- a/crates/tty7-core/src/daemon/pane.rs
+++ b/crates/tty7-core/src/daemon/pane.rs
@@ -1460,6 +1460,8 @@ impl DaemonPane {
         let fg_master = master.clone();
         let remote_master = master.clone();
         let agent_master = master.clone();
+        let process_agent_seen = Mutex::new(None);
+        let agent_state = state.clone();
         let cwd_master = master.clone();
         let reader = Self::spawn_reader(
             state,
@@ -1470,7 +1472,9 @@ impl DaemonPane {
             move || foreground_command_running(&fg_master, shell_pid),
             ForegroundProbes {
                 remote: Box::new(move || foreground_remote_context(&remote_master)),
-                agent: Box::new(move || foreground_agent(&agent_master)),
+                agent: Box::new(move || {
+                    foreground_agent(&agent_master, shell_pid, &process_agent_seen, &agent_state)
+                }),
                 cwd: Box::new(move || foreground_cwd(&cwd_master, shell_pid)),
             },
             death,
@@ -2591,7 +2595,7 @@ fn apply_agent_signals(
     events: Vec<crate::core::cli_agent::AgentEvent>,
     notification: Option<String>,
 ) {
-    use crate::core::cli_agent::{AgentSessionState, AgentStatus};
+    use crate::core::cli_agent::{AgentEventKind, AgentSessionState, AgentStatus};
 
     if events.is_empty() && notification.is_none() {
         return;
@@ -2599,9 +2603,40 @@ fn apply_agent_signals(
     let before = st.agent_session.clone();
 
     for event in &events {
-        if st.agent.is_none() && event.agent.is_some() {
-            st.agent = event.agent;
-            notify(st, DaemonMsg::Agent(st.agent));
+        let same_session = match (
+            event.session_id.as_deref(),
+            st.agent_session
+                .as_ref()
+                .and_then(|session| session.session_id.as_deref()),
+        ) {
+            (Some(event), Some(active)) => event == active,
+            _ => true,
+        };
+        let same_agent = event.agent.is_none() || event.agent == st.agent;
+
+        if event.kind == AgentEventKind::SessionEnd {
+            // A hook can arrive after another agent has already replaced the
+            // process in this pane. Only the session that still owns the row
+            // may remove it; a late Claude shutdown must not erase Cursor.
+            if st.agent.is_some() && same_agent && same_session {
+                st.agent_session = None;
+                st.agent_argv = None;
+                st.agent = None;
+                notify(st, DaemonMsg::Agent(None));
+            }
+            continue;
+        }
+
+        if let Some(agent) = event.agent
+            && st.agent != Some(agent)
+        {
+            // Hook identity is stronger than a stale pane value. Reset the
+            // old session before applying this event so the two agents cannot
+            // share an id/status/launch argv.
+            st.agent_session = None;
+            st.agent_argv = None;
+            st.agent = Some(agent);
+            notify(st, DaemonMsg::Agent(Some(agent)));
         }
         st.agent_session
             .get_or_insert_with(AgentSessionState::default)
@@ -2673,13 +2708,13 @@ fn apply_agent(
         stamp_launch_argv(st, argv);
         return;
     }
-    if agent.is_none() && st.agent_session.is_some() {
+    // Identity changed — including A → B, not just A → none. A leftover
+    // Claude session must not sit under a process-detected Cursor icon.
+    if st.agent_session.is_some() {
         st.agent_session = None;
         notify(st, DaemonMsg::AgentStatus(None));
     }
-    if agent.is_none() {
-        st.agent_argv = None;
-    }
+    st.agent_argv = None;
     notify(st, DaemonMsg::Agent(agent));
     st.agent = agent;
     stamp_launch_argv(st, argv);
@@ -2816,6 +2851,9 @@ fn foreground_remote_context(
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 fn foreground_agent(
     master: &Mutex<Option<Box<dyn MasterPty + Send>>>,
+    _shell_pid: Option<u32>,
+    _process_agent_seen: &Mutex<Option<crate::core::cli_agent::CLIAgent>>,
+    _state: &Mutex<PaneState>,
 ) -> Option<Option<(crate::core::cli_agent::CLIAgent, Vec<String>)>> {
     let detect = || {
         let pid = master
@@ -2832,11 +2870,47 @@ fn foreground_agent(
     Some(detect())
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+#[cfg(windows)]
 fn foreground_agent(
     _master: &Mutex<Option<Box<dyn MasterPty + Send>>>,
+    shell_pid: Option<u32>,
+    process_agent_seen: &Mutex<Option<crate::core::cli_agent::CLIAgent>>,
+    state: &Mutex<PaneState>,
+) -> Option<Option<(crate::core::cli_agent::CLIAgent, Vec<String>)>> {
+    let detected = shell_pid.and_then(|pid| {
+        crate::daemon::winproc::foreground_agent(pid, crate::core::config::agent_commands_cached())
+    });
+    let active_agent = state.lock().ok()?.agent;
+    let mut seen = process_agent_seen.lock().ok()?;
+    windows_agent_probe_signal(&mut seen, detected, active_agent)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+fn foreground_agent(
+    _master: &Mutex<Option<Box<dyn MasterPty + Send>>>,
+    _shell_pid: Option<u32>,
+    _process_agent_seen: &Mutex<Option<crate::core::cli_agent::CLIAgent>>,
+    _state: &Mutex<PaneState>,
 ) -> Option<Option<(crate::core::cli_agent::CLIAgent, Vec<String>)>> {
     None
+}
+
+#[cfg(windows)]
+fn windows_agent_probe_signal(
+    process_agent: &mut Option<crate::core::cli_agent::CLIAgent>,
+    detected: Option<(crate::core::cli_agent::CLIAgent, Vec<String>)>,
+    active_agent: Option<crate::core::cli_agent::CLIAgent>,
+) -> Option<Option<(crate::core::cli_agent::CLIAgent, Vec<String>)>> {
+    match detected {
+        Some(found) => {
+            *process_agent = Some(found.0);
+            Some(Some(found))
+        }
+        None => {
+            let departed = process_agent.take()?;
+            (active_agent == Some(departed)).then_some(None)
+        }
+    }
 }
 
 #[derive(Default, Clone, PartialEq, Eq)]
@@ -3184,10 +3258,12 @@ mod tests {
         cmd.args(["-c", "exec -a codex cat"]);
         let mut child = pty.slave.spawn_command(cmd).expect("spawn child");
         let master = Mutex::new(Some(pty.master));
+        let seen = Mutex::new(None);
+        let state = Mutex::new(test_state(true));
 
         let mut detected = None;
         for _ in 0..200 {
-            if let Some(agent) = foreground_agent(&master).flatten() {
+            if let Some(agent) = foreground_agent(&master, None, &seen, &state).flatten() {
                 detected = Some(agent);
                 break;
             }
@@ -4425,6 +4501,149 @@ mod tests {
         assert!(st.agent_session.is_none());
         assert!(matches!(rx.try_recv(), Ok(DaemonMsg::AgentStatus(None))));
         assert!(matches!(rx.try_recv(), Ok(DaemonMsg::Agent(None))));
+    }
+
+    #[test]
+    fn session_end_removes_the_agent_identity_from_the_pane() {
+        use crate::core::cli_agent::CLIAgent;
+
+        let mut st = test_state(true);
+        st.agent_argv = Some(vec!["claude".into()]);
+        let mut sniffer = OscSniffer::new();
+        let start = concat!(
+            "\x1b]777;notify;tty7://cli-agent;",
+            r#"{"agent":"claude","event":"session-start","session_id":"old"}"#,
+            "\x07",
+        );
+        apply_signals(&mut st, sniffer.feed(start.as_bytes()));
+        assert_eq!(st.agent, Some(CLIAgent::Claude));
+
+        let end = concat!(
+            "\x1b]777;notify;tty7://cli-agent;",
+            r#"{"agent":"claude","event":"session-end","session_id":"old"}"#,
+            "\x07",
+        );
+        apply_signals(&mut st, sniffer.feed(end.as_bytes()));
+
+        assert_eq!(st.agent, None);
+        assert!(st.agent_session.is_none());
+        assert!(st.agent_argv.is_none());
+    }
+
+    #[test]
+    fn a_new_agent_event_replaces_stale_identity_and_ignores_the_old_session_end() {
+        use crate::core::cli_agent::CLIAgent;
+
+        let mut st = test_state(true);
+        let mut sniffer = OscSniffer::new();
+        let old = concat!(
+            "\x1b]777;notify;tty7://cli-agent;",
+            r#"{"agent":"claude","event":"session-start","session_id":"old"}"#,
+            "\x07",
+        );
+        apply_signals(&mut st, sniffer.feed(old.as_bytes()));
+
+        let replacement = concat!(
+            "\x1b]777;notify;tty7://cli-agent;",
+            r#"{"agent":"cursor","event":"session-start","session_id":"new"}"#,
+            "\x07",
+        );
+        apply_signals(&mut st, sniffer.feed(replacement.as_bytes()));
+        assert_eq!(st.agent, Some(CLIAgent::Cursor));
+        assert_eq!(
+            st.agent_session
+                .as_ref()
+                .and_then(|s| s.session_id.as_deref()),
+            Some("new")
+        );
+
+        let late_end = concat!(
+            "\x1b]777;notify;tty7://cli-agent;",
+            r#"{"agent":"claude","event":"session-end","session_id":"old"}"#,
+            "\x07",
+        );
+        apply_signals(&mut st, sniffer.feed(late_end.as_bytes()));
+        assert_eq!(st.agent, Some(CLIAgent::Cursor));
+        assert_eq!(
+            st.agent_session
+                .as_ref()
+                .and_then(|s| s.session_id.as_deref()),
+            Some("new")
+        );
+    }
+
+    #[test]
+    fn a_process_detected_replacement_drops_the_previous_session() {
+        use crate::core::cli_agent::{AgentSessionState, AgentStatus, CLIAgent};
+
+        let mut st = test_state(true);
+        st.agent = Some(CLIAgent::Claude);
+        st.agent_argv = Some(vec!["claude".into()]);
+        st.agent_session = Some(AgentSessionState {
+            status: AgentStatus::Working,
+            session_id: Some("old".into()),
+            launch_argv: Some(vec!["claude".into()]),
+            ..Default::default()
+        });
+        let (tx, rx) = mpsc::channel();
+        st.subscriber = Some(tx);
+
+        apply_agent(&mut st, Some((CLIAgent::Cursor, Vec::new())));
+
+        assert_eq!(st.agent, Some(CLIAgent::Cursor));
+        assert!(
+            st.agent_session.is_none(),
+            "Claude's Working must not ride along"
+        );
+        assert!(st.agent_argv.is_none(), "the probe reports identity only");
+        assert!(matches!(rx.try_recv(), Ok(DaemonMsg::AgentStatus(None))));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(DaemonMsg::Agent(Some(CLIAgent::Cursor)))
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn an_empty_windows_process_probe_only_clears_an_agent_it_previously_found() {
+        use crate::core::cli_agent::CLIAgent;
+
+        let mut process_agent = None;
+        assert_eq!(
+            windows_agent_probe_signal(&mut process_agent, None, Some(CLIAgent::Claude)),
+            None,
+            "an inconclusive process scan must not erase hook-owned state"
+        );
+
+        let codex = Some((CLIAgent::Codex, vec!["codex.exe".into()]));
+        assert_eq!(
+            windows_agent_probe_signal(&mut process_agent, codex.clone(), None),
+            Some(codex)
+        );
+        assert_eq!(process_agent, Some(CLIAgent::Codex));
+        assert_eq!(
+            windows_agent_probe_signal(&mut process_agent, None, Some(CLIAgent::Cursor)),
+            None,
+            "a replacement hook owner must survive the old process exiting"
+        );
+        assert_eq!(process_agent, None);
+
+        let codex = Some((CLIAgent::Codex, vec!["codex.exe".into()]));
+        assert_eq!(
+            windows_agent_probe_signal(&mut process_agent, codex.clone(), None),
+            Some(codex)
+        );
+        assert_eq!(
+            windows_agent_probe_signal(&mut process_agent, None, Some(CLIAgent::Codex)),
+            Some(None),
+            "the first empty scan after a process-owned agent exits clears it"
+        );
+        assert_eq!(process_agent, None);
+        assert_eq!(
+            windows_agent_probe_signal(&mut process_agent, None, Some(CLIAgent::Codex)),
+            None,
+            "later empty scans are inconclusive again"
+        );
     }
 
     #[test]

--- a/crates/tty7-core/src/daemon/winproc.rs
+++ b/crates/tty7-core/src/daemon/winproc.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashSet, VecDeque};
 
+use crate::core::cli_agent::CLIAgent;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct Proc {
     pub pid: u32,
@@ -35,6 +37,51 @@ pub(crate) fn foreground_name(procs: &[Proc], shell_pid: u32) -> Option<String> 
         .into_iter()
         .max_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)))
         .map(|(_, _, name)| name.to_string())
+}
+
+const AGENT_SCAN_MAX_DEPTH: u32 = 3;
+
+fn detect_foreground_agent_with<F>(
+    procs: &[Proc],
+    shell_pid: u32,
+    image_path_for: F,
+    custom: &std::collections::HashMap<String, String>,
+) -> Option<(CLIAgent, Vec<String>)>
+where
+    F: Fn(u32) -> Option<std::path::PathBuf>,
+{
+    for (depth, pid, name) in walk(procs, shell_pid) {
+        if depth > AGENT_SCAN_MAX_DEPTH {
+            break;
+        }
+
+        let launcher = name.to_ascii_lowercase();
+        let mut agent = CLIAgent::detect_from_argv_with(std::slice::from_ref(&launcher), custom);
+        if agent.is_none()
+            && let Some(path) = image_path_for(pid)
+        {
+            // Script-installed agents often leave only a generic interpreter
+            // in ToolHelp (`node.exe`). The image path still carries the
+            // package name (`...\cursor-agent\...\node.exe`). That is not
+            // argv — feeding the whole path to the argv detector would
+            // treat a home folder named `claude` as Claude.
+            agent = CLIAgent::detect_from_image_path_with(&path, custom);
+        }
+        if let Some(agent) = agent {
+            // ToolHelp does not expose the command line. An invented argv is
+            // unsafe to replay for session resume (especially interpreter
+            // wrappers), so this probe reports identity only.
+            return Some((agent, Vec::new()));
+        }
+    }
+    None
+}
+
+pub(crate) fn foreground_agent(
+    shell_pid: u32,
+    custom: &std::collections::HashMap<String, String>,
+) -> Option<(CLIAgent, Vec<String>)> {
+    detect_foreground_agent_with(&snapshot(), shell_pid, image_path, custom)
 }
 
 pub(crate) fn snapshot() -> Vec<Proc> {
@@ -506,6 +553,88 @@ mod tests {
     fn foreground_name_breaks_depth_ties_by_pid() {
         let procs = vec![p(100, 1, "sh"), p(200, 100, "a"), p(201, 100, "b")];
         assert_eq!(foreground_name(&procs, 100).as_deref(), Some("b"));
+    }
+
+    #[test]
+    fn cmder_cursor_agent_is_found_before_its_mcp_children() {
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+
+        let procs = vec![
+            p(100, 1, "cmd.exe"),
+            p(200, 100, "powershell.exe"),
+            p(300, 200, "node.exe"),
+            p(400, 300, "cmd.exe"),
+            p(500, 400, "codex.exe"),
+        ];
+        let detected = detect_foreground_agent_with(
+            &procs,
+            100,
+            |pid| match pid {
+                300 => Some(PathBuf::from(
+                    r"C:\Users\me\AppData\Local\cursor-agent\versions\current\node.exe",
+                )),
+                500 => Some(PathBuf::from(r"C:\tools\codex.exe")),
+                _ => None,
+            },
+            &HashMap::new(),
+        );
+
+        assert_eq!(
+            detected.as_ref().map(|(agent, _)| *agent),
+            Some(CLIAgent::Cursor),
+            "the nearest agent owns the pane; a nested MCP command does not"
+        );
+    }
+
+    #[test]
+    fn cmder_codex_native_child_is_detected() {
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+
+        let procs = vec![
+            p(100, 1, "cmd.exe"),
+            p(200, 100, "node.exe"),
+            p(300, 200, "codex.exe"),
+            p(400, 300, "codex-code-mode-host.exe"),
+        ];
+        let detected = detect_foreground_agent_with(
+            &procs,
+            100,
+            |pid| {
+                (pid == 300).then(|| {
+                    PathBuf::from(
+                        r"C:\Users\me\AppData\Roaming\npm\node_modules\@openai\codex\vendor\codex.exe",
+                    )
+                })
+            },
+            &HashMap::new(),
+        );
+
+        assert_eq!(
+            detected.as_ref().map(|(agent, _)| *agent),
+            Some(CLIAgent::Codex)
+        );
+    }
+
+    #[test]
+    fn a_node_under_a_user_named_claude_is_not_the_agent() {
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+
+        let procs = vec![p(100, 1, "cmd.exe"), p(200, 100, "node.exe")];
+        let detected = detect_foreground_agent_with(
+            &procs,
+            100,
+            |pid| {
+                (pid == 200).then(|| PathBuf::from(r"C:\Users\claude\AppData\Local\fnm\node.exe"))
+            },
+            &HashMap::new(),
+        );
+        assert_eq!(
+            detected, None,
+            "a home-directory name is not an install prefix"
+        );
     }
 
     #[test]

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -470,6 +470,25 @@ fn most_urgent_agent_row(
     rows.into_iter().max_by_key(|(_, status)| urgency(*status))
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct TabAgentBadge {
+    pub(crate) agent: Option<crate::core::cli_agent::CLIAgent>,
+    pub(crate) status: Option<crate::core::cli_agent::AgentStatus>,
+    pub(crate) unread: usize,
+}
+
+fn badge_for_focused_pane(
+    focused: Option<gpui::EntityId>,
+    rows: impl IntoIterator<Item = (gpui::EntityId, TabAgentBadge)>,
+) -> TabAgentBadge {
+    let Some(focused) = focused else {
+        return TabAgentBadge::default();
+    };
+    rows.into_iter()
+        .find_map(|(pane, badge)| (pane == focused).then_some(badge))
+        .unwrap_or_default()
+}
+
 impl Tab {
     pub(crate) fn new(pane: Pane) -> Self {
         Self {
@@ -571,6 +590,36 @@ impl Tab {
 
     pub(crate) fn agent(&self, cx: &App) -> Option<crate::core::cli_agent::CLIAgent> {
         self.agent_row(cx).map(|(agent, _)| agent)
+    }
+
+    pub(crate) fn focused_agent_badge(&self, window: &Window, cx: &App) -> TabAgentBadge {
+        use crate::core::cli_agent::AgentStatus;
+
+        let focused = self
+            .pane
+            .focused_leaf(window, cx)
+            .or_else(|| self.focus_target())
+            .map(|leaf| leaf.entity_id());
+        badge_for_focused_pane(
+            focused,
+            self.pane.terminals().into_iter().map(|leaf| {
+                let view = leaf.read(cx);
+                let agent = view.agent();
+                let session_status = view.agent_session().map(|session| session.status);
+                let status = agent.map(|_| session_status.unwrap_or(AgentStatus::Idle));
+                let unread = usize::from(
+                    session_status == Some(AgentStatus::Done) && view.agent_result_unread(),
+                );
+                (
+                    leaf.entity_id(),
+                    TabAgentBadge {
+                        agent,
+                        status,
+                        unread,
+                    },
+                )
+            }),
+        )
     }
 
     /// The tab's most urgent agent leaf, named and reported by that one leaf.
@@ -8721,11 +8770,11 @@ mod window_drag_tests {
 #[cfg(test)]
 mod tests {
     use super::{
-        CloseReason, DOCUMENT_MIN_W, TERMINAL_MIN_W, TITLE_BAR_HEIGHT, TabAgentSession,
-        clear_window_override_values, close_prompt, document_column_px, join_shell_args,
-        leaf_shares_the_window_daemon, most_urgent_agent_row, mru_order, pane_free_for,
-        parse_ssh_connect_input, parse_ssh_option_words, side_panel_max, split_shell_args,
-        strip_band, wd_path_saveable,
+        CloseReason, DOCUMENT_MIN_W, TERMINAL_MIN_W, TITLE_BAR_HEIGHT, TabAgentBadge,
+        TabAgentSession, badge_for_focused_pane, clear_window_override_values, close_prompt,
+        document_column_px, join_shell_args, leaf_shares_the_window_daemon, most_urgent_agent_row,
+        mru_order, pane_free_for, parse_ssh_connect_input, parse_ssh_option_words, side_panel_max,
+        split_shell_args, strip_band, wd_path_saveable,
     };
     use gpui::{Edges, point, px, size};
 
@@ -8740,6 +8789,41 @@ mod tests {
                 (CLIAgent::Cursor, AgentStatus::Waiting),
             ]),
             Some((CLIAgent::Cursor, AgentStatus::Waiting))
+        );
+    }
+
+    #[test]
+    fn tab_chrome_agent_badges_follow_the_focused_split() {
+        use crate::core::cli_agent::{AgentStatus, CLIAgent};
+
+        let kestrel_pane = gpui::EntityId::from(1);
+        let codex_pane = gpui::EntityId::from(2);
+        let kestrel_badge = TabAgentBadge {
+            agent: Some(CLIAgent::Cursor),
+            status: Some(AgentStatus::Idle),
+            unread: 0,
+        };
+        let codex_badge = TabAgentBadge {
+            agent: Some(CLIAgent::Codex),
+            status: Some(AgentStatus::Done),
+            unread: 1,
+        };
+        let rows = [(kestrel_pane, kestrel_badge), (codex_pane, codex_badge)];
+
+        assert_eq!(
+            badge_for_focused_pane(Some(kestrel_pane), rows),
+            kestrel_badge,
+            "the Kestrel pane owns the badge while it is focused"
+        );
+        assert_eq!(
+            badge_for_focused_pane(Some(codex_pane), rows),
+            codex_badge,
+            "the Codex pane owns the badge after focus moves to it"
+        );
+        assert_eq!(
+            badge_for_focused_pane(Some(kestrel_pane), rows),
+            kestrel_badge,
+            "returning focus to the Kestrel pane must restore its badge even when Codex is more urgent"
         );
     }
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -630,6 +630,15 @@ pub(crate) struct WorkspaceRename {
     _subs: Vec<Subscription>,
 }
 
+pub(crate) struct GroupRename {
+    /// The sidebar group being renamed, by its section key rather than an
+    /// index: `None` is the Scratch group, and a group's index shifts the
+    /// moment a repo probe lands and regroups a tab mid-rename.
+    pub(crate) key: Option<std::path::PathBuf>,
+    pub(crate) input: Entity<InputState>,
+    _subs: Vec<Subscription>,
+}
+
 pub(crate) struct LoopbackForwardPanelState {
     pub(crate) form_pane_id: Option<u64>,
     pub(crate) managed: Vec<crate::daemon::protocol::ManagedForward>,
@@ -776,6 +785,7 @@ pub struct Tty7App {
     window_bounds: Bounds<Pixels>,
     pub(crate) workspace: WorkspaceId,
     pub(crate) workspace_rename: Option<WorkspaceRename>,
+    pub(crate) group_rename: Option<GroupRename>,
     window_title: std::cell::RefCell<String>,
     pub(crate) connect: Option<crate::ui::remote_workspace::ConnectFlow>,
     pub(crate) switcher: Option<crate::ui::switcher::Switcher>,
@@ -1343,6 +1353,7 @@ impl Tty7App {
             window_bounds: window_bounds_to_remember(window),
             workspace,
             workspace_rename: None,
+            group_rename: None,
             window_title: std::cell::RefCell::new(String::new()),
             connect: None,
             switcher: None,
@@ -4720,6 +4731,48 @@ impl Tty7App {
         self.sync_window_title(window, cx);
         self.focus_active(window, cx);
         cx.notify();
+    }
+
+    pub(crate) fn start_group_rename(
+        &mut self,
+        key: Option<std::path::PathBuf>,
+        current: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let input = Self::rename_box(current, window, cx);
+        let subs = vec![cx.subscribe_in(
+            &input,
+            window,
+            |this, _input, ev: &InputEvent, window, cx| match ev {
+                InputEvent::PressEnter { .. } | InputEvent::Blur => {
+                    this.commit_group_rename(window, cx)
+                }
+                _ => {}
+            },
+        )];
+        self.group_rename = Some(GroupRename {
+            key,
+            input,
+            _subs: subs,
+        });
+        cx.notify();
+    }
+
+    pub(crate) fn commit_group_rename(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(rename) = self.group_rename.take() else {
+            return;
+        };
+        let value = rename.input.read(cx).value().trim().to_string();
+        let key = crate::ui::tab_sidebar::group_name_key(&rename.key);
+        self.update_config(cx, |cfg| {
+            if value.is_empty() {
+                cfg.sidebar_group_names.remove(&key);
+            } else {
+                cfg.sidebar_group_names.insert(key, value);
+            }
+        });
+        self.focus_active(window, cx);
     }
 
     fn commit_rename(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -9773,6 +9826,57 @@ mod shell_menu_gpui_tests {
                 app.shells.shells.is_empty(),
                 "a remote window must not offer this computer's shells: {:?}",
                 app.shells.shells
+            );
+        });
+    }
+}
+
+#[cfg(test)]
+mod group_rename_gpui_tests {
+    use gpui::TestAppContext;
+
+    use crate::ui::app::test_window::harness;
+
+    #[gpui::test]
+    fn a_group_rename_lands_in_the_config_and_an_empty_one_reverts(cx: &mut TestAppContext) {
+        let (app, mut vcx) = harness(cx);
+        let key = Some(std::path::PathBuf::from("/w/repo"));
+
+        app.update_in(&mut vcx, |app, window, cx| {
+            app.start_group_rename(key.clone(), "repo".into(), window, cx);
+            let input = app
+                .group_rename
+                .as_ref()
+                .expect("the box is up")
+                .input
+                .clone();
+            input.update(cx, |s, cx| s.set_value("mine", window, cx));
+            app.commit_group_rename(window, cx);
+        });
+        app.update(&mut vcx, |_app, cx| {
+            let cfg = cx.global::<crate::core::config::Config>();
+            assert_eq!(
+                cfg.sidebar_group_names.get("/w/repo").map(String::as_str),
+                Some("mine")
+            );
+        });
+
+        app.update_in(&mut vcx, |app, window, cx| {
+            app.start_group_rename(key.clone(), "mine".into(), window, cx);
+            let input = app
+                .group_rename
+                .as_ref()
+                .expect("the box is up")
+                .input
+                .clone();
+            input.update(cx, |s, cx| s.set_value("  ", window, cx));
+            app.commit_group_rename(window, cx);
+        });
+        app.update(&mut vcx, |_app, cx| {
+            let cfg = cx.global::<crate::core::config::Config>();
+            assert!(
+                cfg.sidebar_group_names.get("/w/repo").is_none(),
+                "an empty rename removes the entry so the derived name returns"
             );
         });
     }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -449,6 +449,27 @@ pub(crate) enum OverlayTop {
     Diff,
 }
 
+fn most_urgent_agent_row(
+    rows: impl IntoIterator<
+        Item = (
+            crate::core::cli_agent::CLIAgent,
+            crate::core::cli_agent::AgentStatus,
+        ),
+    >,
+) -> Option<(
+    crate::core::cli_agent::CLIAgent,
+    crate::core::cli_agent::AgentStatus,
+)> {
+    use crate::core::cli_agent::AgentStatus;
+    let urgency = |status: AgentStatus| match status {
+        AgentStatus::Waiting => 3,
+        AgentStatus::Working => 2,
+        AgentStatus::Done => 1,
+        AgentStatus::Idle => 0,
+    };
+    rows.into_iter().max_by_key(|(_, status)| urgency(*status))
+}
+
 impl Tab {
     pub(crate) fn new(pane: Pane) -> Self {
         Self {
@@ -549,19 +570,13 @@ impl Tab {
     }
 
     pub(crate) fn agent(&self, cx: &App) -> Option<crate::core::cli_agent::CLIAgent> {
-        self.pane
-            .terminals()
-            .into_iter()
-            .find_map(|l| l.read(cx).agent())
+        self.agent_row(cx).map(|(agent, _)| agent)
     }
 
     /// The tab's most urgent agent leaf, named and reported by that one leaf.
     ///
-    /// `agent` and `agent_status` answer independently — the *first* leaf
-    /// carrying an agent, and the highest urgency found *anywhere* in the tab
-    /// — so reading them as a pair can put one pane's name beside another
-    /// pane's state, a row no leaf ever had. Anywhere both halves are shown
-    /// at once reads them from here instead (#543).
+    /// Both `agent` and `agent_status` project this same selection, so callers
+    /// cannot put one pane's icon beside another pane's status (#543).
     pub(crate) fn agent_row(
         &self,
         cx: &App,
@@ -570,28 +585,19 @@ impl Tab {
         crate::core::cli_agent::AgentStatus,
     )> {
         use crate::core::cli_agent::AgentStatus;
-        let urgency = |s: AgentStatus| match s {
-            AgentStatus::Waiting => 3,
-            AgentStatus::Working => 2,
-            AgentStatus::Done => 1,
-            AgentStatus::Idle => 0,
-        };
-        self.pane
-            .terminals()
-            .into_iter()
-            .filter_map(|l| {
-                let view = l.read(cx);
-                let agent = view.agent()?;
-                // A pane whose agent is running but has never reported a
-                // session reads as idle, the same reading the badge has always
-                // given it.
-                let status = view
-                    .agent_session()
-                    .map(|s| s.status)
-                    .unwrap_or(AgentStatus::Idle);
-                Some((agent, status))
-            })
-            .max_by_key(|(_, status)| urgency(*status))
+
+        most_urgent_agent_row(self.pane.terminals().into_iter().filter_map(|l| {
+            let view = l.read(cx);
+            let agent = view.agent()?;
+            // A pane whose agent is running but has never reported a
+            // session reads as idle, the same reading the badge has always
+            // given it.
+            let status = view
+                .agent_session()
+                .map(|s| s.status)
+                .unwrap_or(AgentStatus::Idle);
+            Some((agent, status))
+        }))
     }
 
     pub(crate) fn agent_status(&self, cx: &App) -> Option<crate::core::cli_agent::AgentStatus> {
@@ -8664,10 +8670,25 @@ mod tests {
     use super::{
         CloseReason, DOCUMENT_MIN_W, TERMINAL_MIN_W, TITLE_BAR_HEIGHT, TabAgentSession,
         clear_window_override_values, close_prompt, document_column_px, join_shell_args,
-        leaf_shares_the_window_daemon, mru_order, pane_free_for, parse_ssh_connect_input,
-        parse_ssh_option_words, side_panel_max, split_shell_args, strip_band, wd_path_saveable,
+        leaf_shares_the_window_daemon, most_urgent_agent_row, mru_order, pane_free_for,
+        parse_ssh_connect_input, parse_ssh_option_words, side_panel_max, split_shell_args,
+        strip_band, wd_path_saveable,
     };
     use gpui::{Edges, point, px, size};
+
+    #[test]
+    fn the_agent_icon_and_status_come_from_the_same_most_urgent_pane() {
+        use crate::core::cli_agent::{AgentStatus, CLIAgent};
+
+        assert_eq!(
+            most_urgent_agent_row([
+                (CLIAgent::Claude, AgentStatus::Idle),
+                (CLIAgent::Codex, AgentStatus::Working),
+                (CLIAgent::Cursor, AgentStatus::Waiting),
+            ]),
+            Some((CLIAgent::Cursor, AgentStatus::Waiting))
+        );
+    }
 
     const SIDEBAR_MIN: f32 = crate::ui::tab_sidebar::MIN_SIDEBAR_WIDTH;
     const PANEL_MIN: f32 = crate::ui::right_panel::MIN_WIDTH;

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -1761,6 +1761,7 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         L10nKey::TabUnnamedShell => "Shell {n}",
         L10nKey::ShellDefault => "default",
         L10nKey::SidebarScratchGroup => "Scratch",
+        L10nKey::SidebarRenameGroup => "Rename Group",
         L10nKey::TabContextCloseTab => "Close Tab",
         L10nKey::TabContextCloseTabsBelow => "Close Tabs Below",
         L10nKey::AppAgentHooksOpFailed => "Failed: {error}",

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -1832,6 +1832,7 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         L10nKey::TabUnnamedShell => "シェル {n}",
         L10nKey::ShellDefault => "デフォルト",
         L10nKey::SidebarScratchGroup => "スクラッチ",
+        L10nKey::SidebarRenameGroup => "グループ名を変更",
         L10nKey::TabContextCloseTab => "タブを閉じる",
         L10nKey::TabContextCloseTabsBelow => "下のタブを閉じる",
         L10nKey::AppAgentHooksOpFailed => "失敗: {error}",

--- a/src/ui/i18n/mod.rs
+++ b/src/ui/i18n/mod.rs
@@ -997,6 +997,7 @@ l10n_keys! {
     TabUnnamedShell,
     ShellDefault,
     SidebarScratchGroup,
+    SidebarRenameGroup,
     TabContextCloseTab,
     TabContextCloseTabsBelow,
     TabContextMarkUnread,

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -1675,6 +1675,7 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         L10nKey::TabUnnamedShell => "终端 {n}",
         L10nKey::ShellDefault => "默认",
         L10nKey::SidebarScratchGroup => "草稿",
+        L10nKey::SidebarRenameGroup => "重命名分组",
         L10nKey::TabContextCloseTab => "关闭标签页",
         L10nKey::TabContextCloseTabsBelow => "关闭下方标签页",
         L10nKey::AppAgentHooksOpFailed => "失败：{error}",

--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -885,12 +885,13 @@ impl Tty7App {
                 .into_iter()
                 .map(|i| {
                     let tab = &self.tabs[i];
+                    let agent_row = tab.agent_row(cx);
                     TabRow {
                         id: tab.tree_id.get(),
                         index: i,
                         label: self.tab_label(tab, i, None, cx),
                         named: tab.name.as_deref().is_some_and(|n| !n.trim().is_empty())
-                            || tab.agent(cx).is_some(),
+                            || agent_row.is_some(),
                         path: tab
                             .pane
                             .terminals()
@@ -901,8 +902,8 @@ impl Tty7App {
                             })
                             .map(|(p, home)| crate::ui::home::display_path(&p, home.as_deref()))
                             .unwrap_or_default(),
-                        agent: tab.agent(cx),
-                        status: tab.agent_status(cx),
+                        agent: agent_row.map(|(agent, _)| agent),
+                        status: agent_row.map(|(_, status)| status),
                         unread: tab.agent_unread_count(cx),
                         ssh: self.tab_ssh_dot(tab, cx),
                         active: i == self.active,

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -280,8 +280,9 @@ impl Tty7App {
                 let tab = &self.tabs[i];
                 let is_active = i == active;
                 let ssh_dot = self.tab_ssh_dot(tab, cx);
-                let agent = tab.agent(cx);
-                let agent_status = tab.agent_status(cx);
+                let agent_row = tab.agent_row(cx);
+                let agent = agent_row.map(|(agent, _)| agent);
+                let agent_status = agent_row.map(|(_, status)| status);
                 let agent_unread = tab.agent_unread_count(cx);
                 let git_cwd = diff_click_cwd(
                     cx.global::<Config>(),

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -280,10 +280,10 @@ impl Tty7App {
                 let tab = &self.tabs[i];
                 let is_active = i == active;
                 let ssh_dot = self.tab_ssh_dot(tab, cx);
-                let agent_row = tab.agent_row(cx);
-                let agent = agent_row.map(|(agent, _)| agent);
-                let agent_status = agent_row.map(|(_, status)| status);
-                let agent_unread = tab.agent_unread_count(cx);
+                let agent_badge = tab.focused_agent_badge(window, cx);
+                let agent = agent_badge.agent;
+                let agent_status = agent_badge.status;
+                let agent_unread = agent_badge.unread;
                 let git_cwd = diff_click_cwd(
                     cx.global::<Config>(),
                     tab.pane.focused_or_first(window, cx).and_then(|leaf| {

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -5,7 +5,7 @@ use gpui::{
 };
 use gpui_component::button::{Button, ButtonVariants as _};
 use gpui_component::input::Input;
-use gpui_component::menu::{ContextMenu, ContextMenuExt as _};
+use gpui_component::menu::{ContextMenu, ContextMenuExt as _, PopupMenuItem};
 use gpui_component::{ActiveTheme as _, Icon, IconName, Sizable as _, h_flex, v_flex};
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
@@ -846,8 +846,13 @@ impl Tty7App {
                 })
                 .collect();
             let header = section.name.clone().map(|name| {
-                let label: SharedString = name.to_uppercase().into();
-                h_flex()
+                let shown = effective_group_name(cx.global::<Config>(), &section.key, name);
+                let rename_input = self
+                    .group_rename
+                    .as_ref()
+                    .filter(|r| r.key == section.key)
+                    .map(|r| r.input.clone());
+                let base = h_flex()
                     .id(("sidebar-group", group_ix))
                     .w_full()
                     .items_center()
@@ -875,21 +880,61 @@ impl Tty7App {
                                 cx.new(|_| DragGroup)
                             }
                         })
-                    })
-                    .child(
-                        div()
-                            .flex_shrink(1.)
-                            .min_w_0()
-                            .truncate()
-                            .font_weight(FontWeight::SEMIBOLD)
-                            .child(label),
+                    });
+                if let Some(input) = rename_input {
+                    return base
+                        .child(
+                            div()
+                                .id(("sidebar-group-rename", group_ix))
+                                .flex_1()
+                                .min_w_0()
+                                .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                                // Same guard as the tab rows' rename box: a
+                                // click landing in the field must not reach
+                                // the drag handler behind it and take the
+                                // focus with it.
+                                .on_click(|_, _, cx| cx.stop_propagation())
+                                .child(Input::new(&input).appearance(false)),
+                        )
+                        .into_any_element();
+                }
+                let label: SharedString = shown.to_uppercase().into();
+                let menu_app = cx.entity().downgrade();
+                let key = section.key.clone();
+                base.child(
+                    div()
+                        .flex_shrink(1.)
+                        .min_w_0()
+                        .truncate()
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .child(label),
+                )
+                .child(
+                    div()
+                        .flex_shrink_0()
+                        .text_color(cx.theme().muted_foreground.opacity(0.7))
+                        .child(row_count.to_string()),
+                )
+                .context_menu(move |menu, _window, _cx| {
+                    let app = menu_app.clone();
+                    let key = key.clone();
+                    let current = shown.clone();
+                    menu.min_w(px(160.)).item(
+                        PopupMenuItem::new(t(L10nKey::SidebarRenameGroup)).on_click(
+                            move |_, window, cx| {
+                                let _ = app.update(cx, |this, cx| {
+                                    this.start_group_rename(
+                                        key.clone(),
+                                        current.clone(),
+                                        window,
+                                        cx,
+                                    )
+                                });
+                            },
+                        ),
                     )
-                    .child(
-                        div()
-                            .flex_shrink_0()
-                            .text_color(cx.theme().muted_foreground.opacity(0.7))
-                            .child(row_count.to_string()),
-                    )
+                })
+                .into_any_element()
             });
 
             let block = v_flex()
@@ -1353,6 +1398,24 @@ fn sidebar_sections(keys: &[Option<PathBuf>]) -> Vec<Section> {
     sections
 }
 
+/// The key a group's custom title is stored under in
+/// [`Config::sidebar_group_names`]: the group's root path, with `""` standing
+/// for the Scratch group.
+pub(crate) fn group_name_key(key: &Option<PathBuf>) -> String {
+    key.as_ref()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+/// What a group header shows: the user's custom title when one is stored,
+/// otherwise the name derived from the group's path.
+fn effective_group_name(cfg: &Config, key: &Option<PathBuf>, derived: String) -> String {
+    cfg.sidebar_group_names
+        .get(&group_name_key(key))
+        .cloned()
+        .unwrap_or(derived)
+}
+
 fn reordered_rows(
     keys: &[Option<PathBuf>],
     group: &Option<PathBuf>,
@@ -1461,6 +1524,33 @@ mod tests {
 
     fn p(s: &str) -> PathBuf {
         PathBuf::from(s)
+    }
+
+    #[test]
+    fn custom_group_titles_override_derived_names_by_key() {
+        let mut cfg = Config::default();
+        let repo = Some(p("/w/tty7"));
+        assert_eq!(
+            effective_group_name(&cfg, &repo, "tty7".into()),
+            "tty7",
+            "no entry: the derived name stands"
+        );
+
+        cfg.sidebar_group_names
+            .insert(group_name_key(&repo), "mine".into());
+        cfg.sidebar_group_names
+            .insert(group_name_key(&None), "inbox".into());
+        assert_eq!(effective_group_name(&cfg, &repo, "tty7".into()), "mine");
+        assert_eq!(
+            effective_group_name(&cfg, &None, "Scratch".into()),
+            "inbox",
+            "the scratch group renames through the \"\" key"
+        );
+        assert_eq!(
+            effective_group_name(&cfg, &Some(p("/w/other")), "other".into()),
+            "other",
+            "an entry only covers its own group"
+        );
     }
 
     #[test]

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -1610,10 +1610,10 @@ impl Tty7App {
             let label = self.tab_label(tab, i, Some(window), cx);
             let full_title = self.tab_title_tooltip(tab, i, Some(window), cx);
             let ssh_dot = self.tab_ssh_dot(tab, cx);
-            let agent_row = tab.agent_row(cx);
-            let agent = agent_row.map(|(agent, _)| agent);
-            let agent_status = agent_row.map(|(_, status)| status);
-            let agent_unread = tab.agent_unread_count(cx);
+            let agent_badge = tab.focused_agent_badge(window, cx);
+            let agent = agent_badge.agent;
+            let agent_status = agent_badge.status;
+            let agent_unread = agent_badge.unread;
 
             let rename_input = self
                 .renaming

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -1610,8 +1610,9 @@ impl Tty7App {
             let label = self.tab_label(tab, i, Some(window), cx);
             let full_title = self.tab_title_tooltip(tab, i, Some(window), cx);
             let ssh_dot = self.tab_ssh_dot(tab, cx);
-            let agent = tab.agent(cx);
-            let agent_status = tab.agent_status(cx);
+            let agent_row = tab.agent_row(cx);
+            let agent = agent_row.map(|(agent, _)| agent);
+            let agent_status = agent_row.map(|(_, status)| status);
             let agent_unread = tab.agent_unread_count(cx);
 
             let rename_input = self


### PR DESCRIPTION
## Summary
- derive the tab agent icon, status, and unread count from the focused split
- keep the sidebar and top tab strip on one focused-pane badge snapshot
- add regression coverage for Kestrel -> Codex -> Kestrel focus changes

## Testing
- `cargo fmt --all -- --check`
- `cargo test -p tty7 --bin tty7-app tab_chrome_agent_badges_follow_the_focused_split`
- `cargo test -p tty7 --bin tty7-app`