### PR TITLE
fix(sidebar): activate the row whose counts were clicked before opening its diff (#706)

### DIFF
--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -13,6 +13,7 @@ use std::rc::Rc;
 use std::path::{Path, PathBuf};
 
 use crate::core::config::{Config, SidebarGrouping};
+use crate::terminal::git_diff::DiffSource;
 use crate::terminal::git_status::GitStatusCache;
 use crate::ui::app::{TITLE_BAR_HEIGHT, Tty7App};
 use crate::ui::hints::tab_badge_label;
@@ -434,7 +435,31 @@ impl Tty7App {
                                         MouseButton::Left,
                                         cx.listener(move |this, _: &MouseDownEvent, window, cx| {
                                             cx.stop_propagation();
-                                            this.toggle_diff_overlay(host, cwd.clone(), window, cx);
+                                            // Swallowing the press also swallows the
+                                            // row's click, the only thing that
+                                            // activates a tab — so this row has to
+                                            // activate itself, or the overlay lands
+                                            // in whichever tab was already on
+                                            // screen, carrying this row's repo (#706).
+                                            let toggles = counts_click_toggles(this.active, i);
+                                            this.activate(i, window, cx);
+                                            if toggles {
+                                                this.toggle_diff_overlay(
+                                                    host,
+                                                    cwd.clone(),
+                                                    window,
+                                                    cx,
+                                                );
+                                            } else {
+                                                this.open_diff_overlay(
+                                                    host,
+                                                    cwd.clone(),
+                                                    DiffSource::Head,
+                                                    None,
+                                                    window,
+                                                    cx,
+                                                );
+                                            }
                                         }),
                                     )
                             });
@@ -1455,12 +1480,36 @@ pub(crate) fn diff_click_cwd<T>(cfg: &Config, target: Option<T>) -> Option<T> {
     cfg.sidebar_diff_preview.then_some(target).flatten()
 }
 
+/// Whether a click on row `row`'s counts toggles the overlay, `active` being
+/// the tab on screen.
+///
+/// The click always activates its own row. On the tab already showing, it
+/// toggles, as it always has — the second click on the same counts closes what
+/// the first opened. On any other row it opens: switching to a tab to see its
+/// diff must not close the diff that tab already had open, which a toggle
+/// would do whenever the same repo was up there.
+pub(crate) fn counts_click_toggles(active: usize, row: usize) -> bool {
+    row == active
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn p(s: &str) -> PathBuf {
         PathBuf::from(s)
+    }
+
+    #[test]
+    fn the_counts_click_toggles_only_on_the_tab_already_showing() {
+        assert!(
+            counts_click_toggles(1, 1),
+            "the active row's counts close what they opened"
+        );
+        // #706: clicking another row's counts must switch to it and open its
+        // diff, never toggle against whatever that tab already had up.
+        assert!(!counts_click_toggles(0, 1));
+        assert!(!counts_click_toggles(1, 0));
     }
 
     #[test]

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -13,7 +13,6 @@ use std::rc::Rc;
 use std::path::{Path, PathBuf};
 
 use crate::core::config::{Config, SidebarGrouping};
-use crate::terminal::git_diff::DiffSource;
 use crate::terminal::git_status::GitStatusCache;
 use crate::ui::app::{TITLE_BAR_HEIGHT, Tty7App};
 use crate::ui::hints::tab_badge_label;
@@ -441,25 +440,8 @@ impl Tty7App {
                                             // activate itself, or the overlay lands
                                             // in whichever tab was already on
                                             // screen, carrying this row's repo (#706).
-                                            let toggles = counts_click_toggles(this.active, i);
                                             this.activate(i, window, cx);
-                                            if toggles {
-                                                this.toggle_diff_overlay(
-                                                    host,
-                                                    cwd.clone(),
-                                                    window,
-                                                    cx,
-                                                );
-                                            } else {
-                                                this.open_diff_overlay(
-                                                    host,
-                                                    cwd.clone(),
-                                                    DiffSource::Head,
-                                                    None,
-                                                    window,
-                                                    cx,
-                                                );
-                                            }
+                                            this.toggle_diff_overlay(host, cwd.clone(), window, cx);
                                         }),
                                     )
                             });
@@ -1480,36 +1462,12 @@ pub(crate) fn diff_click_cwd<T>(cfg: &Config, target: Option<T>) -> Option<T> {
     cfg.sidebar_diff_preview.then_some(target).flatten()
 }
 
-/// Whether a click on row `row`'s counts toggles the overlay, `active` being
-/// the tab on screen.
-///
-/// The click always activates its own row. On the tab already showing, it
-/// toggles, as it always has — the second click on the same counts closes what
-/// the first opened. On any other row it opens: switching to a tab to see its
-/// diff must not close the diff that tab already had open, which a toggle
-/// would do whenever the same repo was up there.
-pub(crate) fn counts_click_toggles(active: usize, row: usize) -> bool {
-    row == active
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn p(s: &str) -> PathBuf {
         PathBuf::from(s)
-    }
-
-    #[test]
-    fn the_counts_click_toggles_only_on_the_tab_already_showing() {
-        assert!(
-            counts_click_toggles(1, 1),
-            "the active row's counts close what they opened"
-        );
-        // #706: clicking another row's counts must switch to it and open its
-        // diff, never toggle against whatever that tab already had up.
-        assert!(!counts_click_toggles(0, 1));
-        assert!(!counts_click_toggles(1, 0));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #706. Reported with the trace and the fix by @IhpEcVns — confirmed present on main after #685/#703; the top tab strip renders no counts and the Info panel's `changes` row already targets the active tab, so the sidebar row is the only site.

## The bug

Each sidebar row's `+N −M` opens that row's diff. The counts sit inside the row and swallow the press so the row does not double-act, but the row's `on_click` is the only thing that activates a tab, so the click never switched tabs — and `open_diff_overlay` writes to `self.active`. Click the counts of an inactive tab B while A is showing and B's repository, branch and diff landed in A's document area, with A's `overlay_top` flipped and its own overlay state overwritten by B's path. Later reads keyed on the active tab carried that state on as A's.

## The fix

The handler activates its own row first, so the tab on screen, the tab the overlay is stored on, and the repository shown are one tab. One statement, which is the whole of the bug.

## What this deliberately does not change

An earlier revision of this PR gated `toggle_diff_overlay` against `open_diff_overlay` through a `counts_click_toggles` helper, on the reasoning that switching to a tab to see its diff should not close the diff that tab already had up. That branch was a no-op: `toggle_diff_overlay` forwards to `toggle_diff_overlay_at`, which calls `open_diff_overlay(host, cwd, DiffSource::Head, None, …)` — the same call the other arm made. The toggle does not live in `toggle_diff_overlay` at all; it lives inside `open_diff_overlay`, which closes when `host`, `cwd`, `source` and `focus` all match and the overlay was front. So the helper, its doc comment and its unit test all described behaviour the code did not have, and they are gone.

The behaviour that ships: the counts always activate their own row, then toggle against that row. Clicking an inactive tab's counts when that tab already had the same diff up and front will close it rather than show it. Nobody has reported that, it corrupts nothing, and doing it properly means giving `open_diff_overlay` a non-toggling entry point — worth adding if it ever bites, not before.

## Tests

Formatting checked with `rustfmt`; the behavioural change is one statement in a `cx.listener` closure, which the existing sidebar tests do not reach. I went with the narrow change over the event-level test sketched in the report: that test needs a `debug_selector` on the counts plus a test-only setter for `TerminalView`'s private `git_status_cwd` to make the counts render at all, and then asserts through a full render and hit-test. Happy to add it if you'd rather have it.
