### PR TITLE
feat(sidebar): rename group headers from the context menu (#718)

### DIFF
--- a/crates/tty7-core/src/core/config.rs
+++ b/crates/tty7-core/src/core/config.rs
@@ -206,6 +206,12 @@ pub struct Config {
     pub sidebar_grouping: SidebarGrouping,
     #[serde(default = "default_true")]
     pub sidebar_diff_preview: bool,
+    /// Custom sidebar group titles, keyed by the group's root path — `""`
+    /// stands for the Scratch group. A group without an entry keeps the name
+    /// derived from its path, and an entry is removed (not blanked) when the
+    /// user commits an empty rename, so the derived name comes back.
+    #[serde(default)]
+    pub sidebar_group_names: HashMap<String, String>,
     #[serde(default, deserialize_with = "de_lenient")]
     pub notify_on_command_finish: NotifyMode,
     pub check_for_updates: bool,
@@ -605,6 +611,7 @@ impl Default for Config {
             scm_graph_expanded: false,
             sidebar_grouping: SidebarGrouping::Repo,
             sidebar_diff_preview: true,
+            sidebar_group_names: HashMap::new(),
             notify_on_command_finish: NotifyMode::Unfocused,
             check_for_updates: true,
             update_channel: UpdateChannel::default(),
@@ -1294,6 +1301,39 @@ mod tests {
         assert!(json.contains("\"sidebar_diff_preview\":false"), "persisted");
         let back: Config = serde_json::from_str(&json).unwrap();
         assert!(!back.sidebar_diff_preview);
+    }
+
+    #[test]
+    fn sidebar_group_names_round_trip_and_default_empty() {
+        let mut cfg = Config::default();
+        assert!(cfg.sidebar_group_names.is_empty());
+
+        // A Windows group key is the shape this actually stores on the
+        // platform the sidebar groups are keyed by path on, and its
+        // backslashes are the one part of the key that JSON has to escape.
+        let win = r"D:\gh-prj\tty7";
+        cfg.sidebar_group_names.insert(win.into(), "mine".into());
+        cfg.sidebar_group_names
+            .insert(String::new(), "inbox".into());
+        let text = serde_json::to_string(&cfg).unwrap();
+        assert!(
+            text.contains(r#""D:\\gh-prj\\tty7":"mine""#),
+            "the backslashes are escaped, not dropped: {text}"
+        );
+        let back: Config = serde_json::from_str(&text).unwrap();
+        assert_eq!(
+            back.sidebar_group_names.get(win).map(String::as_str),
+            Some("mine")
+        );
+        assert_eq!(
+            back.sidebar_group_names.get("").map(String::as_str),
+            Some("inbox"),
+            "the scratch group's custom title persists under the \"\" key"
+        );
+
+        // A config predating the key parses to the default empty map.
+        let old: Config = serde_json::from_str("{}").unwrap();
+        assert!(old.sidebar_group_names.is_empty());
     }
 
     #[test]

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -630,6 +630,15 @@ pub(crate) struct WorkspaceRename {
     _subs: Vec<Subscription>,
 }
 
+pub(crate) struct GroupRename {
+    /// The sidebar group being renamed, by its section key rather than an
+    /// index: `None` is the Scratch group, and a group's index shifts the
+    /// moment a repo probe lands and regroups a tab mid-rename.
+    pub(crate) key: Option<std::path::PathBuf>,
+    pub(crate) input: Entity<InputState>,
+    _subs: Vec<Subscription>,
+}
+
 pub(crate) struct LoopbackForwardPanelState {
     pub(crate) form_pane_id: Option<u64>,
     pub(crate) managed: Vec<crate::daemon::protocol::ManagedForward>,
@@ -776,6 +785,7 @@ pub struct Tty7App {
     window_bounds: Bounds<Pixels>,
     pub(crate) workspace: WorkspaceId,
     pub(crate) workspace_rename: Option<WorkspaceRename>,
+    pub(crate) group_rename: Option<GroupRename>,
     window_title: std::cell::RefCell<String>,
     pub(crate) connect: Option<crate::ui::remote_workspace::ConnectFlow>,
     pub(crate) switcher: Option<crate::ui::switcher::Switcher>,
@@ -1343,6 +1353,7 @@ impl Tty7App {
             window_bounds: window_bounds_to_remember(window),
             workspace,
             workspace_rename: None,
+            group_rename: None,
             window_title: std::cell::RefCell::new(String::new()),
             connect: None,
             switcher: None,
@@ -4728,6 +4739,48 @@ impl Tty7App {
         self.sync_window_title(window, cx);
         self.focus_active(window, cx);
         cx.notify();
+    }
+
+    pub(crate) fn start_group_rename(
+        &mut self,
+        key: Option<std::path::PathBuf>,
+        current: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let input = Self::rename_box(current, window, cx);
+        let subs = vec![cx.subscribe_in(
+            &input,
+            window,
+            |this, _input, ev: &InputEvent, window, cx| match ev {
+                InputEvent::PressEnter { .. } | InputEvent::Blur => {
+                    this.commit_group_rename(window, cx)
+                }
+                _ => {}
+            },
+        )];
+        self.group_rename = Some(GroupRename {
+            key,
+            input,
+            _subs: subs,
+        });
+        cx.notify();
+    }
+
+    pub(crate) fn commit_group_rename(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(rename) = self.group_rename.take() else {
+            return;
+        };
+        let value = rename.input.read(cx).value().trim().to_string();
+        let key = crate::ui::tab_sidebar::group_name_key(&rename.key);
+        self.update_config(cx, |cfg| {
+            if value.is_empty() {
+                cfg.sidebar_group_names.remove(&key);
+            } else {
+                cfg.sidebar_group_names.insert(key, value);
+            }
+        });
+        self.focus_active(window, cx);
     }
 
     fn commit_rename(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -9781,6 +9834,57 @@ mod shell_menu_gpui_tests {
                 app.shells.shells.is_empty(),
                 "a remote window must not offer this computer's shells: {:?}",
                 app.shells.shells
+            );
+        });
+    }
+}
+
+#[cfg(test)]
+mod group_rename_gpui_tests {
+    use gpui::TestAppContext;
+
+    use crate::ui::app::test_window::harness;
+
+    #[gpui::test]
+    fn a_group_rename_lands_in_the_config_and_an_empty_one_reverts(cx: &mut TestAppContext) {
+        let (app, mut vcx) = harness(cx);
+        let key = Some(std::path::PathBuf::from("/w/repo"));
+
+        app.update_in(&mut vcx, |app, window, cx| {
+            app.start_group_rename(key.clone(), "repo".into(), window, cx);
+            let input = app
+                .group_rename
+                .as_ref()
+                .expect("the box is up")
+                .input
+                .clone();
+            input.update(cx, |s, cx| s.set_value("mine", window, cx));
+            app.commit_group_rename(window, cx);
+        });
+        app.update(&mut vcx, |_app, cx| {
+            let cfg = cx.global::<crate::core::config::Config>();
+            assert_eq!(
+                cfg.sidebar_group_names.get("/w/repo").map(String::as_str),
+                Some("mine")
+            );
+        });
+
+        app.update_in(&mut vcx, |app, window, cx| {
+            app.start_group_rename(key.clone(), "mine".into(), window, cx);
+            let input = app
+                .group_rename
+                .as_ref()
+                .expect("the box is up")
+                .input
+                .clone();
+            input.update(cx, |s, cx| s.set_value("  ", window, cx));
+            app.commit_group_rename(window, cx);
+        });
+        app.update(&mut vcx, |_app, cx| {
+            let cfg = cx.global::<crate::core::config::Config>();
+            assert!(
+                cfg.sidebar_group_names.get("/w/repo").is_none(),
+                "an empty rename removes the entry so the derived name returns"
             );
         });
     }

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -1761,6 +1761,7 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         L10nKey::TabUnnamedShell => "Shell {n}",
         L10nKey::ShellDefault => "default",
         L10nKey::SidebarScratchGroup => "Scratch",
+        L10nKey::SidebarRenameGroup => "Rename Group",
         L10nKey::TabContextCloseTab => "Close Tab",
         L10nKey::TabContextCloseTabsBelow => "Close Tabs Below",
         L10nKey::AppAgentHooksOpFailed => "Failed: {error}",

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -1832,6 +1832,7 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         L10nKey::TabUnnamedShell => "シェル {n}",
         L10nKey::ShellDefault => "デフォルト",
         L10nKey::SidebarScratchGroup => "スクラッチ",
+        L10nKey::SidebarRenameGroup => "グループ名を変更",
         L10nKey::TabContextCloseTab => "タブを閉じる",
         L10nKey::TabContextCloseTabsBelow => "下のタブを閉じる",
         L10nKey::AppAgentHooksOpFailed => "失敗: {error}",

--- a/src/ui/i18n/mod.rs
+++ b/src/ui/i18n/mod.rs
@@ -997,6 +997,7 @@ l10n_keys! {
     TabUnnamedShell,
     ShellDefault,
     SidebarScratchGroup,
+    SidebarRenameGroup,
     TabContextCloseTab,
     TabContextCloseTabsBelow,
     TabContextMarkUnread,

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -1675,6 +1675,7 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         L10nKey::TabUnnamedShell => "终端 {n}",
         L10nKey::ShellDefault => "默认",
         L10nKey::SidebarScratchGroup => "草稿",
+        L10nKey::SidebarRenameGroup => "重命名分组",
         L10nKey::TabContextCloseTab => "关闭标签页",
         L10nKey::TabContextCloseTabsBelow => "关闭下方标签页",
         L10nKey::AppAgentHooksOpFailed => "失败：{error}",

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -5,7 +5,7 @@ use gpui::{
 };
 use gpui_component::button::{Button, ButtonVariants as _};
 use gpui_component::input::Input;
-use gpui_component::menu::{ContextMenu, ContextMenuExt as _};
+use gpui_component::menu::{ContextMenu, ContextMenuExt as _, PopupMenuItem};
 use gpui_component::{ActiveTheme as _, Icon, IconName, Sizable as _, h_flex, v_flex};
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
@@ -853,8 +853,13 @@ impl Tty7App {
                 })
                 .collect();
             let header = section.name.clone().map(|name| {
-                let label: SharedString = name.to_uppercase().into();
-                h_flex()
+                let shown = effective_group_name(cx.global::<Config>(), &section.key, name);
+                let rename_input = self
+                    .group_rename
+                    .as_ref()
+                    .filter(|r| r.key == section.key)
+                    .map(|r| r.input.clone());
+                let base = h_flex()
                     .id(("sidebar-group", group_ix))
                     .w_full()
                     .items_center()
@@ -882,21 +887,61 @@ impl Tty7App {
                                 cx.new(|_| DragGroup)
                             }
                         })
-                    })
-                    .child(
-                        div()
-                            .flex_shrink(1.)
-                            .min_w_0()
-                            .truncate()
-                            .font_weight(FontWeight::SEMIBOLD)
-                            .child(label),
+                    });
+                if let Some(input) = rename_input {
+                    return base
+                        .child(
+                            div()
+                                .id(("sidebar-group-rename", group_ix))
+                                .flex_1()
+                                .min_w_0()
+                                .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                                // Same guard as the tab rows' rename box: a
+                                // click landing in the field must not reach
+                                // the drag handler behind it and take the
+                                // focus with it.
+                                .on_click(|_, _, cx| cx.stop_propagation())
+                                .child(Input::new(&input).appearance(false)),
+                        )
+                        .into_any_element();
+                }
+                let label: SharedString = shown.to_uppercase().into();
+                let menu_app = cx.entity().downgrade();
+                let key = section.key.clone();
+                base.child(
+                    div()
+                        .flex_shrink(1.)
+                        .min_w_0()
+                        .truncate()
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .child(label),
+                )
+                .child(
+                    div()
+                        .flex_shrink_0()
+                        .text_color(cx.theme().muted_foreground.opacity(0.7))
+                        .child(row_count.to_string()),
+                )
+                .context_menu(move |menu, _window, _cx| {
+                    let app = menu_app.clone();
+                    let key = key.clone();
+                    let current = shown.clone();
+                    menu.min_w(px(160.)).item(
+                        PopupMenuItem::new(t(L10nKey::SidebarRenameGroup)).on_click(
+                            move |_, window, cx| {
+                                let _ = app.update(cx, |this, cx| {
+                                    this.start_group_rename(
+                                        key.clone(),
+                                        current.clone(),
+                                        window,
+                                        cx,
+                                    )
+                                });
+                            },
+                        ),
                     )
-                    .child(
-                        div()
-                            .flex_shrink_0()
-                            .text_color(cx.theme().muted_foreground.opacity(0.7))
-                            .child(row_count.to_string()),
-                    )
+                })
+                .into_any_element()
             });
 
             let block = v_flex()
@@ -1360,6 +1405,24 @@ fn sidebar_sections(keys: &[Option<PathBuf>]) -> Vec<Section> {
     sections
 }
 
+/// The key a group's custom title is stored under in
+/// [`Config::sidebar_group_names`]: the group's root path, with `""` standing
+/// for the Scratch group.
+pub(crate) fn group_name_key(key: &Option<PathBuf>) -> String {
+    key.as_ref()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+/// What a group header shows: the user's custom title when one is stored,
+/// otherwise the name derived from the group's path.
+fn effective_group_name(cfg: &Config, key: &Option<PathBuf>, derived: String) -> String {
+    cfg.sidebar_group_names
+        .get(&group_name_key(key))
+        .cloned()
+        .unwrap_or(derived)
+}
+
 fn reordered_rows(
     keys: &[Option<PathBuf>],
     group: &Option<PathBuf>,
@@ -1468,6 +1531,33 @@ mod tests {
 
     fn p(s: &str) -> PathBuf {
         PathBuf::from(s)
+    }
+
+    #[test]
+    fn custom_group_titles_override_derived_names_by_key() {
+        let mut cfg = Config::default();
+        let repo = Some(p("/w/tty7"));
+        assert_eq!(
+            effective_group_name(&cfg, &repo, "tty7".into()),
+            "tty7",
+            "no entry: the derived name stands"
+        );
+
+        cfg.sidebar_group_names
+            .insert(group_name_key(&repo), "mine".into());
+        cfg.sidebar_group_names
+            .insert(group_name_key(&None), "inbox".into());
+        assert_eq!(effective_group_name(&cfg, &repo, "tty7".into()), "mine");
+        assert_eq!(
+            effective_group_name(&cfg, &None, "Scratch".into()),
+            "inbox",
+            "the scratch group renames through the \"\" key"
+        );
+        assert_eq!(
+            effective_group_name(&cfg, &Some(p("/w/other")), "other".into()),
+            "other",
+            "an entry only covers its own group"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #718.

## The problem

Sidebar group titles are derived from their root paths. That makes similarly named worktrees hard to distinguish and gives the Scratch group no way to carry project context.

## The change

- Add a Rename Group action to each sidebar group's context menu.
- Edit the title inline in the sidebar.
- Persist overrides in `sidebar_group_names`, keyed by the group's root path. Scratch uses the empty key.
- Remove the override when the submitted name is empty so the derived title returns.
- Add English, Japanese, and Chinese labels for the action.

The config field has a serde default, so existing config files continue to load unchanged.

## Tests

- `cargo fmt --all -- --check`
- `cargo test --locked -p tty7-core sidebar_group_names_round_trip_and_default_empty`
- `cargo test --locked -p tty7 --bin tty7-app group_rename`