### PR TITLE
fix(panel): stop a conversation row offering a jump the pane cannot make

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A conversation row no longer offers a jump the pane cannot make.** Clicking
+  one under a full-screen agent did nothing at all: no scroll, no message,
+  nothing. The row had an anchor, so the panel drew it as a link — pointer,
+  hover fill and all — while the view refused the jump, because a pane on the
+  alternate screen has no scrollback to land in. Switching Claude Code into
+  `/tui fullscreen` mid-session is enough to produce it: the turns recorded
+  under the classic renderer keep their anchors, and every one of them goes
+  quiet at once. The two conditions now live in one predicate both sides read,
+  and a row that goes nowhere says why on hover rather than leaving grey text
+  to carry a meaning grey does not have. Jumping is still off while an agent
+  renders full-screen — there is genuinely nothing behind it — but the panel no
+  longer pretends otherwise.
+
 - **In-app updates work again on macOS** (#708). Every "Update and Relaunch"
   failed with `codesign did not report a designated requirement`, on every
   build and both channels, with nothing a user could do but download the app by

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -3787,7 +3787,7 @@ impl TerminalView {
         !self.prompt_editor || self.shell_vi_prompt() || self.handoff_active()
     }
 
-    fn on_alt_screen(&self) -> bool {
+    pub(crate) fn on_alt_screen(&self) -> bool {
         self.terminal
             .term
             .lock()

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -1033,6 +1033,12 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         L10nKey::PanelNoChangesHint => "The working tree is clean.",
         L10nKey::PanelSessionSubtitle => "Session",
         L10nKey::PanelConversationSubtitle => "Conversation",
+        L10nKey::PanelTurnAltScreenNow => {
+            "Nowhere to jump while a full-screen program owns this pane."
+        }
+        L10nKey::PanelTurnNoScrollback => {
+            "This turn was drawn on the alternate screen, so the scrollback never kept it."
+        }
         L10nKey::PanelProcessesSubtitle => "Processes",
         L10nKey::PanelPortsSubtitle => "Ports",
         L10nKey::PanelCwd => "cwd",

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -1097,6 +1097,12 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         L10nKey::PanelNoChangesHint => "ワーキングツリーはクリーンです",
         L10nKey::PanelSessionSubtitle => "セッション",
         L10nKey::PanelConversationSubtitle => "会話",
+        L10nKey::PanelTurnAltScreenNow => {
+            "全画面プログラムがこのペインを占有している間は、戻る先がありません"
+        }
+        L10nKey::PanelTurnNoScrollback => {
+            "このターンは代替画面に描かれたため、スクロールバックに残っていません"
+        }
         L10nKey::PanelProcessesSubtitle => "プロセス",
         L10nKey::PanelPortsSubtitle => "ポート",
         L10nKey::PanelCwd => "作業ディレクトリ",

--- a/src/ui/i18n/mod.rs
+++ b/src/ui/i18n/mod.rs
@@ -768,6 +768,8 @@ l10n_keys! {
     PanelMoreChangedFiles,
     PanelSessionSubtitle,
     PanelConversationSubtitle,
+    PanelTurnAltScreenNow,
+    PanelTurnNoScrollback,
     PanelProcessesSubtitle,
     PanelPortsSubtitle,
     PanelCwd,

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -990,6 +990,8 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         L10nKey::PanelNoChangesHint => "worktree 是干净的。",
         L10nKey::PanelSessionSubtitle => "会话",
         L10nKey::PanelConversationSubtitle => "对话",
+        L10nKey::PanelTurnAltScreenNow => "全屏程序占着此窗格，没有 scrollback 可跳回。",
+        L10nKey::PanelTurnNoScrollback => "这一轮画在 alt screen 上，scrollback 里没有留下它。",
         L10nKey::PanelProcessesSubtitle => "进程",
         L10nKey::PanelPortsSubtitle => "端口",
         L10nKey::PanelCwd => "工作目录",

--- a/src/ui/right_panel.rs
+++ b/src/ui/right_panel.rs
@@ -1021,7 +1021,7 @@ impl Tty7App {
     }
 
     /// The agent's conversation, one row per turn, each a way back to where
-    /// that turn started in the scrollback.
+    /// that turn started in the scrollback — when there is one to go back to.
     ///
     /// It sits under the session facts rather than in a tab of its own: this is
     /// something *this pane* is, like its shell and its cwd, and the tab strip
@@ -1042,15 +1042,18 @@ impl Tty7App {
         if turns.is_empty() {
             return None;
         }
+        // A full-screen program owns the whole drawing surface, so there is no
+        // scrollback under it to land in — while one is up every jump is a
+        // no-op, whatever anchor the turn is carrying. An agent that renders
+        // that way (Claude Code's `/tui fullscreen`, Codex) puts every row in
+        // this section here.
+        let alt_now = leaf.read(cx).on_alt_screen();
         let sf = cx.global::<crate::ui::presets::Surfaces>().sidebar;
         let count = turns.len().to_string();
         let mut list = v_flex().px(px(CONTENT_INSET - 4.)).py(px(1.)).gap(px(1.));
         for turn in turns {
             let id = turn.id;
-            // Only a turn that was drawn into the scrollback has somewhere to
-            // go: one that began on the alt screen is history the pane never
-            // kept, so its row reads as a label and not as a link.
-            let jumpable = turn.row.is_some();
+            let jumpable = turn_is_jumpable(turn.row, alt_now);
             let dot = {
                 let d = div().flex_none().size(px(7.)).rounded_full();
                 if turn.done {
@@ -1078,6 +1081,18 @@ impl Tty7App {
                                     view.scroll_to_agent_turn(&turn, cx);
                                 });
                             }))
+                    })
+                    // A row that goes nowhere says why on hover. Muted text is
+                    // the whole of what it says otherwise, and grey reads as
+                    // "less important" long before it reads as "not a link".
+                    .when(!jumpable, |this| {
+                        let tip = t(match alt_now {
+                            true => L10nKey::PanelTurnAltScreenNow,
+                            false => L10nKey::PanelTurnNoScrollback,
+                        });
+                        this.tooltip(move |window, cx| {
+                            gpui_component::tooltip::Tooltip::new(tip).build(window, cx)
+                        })
                     })
                     .child(dot)
                     .child(
@@ -1488,9 +1503,19 @@ fn compact_path(path: &std::path::Path, home: Option<&std::path::Path>) -> Strin
     crate::ui::path_display::abbreviate_home(&path.to_string_lossy(), home).into_owned()
 }
 
+/// Whether a turn's row is a link back into the scrollback, or only a label.
+///
+/// Both halves have to hold, and they are the same two conditions
+/// [`TerminalView::scroll_to_agent_turn`](crate::terminal::view::TerminalView)
+/// refuses on — deliberately, because a row that draws as a link and then does
+/// nothing is worse than one that never offered. Keep the two in step.
+fn turn_is_jumpable(row: Option<i64>, alt_now: bool) -> bool {
+    row.is_some() && !alt_now
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{InfoRow, InfoValue, split_path_leaf};
+    use super::{InfoRow, InfoValue, split_path_leaf, turn_is_jumpable};
 
     fn diff(added: u32, removed: u32, open: bool) -> InfoRow {
         InfoRow {
@@ -1531,6 +1556,25 @@ mod tests {
             }
             .interactive(),
             "so is Reveal, even with nothing else on the row"
+        );
+    }
+
+    #[test]
+    fn a_turn_offers_the_jump_only_where_the_jump_would_land() {
+        assert!(
+            turn_is_jumpable(Some(42), false),
+            "a turn anchored in the scrollback of a pane on the normal screen"
+        );
+        assert!(
+            !turn_is_jumpable(None, false),
+            "a turn that began on the alt screen was never written down"
+        );
+        // The one this pair exists for: the anchor survives the switch into a
+        // full-screen renderer, and the row it points at does not. Before, the
+        // row kept its pointer and its hover fill and swallowed every click.
+        assert!(
+            !turn_is_jumpable(Some(42), true),
+            "and an anchor is no use while a full-screen program owns the pane"
         );
     }
 


### PR DESCRIPTION
A conversation row in the Info panel drew itself as a link while the click did nothing, whenever the pane was on the alternate screen.

| | Before | After |
|---|---|---|
| Row for a turn anchored in the scrollback, pane on the normal screen | Pointer, hover fill, jumps to the turn | Unchanged |
| Row for a turn that began on the alternate screen | Grey text, no pointer, no click | Grey text, and a hover tooltip saying the scrollback never kept that turn |
| Row for a turn with an anchor, **pane now on the alternate screen** | Pointer and hover fill, click silently does nothing | No pointer, no hover fill, and a hover tooltip saying a full-screen program owns the pane |

## Why

`TerminalView::scroll_to_agent_turn` refuses two cases: a turn with no anchor, and a pane sitting on the alternate screen, which has no scrollback to land in. The panel only checked the first, so the second produced a row that looked live and swallowed every click without a sound.

Switching Claude Code into `/tui fullscreen` mid-session is enough to reach it. Turns recorded under the classic renderer keep their anchors; the pane moves to the alternate screen; every row in the section goes quiet at once, with nothing on screen to say why.

Both conditions now live in one predicate, `turn_is_jumpable(row, alt_now)`, that the panel reads and the view's early-returns mirror. The rows that go nowhere explain themselves on hover instead of leaving grey text to mean "not a link" — a job grey does not do, since it already means "less important" everywhere else in the panel.

Jumping stays off while an agent renders full-screen. There is genuinely nothing behind the alternate screen to scroll to; this PR only stops the panel claiming otherwise.

## Testing

- New guard `a_turn_offers_the_jump_only_where_the_jump_would_land` in `src/ui/right_panel.rs`, covering all three rows of the table — including `(Some(anchor), alt_now = true)`, the case this PR fixes.
- Existing outline guards still pass: `jumping_to_a_turn_puts_the_prompt_at_the_top_of_the_viewport`, `a_turn_with_nowhere_to_go_reports_that_it_did_not_move`, the `agent_marks` suite (23 tests), and `right_panel` (7 tests).
- `cargo fmt --check` clean; `cargo check -p tty7` clean.
- Not verified in the running app: doing so means driving the GUI, which this repo requires the owner to authorize.

https://claude.ai/code/session_01A8Hiu4o14SkF5bpoPiV7Ko
