### PR TITLE
fix(theme): give a pane divider its own, lighter weight

### DIFF
--- a/src/ui/presets.rs
+++ b/src/ui/presets.rs
@@ -51,6 +51,7 @@ pub struct Neutrals {
     pub background: u32,
     pub foreground: u32,
     pub border: u32,
+    pub divider: u32,
     pub secondary: u32,
     pub muted: u32,
     pub muted_foreground: u32,
@@ -153,18 +154,35 @@ impl Theme {
         let fg = legible_foreground(bg, self.foreground);
         let sidebar = mix(bg, fg, 0.03);
         let popover = mix(bg, fg, 0.05);
-        // One hairline value divides all three neutral fills — it is handed to
-        // `sidebar_border` too, and popover chrome draws with it. Floor it on
-        // each of them, not only on the window.
-        let border = [bg, sidebar, popover]
-            .into_iter()
-            .fold(mix(bg, fg, 0.16), |hairline, surface| {
-                at_least(hairline, fg, surface, BORDER_FLOOR)
-            });
+        // Two weights, one derivation. Which one a line gets is decided by
+        // whether it is the *only* thing separating what it sits between:
+        //
+        // - `border` closes an outline around a surface that floats on top of
+        //   other content (menu, tooltip, dialog, card) and rules a header off
+        //   from the rows under it. Nothing else says where the edge is, so it
+        //   has to be visible.
+        // - `divider` runs between two panes that already carry their own
+        //   fills — the sidebar against the terminal, the right panel against
+        //   the workspace. There the line is the second signal, not the first,
+        //   and painting it at full weight is what makes a workspace read as
+        //   boxes bolted together rather than one surface.
+        //
+        // Both are floored on all three neutral fills, not only on the window:
+        // the same value has to be worth something wherever it is painted.
+        let hairline = |seed: f32, floor: f32| {
+            [bg, sidebar, popover]
+                .into_iter()
+                .fold(mix(bg, fg, seed), |ink, surface| {
+                    at_least(ink, fg, surface, floor)
+                })
+        };
+        let border = hairline(0.16, BORDER_FLOOR);
+        let divider = hairline(0.16, DIVIDER_FLOOR);
         Neutrals {
             background: bg,
             foreground: fg,
             border,
+            divider,
             secondary: mix(bg, fg, 0.09),
             muted: mix(bg, fg, 0.06),
             muted_foreground: dim(fg, bg, state::TEXT_RESTING),
@@ -561,6 +579,14 @@ const TEXT_FLOOR: f32 = 4.5;
 /// where the flat blend disappears entirely, so a divider is worth the same
 /// amount in every theme.
 const BORDER_FLOOR: f32 = 1.5;
+
+/// The same idea one step down, for a line that is not carrying the separation
+/// on its own.
+///
+/// Worth stating because the seed blend cannot say it: `mix(bg, fg, 0.16)`
+/// clears neither floor in any builtin theme, so both values are decided
+/// entirely here. Lowering the seed changes nothing; this constant is the knob.
+const DIVIDER_FLOOR: f32 = 1.2;
 
 /// Keep an authored blend when it already clears `target` on the surface it is
 /// painted on, and walk it back toward `toward` only when it does not.
@@ -1947,27 +1973,46 @@ mod tests {
     fn hairlines_are_worth_the_same_in_every_theme() {
         for t in builtins() {
             let m = t.neutrals();
-            for (name, surface) in [
-                ("background", m.background),
-                ("sidebar", m.sidebar),
-                ("popover", m.popover),
+            for (tier, ink, floor) in [
+                ("border", m.border, BORDER_FLOOR),
+                ("divider", m.divider, DIVIDER_FLOOR),
             ] {
-                let ratio = contrast(m.border, surface);
-                assert!(
-                    ratio >= BORDER_FLOOR - 0.01,
-                    "{}: border {:#08x} is only {ratio:.2}:1 on the {name}",
-                    t.id,
-                    m.border
-                );
-                // A floor, not a target — a hairline that shouts is worse than
-                // one that whispers.
-                assert!(
-                    ratio <= 2.2,
-                    "{}: border {:#08x} is {ratio:.2}:1 on the {name} and reads as a frame",
-                    t.id,
-                    m.border
-                );
+                for (name, surface) in [
+                    ("background", m.background),
+                    ("sidebar", m.sidebar),
+                    ("popover", m.popover),
+                ] {
+                    let ratio = contrast(ink, surface);
+                    assert!(
+                        ratio >= floor - 0.01,
+                        "{}: {tier} {ink:#08x} is only {ratio:.2}:1 on the {name}",
+                        t.id
+                    );
+                    // A floor, not a target — a hairline that shouts is worse
+                    // than one that whispers.
+                    assert!(
+                        ratio <= 2.2,
+                        "{}: {tier} {ink:#08x} is {ratio:.2}:1 on the {name} and reads as a frame",
+                        t.id
+                    );
+                }
             }
+        }
+    }
+
+    /// The two tiers have to stay apart, or the split is decoration. A divider
+    /// that lands on the same value as the border is the state this replaced.
+    #[test]
+    fn a_divider_is_lighter_than_a_border_in_every_theme() {
+        for t in builtins() {
+            let m = t.neutrals();
+            assert!(
+                contrast(m.divider, m.sidebar) < contrast(m.border, m.sidebar),
+                "{}: divider {:#08x} is not lighter than border {:#08x}",
+                t.id,
+                m.divider,
+                m.border
+            );
         }
     }
 

--- a/src/ui/right_panel.rs
+++ b/src/ui/right_panel.rs
@@ -519,8 +519,11 @@ impl Tty7App {
                 (None, true) => tile_trailing_inset_sm(),
                 (None, false) => CONTENT_INSET,
             }))
+            // `border`, not `sidebar_border`: this rules the tab row off from
+            // the content below it, with the same fill on both sides, so the
+            // line is the only thing saying where one ends.
             .when(tabs.is_some(), |this| {
-                this.border_b_1().border_color(cx.theme().sidebar_border)
+                this.border_b_1().border_color(cx.theme().border)
             })
             .child(
                 h_flex()

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -815,7 +815,9 @@ pub(crate) fn apply_theme(mut window: Option<&mut Window>, cx: &mut App) {
     // see `workspace_surface_color`.
     t.sidebar = sidebar_bg.into();
     t.tokens.sidebar = sidebar_bg.into();
-    t.sidebar_border = rgb(m.border).into();
+    // The lighter tier: every `sidebar_border` site is a pane meeting another
+    // pane, and both already carry their own fill. See `Neutrals`.
+    t.sidebar_border = rgb(m.divider).into();
     t.sidebar_foreground = rgb(surfaces.sidebar.text_resting).into();
     t.sidebar_accent = sidebar_sel.into();
     t.tokens.sidebar_accent = Hsla::from(sidebar_sel).into();


### PR DESCRIPTION
Splits the one hairline colour into two tiers so the seam between panes stops reading as a hard edge, while every outline that has to hold its own shape keeps the weight it had.

| | Before | After |
|---|---|---|
| Sidebar ⇄ terminal seam (light theme) | `#c8c8c8`, 1.67:1 on the sidebar fill | `#dfdfdf`, 1.33:1 |
| Right panel / document column edge | Same value as a popover outline | The lighter tier |
| Menu, tooltip, dialog, card outline | `#c8c8c8` | Unchanged |
| Rule under a section header | `#c8c8c8` | Unchanged |
| Rule under the right panel's tab row | Lighter tier (`sidebar_border`) | `border` — same fill above and below, so the line is the only separator |
| Lowering the `mix(bg, fg, 0.16)` seed | Silently no-ops | Still no-ops, now documented; `DIVIDER_FLOOR` is the knob |

## Why

Three different jobs were painted with one colour:

- **An outline that closes a floating surface** — a context menu, a tooltip, a settings card. It sits on top of other content and nothing else marks its edge, so it has to be visible.
- **A rule inside one pane** — under a header, between groups. Same fill above and below; the line carries the separation alone.
- **A seam between two panes** — sidebar against terminal, right panel against workspace. Both sides already have their own fill, so the line is the *second* signal, not the first.

Giving the third the same weight as the first is what makes a workspace look like boxes bolted together rather than one surface.

The tier already had a token: `sidebar_border` is used at exactly the six pane seams (`tab_sidebar.rs`, `right_panel.rs`, `document_column.rs`, and the two workspace edges in `app.rs`). It was simply assigned the same value as `border`. Now it gets its own.

```
Neutrals::neutrals()
  hairline(seed, floor) = fold(mix(bg, fg, seed), over [bg, sidebar, popover],
                               at_least(.., floor))

  border  = hairline(0.16, BORDER_FLOOR  = 1.5)  -> outlines, in-pane rules
  divider = hairline(0.16, DIVIDER_FLOOR = 1.2)  -> pane seams (sidebar_border)
```

One derivation, two floors — the tier is chosen by whether the line is the only thing separating what it sits between.

Worth calling out because the code hid it: the `0.16` seed clears **neither** floor in any of the eight builtin themes, so both values are decided entirely by the constants. Anyone reaching for the seed to soften a line would have found it did nothing. That is now in the comment.

## Values

| Theme | Before (= border) | After (divider) |
|---|---|---|
| default light | `#c8c8c8` | `#dfdfdf` |
| one-light | `#c5c6c8` | `#dcdcde` |
| latte | `#bdbfca` | `#d3d5dd` |
| rosé pine dawn | `#c7c1c9` | `#ded8d9` |
| dracula | `#4d4f57` | `#3f404a` |
| one-dark | `#494e57` | `#3b3f48` |

## Testing

- `hairlines_are_worth_the_same_in_every_theme` now checks both tiers against all three neutral fills, each against its own floor and the shared 2.2:1 ceiling.
- New `a_divider_is_lighter_than_a_border_in_every_theme` — guards the split itself, so a future edit that collapses the two values back together turns it red.
- `cargo test --bin tty7-app ui::presets` — 40 passed.
- Manually accepted in an isolated dev instance (`--config-dir`): sidebar and right-panel seams read as edges rather than dividers, and the context-menu / tooltip outlines are visibly unchanged.

https://claude.ai/code/session_01GAjHNse9BDu5jSCjU5QTKe
