### PR TITLE
fix(settings): say what turning off mouse reporting costs (#722)

### DIFF
--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -437,7 +437,8 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         L10nKey::SettingsMouseZoomOff => "Off",
         L10nKey::SettingsReportMouseToApps => "Report mouse to apps",
         L10nKey::SettingsReportMouseToAppsDesc => {
-            "Let full-screen apps (vim, tmux) handle clicks and scrolling; hold Shift to keep a gesture local."
+            "Let full-screen apps (vim, tmux) handle clicks and scrolling; hold Shift to keep a gesture local. \
+             Off keeps clicks from reaching them and turns the wheel into arrow keys."
         }
         L10nKey::SettingsBell => "Bell",
         L10nKey::SettingsTerminalBell => "Terminal bell",

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -448,7 +448,8 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         L10nKey::SettingsMouseZoomOff => "オフ",
         L10nKey::SettingsReportMouseToApps => "マウスイベントをアプリに報告",
         L10nKey::SettingsReportMouseToAppsDesc => {
-            "フルスクリーンアプリ（vim、tmux）にクリックとスクロールを処理させる。Shift を押している間はローカルで処理されます"
+            "フルスクリーンアプリ（vim、tmux）にクリックとスクロールを処理させる。Shift を押している間はローカルで処理されます。\
+             オフにするとクリックは届かず、ホイールは矢印キーとして送られます"
         }
         L10nKey::SettingsBell => "ベル通知",
         L10nKey::SettingsTerminalBell => "ターミナルベル",

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -385,7 +385,8 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         L10nKey::SettingsMouseZoomOff => "关闭",
         L10nKey::SettingsReportMouseToApps => "向应用报告鼠标",
         L10nKey::SettingsReportMouseToAppsDesc => {
-            "让全屏应用（如 vim、tmux）处理点击和滚动；按住 Shift 可让操作保持本地。"
+            "让全屏应用（如 vim、tmux）处理点击和滚动；按住 Shift 可让操作保持本地。\
+             关闭后点击不再传给它们，滚轮也会变成方向键。"
         }
         L10nKey::SettingsBell => "铃声",
         L10nKey::SettingsTerminalBell => "终端铃声",


### PR DESCRIPTION
The "Report mouse to apps" row said what the switch turns on and nothing about what it turns off. Turning it off is not a small thing: `TerminalView::scroll` strips `MOUSE_MODE` when `report_mouse` is false (src/terminal/view.rs), so `wheel_route` falls through to the `ALT_SCREEN | ALTERNATE_SCROLL` branch and sends `ESC [A` / `ESC [B` instead — and clicks and motion are dropped before they are ever encoded. A full-screen app (vim, htop, btop, fzf, Claude Code) then behaves as if arrow keys were being pressed, with nothing in the UI tying that back to this switch.

Copy-only change, in all three locales.

## Before / after

**en**

- before: `Let full-screen apps (vim, tmux) handle clicks and scrolling; hold Shift to keep a gesture local.`
- after: `Let full-screen apps (vim, tmux) handle clicks and scrolling; hold Shift to keep a gesture local. Off keeps clicks from reaching them and turns the wheel into arrow keys.`

**zh**

- before: `让全屏应用（如 vim、tmux）处理点击和滚动；按住 Shift 可让操作保持本地。`
- after: `让全屏应用（如 vim、tmux）处理点击和滚动；按住 Shift 可让操作保持本地。关闭后点击不再传给它们，滚轮也会变成方向键。`

**ja**

- before: `フルスクリーンアプリ（vim、tmux）にクリックとスクロールを処理させる。Shift を押している間はローカルで処理されます`
- after: `フルスクリーンアプリ（vim、tmux）にクリックとスクロールを処理させる。Shift を押している間はローカルで処理されます。オフにするとクリックは届かず、ホイールは矢印キーとして送られます`

## Why nothing else changed

Most of #722 was already there before the issue was filed — see https://github.com/l0ng-ai/tty7/issues/722#issuecomment-5568520962 for the full walk-through. In short: the switch (`term-mouse-report`) landed in 61da15dc for v0.14.0, it is searchable from the settings search, it has always defaulted to `true`, and it already had an i18n'd description in en/zh/ja. The single real gap was that the description only described the on state.

No warning colour or icon either: `settings_row` renders every description as muted subtext, and the danger/warning colours in the settings panel are used for field validation errors, destructive menu items and status text — there is no established "cautionary row" treatment to reuse, and inventing one for a switch that is on by default would be louder than the setting deserves. The copy is the fix.

`cargo test --bin tty7-app i18n` — 7 passed, including `every_key_is_translated_in_every_locale`. `cargo test --bin tty7-app settings` — 45 passed. `cargo fmt` clean.

Fixes #722
