### PR TITLE
feat(ui): mark the tab whose pane is zoomed (#752)

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -4125,6 +4125,27 @@ impl Tty7App {
         }
     }
 
+    /// Whether tab `index` has a pane zoomed over hidden siblings — what the
+    /// chrome marks so the state is readable without toggling it (#752).
+    ///
+    /// Zoom rides with its tab (#599): the active tab's lives in
+    /// `self.maximized`, every other tab's is parked in `Tab::zoomed`. Either
+    /// can name a pane that exited while nobody was looking, which is why the
+    /// answer is asked of the layout rather than of the handle alone.
+    pub(crate) fn tab_is_zoomed(&self, index: usize) -> bool {
+        let Some(tab) = self.tabs.get(index) else {
+            return false;
+        };
+        let zoom = match index == self.active {
+            true => self.maximized.as_ref(),
+            false => tab.zoomed.as_ref(),
+        };
+        zoom.is_some_and(|zoom| {
+            tab.pane
+                .zoom_hides_siblings(|slot| slot.entity_id() == zoom.entity_id())
+        })
+    }
+
     fn toggle_maximize(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if self.maximized.is_some() {
             self.maximized = None;

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -10170,6 +10170,86 @@ mod zoom_gpui_tests {
             );
         });
     }
+
+    /// The mark the chrome wears (#752) has to go out again by every road the
+    /// zoom itself leaves by, and it has to name the right tab while several
+    /// tabs are each holding one.
+    #[gpui::test]
+    fn the_zoom_mark_is_on_whichever_tabs_are_hiding_panes(cx: &mut TestAppContext) {
+        use crate::terminal::view::quiet_test_pane;
+        use crate::ui::pane::{Pane, PaneSlot};
+
+        let (app, mut vcx, _streams) = harness_with_tabs(cx, 3);
+
+        app.update_in(&mut vcx, |app, window, cx| {
+            // A zoom only hides something where there is a sibling to hide, so
+            // tabs 0 and 1 get a second pane and tab 2 stays single.
+            let mut held = Vec::new();
+            for tab in 0..2 {
+                let (view, stream) = quiet_test_pane(90 + tab as u64, window, cx);
+                held.push(stream);
+                let first = app.tabs[tab].pane.first_leaf().expect("tab has a pane");
+                app.tabs[tab].pane = Pane::split_node(
+                    gpui::Axis::Horizontal,
+                    0.5,
+                    Pane::leaf(first),
+                    Pane::leaf(PaneSlot::Ready(view)),
+                );
+            }
+
+            for i in 0..app.tabs.len() {
+                assert!(!app.tab_is_zoomed(i), "nothing is zoomed yet");
+            }
+
+            // Zooming marks the tab it happened in, and only that one.
+            app.toggle_maximize(window, cx);
+            assert!(app.tab_is_zoomed(0), "the zoomed tab wears the mark");
+            assert!(!app.tab_is_zoomed(1));
+            assert!(!app.tab_is_zoomed(2));
+
+            // And un-zooming takes it away again.
+            app.toggle_maximize(window, cx);
+            assert!(!app.tab_is_zoomed(0), "un-zooming clears the mark");
+
+            // The mark rides with its tab across a switch (#599) — an inactive
+            // tab holding a zoom still wears it — and two tabs can wear one at
+            // the same time, each reading its own handle.
+            app.toggle_maximize(window, cx);
+            app.activate(1, window, cx);
+            assert!(app.tab_is_zoomed(0), "the parked zoom is still a zoom");
+            assert!(!app.tab_is_zoomed(1));
+            app.toggle_maximize(window, cx);
+            assert!(app.tab_is_zoomed(0) && app.tab_is_zoomed(1));
+            assert!(!app.tab_is_zoomed(2), "a single-pane tab hides nothing");
+
+            // A parked zoom naming a pane that has since left the tab is no
+            // zoom: it would not come back on a switch, so it is not marked.
+            let parked = app.tabs[0].zoomed.clone().expect("tab 0 parked a zoom");
+            let elsewhere = app.tabs[2]
+                .pane
+                .first_leaf()
+                .and_then(|slot| slot.terminal().cloned());
+            app.tabs[0].zoomed = elsewhere;
+            assert!(
+                !app.tab_is_zoomed(0),
+                "a zoom over a pane this tab does not hold is not marked"
+            );
+            app.tabs[0].zoomed = Some(parked.clone());
+            assert!(app.tab_is_zoomed(0));
+
+            // Nor is a zoom over the last pane standing: its siblings closed
+            // while the tab was away, and the tab now looks like — and draws
+            // as — an ordinary single pane.
+            app.tabs[0].pane = Pane::leaf(PaneSlot::Ready(parked));
+            assert!(
+                !app.tab_is_zoomed(0),
+                "a zoom that covers nothing stops being marked"
+            );
+
+            assert!(!app.tab_is_zoomed(9), "there is no tab 9 to mark");
+            drop(held);
+        });
+    }
 }
 
 // A test window has no daemon behind it — its socket path is under the pinned

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -1772,6 +1772,7 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         L10nKey::TabTooltipHideSidebar => "Hide Sidebar",
         L10nKey::TabTooltipHideDetailPanel => "Hide Detail Panel",
         L10nKey::TabTooltipShowDetailPanel => "Show Detail Panel",
+        L10nKey::TabTooltipZoomed => "Pane zoomed — other panes hidden",
         L10nKey::TabMenuLocalShells => "Local",
         L10nKey::TabMenuAddHost => "Add SSH Host…",
         L10nKey::TabMenuAllHosts => "All SSH Hosts…",

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -1843,6 +1843,7 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         L10nKey::TabTooltipHideSidebar => "サイドバーを非表示",
         L10nKey::TabTooltipHideDetailPanel => "詳細パネルを非表示",
         L10nKey::TabTooltipShowDetailPanel => "詳細パネルを表示",
+        L10nKey::TabTooltipZoomed => "ペインを拡大中 — 他のペインは非表示",
         L10nKey::TabMenuLocalShells => "ローカル",
         L10nKey::TabMenuAddHost => "SSH ホストを追加…",
         L10nKey::TabMenuAllHosts => "すべての SSH ホスト…",

--- a/src/ui/i18n/mod.rs
+++ b/src/ui/i18n/mod.rs
@@ -997,6 +997,7 @@ l10n_keys! {
     TabTooltipHideSidebar,
     TabTooltipHideDetailPanel,
     TabTooltipShowDetailPanel,
+    TabTooltipZoomed,
     TabMenuLocalShells,
     TabMenuAddHost,
     TabMenuAllHosts,

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -1682,6 +1682,7 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         L10nKey::TabTooltipHideSidebar => "隐藏侧栏",
         L10nKey::TabTooltipHideDetailPanel => "隐藏详情面板",
         L10nKey::TabTooltipShowDetailPanel => "显示详情面板",
+        L10nKey::TabTooltipZoomed => "窗格已缩放 — 其他窗格已隐藏",
         L10nKey::TabMenuLocalShells => "本地",
         L10nKey::TabMenuAddHost => "添加 SSH 主机…",
         L10nKey::TabMenuAllHosts => "所有 SSH 主机…",

--- a/src/ui/pane.rs
+++ b/src/ui/pane.rs
@@ -183,6 +183,17 @@ impl<L: Clone> Pane<L> {
         }
     }
 
+    /// Whether zooming the leaf `pred` names would actually hide anything.
+    ///
+    /// The zoom that gets marked in the chrome is the one a reader cannot see
+    /// for themselves: a zoom naming a pane that has since exited names no
+    /// leaf here, and a zoom over the last pane standing covers nothing. Both
+    /// look exactly like an unzoomed single pane, so neither earns a badge.
+    pub fn zoom_hides_siblings(&self, pred: impl Fn(&L) -> bool) -> bool {
+        let leaves = self.leaves();
+        leaves.len() > 1 && leaves.iter().any(pred)
+    }
+
     pub fn leaf_matching_or_first(&self, pred: impl Fn(&L) -> bool) -> Option<L> {
         self.leaves()
             .into_iter()
@@ -1277,6 +1288,24 @@ mod tests {
         assert_eq!(pane.leaf_matching_or_first(is(1)), Some(1));
         assert_eq!(pane.leaf_matching_or_first(is(99)), Some(0));
         assert_eq!(TestPane::Empty.leaf_matching_or_first(is(0)), None);
+    }
+
+    #[test]
+    fn a_zoom_is_only_worth_marking_while_it_covers_something() {
+        let mut pane = TestPane::leaf(0);
+        assert!(
+            !pane.zoom_hides_siblings(is(0)),
+            "zooming the only pane covers nothing"
+        );
+
+        split(&mut pane, 0, Axis::Horizontal, 1);
+        assert!(pane.zoom_hides_siblings(is(0)));
+        assert!(pane.zoom_hides_siblings(is(1)));
+        assert!(
+            !pane.zoom_hides_siblings(is(99)),
+            "a zoom whose pane has exited is not a zoom"
+        );
+        assert!(!TestPane::Empty.zoom_hides_siblings(is(0)));
     }
 
     #[test]

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -47,6 +47,8 @@ mod row_metrics {
     pub(super) const GAP: f32 = 8.;
     /// The ⌘N badge, when one is shown.
     pub(super) const BADGE: f32 = 20.;
+    /// The zoom mark, when the tab has a pane zoomed over the others.
+    pub(super) const ZOOM: f32 = 16.;
     /// `gap_1p5`, between the branch icon and its text and before the counts.
     pub(super) const META_GAP: f32 = 6.;
     /// The branch icon.
@@ -296,9 +298,16 @@ impl Tty7App {
                 } else {
                     0.
                 };
+                let zoomed = self.tab_is_zoomed(i);
+                let zoom_extra = if zoomed {
+                    row_metrics::ZOOM + row_metrics::GAP
+                } else {
+                    0.
+                };
                 // Elision is measured against this budget so the label and
                 // branch never wrap or overflow into CSS truncation.
-                let label_avail = (row_metrics::text_budget(width) - badge_extra).max(48.);
+                let label_avail =
+                    (row_metrics::text_budget(width) - badge_extra - zoom_extra).max(48.);
                 let title_size = 0.875 * rem;
                 let meta_size = 0.75 * rem;
                 let title_font = if is_active { &title_font_active } else { &font };
@@ -723,6 +732,11 @@ impl Tty7App {
                         22.,
                         cx,
                     ))
+                    // Leading, like the chip's: the trailing end of a row is
+                    // the badge's, and the close button fades in over it.
+                    .when(zoomed, |row| {
+                        row.child(self.zoom_mark(("sidebar-zoom", i), cx))
+                    })
                     .child(label_region)
                     .when(show_badges && badge_pos < 9, |row| {
                         row.child(

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -1222,6 +1222,30 @@ impl Tty7App {
         }
     }
 
+    /// The mark a tab wears while one of its panes is zoomed over the others
+    /// (#752). Without it a zoomed tab is pixel-for-pixel a tab that only ever
+    /// had one pane, and the only way to tell was to toggle the zoom off.
+    ///
+    /// Drawn in the tab entry rather than on the pane so it reads from either
+    /// tab surface, and so it says something about the tabs you are *not*
+    /// looking at — the zoom outlives a switch away from them.
+    pub(crate) fn zoom_mark(&self, id: impl Into<gpui::ElementId>, cx: &App) -> gpui::AnyElement {
+        let tip = chord_hint(t(L10nKey::TabTooltipZoomed), "ToggleMaximizePane", cx);
+        div()
+            .id(id)
+            .flex_shrink_0()
+            .flex()
+            .items_center()
+            .justify_center()
+            .size(px(16.))
+            .text_color(cx.theme().muted_foreground)
+            .child(Icon::new(IconName::Maximize).size(px(11.)))
+            .tooltip(move |window, cx| {
+                gpui_component::tooltip::Tooltip::new(tip.clone()).build(window, cx)
+            })
+            .into_any_element()
+    }
+
     /// The full title behind a shortened one, for the row to name on hover.
     ///
     /// `tab_label` hands back a path elided to its last three segments and then
@@ -1613,6 +1637,7 @@ impl Tty7App {
             let agent = tab.agent(cx);
             let agent_status = tab.agent_status(cx);
             let agent_unread = tab.agent_unread_count(cx);
+            let zoomed = self.tab_is_zoomed(i);
 
             let rename_input = self
                 .renaming
@@ -1739,6 +1764,13 @@ impl Tty7App {
                         18.,
                         cx,
                     ))
+                })
+                // Leading, beside the other state marks: the trailing end of a
+                // chip belongs to the badge and to the close button that fades
+                // in over it, and a mark parked there would vanish under the
+                // pointer that came to read it.
+                .when(zoomed, |chip| {
+                    chip.child(self.zoom_mark(("tab-zoom", i), cx))
                 })
                 .child(label_region)
                 .when(show_badges && i < 9, |chip| {


### PR DESCRIPTION
Fixes #752

## Verified first

The gap is real on `main` as of 893172f5. `Tty7App::maximized` is read in
exactly one render site — `render` swaps the pane tree for the zoomed leaf
(`src/ui/app.rs`) — and nowhere else. The tab chip, the sidebar row and the
pane chrome (`PaneChrome` carries `dim_inactive`, `rearrangeable`, `hovered`,
`lifted`, `drag`) have no cue keyed off it, and no i18n key mentions the
state. A zoomed tab is pixel-for-pixel a tab that only ever had one pane.

Also checked how the state moves before wiring anything to it: zoom is
per-tab and *does* survive a tab switch (#599) — `activate` parks the
outgoing tab's zoom in `Tab::zoomed` and takes the incoming tab's back — so
the cue is per tab entry, not per window, and it is right for an inactive
tab to wear it too.

## The cue

A small `maximize` glyph (the icon set the strip already draws from) in the
tab entry, leading, beside the ssh dot and the agent avatar — in the
horizontal chip and in the sidebar row, so it is there in either tab-bar
position. Tinted `muted_foreground`; no new visual language, no config
option.

It sits leading rather than trailing because the trailing end of both a chip
and a row is already spoken for: the ⌘N badge sits there and the close
button fades in over it, so a mark parked there would disappear under the
pointer that came to read it. The sidebar's text budget takes the glyph's
width out of the label the same way it takes the badge's.

On hover it names itself through the i18n layer —
`TabTooltipZoomed` ("Pane zoomed — other panes hidden", added to en/ja/zh)
run through `chord_hint` like its neighbours, so the tooltip also carries the
chord that undoes the zoom.

## Shape

`Pane::zoom_hides_siblings(pred)` answers whether a zoom covers anything: a
zoom naming a pane that has since exited names no leaf, and a zoom over the
last pane standing hides nothing — both look like an ordinary single pane, so
neither gets a badge. `Tty7App::tab_is_zoomed(index)` picks the right handle
for the tab (`self.maximized` for the active one, `Tab::zoomed` for the rest)
and asks the layout.

## Tests

- New: `ui::pane::tests::a_zoom_is_only_worth_marking_while_it_covers_something`
  — the predicate is generic over the leaf type, so it is unit-testable
  without a window.
- `cargo test --bin tty7-app`: 1466 passed, 1 failed —
  `ui::remote_connect::tests::a_routed_auth_prompt_carries_the_machine_that_raised_it`,
  a known pre-existing flake unrelated to this change.
- i18n completeness tests pass (`every_key_is_translated_in_every_locale`,
  `chinese_covers_every_key`, `japanese_covers_every_key`).
- `cargo fmt --check` clean; `cargo clippy --bin tty7-app` reports nothing on
  the touched lines.

Not launched as a GUI (another agent owns the foreground), so the glyph's
pixel placement has not been eyeballed.
