### PR TITLE
fix(terminal): keep a solo glyph inside its cell when the next one is taken (#737)

### DIFF
--- a/src/terminal/element.rs
+++ b/src/terminal/element.rs
@@ -977,10 +977,15 @@ fn native_cell_residue(style: &GlyphStyle) -> Option<char> {
 /// when the neighbouring cell is blank and has nothing to lose.
 fn seg_budget(solo: bool, cells: usize, room: bool, cell_width: Pixels) -> Pixels {
     if solo {
-        // Single-cell glyphs have always been allowed to lean into the next
-        // cell. Narrowing that here would shrink a pile of symbols that look
-        // fine today, so it stays a separate decision.
-        cell_width * 2.
+        // Single-cell glyphs are allowed to lean into the next cell — that is
+        // what keeps the pile of symbols that look fine today from shrinking —
+        // but only while that cell is empty. A Nerd Font icon pulled from a
+        // fallback face inks well past a narrow primary's cell (1.6 cells is
+        // typical), and where the next cell has a glyph of its own the lean is
+        // not a lean, it is an overlap: the neighbour is painted afterwards
+        // and lands on top of the overshoot. Hand those their own cell and let
+        // `fit_scale` bring them down into it, the way kitty and ghostty do.
+        if room { cell_width * 2. } else { cell_width }
     } else if room {
         cell_width * (cells as f32 + 1.)
     } else {
@@ -2707,7 +2712,16 @@ mod tests {
     #[test]
     fn seg_budget_frees_solo_symbols_and_lends_a_cell_only_when_one_is_free() {
         let cell = px(10.);
-        assert_eq!(seg_budget(true, 1, false, cell), px(20.), "solo keeps two");
+        assert_eq!(
+            seg_budget(true, 1, true, cell),
+            px(20.),
+            "a solo glyph leans into a free cell"
+        );
+        assert_eq!(
+            seg_budget(true, 1, false, cell),
+            px(10.),
+            "but keeps to its own once the next cell is taken"
+        );
         assert_eq!(
             seg_budget(false, 2, false, cell),
             px(22.5),
@@ -2715,6 +2729,24 @@ mod tests {
         );
         assert_eq!(seg_budget(false, 2, true, cell), px(30.), "a whole cell");
         assert_eq!(seg_budget(false, 1, false, cell), px(12.5));
+    }
+
+    #[test]
+    fn a_fallback_icon_is_fitted_to_its_cell_only_when_the_next_one_is_taken() {
+        // Measured on Windows: Maple Mono NF CN supplying U+F059 to a
+        // 15px Cascadia Mono grid inks 13.85px across an 8.79px cell.
+        let cell = px(8.789);
+        let ink = px(13.845);
+
+        let leaning = fit_scale(ink, seg_budget(true, 1, true, cell));
+        assert_eq!(leaning, 1., "a blank neighbour still lends its cell");
+
+        let crowded = fit_scale(ink, seg_budget(true, 1, false, cell));
+        assert!(crowded < 1., "an occupied neighbour does not");
+        assert!(
+            ink * crowded <= cell,
+            "and the icon has to end inside its own cell"
+        );
     }
 
     #[test]

--- a/src/terminal/element.rs
+++ b/src/terminal/element.rs
@@ -975,7 +975,7 @@ fn native_cell_residue(style: &GlyphStyle) -> Option<char> {
 /// and letting it spill. This follows WezTerm, whose answer shows the glyph
 /// whole most often: a quarter cell of slack always, and a whole extra cell
 /// when the neighbouring cell is blank and has nothing to lose.
-fn seg_budget(solo: bool, cells: usize, room: bool, cell_width: Pixels) -> Pixels {
+fn seg_budget(solo: bool, measured: bool, cells: usize, room: bool, cell_width: Pixels) -> Pixels {
     if solo {
         // Single-cell glyphs are allowed to lean into the next cell — that is
         // what keeps the pile of symbols that look fine today from shrinking —
@@ -985,7 +985,16 @@ fn seg_budget(solo: bool, cells: usize, room: bool, cell_width: Pixels) -> Pixel
         // not a lean, it is an overlap: the neighbour is painted afterwards
         // and lands on top of the overshoot. Hand those their own cell and let
         // `fit_scale` bring them down into it, the way kitty and ghostty do.
-        if room { cell_width * 2. } else { cell_width }
+        //
+        // Only where the ink was measured, though. This number is the clip as
+        // well as the threshold to shrink at, so narrowing it for a segment
+        // nothing could measure would cut the glyph instead of scaling it —
+        // see `ink_covers_segment`.
+        if room || !measured {
+            cell_width * 2.
+        } else {
+            cell_width
+        }
     } else if room {
         cell_width * (cells as f32 + 1.)
     } else {
@@ -1040,6 +1049,21 @@ fn ink_extent(
         cache.borrow_mut().1.insert((font_id, c), extent);
         extent
     })
+}
+
+/// Whether [`ink_extent`]'s answer speaks for the whole segment.
+///
+/// It measures the segment's first character in the run's first face. That is
+/// all of a one-character segment and only part of anything longer: a
+/// cluster's combining marks can ink well to the right of the base they hang
+/// off — Devanagari `\u{915}` + `\u{93E}` — and are not in the number. `None`
+/// is a face that answered no bounds at all, which is no measurement either.
+///
+/// Neither can be scaled to fit, so neither may be held to one cell: the
+/// budget doubles as the clip, and a segment that cannot shrink into a
+/// narrowed one is simply cut off at it.
+fn ink_covers_segment(ink: Option<Pixels>, text: &str) -> bool {
+    ink.is_some() && text.chars().nth(1).is_none()
 }
 
 /// Whether the cell after a segment is free for its glyph to lean into.
@@ -1178,9 +1202,20 @@ fn paint_glyphs(
             };
 
             let x = geom.origin.x + geom.cell_width * (start as f32);
+
+            let mut shaped =
+                window
+                    .text_system()
+                    .shape_line(text.clone(), font_size, run_buf, force_width);
+            // Measured before the budget is set, because how far a solo glyph
+            // may reach turns on whether its ink is known at all.
+            let ink = fit
+                .then(|| ink_extent(cx, &shaped, &text, font_size))
+                .flatten();
             let budget = if fit {
                 seg_budget(
                     solo,
+                    ink_covers_segment(ink, &text),
                     cells,
                     has_room_after(row_cells, start, cells),
                     geom.cell_width,
@@ -1188,12 +1223,7 @@ fn paint_glyphs(
             } else {
                 geom.cell_width * cells as f32
             };
-
-            let mut shaped =
-                window
-                    .text_system()
-                    .shape_line(text.clone(), font_size, run_buf, force_width);
-            if fit && let Some(ink) = ink_extent(cx, &shaped, &text, font_size) {
+            if let Some(ink) = ink {
                 let scale = fit_scale(ink, budget);
                 if scale < 1. {
                     shaped = window.text_system().shape_line(
@@ -2363,7 +2393,7 @@ mod tests {
         let ink = px(18.75);
         let scale = |advance_em: f32, room: bool| {
             let cell = px(15. * advance_em);
-            fit_scale(ink, seg_budget(false, 2, room, cell))
+            fit_scale(ink, seg_budget(false, true, 2, room, cell))
         };
 
         // Menlo and friends: a quarter cell of slack is enough on its own.
@@ -2713,22 +2743,26 @@ mod tests {
     fn seg_budget_frees_solo_symbols_and_lends_a_cell_only_when_one_is_free() {
         let cell = px(10.);
         assert_eq!(
-            seg_budget(true, 1, true, cell),
+            seg_budget(true, true, 1, true, cell),
             px(20.),
             "a solo glyph leans into a free cell"
         );
         assert_eq!(
-            seg_budget(true, 1, false, cell),
+            seg_budget(true, true, 1, false, cell),
             px(10.),
             "but keeps to its own once the next cell is taken"
         );
         assert_eq!(
-            seg_budget(false, 2, false, cell),
+            seg_budget(false, true, 2, false, cell),
             px(22.5),
             "a quarter cell"
         );
-        assert_eq!(seg_budget(false, 2, true, cell), px(30.), "a whole cell");
-        assert_eq!(seg_budget(false, 1, false, cell), px(12.5));
+        assert_eq!(
+            seg_budget(false, true, 2, true, cell),
+            px(30.),
+            "a whole cell"
+        );
+        assert_eq!(seg_budget(false, true, 1, false, cell), px(12.5));
     }
 
     #[test]
@@ -2738,15 +2772,52 @@ mod tests {
         let cell = px(8.789);
         let ink = px(13.845);
 
-        let leaning = fit_scale(ink, seg_budget(true, 1, true, cell));
+        let leaning = fit_scale(ink, seg_budget(true, true, 1, true, cell));
         assert_eq!(leaning, 1., "a blank neighbour still lends its cell");
 
-        let crowded = fit_scale(ink, seg_budget(true, 1, false, cell));
+        let crowded = fit_scale(ink, seg_budget(true, true, 1, false, cell));
         assert!(crowded < 1., "an occupied neighbour does not");
         assert!(
             ink * crowded <= cell,
             "and the icon has to end inside its own cell"
         );
+    }
+
+    #[test]
+    fn a_solo_segment_is_held_to_its_cell_only_where_its_ink_was_measured() {
+        let cell = px(10.);
+        let budget = |ink, text| seg_budget(true, ink_covers_segment(ink, text), 1, false, cell);
+
+        // One character the face answered bounds for: the whole of it was
+        // measured, so `fit_scale` can bring it into one cell and the clip
+        // may be drawn there.
+        assert!(ink_covers_segment(Some(px(15.)), "\u{f059}"));
+        assert_eq!(budget(Some(px(15.)), "\u{f059}"), px(10.));
+
+        // A base with a combining mark hanging off it reaches paint_glyphs as
+        // a one-cell `Cluster`, which counts as solo. `ink_extent` read the
+        // base alone: Devanagari ka plus the aa matra inks to the right of the
+        // base, and none of that overhang is in the 9px. Nothing would shrink
+        // it, so a one-cell clip would cut the matra clean off.
+        assert!(!ink_covers_segment(Some(px(9.)), "\u{915}\u{93E}"));
+        assert_eq!(budget(Some(px(9.)), "\u{915}\u{93E}"), px(20.));
+
+        // A face that answers no bounds at all is the same story from the
+        // other side: `fit_scale` is never reached, so halving the clip only
+        // clips.
+        assert!(!ink_covers_segment(None, "\u{f059}"));
+        assert_eq!(budget(None, "\u{f059}"), px(20.));
+
+        // A free neighbour lends its cell either way \u2014 the measurement only
+        // decides whether the lean can be withdrawn.
+        for ink in [Some(px(15.)), None] {
+            for text in ["\u{f059}", "\u{915}\u{93E}"] {
+                assert_eq!(
+                    seg_budget(true, ink_covers_segment(ink, text), 1, true, cell),
+                    px(20.)
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #737

## What the report claims, and what is actually true

`RowSeg::Solo` shapes with `force_width = None`, and `seg_budget` hands a solo
segment two cells no matter what is next to it. `fit_scale` therefore never
fires and the paint clip is two cells wide, so a fallback glyph that inks past
its column is neither shrunk nor cut — and because segments are painted left to
right, the next column's run is drawn *after* the overshoot and lands on top of
it. That part of the issue is correct as written.

## Verified on Windows

The report is from macOS/CoreText with Cartograph CF, which is not installed
here, so I reproduced the measurement with the equivalent Windows stack —
`Cascadia Mono` primary, `Maple Mono NF CN` as the Nerd Font fallback — by
shaping through the real DirectWrite text system headlessly (a throwaway gpui
example, not committed) and reading `typographic_bounds`, which is the same
number `ink_extent` feeds to `fit_scale`:

```
primary cell width @ 15px = 8.789px
U+F059 (nf-fa-question_circle)  advance 9px   ink 13.845px  = 1.58 cells
U+F07B (nf-fa-folder)           advance 9px   ink 13.860px  = 1.58 cells
U+F015 (nf-fa-home)             advance 9px   ink 15.615px  = 1.78 cells
```

With the old budget of `2 × cell_width = 17.58px`, `fit_scale` returns 1 for all
three: nothing is shrunk, and the clip lets all of it through. So the overflow
reproduces on Windows too — this is not a CoreText-only bug. The segmentation
and budget code in `element.rs` has no `cfg(target_os)` gates, which is
consistent with that.

## The change

`seg_budget` now asks `has_room_after` for solo segments, the same question the
multi-cell branch already asks. The call site already computes and passes it;
only the `solo` arm ignored it.

- next cell free → still two cells, exactly as before. The deliberate comment
  about not shrinking the pile of symbols that look fine today is why this case
  is left alone.
- next cell occupied → one cell, and `fit_scale` scales the glyph down into it
  through the machinery already used for wide clusters.

kitty and ghostty fit fallback glyphs to the cell unconditionally. This is
narrower: it only does so where the alternative is painting over a neighbour.

### …but only where the ink was measured

The first version of this branch narrowed the budget for every crowded solo
segment, which was wrong, because that number is the `ContentMask` as well as
the threshold `fit_scale` shrinks at. Two kinds of segment cannot be shrunk
into it, so narrowing it only cut them:

- **A one-cell `Cluster`** — a base with combining marks — reaches this path
  with `solo = true`. `ink_extent` measures `text.chars().next()`, the base
  alone, so a mark that inks to the right of its base is not in the number.
  Devanagari `क` + `ा` measured as its base, took no shrink, and would have
  been clipped at one cell where it used to draw whole. That is a worse fault
  than the overlap this branch is about, on scripts with no Nerd Font in them.
- **A face that answers no bounds**: `ink_extent` returns `None`, no shrink is
  possible, and halving the clip only clips.

So the ink is measured before the budget is chosen, and `ink_covers_segment`
gates the narrowing on the measurement covering the whole segment — one
character, and bounds that came back. Everything else keeps the two cells it
has always had.

No config knob. The gate makes the "lean into a blank" behaviour the issue asks
to preserve the default everywhere it was ever visible.

## Tests

Verification here was by measurement and unit test, not by eye: the shrink is a
pure function of ink and budget, and pinning it in a test is stronger evidence
than a screenshot. `TestAppContext` shapes through gpui's `NoopTextSystem`, so a
test cannot obtain a real fallback advance — the measured ink above is baked
into the fixtures instead.

- `seg_budget_frees_solo_symbols_and_lends_a_cell_only_when_one_is_free`
  extended with the crowded case.
- `a_fallback_icon_is_fitted_to_its_cell_only_when_the_next_one_is_taken`
  drives the measured U+F059 ink through `seg_budget` + `fit_scale` and asserts
  the glyph is untouched beside a blank and ends inside its own cell beside a
  glyph.
- `a_solo_segment_is_held_to_its_cell_only_where_its_ink_was_measured` covers
  both cases the narrowing must not touch: the `क` + `ा` cluster whose marks
  were never measured, and the `None` from a failed bounds query. Both keep two
  cells; the measured single glyph keeps one.

```
cargo test --bin tty7-app terminal::element
test result: ok. 65 passed; 0 failed; 0 ignored; 0 measured; 1405 filtered out

cargo test --bin tty7-app terminal::
test result: ok. 618 passed; 0 failed; 0 ignored; 0 measured; 852 filtered out
```

`cargo fmt --check` and `cargo clippy --bin tty7-app --all-features` are clean on
the touched file (the `too_many_arguments` warnings there predate this).

## Note for whoever merges

This and #785 both touch `mod tests` in `src/terminal/element.rs` around the
`seg_budget` tests; `git merge-tree` reports a conflict there. Whichever lands
second needs a manual fixup.
