### PR TITLE
fix(keymap): fold a shift-punctuation chord into the key the platform reports (#750)

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -6659,16 +6659,15 @@ impl Tty7App {
     }
 
     fn assign_keybinding(&mut self, action: String, spec: String, cx: &mut Context<Self>) {
-        // Compared as the keymap will build them, not as they are spelled: a
-        // recorded `secondary-}` and a config's `secondary-shift-]` are one
-        // chord, and only the folded form tells you so. Left unfolded, the
-        // displacement never fires and both bindings survive onto the same
-        // keystroke, where which one wins is arbitrary (#750).
-        let chord = crate::ui::keymap::dispatchable_spec(&spec);
+        // Compared as chords, not as spellings: a recorded `secondary-}` and a
+        // config's `secondary-shift-]` are one keystroke written two ways, and
+        // only `same_chord` sees it. Compared as text, the displacement never
+        // fires and both bindings survive onto that keystroke, where which one
+        // wins is arbitrary (#750).
         let displaced = crate::ui::keymap::effective_bindings(cx)
             .into_iter()
             .chain(crate::ui::keymap::extra_bindings(cx))
-            .find(|(a, k)| crate::ui::keymap::dispatchable_spec(k) == chord && *a != action)
+            .find(|(a, k)| *a != action && crate::ui::keymap::same_chord(k, &spec))
             .map(|(a, _)| a);
         // A trailing "…" on an action name marks a command that opens
         // something; it is not punctuation, and inside a sentence it reads as

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -6659,10 +6659,16 @@ impl Tty7App {
     }
 
     fn assign_keybinding(&mut self, action: String, spec: String, cx: &mut Context<Self>) {
+        // Compared as the keymap will build them, not as they are spelled: a
+        // recorded `secondary-}` and a config's `secondary-shift-]` are one
+        // chord, and only the folded form tells you so. Left unfolded, the
+        // displacement never fires and both bindings survive onto the same
+        // keystroke, where which one wins is arbitrary (#750).
+        let chord = crate::ui::keymap::dispatchable_spec(&spec);
         let displaced = crate::ui::keymap::effective_bindings(cx)
             .into_iter()
             .chain(crate::ui::keymap::extra_bindings(cx))
-            .find(|(a, k)| *k == spec && *a != action)
+            .find(|(a, k)| crate::ui::keymap::dispatchable_spec(k) == chord && *a != action)
             .map(|(a, _)| a);
         // A trailing "…" on an action name marks a command that opens
         // something; it is not punctuation, and inside a sentence it reads as

--- a/src/ui/keymap.rs
+++ b/src/ui/keymap.rs
@@ -935,6 +935,88 @@ pub(crate) fn spec_from_keystroke(ks: &Keystroke) -> Option<String> {
     Some(spec)
 }
 
+/// The glyph a US keyboard prints on the shifted half of every key that is not
+/// a letter — `shift-]` types `}`, `shift-2` types `@`.
+const SHIFTED_GLYPHS: [(char, char); 21] = [
+    ('`', '~'),
+    ('1', '!'),
+    ('2', '@'),
+    ('3', '#'),
+    ('4', '$'),
+    ('5', '%'),
+    ('6', '^'),
+    ('7', '&'),
+    ('8', '*'),
+    ('9', '('),
+    ('0', ')'),
+    ('-', '_'),
+    ('=', '+'),
+    ('[', '{'),
+    (']', '}'),
+    ('\\', '|'),
+    (';', ':'),
+    ('\'', '"'),
+    (',', '<'),
+    ('.', '>'),
+    ('/', '?'),
+];
+
+/// Rewrites one chord into the shape the platform actually delivers, or
+/// returns `None` when it is already that shape.
+///
+/// Every gpui backend carries Shift as a modifier for letters only. Over the
+/// digits and the punctuation it spends the modifier on the character instead
+/// and clears the flag: that is the `chars_with_shift` branch on macOS,
+/// `need_to_convert_to_shifted_key` in the Windows mapper, and Linux's "we
+/// only include the shift for upper-case letters by convention". So the chord
+/// written `secondary-shift-]` arrives as `secondary-}` and the two never
+/// meet — the binding installs and is unreachable, which is why Ctrl+Shift+]
+/// stopped cycling panes off macOS and why hand-editing a config to that
+/// spelling changed nothing (#750).
+///
+/// Folding the spec the same way on the lookup side closes the round trip.
+/// The recorder already writes `secondary-}`, because that is what
+/// `spec_from_keystroke` was handed; a default or a config written the other
+/// way now installs the very same binding, so both spellings keep working and
+/// nobody's config comes undone. `secondary-shift-}`, which people also reach
+/// for, folds onto it too — the flag is simply redundant there.
+///
+/// The table is US-layout, and a chord it does not know is left alone rather
+/// than guessed at: this can only turn a dead spec into a live one.
+fn fold_shift_into_glyph(chord: &str) -> Option<String> {
+    let mut ks = Keystroke::parse(chord).ok()?;
+    if !ks.modifiers.shift {
+        return None;
+    }
+    let mut chars = ks.key.chars();
+    let (Some(key), None) = (chars.next(), chars.next()) else {
+        return None;
+    };
+    if let Some((_, shifted)) = SHIFTED_GLYPHS.iter().find(|(plain, _)| *plain == key) {
+        ks.key = shifted.to_string();
+    } else if !SHIFTED_GLYPHS.iter().any(|(_, shifted)| *shifted == key) {
+        return None;
+    }
+    ks.modifiers.shift = false;
+    spec_from_keystroke(&ks)
+}
+
+/// `spec` with every chord folded by `fold_shift_into_glyph`, ready to hand to
+/// `KeyBinding::new`. Anything already canonical comes back untouched.
+pub(crate) fn dispatchable_spec(spec: &str) -> String {
+    let mut out = String::with_capacity(spec.len());
+    for chord in spec.split_whitespace() {
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        match fold_shift_into_glyph(chord) {
+            Some(folded) => out.push_str(&folded),
+            None => out.push_str(chord),
+        }
+    }
+    out
+}
+
 pub(crate) fn key_chords(spec: &str) -> Vec<Vec<String>> {
     spec.split_whitespace().map(key_tokens).collect()
 }
@@ -1029,6 +1111,10 @@ fn action_context(action: &str) -> Option<&'static str> {
 }
 
 fn make_binding(action: &str, keystroke: &str) -> Option<KeyBinding> {
+    // The one place every binding is built, and so the one place worth folding
+    // a `shift-<punctuation>` spec into the chord the dispatcher will see.
+    let folded = dispatchable_spec(keystroke);
+    let keystroke = folded.as_str();
     Some(match action {
         "NewTab" => KeyBinding::new(keystroke, NewTab, None),
         "NewWorkspace" => KeyBinding::new(keystroke, NewWorkspace, None),
@@ -1158,19 +1244,47 @@ mod tests {
     /// table, so a chord the app would not really install, or would install in
     /// another context, cannot pass.
     fn dispatched(effective: &[(String, String)], keys: &str, context: &str) -> Vec<&'static str> {
-        let mut keymap = gpui::Keymap::default();
-        keymap.add_bindings(action_bindings(effective));
         let input: Vec<Keystroke> = keys
             .split(' ')
             .map(|k| Keystroke::parse(k).expect("the typed keystroke parses"))
             .collect();
+        dispatched_keystrokes(effective, &input, context)
+    }
+
+    /// The same lookup for input a spec cannot spell — the shifted-glyph shape
+    /// a backend hands over for `secondary-shift-]` has no written form that
+    /// `Keystroke::parse` turns back into it.
+    fn dispatched_keystrokes(
+        effective: &[(String, String)],
+        input: &[Keystroke],
+        context: &str,
+    ) -> Vec<&'static str> {
+        let mut keymap = gpui::Keymap::default();
+        keymap.add_bindings(action_bindings(effective));
         let context = [gpui::KeyContext::parse(context).expect("the context parses")];
         keymap
-            .bindings_for_input(&input, &context)
+            .bindings_for_input(input, &context)
             .0
             .iter()
             .map(|b| b.action().name())
             .collect()
+    }
+
+    /// What every gpui backend delivers when the secondary modifier is held
+    /// over a key whose shifted half is `glyph`: the glyph, and no shift flag —
+    /// the modifier is already spent on the character.
+    fn delivered_with_secondary(glyph: &str) -> Keystroke {
+        Keystroke {
+            modifiers: gpui::Modifiers {
+                control: cfg!(not(target_os = "macos")),
+                platform: cfg!(target_os = "macos"),
+                shift: false,
+                alt: false,
+                function: false,
+            },
+            key: glyph.to_string(),
+            key_char: None,
+        }
     }
 
     #[test]
@@ -1654,16 +1768,20 @@ mod tests {
         // `ScmCommit` and `ToggleFullscreen` both take secondary-enter on that
         // basis. Two bindings sharing a chord *and* a context is still a bug,
         // because then which one fires is arbitrary.
-        let mut seen: Vec<(&str, &str, Option<&'static str>)> = Vec::new();
+        // Compared folded, since `secondary-shift-]` and `secondary-}` are two
+        // spellings of one keystroke and would otherwise both slip through.
+        let mut seen: Vec<(&str, String, Option<&'static str>)> = Vec::new();
         for (action, spec) in default_bindings() {
             if spec.is_empty() {
                 continue;
             }
+            let chord = dispatchable_spec(spec);
             let context = action_context(action);
-            if let Some((other, _, _)) = seen.iter().find(|(_, s, c)| *s == spec && *c == context) {
-                panic!("{action} and {other} both claim {spec} in context {context:?}");
+            if let Some((other, _, _)) = seen.iter().find(|(_, s, c)| *s == chord && *c == context)
+            {
+                panic!("{action} and {other} both claim {chord} in context {context:?}");
             }
-            seen.push((action, spec, context));
+            seen.push((action, chord, context));
         }
     }
 
@@ -1685,6 +1803,63 @@ mod tests {
                 "round trip diverged for {spec}"
             );
         }
+    }
+
+    #[test]
+    fn a_shifted_punctuation_chord_dispatches_however_it_is_spelled() {
+        // Recording ⌘⇧] wrote `secondary-}` — correctly, since that is the
+        // keystroke it was handed — while the default table and every config
+        // in the wild spell the same chord `secondary-shift-]`. Only one of
+        // the two used to reach the dispatcher (#750); all three do now.
+        let typed = delivered_with_secondary("}");
+        let recorded = spec_from_keystroke(&typed).expect("the recorder spells the chord");
+        assert_eq!(recorded, "secondary-}");
+        for spec in [recorded.as_str(), "secondary-shift-]", "secondary-shift-}"] {
+            let effective = [("NextTab".to_string(), spec.to_string())];
+            assert_eq!(
+                dispatched_keystrokes(&effective, std::slice::from_ref(&typed), ""),
+                vec![NextTab::name_for_type()],
+                "{spec} never reaches the dispatcher"
+            );
+        }
+    }
+
+    #[test]
+    fn the_default_pane_cycle_chord_reaches_its_action() {
+        // `secondary-]` on macOS, `secondary-shift-]` everywhere else — and
+        // either way the backend reports the chord as the bare glyph. The
+        // second spelling installed a binding nothing could press.
+        let effective: Vec<(String, String)> = default_bindings()
+            .into_iter()
+            .map(|(a, k)| (a.to_string(), k.to_string()))
+            .collect();
+        let glyph = if cfg!(target_os = "macos") { "]" } else { "}" };
+        assert!(
+            dispatched_keystrokes(&effective, &[delivered_with_secondary(glyph)], "")
+                .contains(&FocusNextPane::name_for_type()),
+            "the default pane-cycle chord dispatches nothing"
+        );
+    }
+
+    #[test]
+    fn folding_leaves_every_other_spelling_alone() {
+        // Shift over a letter is a real modifier, and the named keys have no
+        // shifted half at all — folding either would break far more than it
+        // fixed.
+        for spec in [
+            "secondary-shift-t",
+            "shift-enter",
+            "shift-insert",
+            "shift-tab",
+            "ctrl-shift-up",
+            "secondary-t",
+            "secondary--",
+            "ctrl-b n",
+        ] {
+            assert_eq!(dispatchable_spec(spec), spec, "{spec} was rewritten");
+        }
+        // A prefix chord folds per chord, not as a whole.
+        assert_eq!(dispatchable_spec("ctrl-b shift-5"), "ctrl-b %");
     }
 
     #[test]

--- a/src/ui/keymap.rs
+++ b/src/ui/keymap.rs
@@ -203,13 +203,27 @@ fn action_bindings(effective: &[(String, String)]) -> Vec<KeyBinding> {
         // without saying so — `no_default_binding_sits_on_a_terminal_control_code`
         // is the half of it that fails a build. A single chord only, since a
         // prefix like `ctrl-b n` is that choice made deliberately.
-        if !key.contains(' ')
-            && steals_a_control_code(key)
-            && !control_code_binding_allowed(action, key)
+        // Over both spellings that reach the keymap, because the fold is what
+        // decides which of them the shell actually loses. `steals_a_control_code`
+        // only ever recognises a bare Ctrl, so it waves `ctrl-shift-2` through —
+        // and then the fold installs `ctrl-@` beside it, which is NUL. The chord
+        // was dead before it was folded and stole nothing; now that it is live
+        // the warning has to follow it (#750). At most one of the two can trip:
+        // a written chord that folds carries Shift, and one that carries Shift
+        // is never a control code.
+        let folded = folded_spec(key);
+        for chord in [Some(key.as_str()), folded.as_deref()]
+            .into_iter()
+            .flatten()
         {
-            log::warn!(
-                "keybinding '{key}' for '{action}' takes a control code away from the shell"
-            );
+            if !chord.contains(' ')
+                && steals_a_control_code(chord)
+                && !control_code_binding_allowed(action, chord)
+            {
+                log::warn!(
+                    "keybinding '{chord}' for '{action}' takes a control code away from the shell"
+                );
+            }
         }
         if !push_binding(&mut bindings, action, key) {
             log::warn!("ignoring keybinding: unknown action '{action}'");
@@ -997,7 +1011,15 @@ const SHIFTED_GLYPHS: [(char, char); 21] = [
 /// for, folds onto it too — the flag is simply redundant there.
 ///
 /// The table is US-layout, and a chord it does not know is left alone rather
-/// than guessed at.
+/// than guessed at. It cannot be layout-aware from here: `?` is Shift+ß on a
+/// German keyboard and Shift+, on a French one, and the only mapper that knows
+/// which is gpui's, reached through `KeyBinding::load` rather than the
+/// `KeyBinding::new` that `make_binding` uses — and it exists on Windows only,
+/// where `MacKeyboardMapper` does no shift folding at all. So off a US layout
+/// the fold is a widening that may not land: `ctrl-shift-4` picks up `ctrl-$`,
+/// which on AZERTY is a key of its own. Harmless, because the fold only ever
+/// adds — the spec as written stays bound whatever the layout — but it is why
+/// this is not the last word on #750.
 ///
 /// The fold is *added* to a spec's bindings, never substituted for them,
 /// because the convention is not universal. Windows leaves Shift intact on
@@ -1744,15 +1766,25 @@ mod tests {
         // `control_code_binding_allowed`; anything new needs a fall-through of
         // its own to join them.
         for (action, spec) in default_bindings() {
-            for chord in spec.split_whitespace() {
-                Keystroke::parse(chord).expect("default chords parse");
-                assert!(
-                    !steals_a_control_code(chord) || control_code_binding_allowed(action, chord),
-                    "{action} is bound to {chord}, which the shell needs as a control code \
-                     (Ctrl+[ is ESC, Ctrl+D is EOF, Ctrl+W deletes a word, \
-                     Ctrl+2..8 are NUL/ESC/FS/GS/RS/US/DEL). \
-                     Window actions belong on ctrl-shift-* off macOS."
-                );
+            // Both spellings, because `push_binding` installs both. "Window
+            // actions belong on ctrl-shift-*" stops being an escape over the
+            // digits and the punctuation the moment the fold clears the Shift
+            // again: `ctrl-shift-2` goes into the keymap as `ctrl-@` (#750).
+            let folded = folded_spec(spec);
+            for spelling in [Some(spec), folded.as_deref()].into_iter().flatten() {
+                for chord in spelling.split_whitespace() {
+                    Keystroke::parse(chord).expect("default chords parse");
+                    assert!(
+                        !steals_a_control_code(chord)
+                            || control_code_binding_allowed(action, chord),
+                        "{action} is bound to {spec}, installed as {chord}, which the shell \
+                         needs as a control code \
+                         (Ctrl+[ is ESC, Ctrl+D is EOF, Ctrl+W deletes a word, \
+                         Ctrl+2..8 are NUL/ESC/FS/GS/RS/US/DEL). \
+                         Window actions belong on ctrl-shift-* off macOS — over a letter, \
+                         where the platform keeps the Shift."
+                    );
+                }
             }
         }
     }
@@ -1950,6 +1982,60 @@ mod tests {
         assert!(same_chord("secondary-t", "secondary-t"));
         assert!(!same_chord("secondary-shift-]", "secondary-shift-["));
         assert!(!same_chord("secondary-}", "secondary-{"));
+    }
+
+    #[test]
+    fn the_control_code_guard_follows_the_folded_chord() {
+        // The half of the control-code rule that only warns. A chord carrying
+        // Shift reads as safe on its own — `steals_a_control_code` recognises a
+        // bare Ctrl and nothing else — and it *was* safe while nothing could
+        // press it. The fold makes it live, and Ctrl+Shift+2 is delivered as
+        // Ctrl+@, which is the NUL the program on the far end is waiting for.
+        // So the guard is asked about the spelling that goes into the keymap
+        // (#750); `action_bindings` runs exactly this pair.
+        for (written, folded) in [
+            ("ctrl-shift-2", per_platform("ctrl-@", "secondary-@")),
+            ("ctrl-shift-6", per_platform("ctrl-^", "secondary-^")),
+            ("ctrl-shift--", per_platform("ctrl-_", "secondary-_")),
+            ("ctrl-shift-/", per_platform("ctrl-?", "secondary-?")),
+        ] {
+            assert!(
+                !steals_a_control_code(written),
+                "{written} reads as safe as written, which is why the fold has to be checked"
+            );
+            assert_eq!(folded_spec(written).as_deref(), Some(folded));
+            assert!(
+                steals_a_control_code(folded),
+                "{written} is installed as {folded} and takes a control code"
+            );
+        }
+    }
+
+    #[test]
+    fn a_key_the_us_table_does_not_know_is_left_alone() {
+        // `SHIFTED_GLYPHS` is a US keyboard, and every other layout prints
+        // something else on the shifted half: `?` is Shift+ß on a German
+        // keyboard and Shift+, on a French one. The fold cannot know that, so
+        // it declines rather than guesses — a key it has never seen keeps its
+        // Shift, and the binding written for it stays exactly as written. That
+        // is also what keeps the fold additive: it can widen a spec's reach but
+        // never move it onto a chord the user did not ask for.
+        for spec in [
+            "secondary-shift-ß",
+            "secondary-shift-é",
+            "secondary-shift-ä",
+            "secondary-shift-ç",
+            "secondary-shift-ñ",
+        ] {
+            assert_eq!(folded_spec(spec), None, "{spec} was guessed at");
+        }
+        // And the recorded spelling, which is what a non-US layout actually
+        // produces, needs no fold to reach the dispatcher in the first place.
+        let effective = [("NextTab".to_string(), "secondary-?".to_string())];
+        assert_eq!(
+            dispatched_keystrokes(&effective, &[delivered_with_secondary("?")], ""),
+            vec![NextTab::name_for_type()],
+        );
     }
 
     #[test]

--- a/src/ui/keymap.rs
+++ b/src/ui/keymap.rs
@@ -163,12 +163,31 @@ pub(crate) fn extra_bindings(cx: &App) -> Vec<(String, String)> {
         .collect()
 }
 
+/// Installs `key` for `action`, and alongside it the chord the platform will
+/// actually deliver when the two are spelled differently — `secondary-shift-]`
+/// is pressed as `secondary-}`, and only the second ever reaches the
+/// dispatcher. Both go in rather than one replacing the other, so a spec that
+/// was already live stays live whatever the backend does with Shift (#750).
+///
+/// Answers whether the action was known at all, which is the caller's cue to
+/// warn about a name it cannot bind.
+fn push_binding(bindings: &mut Vec<KeyBinding>, action: &str, key: &str) -> bool {
+    let Some(binding) = make_binding(action, key) else {
+        return false;
+    };
+    bindings.push(binding);
+    if let Some(folded) = folded_spec(key)
+        && let Some(alias) = make_binding(action, &folded)
+    {
+        bindings.push(alias);
+    }
+    true
+}
+
 fn action_bindings(effective: &[(String, String)]) -> Vec<KeyBinding> {
     let mut bindings = Vec::new();
     for (action, key) in extra_keystrokes(effective) {
-        if let Some(b) = make_binding(action, key) {
-            bindings.push(b);
-        }
+        push_binding(&mut bindings, action, key);
     }
     for (action, key) in effective {
         if key.is_empty() {
@@ -192,18 +211,14 @@ fn action_bindings(effective: &[(String, String)]) -> Vec<KeyBinding> {
                 "keybinding '{key}' for '{action}' takes a control code away from the shell"
             );
         }
-        match make_binding(action, key) {
-            Some(b) => {
-                bindings.push(b);
-                if is_default_insert_newline_binding(action, key) {
-                    bindings.push(KeyBinding::new(
-                        INSERT_NEWLINE_DEFAULT,
-                        InsertNewlineFallback,
-                        Some("Terminal"),
-                    ));
-                }
-            }
-            None => log::warn!("ignoring keybinding: unknown action '{action}'"),
+        if !push_binding(&mut bindings, action, key) {
+            log::warn!("ignoring keybinding: unknown action '{action}'");
+        } else if is_default_insert_newline_binding(action, key) {
+            bindings.push(KeyBinding::new(
+                INSERT_NEWLINE_DEFAULT,
+                InsertNewlineFallback,
+                Some("Terminal"),
+            ));
         }
     }
     bindings
@@ -982,7 +997,19 @@ const SHIFTED_GLYPHS: [(char, char); 21] = [
 /// for, folds onto it too — the flag is simply redundant there.
 ///
 /// The table is US-layout, and a chord it does not know is left alone rather
-/// than guessed at: this can only turn a dead spec into a live one.
+/// than guessed at.
+///
+/// The fold is *added* to a spec's bindings, never substituted for them,
+/// because the convention is not universal. Windows leaves Shift intact on
+/// the numpad's `/ * + -`: `need_to_convert_to_shifted_key` lists the OEM
+/// keys and `VK_0..VK_9` but none of `VK_DIVIDE`/`VK_MULTIPLY`/`VK_ADD`/
+/// `VK_SUBTRACT`, so `get_keystroke_key` falls through to `get_key_from_vkey`
+/// and Ctrl+Shift+numpad-/ really does arrive as `ctrl-shift-/`. Substituting
+/// `ctrl-?` for it would unbind a chord that works today — the same class of
+/// bug this is fixing. macOS clears the flag there anyway (the numpad glyph
+/// is the same shifted or not, so `chars_with_shift` takes the branch that
+/// drops it) and Linux names those keys `divide`/`multiply`/`add`/`subtract`,
+/// which are not one character and never reach this.
 fn fold_shift_into_glyph(chord: &str) -> Option<String> {
     let mut ks = Keystroke::parse(chord).ok()?;
     if !ks.modifiers.shift {
@@ -1001,20 +1028,38 @@ fn fold_shift_into_glyph(chord: &str) -> Option<String> {
     spec_from_keystroke(&ks)
 }
 
-/// `spec` with every chord folded by `fold_shift_into_glyph`, ready to hand to
-/// `KeyBinding::new`. Anything already canonical comes back untouched.
-pub(crate) fn dispatchable_spec(spec: &str) -> String {
-    let mut out = String::with_capacity(spec.len());
+/// `spec` with every chord folded, or `None` when it is already the shape the
+/// platform delivers and there is nothing to add.
+pub(crate) fn folded_spec(spec: &str) -> Option<String> {
+    let mut folded = String::with_capacity(spec.len());
+    let mut changed = false;
     for chord in spec.split_whitespace() {
-        if !out.is_empty() {
-            out.push(' ');
+        if !folded.is_empty() {
+            folded.push(' ');
         }
         match fold_shift_into_glyph(chord) {
-            Some(folded) => out.push_str(&folded),
-            None => out.push_str(chord),
+            Some(chord) => {
+                folded.push_str(&chord);
+                changed = true;
+            }
+            None => folded.push_str(chord),
         }
     }
-    out
+    changed.then_some(folded)
+}
+
+/// Whether two specs claim the same keystroke — spelled the same way, or one
+/// the fold of the other. `secondary-shift-]` and `secondary-}` are one chord
+/// written twice, and a rebind that cannot see that leaves both installed on
+/// it, where which one fires is arbitrary (#750).
+pub(crate) fn same_chord(a: &str, b: &str) -> bool {
+    if a == b {
+        return true;
+    }
+    let (folded_a, folded_b) = (folded_spec(a), folded_spec(b));
+    folded_a.as_deref() == Some(b)
+        || folded_b.as_deref() == Some(a)
+        || (folded_a.is_some() && folded_a == folded_b)
 }
 
 pub(crate) fn key_chords(spec: &str) -> Vec<Vec<String>> {
@@ -1111,10 +1156,6 @@ fn action_context(action: &str) -> Option<&'static str> {
 }
 
 fn make_binding(action: &str, keystroke: &str) -> Option<KeyBinding> {
-    // The one place every binding is built, and so the one place worth folding
-    // a `shift-<punctuation>` spec into the chord the dispatcher will see.
-    let folded = dispatchable_spec(keystroke);
-    let keystroke = folded.as_str();
     Some(match action {
         "NewTab" => KeyBinding::new(keystroke, NewTab, None),
         "NewWorkspace" => KeyBinding::new(keystroke, NewWorkspace, None),
@@ -1768,20 +1809,21 @@ mod tests {
         // `ScmCommit` and `ToggleFullscreen` both take secondary-enter on that
         // basis. Two bindings sharing a chord *and* a context is still a bug,
         // because then which one fires is arbitrary.
-        // Compared folded, since `secondary-shift-]` and `secondary-}` are two
-        // spellings of one keystroke and would otherwise both slip through.
-        let mut seen: Vec<(&str, String, Option<&'static str>)> = Vec::new();
+        // `same_chord`, not string equality: `secondary-shift-]` and
+        // `secondary-}` are two spellings of one keystroke and both install it.
+        let mut seen: Vec<(&str, &str, Option<&'static str>)> = Vec::new();
         for (action, spec) in default_bindings() {
             if spec.is_empty() {
                 continue;
             }
-            let chord = dispatchable_spec(spec);
             let context = action_context(action);
-            if let Some((other, _, _)) = seen.iter().find(|(_, s, c)| *s == chord && *c == context)
+            if let Some((other, _, _)) = seen
+                .iter()
+                .find(|(_, s, c)| same_chord(s, spec) && *c == context)
             {
-                panic!("{action} and {other} both claim {chord} in context {context:?}");
+                panic!("{action} and {other} both claim {spec} in context {context:?}");
             }
-            seen.push((action, chord, context));
+            seen.push((action, spec, context));
         }
     }
 
@@ -1856,10 +1898,58 @@ mod tests {
             "secondary--",
             "ctrl-b n",
         ] {
-            assert_eq!(dispatchable_spec(spec), spec, "{spec} was rewritten");
+            assert_eq!(folded_spec(spec), None, "{spec} was rewritten");
         }
         // A prefix chord folds per chord, not as a whole.
-        assert_eq!(dispatchable_spec("ctrl-b shift-5"), "ctrl-b %");
+        assert_eq!(folded_spec("ctrl-b shift-5").as_deref(), Some("ctrl-b %"));
+    }
+
+    #[test]
+    fn a_chord_the_platform_delivers_with_shift_intact_stays_bound() {
+        // Windows leaves Shift on the numpad's `/ * + -` — they are absent
+        // from gpui's `need_to_convert_to_shifted_key`, so Ctrl+Shift+numpad-/
+        // arrives as `ctrl-shift-/` and the recorder writes exactly that.
+        // Folding is an addition, never a substitution, so that spec has to
+        // survive the treatment `secondary-shift-]` gets (#750).
+        let numpad = Keystroke {
+            modifiers: gpui::Modifiers {
+                control: cfg!(not(target_os = "macos")),
+                platform: cfg!(target_os = "macos"),
+                shift: true,
+                alt: false,
+                function: false,
+            },
+            key: "/".to_string(),
+            key_char: None,
+        };
+        assert_eq!(
+            spec_from_keystroke(&numpad).as_deref(),
+            Some("secondary-shift-/")
+        );
+        let effective = [("NextTab".to_string(), "secondary-shift-/".to_string())];
+        assert_eq!(
+            dispatched_keystrokes(&effective, std::slice::from_ref(&numpad), ""),
+            vec![NextTab::name_for_type()],
+            "the numpad chord lost the binding written for it"
+        );
+        // And the main row's `?`, which the same spec also stands for, still
+        // reaches the action — the fold added it rather than taking over.
+        assert_eq!(
+            dispatched_keystrokes(&effective, &[delivered_with_secondary("?")], ""),
+            vec![NextTab::name_for_type()],
+        );
+    }
+
+    #[test]
+    fn two_spellings_of_one_chord_are_recognised_as_one() {
+        // What `assign_keybinding` leans on to displace the action already
+        // holding a chord, whichever way either of them is written down.
+        assert!(same_chord("secondary-shift-]", "secondary-}"));
+        assert!(same_chord("secondary-}", "secondary-shift-]"));
+        assert!(same_chord("secondary-shift-}", "secondary-shift-]"));
+        assert!(same_chord("secondary-t", "secondary-t"));
+        assert!(!same_chord("secondary-shift-]", "secondary-shift-["));
+        assert!(!same_chord("secondary-}", "secondary-{"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #750

## What is actually wrong

The recorder is not the bug. Every gpui backend carries Shift as a modifier
for **letters only**; over the main row's digits and punctuation it spends the
modifier on the character and clears the flag:

- macOS `crates/gpui_macos/src/events.rs:469-480` — `else if shift { shift = false;
  chars_with_shift }`
- Windows `crates/gpui_windows/src/keyboard.rs:148-160` — `get_keystroke_key` +
  `need_to_convert_to_shifted_key` (`:175-203`, which lists `VK_OEM_*` and `VK_0..VK_9`)
- Linux `crates/gpui_linux/src/linux/platform.rs:997-1003` — "we only include the
  shift for upper-case letters by convention, so don't include for numbers and
  symbols"

So `⌘⇧]` is delivered as `key: "}"`, `shift: false`, and the recorder writing
`secondary-}` is writing down exactly what it was handed. What it cannot reach
is a binding spelled the other way.

Two of our own defaults are spelled the other way:

```rust
("FocusNextPane", per_platform("secondary-]", "secondary-shift-]")),
("FocusPrevPane", per_platform("secondary-[", "secondary-shift-[")),
```

Off macOS those install a binding nothing can press — **Ctrl+Shift+] and
Ctrl+Shift+[ have not cycled panes on Windows or Linux at all**. It is the
same reason the reporter's hand-edited `secondary-shift-]` changed nothing.

## The fix

`push_binding` lays down the spec **as written**, and the folded chord
**beside** it when the two differ. A US-layout table maps the unshifted key to
its shifted glyph and drops the flag.

Adding rather than substituting is the load-bearing part, because the
convention is *not* universal — see below. Since the fold only ever adds a
binding, it cannot unbind anything, whatever the backend does with Shift.
Still working after this:

| spelling              | source                     |
|-----------------------|----------------------------|
| `secondary-}`         | what the recorder writes for the main-row key |
| `secondary-shift-]`   | the default table, and hand-written configs |
| `secondary-shift-}`   | the third form people try; the flag is just redundant |
| `secondary-shift-/`   | what the recorder writes for Ctrl+Shift+numpad-`/` on Windows |
| `secondary-shift-t`   | shift over a letter — no fold |
| `shift-enter`, `shift-tab`, `shift-insert`, `ctrl-shift-up` | named keys have no shifted half — no fold |

`assign_keybinding` and the default-chord dedup test use `same_chord`, which
asks whether two specs claim one keystroke; comparing them as text, a recorded
`secondary-}` never displaces a config's `secondary-shift-]` and both survive
onto one keystroke, where which fires is arbitrary.

macOS behaviour stays behind the existing `secondary` abstraction —
`spec_from_keystroke` already writes it and `Keystroke::parse` already reads
it, so the fold round-trips through both without a new platform fork.

## Why the fold adds instead of substitutes

An earlier revision of this PR replaced the written spec with the folded one
and claimed that "can only turn a dead spec into a live one". That was too
broad, and review caught it. **Windows leaves Shift intact on the numpad's
`/ * + -`**: `need_to_convert_to_shifted_key` does not list `VK_DIVIDE`,
`VK_MULTIPLY`, `VK_ADD` or `VK_SUBTRACT`, so `get_keystroke_key` falls through
to `get_key_from_vkey` (`keyboard.rs:162-172`), and
`MapVirtualKeyW(VK_DIVIDE, MAPVK_VK_TO_CHAR)` returns `/` — verified by probe
on Windows 11. Ctrl+Shift+numpad-`/` therefore really is delivered as
`ctrl-shift-/`; the recorder writes `secondary-shift-/` and it dispatches
today. Substituting `secondary-?` for it would have unbound a working chord.

The other two backends differ again, so no glyph list can separate the cases:

- **macOS** clears the flag for numpad keys anyway — the numpad glyph is the
  same shifted or not, so `chars_with_shift` takes the branch that drops it.
- **Linux** names them `divide` / `multiply` / `add` / `subtract`
  (`platform.rs:970-971`), which are not one character and never reached the
  fold at all.

Installing both spellings sidesteps the ambiguity entirely.

## How this was verified

The chord cannot be pressed on the machine this was written on (Windows), so
it is verified by unit test rather than by hand. `cargo test --bin tty7-app
keymap` — **33 passed**; full `cargo test --bin tty7-app` — 1471 passed, 0
failed. Target dir private to the worktree.

Five new tests, none of them platform-gated:

- `a_shifted_punctuation_chord_dispatches_however_it_is_spelled` — builds the
  keystroke a backend really delivers (`}`, no shift), asserts
  `spec_from_keystroke` writes `secondary-}`, then asserts all three spellings
  dispatch `NextTab` for it. This is the round trip: record → serialize →
  parse → dispatch.
- `the_default_pane_cycle_chord_reaches_its_action` — the real
  `default_bindings()` table against the delivered keystroke. **This one fails
  on `main` on Windows**, which is the Ctrl+Shift+] regression above.
- `a_chord_the_platform_delivers_with_shift_intact_stays_bound` — the numpad
  case: `secondary-shift-/` still dispatches for a `ctrl-shift-/` keystroke,
  *and* for the main row's `?`. **Fails against the substituting fold**, which
  is how the review's finding was confirmed.
- `two_spellings_of_one_chord_are_recognised_as_one` — `same_chord`.
- `folding_leaves_every_other_spelling_alone` — the untouched column of the
  table, plus per-chord folding inside a `ctrl-b shift-5` prefix sequence.

Each behavioural test was confirmed to fail with its fix reverted and pass with
it restored.

## The unexplained part of the report

The reporter also saw the workspace switcher open on `⌘⇧]`. Nothing in
`default_bindings()` can catch that chord — `ToggleSwitcher` is
`secondary-shift-o`, which is a letter and so keeps its shift flag — and
nothing else in the tree binds `}` outside the tmux prefix sequence. That part
is not explained by this change and I did not invent an explanation for it.
