### PR TITLE
fix(terminal): name every ligature feature off, not just calt

### DIFF
--- a/docs/customization/fonts.mdx
+++ b/docs/customization/fonts.mdx
@@ -14,7 +14,7 @@ description: "The bundled default, fallback chains, ligatures, and why CJK needs
 | **Interface font family** | system UI font | The face for everything outside the grid |
 | **Line height** | 1.4 | A multiple of the font size |
 | **Bold font** / **Italic font** | — | Distinct faces, when you want them |
-| **Font ligatures** | off | Contextual alternates stay off unless you ask |
+| **Font ligatures** | off | `calt`, `liga` and `clig` all stay off unless you ask |
 
 ## Hack is bundled
 
@@ -59,6 +59,17 @@ another platform still resolves.
 A tag must be four alphanumeric characters; `true`/`false` map to `1`/`0`.
 Anything malformed is skipped with a log line rather than failing the whole
 config.
+
+Writing *any* tag hands the whole feature set to you: the terminal only names
+`calt: 0`, `liga: 0` and `clig: 0` itself while `font_features` is unset. So
+`{"font_features": {"zero": 1}}` turns slashed zeroes on **and** ligatures back
+on. Name them explicitly if you want both:
+
+```json
+{
+  "font_features": { "zero": 1, "calt": 0, "liga": 0, "clig": 0 }
+}
+```
 
 ## CJK and the two-column grid
 

--- a/src/terminal/element.rs
+++ b/src/terminal/element.rs
@@ -149,9 +149,37 @@ fn build_font(base: &Font, bold: bool, italic: bool) -> Font {
         FontStyle::Normal
     };
     if f.features.tag_value_list().is_empty() {
-        f.features = gpui::FontFeatures::disable_ligatures();
+        f.features = ligatures_off();
     }
     f
+}
+
+/// The feature set that actually turns ligatures off in a terminal grid.
+///
+/// gpui's own `FontFeatures::disable_ligatures()` emits `calt: 0` and nothing
+/// else. `calt` is only the contextual-alternate feature a programming face
+/// drives `=>` and `!=` from; the `fi`/`ffl`/`ffi` ligatures live in `liga` and
+/// `clig`, which that call never mentions — so they were left at the shaper's
+/// default, and CoreText, DirectWrite and rustybuzz all default them on. A
+/// terminal cannot have them: a ligature is one glyph where the grid budgeted a
+/// cell per character, so the row drifts.
+///
+/// Naming all three is therefore the whole fix, and it is not platform
+/// specific. Windows is the sharpest case only because gpui's DirectWrite
+/// backend always attaches an `IDWriteTypography` to the run: an empty feature
+/// list leaves that object empty, which suppresses DirectWrite's own defaults,
+/// while any non-empty list has `liga: 1`/`clig: 1` appended to it
+/// (`gpui_windows/src/direct_write.rs`, `apply_font_features`). Asking for
+/// `calt: 0` there bought ligatures that asking for nothing would not have.
+///
+/// `rlig` is deliberately left alone: it carries the required ligatures a
+/// script cannot be written without.
+fn ligatures_off() -> gpui::FontFeatures {
+    gpui::FontFeatures(std::sync::Arc::new(vec![
+        ("calt".to_string(), 0),
+        ("liga".to_string(), 0),
+        ("clig".to_string(), 0),
+    ]))
 }
 
 fn snapshot_cell(
@@ -2717,20 +2745,64 @@ mod tests {
         assert_eq!(seg_budget(false, 1, false, cell), px(12.5));
     }
 
+    /// The emitted feature set is the whole contract with the shaper, so pin it
+    /// tag for tag rather than asking after one tag at a time.
+    ///
+    /// `calt: 0` alone is not "ligatures off" on any platform: it never asks
+    /// for `liga`/`clig`, which every shaper defaults on. Shaping "office
+    /// waffle fluffier" in Calibri through the real DirectWrite shaper gives 15
+    /// glyphs for 22 characters with `calt: 0`, and 22 once all three are named
+    /// zero.
     #[test]
-    fn build_font_disables_ligatures_unless_features_are_configured() {
-        let font = build_font(&gpui::font("Test"), false, false);
-        assert_eq!(font.features.is_calt_enabled(), Some(false));
-
-        let mut configured = gpui::font("Test");
-        configured.features = serde_json::from_str(r#"{"calt":true,"liga":1}"#).unwrap();
-        let font = build_font(&configured, false, false);
-        assert_eq!(font.features.is_calt_enabled(), Some(true));
-        assert!(
+    fn build_font_emits_the_pinned_feature_set_for_each_ligature_setting() {
+        fn tags(font: &Font) -> Vec<(&str, u32)> {
             font.features
                 .tag_value_list()
                 .iter()
-                .any(|(tag, value)| tag == "liga" && *value == 1)
+                .map(|(tag, value)| (tag.as_str(), *value))
+                .collect()
+        }
+
+        // Default config, and the settings toggle switched off: both leave
+        // `font_features` unset, so the terminal names its own.
+        let font = build_font(&gpui::font("Test"), false, false);
+        assert_eq!(
+            tags(&font),
+            vec![("calt", 0), ("liga", 0), ("clig", 0)],
+            "an unconfigured face must name every ligature feature off",
+        );
+        assert_eq!(font.features.is_calt_enabled(), Some(false));
+
+        // Every face the grid paints with gets the same set, not just the plain one.
+        for (bold, italic) in [(true, false), (false, true), (true, true)] {
+            assert_eq!(
+                tags(&build_font(&gpui::font("Test"), bold, italic)),
+                vec![("calt", 0), ("liga", 0), ("clig", 0)],
+                "bold={bold} italic={italic}",
+            );
+        }
+
+        // Explicitly on: what Settings → Appearance → Font ligatures writes.
+        let mut configured = gpui::font("Test");
+        configured.features = crate::core::config::gpui_font_features(
+            &serde_json::from_str(r#"{"calt":true,"liga":1}"#).unwrap(),
+        );
+        let font = build_font(&configured, false, false);
+        assert_eq!(
+            tags(&font),
+            vec![("calt", 1), ("liga", 1)],
+            "an explicit request for ligatures must survive untouched",
+        );
+        assert_eq!(font.features.is_calt_enabled(), Some(true));
+
+        // Explicitly off in `config.json`: also passed through unchanged.
+        let mut configured = gpui::font("Test");
+        configured.features = crate::core::config::gpui_font_features(
+            &serde_json::from_str(r#"{"calt":0,"liga":0,"clig":0}"#).unwrap(),
+        );
+        assert_eq!(
+            tags(&build_font(&configured, false, false)),
+            vec![("calt", 0), ("liga", 0), ("clig", 0)],
         );
     }
 


### PR DESCRIPTION
`build_font` promised ligatures off by default and did not deliver it — on any
platform. Found while fixing #751 (ligature/grid drift); left alone there
because it changes a default and deserved its own change.

> **Not a Windows-only change.** It corrects the rendered result on macOS and
> Linux too. See [User-visible impact](#user-visible-impact) — the branch name
> predates the diagnosis and undersells the scope.

## The bug

`build_font` used gpui's `FontFeatures::disable_ligatures()`, which emits
exactly one tag:

```rust
pub fn disable_ligatures() -> Self {
    Self(Arc::new(vec![("calt".into(), 0)]))
}
```

`calt` is the contextual-alternate feature a programming face drives its `=>`
and `!=` ligatures from. It is not the only ligature feature: `liga` and `clig`
carry `fi`, `ffl`, `ffi` and friends. `calt: 0` never asked for those to be
off, so they stayed at the shaper's default — and CoreText, DirectWrite and
rustybuzz all default `liga`/`clig` on.

A terminal cannot have them. A ligature is one glyph where the grid budgeted
one cell per character, so the row drifts. The documented contract says so:
`docs/customization/fonts.mdx` lists **Font ligatures — off** as the default.

That is the whole bug, and the fix is to name all three. Nothing about it is
platform specific.

## Why Windows is the sharpest case

gpui's DirectWrite backend always attaches an `IDWriteTypography` object to the
run — `generate_font_features` creates one unconditionally
(`crates/gpui_windows/src/direct_write.rs:509-513`) and `SetTypography` is
called on every range (lines 627 and 665). `apply_font_features`
(`direct_write.rs:1717-1756`) early-returns on an empty list, leaving that
object *empty*, which suppresses DirectWrite's own defaults. Any non-empty list
instead gets `liga: 1`/`clig: 1`/`calt: 1` appended to it:

```rust
let mut feature_liga = make_direct_write_feature("liga", 1);
let mut feature_clig = make_direct_write_feature("clig", 1);
let mut feature_calt = make_direct_write_feature("calt", 1);
...
direct_write_features.AddFontFeature(feature_liga)?;
direct_write_features.AddFontFeature(feature_clig)?;
direct_write_features.AddFontFeature(feature_calt)?;
```

The in-source comment above that block says these are DirectWrite defaults
being restored, and as a statement about *unstyled* DirectWrite it is right —
but in the path gpui actually takes, the typography object is always installed,
so the observable effect is that a non-empty list re-enables ligatures that an
empty one did not. Measured, not inferred: two tags with nothing to do with
ligatures produce the same collapse as `calt: 0`.

| feature set | glyphs (22 chars) |
|---|---|
| `{}` — empty list | 22 |
| `{"zero": 1}` — unrelated tag | **15** |
| `{"kern": 1}` — unrelated tag | **15** |

So on Windows, asking for `calt: 0` bought ligatures that asking for nothing
would not have.

## Evidence: the real DirectWrite shaper

A throwaway probe on gpui's `DirectWriteTextSystem::layout_line`, shaping
`"office waffle fluffier"` (22 characters) in Calibri, which has `liga`
ligatures that visibly collapse:

| feature set | glyphs | width |
|---|---|---|
| `{}` (nothing sent) | 22 | 120.256 px |
| `{"calt": 0}` — **before** | **15** | 118.726 px |
| `{"calt": 0, "liga": 0, "clig": 0}` — **after** | **22** | 120.256 px |
| `{"liga": 0}` alone | 22 | 120.256 px |
| `{"calt": 1, "liga": 1}` — user opt-in | 15 | 118.726 px |

Seven ligature collapses under the setting that was supposed to prevent them,
and none once all three are named. Cascadia Code shapes 17 glyphs for 17
characters in every one of those cases, which is why Calibri is the probe.

These numbers are measured on Windows because that is the host — but the row
that matters (`calt: 0` does not disable `liga`) follows from the tag semantics
and holds on CoreText and rustybuzz alike, both of which take our tags verbatim
(`gpui_macos/src/open_type.rs:76-99`,
`gpui_wgpu/src/cosmic_text_system.rs:806-820`) on top of defaults that have
`liga`/`clig` on.

## The change

`build_font` now emits `calt: 0`, `liga: 0`, `clig: 0` when the user has
configured no `font_features`. `rlig` is deliberately untouched — it carries
the required ligatures a script cannot be written without.

Precedence is unchanged: this only fills in a face whose feature list is empty.
Anything in `font_features` is passed to the shaper verbatim, so
`{"liga": 1}` or `{"calt": 1}` still gets ligatures, and the
**Settings → Appearance → Font ligatures** switch (which writes
`{"calt": 1, "liga": 1}`) still works in both directions.

The fix is in tty7, not the gpui fork: naming the tags you want is the
supported way to drive any of these shapers, and gpui's own default is only
`disable_ligatures()`'s narrow definition of the word.

## User-visible impact

Every platform. Anyone running a terminal font with `liga`/`clig` ligatures —
`fi`, `ffl`, `ffi` and friends — will see those stop ligating and start
occupying one cell each.

- **macOS and Linux**: `calt`-driven programming ligatures (`=>`, `!=`) were
  already off and stay off, but `fi`/`ffl` were silently ligating and now do
  not. A mac user with such a face in their terminal will notice the change.
- **Windows**: the same, plus the `calt`-driven ones, which `calt: 0` was
  failing to suppress for the reason above. This is the biggest visible shift.

In all cases the new behaviour is the documented one, and the grid stops
drifting. To get ligatures back, turn on **Settings → Appearance → Font
ligatures**, or put this in `config.json`:

```json
{ "font_features": { "calt": 1, "liga": 1 } }
```

## Tests

`build_font_emits_the_pinned_feature_set_for_each_ligature_setting` pins the
emitted tag list for the default config, for explicit ligatures-on, and for
explicit ligatures-off, across all four bold/italic faces.

```
running 2 tests
test terminal::element::tests::build_font_sets_weight_and_style ... ok
test terminal::element::tests::build_font_emits_the_pinned_feature_set_for_each_ligature_setting ... ok

test result: ok. 2 passed; 0 failed
```

The docs table and the `font_features` section now say that writing any tag
hands you the whole feature set, ligatures included.
