### PR TITLE
fix(terminal): submit a plain single line as typed, not as a paste (#660)

### DIFF
--- a/src/terminal/cmd_editor.rs
+++ b/src/terminal/cmd_editor.rs
@@ -106,6 +106,16 @@ impl CmdEditor {
         self.pasted
     }
 
+    /// Prepend text the gap hold collected, and remember that some of it came
+    /// off the clipboard. The counterpart to [`insert_pasted`](Self::insert_pasted)
+    /// for the one route into this buffer that does not go through the editor:
+    /// a paste made before the prompt arrived is held outside it and prepended
+    /// when the editor takes over.
+    pub fn prepend_pasted(&mut self, s: &str) {
+        self.pasted = true;
+        self.prepend_str(s);
+    }
+
     pub fn prepend_str(&mut self, s: &str) {
         if s.is_empty() {
             return;
@@ -889,5 +899,17 @@ mod tests {
         assert!(!e.pasted());
         e.insert_str("j build");
         assert!(!e.pasted());
+
+        // Text pasted before the prompt arrived is held outside this buffer
+        // and prepended when the editor takes over; it has to bring the mark
+        // with it, or the gap would be a way around `insert_pasted`.
+        e.clear();
+        e.insert_str(" /tmp");
+        e.prepend_pasted("l");
+        assert_eq!(e.text(), "l /tmp");
+        assert!(e.pasted());
+        e.clear();
+        e.prepend_str("ls");
+        assert!(!e.pasted(), "typed gap text stays typed");
     }
 }

--- a/src/terminal/cmd_editor.rs
+++ b/src/terminal/cmd_editor.rs
@@ -6,6 +6,7 @@ pub struct CmdEditor {
     undo: Vec<(Vec<char>, usize)>,
     redo: Vec<(Vec<char>, usize)>,
     kill: String,
+    pasted: bool,
 }
 
 const UNDO_LIMIT: usize = 200;
@@ -78,6 +79,31 @@ impl CmdEditor {
             self.chars.insert(self.cursor, c);
             self.cursor += 1;
         }
+    }
+
+    /// Insert clipboard (or dropped-file) text, and remember that this line has
+    /// carried some.
+    ///
+    /// The mark is what lets the submit path keep bracketed paste's contract —
+    /// what was pasted is what runs, with no shell-side rewriting — for a line
+    /// that came from outside, while a line the user typed goes to the shell as
+    /// typed. See `submit_bytes` in the terminal view.
+    pub fn insert_pasted(&mut self, s: &str) {
+        self.pasted = true;
+        self.insert_str(s);
+    }
+
+    /// Whether clipboard text has been inserted into the line being edited.
+    ///
+    /// Deliberately sticky for the life of the buffer rather than tracked per
+    /// character: `clear` runs on every submit and every handoff, so the mark
+    /// is already scoped to exactly one line, and every edit that survives
+    /// inside that line — a completion accepted over the pasted text, a ghost
+    /// suggestion, a kill and yank — keeps it. Erring toward "pasted" only ever
+    /// costs the shell-side expansion this line might have had; erring the
+    /// other way would hand the shell's binding table something the user pasted.
+    pub fn pasted(&self) -> bool {
+        self.pasted
     }
 
     pub fn prepend_str(&mut self, s: &str) {
@@ -391,6 +417,7 @@ impl CmdEditor {
         self.anchor = None;
         self.undo.clear();
         self.redo.clear();
+        self.pasted = false;
     }
 
     pub fn set(&mut self, text: &str) {
@@ -832,5 +859,35 @@ mod tests {
         assert_eq!((e.text().as_str(), e.cursor()), ("git status", 3));
         e.set_with_cursor("hi", 99);
         assert_eq!((e.text().as_str(), e.cursor()), ("hi", 2));
+    }
+
+    #[test]
+    fn the_paste_mark_lasts_exactly_one_line() {
+        let mut e = ed("git ", 4);
+        assert!(!e.pasted(), "a typed line carries no mark");
+        e.insert_str("status");
+        assert!(!e.pasted());
+
+        e.insert_pasted(" --short");
+        assert!(e.pasted());
+
+        // Every edit that leaves the pasted text inside this line keeps the
+        // mark, including the ones that rewrite the buffer wholesale on top of
+        // it -- a completion accepted over the paste, a ghost suggestion.
+        e.backspace();
+        e.delete_word_left();
+        e.set("git status --shor");
+        e.set_with_cursor("git status --short", 18);
+        assert!(
+            e.pasted(),
+            "losing the mark mid-line would hand the paste to the shell's bindings"
+        );
+
+        // `clear` runs on every submit and every handoff, so the next line
+        // starts clean and gets the typed delivery again.
+        e.clear();
+        assert!(!e.pasted());
+        e.insert_str("j build");
+        assert!(!e.pasted());
     }
 }

--- a/src/terminal/hold.rs
+++ b/src/terminal/hold.rs
@@ -17,6 +17,7 @@ pub struct GapHold {
     net: String,
     bytes: Vec<u8>,
     epoch: u64,
+    pasted: bool,
 }
 
 impl GapHold {
@@ -26,6 +27,28 @@ impl GapHold {
 
     pub fn hold_text(&mut self, s: &str, bytes: &[u8]) -> Verdict {
         self.hold(bytes, |net| net.push_str(s))
+    }
+
+    /// [`hold_text`](Self::hold_text) for text that came off the clipboard
+    /// rather than the keyboard.
+    ///
+    /// The provenance has to ride along with the held text: a paste made while
+    /// the prompt was still on its way lands here, not in the editor, and the
+    /// editor takes the whole net over when the gap ends. Without the mark
+    /// that text would arrive looking typed and be submitted as typed (#660),
+    /// which is exactly what `CmdEditor::insert_pasted` exists to prevent.
+    pub fn hold_pasted_text(&mut self, s: &str, bytes: &[u8]) -> Verdict {
+        let verdict = self.hold_text(s, bytes);
+        if matches!(verdict, Verdict::Held(_)) {
+            self.pasted = true;
+        }
+        verdict
+    }
+
+    /// Whether any of the text held for the editor came off the clipboard.
+    /// Read it before [`engage`](Self::engage), which clears it with the net.
+    pub fn pasted(&self) -> bool {
+        self.pasted
     }
 
     pub fn hold_backspace(&mut self, bytes: &[u8]) -> Verdict {
@@ -53,6 +76,7 @@ impl GapHold {
     pub fn release(&mut self) -> Option<(String, Vec<u8>)> {
         let held = matches!(self.state, State::Holding);
         self.state = State::Passthrough;
+        self.pasted = false;
         held.then(|| {
             (
                 std::mem::take(&mut self.net),
@@ -72,6 +96,7 @@ impl GapHold {
     pub fn engage(&mut self) -> Option<String> {
         self.state = State::Idle;
         self.bytes.clear();
+        self.pasted = false;
         let net = std::mem::take(&mut self.net);
         (!net.is_empty()).then_some(net)
     }
@@ -88,6 +113,44 @@ mod tests {
         assert!(matches!(h.hold_text("s", b"s"), Verdict::Held(None)));
         assert_eq!(h.engage(), Some("ls".to_string()));
         assert_eq!(h.engage(), None);
+    }
+
+    #[test]
+    fn a_paste_held_in_the_gap_reaches_the_editor_marked() {
+        // Pasting while the previous command is still finishing puts the
+        // clipboard text here rather than in the editor. It must not arrive
+        // looking typed: the submit path would then hand it to the shell's
+        // binding table (#660).
+        let mut h = GapHold::new();
+        assert!(!h.pasted(), "a fresh hold carries nothing pasted");
+        assert!(matches!(
+            h.hold_text("cat ", b"cat "),
+            Verdict::Held(Some(_))
+        ));
+        assert!(!h.pasted());
+        assert!(matches!(
+            h.hold_pasted_text("/tmp/x", b"/tmp/x"),
+            Verdict::Held(None)
+        ));
+        assert!(h.pasted(), "the whole net is pasted once any of it is");
+        assert_eq!(h.engage(), Some("cat /tmp/x".to_string()));
+        assert!(!h.pasted(), "engage hands the mark over with the net");
+
+        // A dump to the PTY takes the mark with it too: what the editor never
+        // receives cannot be submitted from it.
+        let mut h = GapHold::new();
+        h.hold_pasted_text("ls", b"ls");
+        assert!(h.pasted());
+        assert_eq!(h.release(), Some(("ls".to_string(), b"ls".to_vec())));
+        assert!(!h.pasted());
+
+        // Past the window the hold is a passthrough, so there is nothing to
+        // mark -- the bytes went straight to the shell.
+        assert!(matches!(
+            h.hold_pasted_text("x", b"x"),
+            Verdict::Passthrough
+        ));
+        assert!(!h.pasted());
     }
 
     #[test]

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -714,16 +714,19 @@ fn paste_bytes(text: &str, bracketed: bool) -> Vec<u8> {
 /// caller keeps pasted text away from this path entirely.
 ///
 /// The length bound is a cost ceiling, not a correctness one, and it is a
-/// policy choice rather than a discontinuity in the data. A paste lands in one
+/// policy dial rather than a discontinuity in the data. A paste lands in one
 /// go; raw bytes make the shell's line editor redraw as it consumes them, so
-/// the cost is linear in length from the very first byte — measured on a pty it
-/// rises smoothly, with no knee to put a bound at. What 512 buys is a ceiling
-/// on how much submit latency that can add: the slowest configuration measured
-/// (zsh with zsh-syntax-highlighting and zsh-autosuggestions, both of which
-/// re-run per keystroke) costs about a quarter of a millisecond per byte, so a
-/// hand-typed command pays single-digit-to-tens of milliseconds and a pasted-in
-/// wall of text keeps the flat cost the paste framing exists to give it. See
-/// the PR for #660 for the measured curve.
+/// the added latency is linear in length from the very first byte — measured on
+/// a pty it rises perfectly smoothly, with no knee to hang a bound on.
+///
+/// What 512 buys is a ceiling on that latency. The worst configuration measured
+/// is zsh with zsh-syntax-highlighting and zsh-autosuggestions, which both
+/// re-run per keystroke: ~0.26 ms per byte, so +15 ms on a typical 60-byte
+/// command and +126 ms at the bound. Bare zsh is ~0.012 ms per byte (+6 ms at
+/// the bound), bash is free at every length, and fish — the shell #660 is about
+/// — shows no penalty this harness can resolve. Halving the bound would halve
+/// the worst case; the number is a judgement about how much latency a long
+/// typed line may pay, not something the curve picks out.
 fn types_cleanly(line: &str) -> bool {
     line.len() <= 512 && !line.chars().any(char::is_control)
 }

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -697,6 +697,50 @@ fn paste_bytes(text: &str, bracketed: bool) -> Vec<u8> {
     }
 }
 
+/// A line the shell can be handed byte for byte, exactly as if it had been
+/// typed at its own prompt.
+///
+/// Control characters are what rule a line out. Under bracketed paste the shell
+/// inserts every byte literally; delivered raw, each one runs through the line
+/// editor's binding table instead, and a Tab completes, a `^U` kills, a `^C`
+/// abandons the line. ESC is already stripped upstream; `is_control` covers the
+/// rest, embedded newlines included — a multi-line command still goes as one
+/// paste, which is what [`submit_bytes`] was built for.
+///
+/// The length bound is a cost ceiling, not a correctness one. Raw bytes make
+/// the shell redraw as it consumes them; measured against zsh 5.9 +
+/// zsh-syntax-highlighting + zsh-autosuggestions, submit-to-output stays at the
+/// bracketed 85ms up to ~300 bytes and then climbs — 233ms at 600, 390ms at
+/// 1200, 735ms at 2400. 512 sits at the knee: every command anyone types by
+/// hand takes the typed path, and a pasted-in wall of text keeps the flat cost
+/// the paste framing exists to give it.
+fn types_cleanly(line: &str) -> bool {
+    line.len() <= 512 && !line.chars().any(char::is_control)
+}
+
+/// Build the byte sequence that submits the local editor's buffer to the shell.
+///
+/// A plain single-line command goes raw, no paste markers: the shell's own
+/// reader then sees the same bytes a human typing would produce, so its
+/// input-time expansions run — fish abbreviations (#660), zsh `magic-space`,
+/// any readline macro bound to a printable key. Inside a bracketed paste none
+/// of that fires; fish's expand-on-execute only reaches the token under the
+/// cursor, so `j` expanded but `j build` ran literally.
+///
+/// Everything else keeps the paste framing. A multi-line command goes in as one
+/// paste and one CR, so it costs one prompt cycle instead of one per line —
+/// preexec, the user's precmd chain, a syntax-highlight pass over the whole
+/// buffer — and zle keeps the embedded newlines in its buffer, so backslash /
+/// open-quote continuation and heredocs still parse as one unit. A line
+/// carrying control characters goes as a paste because raw delivery would let
+/// the shell's binding table act on them.
+///
+/// ESC is stripped either way (unlike the paste path): clipboard text carrying
+/// its own `ESC[201~` could otherwise close the paste early and have the rest
+/// run as typed input, and a raw ESC reaching zle is an editor command.
+///
+/// An empty buffer skips the markers: zsh's `bracketed-paste-magic` (which
+/// oh-my-zsh turns on) errors on a paste with nothing between them.
 fn submit_bytes(line: &str, bracketed: bool) -> Vec<u8> {
     let clean: String = line
         .replace("\r\n", "\n")
@@ -704,7 +748,8 @@ fn submit_bytes(line: &str, bracketed: bool) -> Vec<u8> {
         .filter(|&c| c != '\x1b')
         .map(|c| if c == '\r' { '\n' } else { c })
         .collect();
-    let mut bytes = paste_bytes(&clean, bracketed && !clean.is_empty());
+    let framed = bracketed && !clean.is_empty() && !types_cleanly(&clean);
+    let mut bytes = paste_bytes(&clean, framed);
     bytes.push(b'\r');
     bytes
 }
@@ -8353,9 +8398,48 @@ mod tests {
         );
         let out = submit_bytes("a\nb\nc\nd", true);
         assert_eq!(out.iter().filter(|&&b| b == b'\r').count(), 1);
+    }
+
+    #[test]
+    fn submit_bytes_types_a_plain_single_line_instead_of_pasting_it() {
+        // #660: inside a bracketed paste fish never runs `expand-abbr`, so an
+        // abbreviation with arguments reached the shell verbatim and `j build`
+        // died as "command not found". Raw bytes are what a human typing
+        // produces, and that is the delivery every input-time expansion --
+        // fish abbreviations, zsh magic-space -- is bound to.
+        assert_eq!(submit_bytes("j build", true), b"j build\r".to_vec());
         assert_eq!(
-            submit_bytes("ls -la", true),
-            b"\x1b[200~ls -la\x1b[201~\r".to_vec()
+            submit_bytes("echo 'a  b' | cat", true),
+            b"echo 'a  b' | cat\r".to_vec()
+        );
+        // Non-ASCII is text, not a control character.
+        assert_eq!(submit_bytes("echo 中文", true), "echo 中文\r".as_bytes());
+
+        // A control character would be acted on by the shell's binding table
+        // rather than inserted -- a Tab completes, a ^U kills the line -- so
+        // those keep the paste framing.
+        assert_eq!(
+            submit_bytes("echo a\tb", true),
+            b"\x1b[200~echo a\tb\x1b[201~\r".to_vec()
+        );
+        assert_eq!(
+            submit_bytes("echo a\x15b", true),
+            b"\x1b[200~echo a\x15b\x1b[201~\r".to_vec()
+        );
+
+        // Past the length bound the flat cost of a paste wins over replaying
+        // the shell's redraw per byte.
+        let at_bound = format!("echo {}", "y".repeat(507));
+        assert_eq!(at_bound.len(), 512);
+        assert_eq!(
+            submit_bytes(&at_bound, true),
+            [at_bound.as_bytes(), b"\r"].concat()
+        );
+        let over_bound = format!("echo {}", "y".repeat(508));
+        assert_eq!(over_bound.len(), 513);
+        assert_eq!(
+            submit_bytes(&over_bound, true),
+            [b"\x1b[200~", over_bound.as_bytes(), b"\x1b[201~\r"].concat()
         );
     }
 
@@ -8385,6 +8469,13 @@ mod tests {
         assert_eq!(out.windows(end.len()).filter(|w| *w == end).count(), 1);
         assert_eq!(out, b"\x1b[200~foo[201~\nrm -rf ~\x1b[201~\r".to_vec());
         assert_eq!(submit_bytes("a\x1bb", false), b"ab\r".to_vec());
+        // The same smuggling attempt on the typed path is just literal text at
+        // the prompt: there is no paste to break out of, and no ESC survives to
+        // reach the line editor as a command.
+        assert_eq!(
+            submit_bytes("foo\x1b[201~; rm -rf ~", true),
+            b"foo[201~; rm -rf ~\r".to_vec()
+        );
 
         assert_eq!(submit_bytes("", true), b"\r".to_vec());
     }

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -2835,7 +2835,7 @@ impl TerminalView {
             .lock()
             .mode()
             .contains(TermMode::BRACKETED_PASTE);
-        self.write_gap_text(&text, paste_bytes(&text, bracketed), cx);
+        self.write_gap_text(&text, paste_bytes(&text, bracketed), true, cx);
         cx.notify();
     }
 
@@ -4017,14 +4017,21 @@ impl TerminalView {
         self.terminal.shell_active() && !self.on_alt_screen() && !self.shell_owns_prompt()
     }
 
-    fn write_gap_text(&mut self, text: &str, bytes: Vec<u8>, cx: &mut Context<Self>) {
+    /// `pasted` says the text came off the clipboard rather than the keyboard,
+    /// so that a paste the hold keeps for the editor still reaches it marked.
+    fn write_gap_text(&mut self, text: &str, bytes: Vec<u8>, pasted: bool, cx: &mut Context<Self>) {
         if self.shell_owns_prompt() {
             self.release_hold();
             self.terminal.write(bytes);
             return;
         }
         if self.gap_holdable() && !text.chars().any(char::is_control) {
-            match self.hold.hold_text(text, &bytes) {
+            let held = if pasted {
+                self.hold.hold_pasted_text(text, &bytes)
+            } else {
+                self.hold.hold_text(text, &bytes)
+            };
+            match held {
                 Verdict::Held(arm) => {
                     if let Some(epoch) = arm {
                         self.arm_hold_timer(epoch, cx);
@@ -4038,6 +4045,26 @@ impl TerminalView {
         }
         self.terminal.write(bytes);
         self.observe_typeahead(RawInput::Text(text));
+    }
+
+    /// Move whatever the gap hold collected into the editor's buffer, keeping
+    /// the paste mark with it.
+    ///
+    /// The hold is the one route into that buffer that does not run through
+    /// the editor: text arriving before the prompt does is kept out here and
+    /// prepended when the editor takes over. A paste that lost its provenance
+    /// on the way would be submitted as typed (#660) — see
+    /// [`CmdEditor::prepend_pasted`].
+    fn engage_hold_into_editor(&mut self) {
+        let pasted = self.hold.pasted();
+        let Some(net) = self.hold.engage() else {
+            return;
+        };
+        if pasted {
+            self.cmd.prepend_pasted(&net);
+        } else {
+            self.cmd.prepend_str(&net);
+        }
     }
 
     fn release_hold(&mut self) {
@@ -4112,9 +4139,7 @@ impl TerminalView {
         if self.terminal.exited || !self.accepts_input(cx) {
             return;
         }
-        if let Some(net) = self.hold.engage() {
-            self.cmd.prepend_str(&net);
-        }
+        self.engage_hold_into_editor();
         let line = self.cmd.text();
         if !line.trim().is_empty() {
             let cwd = self.cwd();
@@ -4385,9 +4410,7 @@ impl TerminalView {
         if !self.accepts_input(cx) {
             return;
         }
-        if let Some(net) = self.hold.engage() {
-            self.cmd.prepend_str(&net);
-        }
+        self.engage_hold_into_editor();
         let line = self.cmd.text();
         if line.contains('\n') {
             cx.notify();
@@ -4878,7 +4901,7 @@ impl TerminalView {
             cx.notify();
             return;
         }
-        self.write_gap_text(text, text.as_bytes().to_vec(), cx);
+        self.write_gap_text(text, text.as_bytes().to_vec(), false, cx);
         self.cursor_visible = true;
         cx.notify();
     }
@@ -6388,9 +6411,7 @@ impl Render for TerminalView {
             }
             self.typeahead.drain();
         } else if self.input_active() {
-            if let Some(net) = self.hold.engage() {
-                self.cmd.prepend_str(&net);
-            }
+            self.engage_hold_into_editor();
             if self.terminal.zle_reading() {
                 self.flush_typeahead();
             }

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -697,8 +697,8 @@ fn paste_bytes(text: &str, bracketed: bool) -> Vec<u8> {
     }
 }
 
-/// A line the shell can be handed byte for byte, exactly as if it had been
-/// typed at its own prompt.
+/// A line the shell can be handed byte for byte, as if it had been typed at its
+/// own prompt.
 ///
 /// Control characters are what rule a line out. Under bracketed paste the shell
 /// inserts every byte literally; delivered raw, each one runs through the line
@@ -707,33 +707,47 @@ fn paste_bytes(text: &str, bracketed: bool) -> Vec<u8> {
 /// rest, embedded newlines included — a multi-line command still goes as one
 /// paste, which is what [`submit_bytes`] was built for.
 ///
-/// The length bound is a cost ceiling, not a correctness one. Raw bytes make
-/// the shell redraw as it consumes them; measured against zsh 5.9 +
-/// zsh-syntax-highlighting + zsh-autosuggestions, submit-to-output stays at the
-/// bracketed 85ms up to ~300 bytes and then climbs — 233ms at 600, 390ms at
-/// 1200, 735ms at 2400. 512 sits at the knee: every command anyone types by
-/// hand takes the typed path, and a pasted-in wall of text keeps the flat cost
-/// the paste framing exists to give it.
+/// Printable keys are deliberately *not* excluded, and cannot be: a line editor
+/// binding one is exactly the mechanism this exists to reach. fish binds space
+/// to `expand-abbr`; zsh users bind `.` to `rationalise-dot` and quotes to
+/// zsh-autopair. Reaching the first means reaching the others, which is why the
+/// caller keeps pasted text away from this path entirely.
+///
+/// The length bound is a cost ceiling, not a correctness one, and it is a
+/// policy choice rather than a discontinuity in the data. A paste lands in one
+/// go; raw bytes make the shell's line editor redraw as it consumes them, so
+/// the cost is linear in length from the very first byte — measured on a pty it
+/// rises smoothly, with no knee to put a bound at. What 512 buys is a ceiling
+/// on how much submit latency that can add: the slowest configuration measured
+/// (zsh with zsh-syntax-highlighting and zsh-autosuggestions, both of which
+/// re-run per keystroke) costs about a quarter of a millisecond per byte, so a
+/// hand-typed command pays single-digit-to-tens of milliseconds and a pasted-in
+/// wall of text keeps the flat cost the paste framing exists to give it. See
+/// the PR for #660 for the measured curve.
 fn types_cleanly(line: &str) -> bool {
     line.len() <= 512 && !line.chars().any(char::is_control)
 }
 
 /// Build the byte sequence that submits the local editor's buffer to the shell.
 ///
-/// A plain single-line command goes raw, no paste markers: the shell's own
-/// reader then sees the same bytes a human typing would produce, so its
-/// input-time expansions run — fish abbreviations (#660), zsh `magic-space`,
-/// any readline macro bound to a printable key. Inside a bracketed paste none
-/// of that fires; fish's expand-on-execute only reaches the token under the
-/// cursor, so `j` expanded but `j build` ran literally.
+/// A plain single-line command the user *typed* goes raw, no paste markers: the
+/// shell's own reader then sees the same bytes typing at its prompt would
+/// produce, so its input-time expansions run — fish abbreviations (#660), zsh
+/// `magic-space`, a readline macro on a printable key. Inside a bracketed paste
+/// none of that fires; fish's expand-on-execute only reaches the token under
+/// the cursor, so `j` expanded but `j build` ran literally.
 ///
-/// Everything else keeps the paste framing. A multi-line command goes in as one
-/// paste and one CR, so it costs one prompt cycle instead of one per line —
-/// preexec, the user's precmd chain, a syntax-highlight pass over the whole
-/// buffer — and zle keeps the embedded newlines in its buffer, so backslash /
-/// open-quote continuation and heredocs still parse as one unit. A line
-/// carrying control characters goes as a paste because raw delivery would let
-/// the shell's binding table act on them.
+/// `pasted` is what keeps that from rewriting text the user did not type. A
+/// paste's contract is that what went in is what runs, and a fish user with
+/// `abbr -a l 'ls -la'` pasting `l /tmp` from their notes must not get
+/// `ls -la /tmp`. So a line that has carried clipboard content keeps the paste
+/// framing whatever else is true of it — see [`CmdEditor::pasted`].
+///
+/// Multi-line and control characters keep it too. A multi-line command goes in
+/// as one paste and one CR, so it costs one prompt cycle instead of one per
+/// line — preexec, the user's precmd chain, a syntax-highlight pass over the
+/// whole buffer — and zle keeps the embedded newlines in its buffer, so
+/// backslash / open-quote continuation and heredocs still parse as one unit.
 ///
 /// ESC is stripped either way (unlike the paste path): clipboard text carrying
 /// its own `ESC[201~` could otherwise close the paste early and have the rest
@@ -741,14 +755,14 @@ fn types_cleanly(line: &str) -> bool {
 ///
 /// An empty buffer skips the markers: zsh's `bracketed-paste-magic` (which
 /// oh-my-zsh turns on) errors on a paste with nothing between them.
-fn submit_bytes(line: &str, bracketed: bool) -> Vec<u8> {
+fn submit_bytes(line: &str, bracketed: bool, pasted: bool) -> Vec<u8> {
     let clean: String = line
         .replace("\r\n", "\n")
         .chars()
         .filter(|&c| c != '\x1b')
         .map(|c| if c == '\r' { '\n' } else { c })
         .collect();
-    let framed = bracketed && !clean.is_empty() && !types_cleanly(&clean);
+    let framed = bracketed && !clean.is_empty() && (pasted || !types_cleanly(&clean));
     let mut bytes = paste_bytes(&clean, framed);
     bytes.push(b'\r');
     bytes
@@ -2804,7 +2818,7 @@ impl TerminalView {
         self.jump_to_prompt();
         if self.input_active() {
             let trimmed = text.strip_suffix('\n').unwrap_or(&text);
-            self.cmd.insert_str(trimmed);
+            self.cmd.insert_pasted(trimmed);
             self.history_nav = None;
             self.editor_goal_col = None;
             self.close_completion();
@@ -4140,7 +4154,8 @@ impl TerminalView {
             .lock()
             .mode()
             .contains(TermMode::BRACKETED_PASTE);
-        self.terminal.write(submit_bytes(&line, bracketed));
+        let pasted = self.cmd.pasted();
+        self.terminal.write(submit_bytes(&line, bracketed, pasted));
         self.cmd.clear();
         self.cursor_visible = true;
         self.jump_to_prompt();
@@ -8393,10 +8408,10 @@ mod tests {
     #[test]
     fn submit_bytes_sends_a_multi_line_command_as_one_bracketed_paste() {
         assert_eq!(
-            submit_bytes("echo a\necho b\necho c", true),
+            submit_bytes("echo a\necho b\necho c", true, false),
             b"\x1b[200~echo a\necho b\necho c\x1b[201~\r".to_vec()
         );
-        let out = submit_bytes("a\nb\nc\nd", true);
+        let out = submit_bytes("a\nb\nc\nd", true, false);
         assert_eq!(out.iter().filter(|&&b| b == b'\r').count(), 1);
     }
 
@@ -8404,80 +8419,111 @@ mod tests {
     fn submit_bytes_types_a_plain_single_line_instead_of_pasting_it() {
         // #660: inside a bracketed paste fish never runs `expand-abbr`, so an
         // abbreviation with arguments reached the shell verbatim and `j build`
-        // died as "command not found". Raw bytes are what a human typing
-        // produces, and that is the delivery every input-time expansion --
-        // fish abbreviations, zsh magic-space -- is bound to.
-        assert_eq!(submit_bytes("j build", true), b"j build\r".to_vec());
+        // died as "command not found". Raw bytes are what typing produces, and
+        // that is the delivery every input-time expansion -- fish
+        // abbreviations, zsh magic-space -- is bound to.
+        assert_eq!(submit_bytes("j build", true, false), b"j build\r".to_vec());
         assert_eq!(
-            submit_bytes("echo 'a  b' | cat", true),
+            submit_bytes("echo 'a  b' | cat", true, false),
             b"echo 'a  b' | cat\r".to_vec()
         );
         // Non-ASCII is text, not a control character.
-        assert_eq!(submit_bytes("echo 中文", true), "echo 中文\r".as_bytes());
+        assert_eq!(
+            submit_bytes("echo 中文", true, false),
+            "echo 中文\r".as_bytes()
+        );
 
         // A control character would be acted on by the shell's binding table
         // rather than inserted -- a Tab completes, a ^U kills the line -- so
         // those keep the paste framing.
         assert_eq!(
-            submit_bytes("echo a\tb", true),
+            submit_bytes("echo a\tb", true, false),
             b"\x1b[200~echo a\tb\x1b[201~\r".to_vec()
         );
         assert_eq!(
-            submit_bytes("echo a\x15b", true),
+            submit_bytes("echo a\x15b", true, false),
             b"\x1b[200~echo a\x15b\x1b[201~\r".to_vec()
         );
 
-        // Past the length bound the flat cost of a paste wins over replaying
-        // the shell's redraw per byte.
+        // Past the length bound the flat cost of a paste wins over the shell's
+        // per-byte redraw. The bound is a latency ceiling, not a knee in the
+        // curve -- see `types_cleanly`.
         let at_bound = format!("echo {}", "y".repeat(507));
         assert_eq!(at_bound.len(), 512);
         assert_eq!(
-            submit_bytes(&at_bound, true),
+            submit_bytes(&at_bound, true, false),
             [at_bound.as_bytes(), b"\r"].concat()
         );
         let over_bound = format!("echo {}", "y".repeat(508));
         assert_eq!(over_bound.len(), 513);
         assert_eq!(
-            submit_bytes(&over_bound, true),
+            submit_bytes(&over_bound, true, false),
             [b"\x1b[200~", over_bound.as_bytes(), b"\x1b[201~\r"].concat()
         );
     }
 
     #[test]
+    fn submit_bytes_keeps_pasted_text_inside_a_bracketed_paste() {
+        // A paste's contract is that what went in is what runs. The typed path
+        // hands the line to the shell's binding table, and a printable key can
+        // be bound there: a fish user with `abbr -a l 'ls -la'` who pastes
+        // `l /tmp` out of their notes must not run `ls -la /tmp`, and a zsh
+        // user with `bindkey . rationalise-dot` must not have a pasted
+        // `echo a...b` become `echo a../..b`. Both were reproduced on a pty.
+        assert_eq!(
+            submit_bytes("l /tmp", true, true),
+            b"\x1b[200~l /tmp\x1b[201~\r".to_vec()
+        );
+        assert_eq!(
+            submit_bytes("echo a...b", true, true),
+            b"\x1b[200~echo a...b\x1b[201~\r".to_vec()
+        );
+        // Same text typed rather than pasted takes the typed path -- that is
+        // the whole point, and it is the same delivery the user's own shell
+        // prompt would have given it.
+        assert_eq!(submit_bytes("l /tmp", true, false), b"l /tmp\r".to_vec());
+        // A shell with no bracketed paste has no framing to fall back on, so
+        // the mark changes nothing there.
+        assert_eq!(submit_bytes("l /tmp", false, true), b"l /tmp\r".to_vec());
+        // An empty buffer still skips the markers, pasted or not.
+        assert_eq!(submit_bytes("", true, true), b"\r".to_vec());
+    }
+
+    #[test]
     fn submit_bytes_falls_back_to_per_line_cr_without_bracketed_paste() {
-        assert_eq!(submit_bytes("a\nb", false), b"a\rb\r".to_vec());
-        assert_eq!(submit_bytes("a\r\nb", false), b"a\rb\r".to_vec());
+        assert_eq!(submit_bytes("a\nb", false, false), b"a\rb\r".to_vec());
+        assert_eq!(submit_bytes("a\r\nb", false, false), b"a\rb\r".to_vec());
     }
 
     #[test]
     fn submit_bytes_normalizes_line_breaks_inside_the_paste() {
         assert_eq!(
-            submit_bytes("a\r\nb", true),
+            submit_bytes("a\r\nb", true, false),
             b"\x1b[200~a\nb\x1b[201~\r".to_vec()
         );
         assert_eq!(
-            submit_bytes("a\rb", true),
+            submit_bytes("a\rb", true, false),
             b"\x1b[200~a\nb\x1b[201~\r".to_vec()
         );
-        assert_eq!(submit_bytes("a\rb", false), b"a\rb\r".to_vec());
+        assert_eq!(submit_bytes("a\rb", false, false), b"a\rb\r".to_vec());
     }
 
     #[test]
     fn submit_bytes_strips_esc_and_skips_markers_on_an_empty_line() {
-        let out = submit_bytes("foo\x1b[201~\nrm -rf ~", true);
+        let out = submit_bytes("foo\x1b[201~\nrm -rf ~", true, false);
         let end = b"\x1b[201~";
         assert_eq!(out.windows(end.len()).filter(|w| *w == end).count(), 1);
         assert_eq!(out, b"\x1b[200~foo[201~\nrm -rf ~\x1b[201~\r".to_vec());
-        assert_eq!(submit_bytes("a\x1bb", false), b"ab\r".to_vec());
+        assert_eq!(submit_bytes("a\x1bb", false, false), b"ab\r".to_vec());
         // The same smuggling attempt on the typed path is just literal text at
         // the prompt: there is no paste to break out of, and no ESC survives to
         // reach the line editor as a command.
         assert_eq!(
-            submit_bytes("foo\x1b[201~; rm -rf ~", true),
+            submit_bytes("foo\x1b[201~; rm -rf ~", true, false),
             b"foo[201~; rm -rf ~\r".to_vec()
         );
 
-        assert_eq!(submit_bytes("", true), b"\r".to_vec());
+        assert_eq!(submit_bytes("", true, false), b"\r".to_vec());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #660

## What was wrong

`submit_bytes` wrapped the editor's buffer in `ESC[200~ … ESC[201~` whenever the
shell had bracketed paste on — which is always, at a live prompt. Inside a paste
the shell inserts every byte literally instead of running it through its binding
table, so **none of the shell's input-time expansions fire**.

fish binds space (and `;`, `|`, `&`, …) to `expand-abbr`. An abbreviation
therefore only ever expanded when the *whole line was the abbreviation* — `j`
worked, because fish's expand-on-execute covers the token under the cursor — and
`j build` arrived verbatim and died as `Unknown command: j`.

Byte-level, against a real fish 4.9.2 on a pty:

| bytes sent | result |
|---|---|
| `j`, SPACE, ENTER (typed) | expands |
| `ESC[200~j ESC[201~` + CR | `j: command not found` |
| `ESC[200~j build ESC[201~` + CR | `j: command not found` |
| `ESC[200~jESC[201~` + CR | expands (bare token only) |
| `j build` + CR (raw) | **expands** |

## The change

A single line with no control characters **that the user typed** is handed over
as typing would produce it: raw bytes, then CR. Anything else — multi-line,
control characters, or a line that has carried clipboard text — keeps the paste
framing.

```rust
fn types_cleanly(line: &str) -> bool {
    line.len() <= 512 && !line.chars().any(char::is_control)
}
// let framed = bracketed && !clean.is_empty() && (pasted || !types_cleanly(&clean));
```

**This is strictly more conservative than a raw path this codebase already
ships.** `handoff_line_to_shell` (Tab handover, ⌃R handover, turning
`prompt_editor` off mid-line) writes the buffer raw to the PTY with *no* length
cap, *no* control-character filter and *no* ESC strip, and has done so for a long
time. The submit path now uses the same delivery under strictly tighter
conditions.

## The 512-byte bound: what the measurement actually shows

**Correction to the first version of this PR.** It claimed 512 "sits at the
measured knee". It does not, and the table it rested on was not measurable: the
timer included sourcing the zsh plugins, and the completion marker (`DONEMARK`)
was a substring of the line being echoed back — so the bracketed column stopped
on the echo while the raw column stopped on the output. The small end was noise.

Remeasured with the prelude sourced and settled *before* the timer starts, the
marker printed by a prelude-defined function so it never appears in the echoed
line, framings interleaved per iteration, 11 iterations, medians (min-max in
brackets). Metric: seconds from writing the submit bytes to the command's output.

zsh 5.9 + zsh-syntax-highlighting + zsh-autosuggestions (both re-run per
keystroke — the worst realistic config):

| line bytes | bracketed | raw | added |
|---|---|---|---|
| 60 | 0.084 [0.072-0.097] | 0.099 [0.093-0.101] | +15 ms |
| 140 | 0.084 [0.073-0.086] | 0.117 [0.111-0.121] | +33 ms |
| 280 | 0.085 [0.083-0.087] | 0.153 [0.149-0.157] | +68 ms |
| 400 | 0.084 [0.082-0.089] | 0.181 [0.177-0.183] | +97 ms |
| **520** | 0.084 [0.080-0.087] | 0.210 [0.204-0.217] | **+126 ms** |
| 780 | 0.084 [0.081-0.087] | 0.277 [0.268-0.281] | +193 ms |
| 1260 | 0.086 [0.082-0.087] | 0.400 [0.395-0.412] | +314 ms |
| 2460 | 0.088 [0.086-0.090] | 0.736 [0.720-0.761] | +648 ms |

Other configurations, added latency only:

| line bytes | bare zsh | bash 5.2 | fish 4.9.2 |
|---|---|---|---|
| 60 | +0 ms | +0 ms | not resolvable |
| 280 | +2 ms | +0 ms | not resolvable |
| 520 | +6 ms | +0 ms | not resolvable |
| 1260 | +23 ms | +0 ms | not resolvable |
| 2460 | +61 ms | +0 ms | not resolvable |

**What this says.** Bracketed is flat in length by construction (84-88 ms across
a 40x range, the constant being the plugins' own per-prompt work). Raw is linear
from the very first byte: ~0.26 ms/byte with those plugins, ~0.012 ms/byte in
bare zsh, immeasurable in bash. **There is no knee.** fish — the shell #660 is
about — showed no penalty this harness can resolve; its numbers swing so widely
(medians 0.005-0.079 s with min-max 0.003-0.178 s) that they are reported as
"not resolvable" rather than as a curve, which is why fish is absent from the
first table.

So 512 is a **ceiling on added submit latency, not a feature of the data**:
+126 ms worst case at the bound, +15-33 ms for a normally-sized command, nothing
at all for bash and fish users. Halving the bound halves the worst case; the
number is a judgement about how much latency a long *typed* line may pay, and
the maintainer should feel free to move it. What the data does support without
judgement is that the bound must exist: without one, a 2460-byte typed line
costs +648 ms in a config plenty of people run.

## What raw delivery means, stated plainly

Raw delivery runs the line through the shell's binding table. That is the
mechanism the fix depends on, and it is not selective: **you cannot reach fish's
`expand-abbr` without also reaching every other printable-key binding the user
has.** `char::is_control` excludes keys the editor would *execute* (Tab
completes, `^U` kills, `^C` abandons) but it cannot exclude a rebound printable
key, because that is the feature.

Reproduced on a pty, typed lines only (pasted lines are excluded by the change):

| config | line submitted | bracketed (today) | raw (this PR) |
|---|---|---|---|
| fish, `abbr --add j echo RAN_JUST` | `j build` | `j: command not found` | `RAN_JUST build` |
| zsh + `bindkey . rationalise-dot` | `cd ...; pwd` | `cd: no such file or directory: ...` | `cd ../..` → `/home` |
| zsh + `bindkey . rationalise-dot` | `echo a...b` | `a...b` | **`a../..b`** |
| zsh + zsh-autopair | `echo "hi there"` (balanced) | `hi there` | `hi there` |
| zsh + zsh-autopair | `ls '/tmp` (unbalanced) | `quote>` continuation | runs `ls /tmp` |
| zsh + zsh-autopair | `echo (` | `>` continuation | `echo ()`, then a `function>` continuation and a 7755-item "do you wish to see all possibilities" prompt |
| bash + `bind '"@@": "AT-EXPANDED"'` | `echo @@` | `@@` | `AT-EXPANDED` |

Two of these deserve calling out because they are *silent rewrites of ordinary
text*, not just different error handling:

- **`bindkey . rationalise-dot`** (a very widely copied zsh snippet) turns a
  typed `echo a...b` into `echo a../..b`.
- **zsh-autopair** changes what an unbalanced quote or paren does. It
  deliberately disables itself inside a bracketed paste, so today tty7 never
  triggers it; after this change a typed line does.

The defence is consistency, not harmlessness: with `prompt_editor: false` — the
current workaround for #660 — these users already get exactly the raw behaviour,
because the keys go straight to the shell. Today tty7's editor silently
*diverges* from the shell the user configured; this makes it agree. But it is a
real behaviour change for those configs and the maintainer should decide whether
that trade is the right one.

## Pasted text keeps the paste contract

`TerminalView::paste` inserts the clipboard into the editor's buffer, so without
provenance a pasted `l /tmp` would be submitted raw and a fish user with
`abbr -a l 'ls -la'` would run `ls -la /tmp` — bracketed paste's contract, *what
I pasted is what runs*, broken.

`CmdEditor` now carries a paste mark:

- `insert_pasted` sets it; all three paste entry points (clipboard text, dropped
  files, staged clipboard image path) funnel through `TerminalView::paste`, so
  there is one choke point.
- `clear` resets it — and `clear` runs on every submit and every handoff, so the
  mark is scoped to exactly one line.
- Every other edit keeps it, deliberately. A completion accepted over pasted
  text and a ghost suggestion both replace the buffer wholesale (`set` /
  `set_with_cursor`) but are *derived from* the pasted line, so dropping the mark
  there would reopen the hole. Erring toward "pasted" only costs that line its
  shell-side expansion.

The one cost of the sticky mark: paste something, then arrow-up to a history
entry (replacing the buffer), then Enter — that line keeps the paste framing even
though no pasted character survives. That is today's behaviour, in the safe
direction, and it is pinned by a test.

## What was tested on a real pty

A Python `pty.fork()` harness answering fish 4's startup queries (`CSI ? u`,
XTVERSION, OSC 11, DA1) and deliberately not XTGETTCAP, replaying the exact byte
sequences `submit_bytes` produces into fish 4.9.2 (upstream static
`fish-4.9.2-linux-x86_64`), bash 5.2.21 and zsh 5.9.

- **Differential sweep, 57 cases** (19 lines × 3 shells) on stock shells:
  quoting, nested quotes, globs, command substitution, `&&`/`||`, pipelines,
  redirection, `;`-separated lists, unicode (CJK + emoji), `~`, `#`, `%`,
  `--flag=value`, leading space, trailing space, `!notahistory`,
  `http://x/?a=b`. Output captured through a redirect to a file so the comparison
  is on what the shell *parsed and executed*. **0 differences.**
- **`!` history expansion** (bash and zsh, seeded history): identical under both
  framings — it is parse-time, not input-time.
- **`bracketed-paste-magic` + `url-quote-magic`** (the oh-my-zsh pairing):
  `echo http://x/?a=b` is quoted to `echo http://x/\?a\=b` under *both* framings.
- **Plugin rewrites**: the table above.
- **Tab hazard, confirmed positively**: raw `echo a<TAB>b` in fish completes to
  `echo cases.py b`; bracketed gives `echo ab`. This is why the control-character
  gate exists.
- **PowerShell on a real ConPTY** (pywinpty, Windows PowerShell 5.1 + PSReadLine
  2.0.0): **`ESC[?2004h` never appears** anywhere in the session, so
  `TermMode::BRACKETED_PASTE` is never set in a PowerShell pane, `bracketed` is
  `false`, and this change is a **no-op there** — that path already sent raw
  bytes. Confirming it from the other side: a `Set-PSReadLineKeyHandler -Chord
  'q'` handler fired under *both* framings, because PSReadLine does not implement
  bracketed paste at all. PowerShell panes have always had input-time rewriting on
  submit.

## What I could not test

- **PowerShell 7 / pwsh with PSReadLine 2.2+**, which added bracketed-paste
  handling — not installed on this machine. If a newer PSReadLine does emit
  `ESC[?2004h`, pwsh panes would start taking the typed path; the 5.1 result
  above does not settle that.
- **The GUI** (another agent owned the foreground). The change is a pure
  function, a one-field editor flag, and two wiring lines.
- **An end-to-end gpui test** of paste → submit: `mod gpui_tests` is
  `#[cfg(all(test, unix))]` and cannot run on this Windows machine. Rather than
  ship a test I could not execute, the coverage is the pure-function framing test
  plus a `CmdEditor` test for the mark's lifecycle; the wiring between them is two
  lines.
- **vi mode.** Raw bytes in vi *normal* mode would be editor commands.
  `input_inactive_reason` already refuses the prompt editor when
  `shell_vi_prompt()` is true, so `submit_command` is unreachable there, and
  `handoff_line_to_shell` has relied on that same gate for as long as it has
  existed. That detection is OSC `133;V`-driven, so a vi-mode shell without tty7's
  shell integration is an untested edge in this path as it was in the handover one.

## Known gap this does not close

`handoff_line_to_shell` still writes pasted content raw on Tab / ⌃R handover —
it has to put the text in the shell's own buffer for further editing, so it
cannot use paste framing without changing what handover means. Now that the
paste mark exists, framing that path is a plausible follow-up; it is out of scope
here.

Also unchanged: the user still does not see an abbreviation expand *as they
type*, the way fish does. `CmdEditor` intercepts every keystroke, so no
shell-side input-time expansion runs until submit — the expanded command appears
when fish echoes it, not in tty7's input bar beforehand. Forwarding keystrokes
live is a much larger design change and is not attempted here.

## Tests

- `submit_bytes_types_a_plain_single_line_instead_of_pasting_it` — plain line,
  unicode, Tab, `^U`, both sides of the 512-byte bound.
- `submit_bytes_keeps_pasted_text_inside_a_bracketed_paste` — the `l /tmp` and
  `echo a...b` cases above, plus the typed control and the no-bracketed-mode case.
- `the_paste_mark_lasts_exactly_one_line` — the mark survives edits, completion
  and ghost accepts inside a line, and is gone after `clear`.

```
running 8 tests
test core::agent_prompt::tests::submit_bytes_bracket_and_sanitize ... ok
test terminal::view::tests::submit_bytes_falls_back_to_per_line_cr_without_bracketed_paste ... ok
test terminal::view::tests::submit_bytes_keeps_pasted_text_inside_a_bracketed_paste ... ok
test terminal::view::tests::submit_bytes_strips_esc_and_skips_markers_on_an_empty_line ... ok
test terminal::view::tests::submit_bytes_sends_a_multi_line_command_as_one_bracketed_paste ... ok
test terminal::cmd_editor::tests::the_paste_mark_lasts_exactly_one_line ... ok
test terminal::view::tests::submit_bytes_normalizes_line_breaks_inside_the_paste ... ok
test terminal::view::tests::submit_bytes_types_a_plain_single_line_instead_of_pasting_it ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 1463 filtered out
```

Full `cargo test --bin tty7-app`: **1469 passed, 0 failed** on the final run (the known `a_routed_auth_prompt_carries_the_machine_that_raised_it` flake, which also fails on a clean tree, did not fire this time). `cargo fmt` clean; `cargo clippy --all-targets` reports the same
11 pre-existing warnings in the touched files before and after.
