### PR TITLE
test(ui): run the window and pane gpui tests on Windows too

### DIFF
--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -98,7 +98,7 @@ pub fn declare_displayed(cx: &App, panes: impl IntoIterator<Item = (EntityId, bo
 
 /// What the registry holds for `id`: `None` when the pane never registered
 /// (or already released), otherwise the flag the output gate would consult.
-#[cfg(all(test, unix))]
+#[cfg(test)]
 pub(crate) fn displayed_for_test(cx: &App, id: EntityId) -> Option<bool> {
     cx.try_global::<DisplayedRegistry>()?
         .0
@@ -8848,34 +8848,54 @@ mod tests {
     }
 }
 
+/// A connected pair of [`crate::daemon::transport::Stream`]s, one for each end
+/// of a pane's link to its daemon.
+///
+/// The client half is what a pane really reads and writes; the daemon half is
+/// the test's, to speak protocol into.
+///
+/// This is the one thing a pane harness needs that Unix and Windows spell
+/// differently — `socketpair` there, a loopback connect here — and every gpui
+/// test in this crate is portable once it goes through this instead of naming
+/// `UnixStream` itself.
+#[cfg(test)]
+pub(crate) fn test_stream_pair() -> (
+    crate::daemon::transport::Stream,
+    crate::daemon::transport::Stream,
+) {
+    #[cfg(unix)]
+    {
+        std::os::unix::net::UnixStream::pair().unwrap()
+    }
+    #[cfg(windows)]
+    {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client_side = std::net::TcpStream::connect(addr).unwrap();
+        let (daemon_side, _) = listener.accept().unwrap();
+        (client_side, daemon_side)
+    }
+}
+
 #[cfg(test)]
 pub(crate) fn quiet_test_pane(
     pane_id: u64,
     window: &mut Window,
     cx: &mut gpui::App,
 ) -> (gpui::Entity<TerminalView>, crate::daemon::transport::Stream) {
-    #[cfg(unix)]
-    let (client_side, daemon_side) = std::os::unix::net::UnixStream::pair().unwrap();
-    #[cfg(windows)]
-    let (client_side, daemon_side) = {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = listener.local_addr().unwrap();
-        let client_side = std::net::TcpStream::connect(addr).unwrap();
-        let (daemon_side, _) = listener.accept().unwrap();
-        (client_side, daemon_side)
-    };
+    let (client_side, daemon_side) = test_stream_pair();
     let terminal = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24))
         .expect("quiet test terminal");
     let view = cx.new(|cx| TerminalView::with_terminal(terminal, pane_id, window, cx));
     (view, daemon_side)
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 pub(crate) fn quiet_test_ssh_pane(
     pane_id: u64,
     window: &mut Window,
     cx: &mut gpui::App,
-) -> (gpui::Entity<TerminalView>, std::os::unix::net::UnixStream) {
+) -> (gpui::Entity<TerminalView>, crate::daemon::transport::Stream) {
     let (view, stream) = quiet_test_pane(pane_id, window, cx);
     view.update(cx, |view, _| {
         view.ssh_spec = Some(Box::new(
@@ -8888,20 +8908,20 @@ pub(crate) fn quiet_test_ssh_pane(
     (view, stream)
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod gpui_tests {
     use super::*;
     use crate::daemon::protocol::{ClientMsg, DaemonMsg};
+    use crate::daemon::transport::Stream;
     use gpui::{Entity, TestAppContext, point};
-    use std::os::unix::net::UnixStream;
 
-    fn harness(cx: &mut TestAppContext) -> (gpui::WindowHandle<TerminalView>, UnixStream) {
+    fn harness(cx: &mut TestAppContext) -> (gpui::WindowHandle<TerminalView>, Stream) {
         // Building a view reads the config. Whether that hit the real user
         // directory used to come down to which test happened to pin the
         // scratch dir first.
         crate::core::config::pin_test_config_dir();
         cx.executor().allow_parking();
-        let (client_side, daemon_side) = UnixStream::pair().unwrap();
+        let (client_side, daemon_side) = super::test_stream_pair();
         cx.update(|cx| {
             gpui_component::init(cx);
             cx.set_global(Config::default());
@@ -8926,11 +8946,11 @@ mod gpui_tests {
     ) -> (
         gpui::WindowHandle<gpui_component::Root>,
         Entity<TerminalView>,
-        UnixStream,
+        Stream,
     ) {
         crate::core::config::pin_test_config_dir();
         cx.executor().allow_parking();
-        let (client_side, daemon_side) = UnixStream::pair().unwrap();
+        let (client_side, daemon_side) = super::test_stream_pair();
         cx.update(|cx| {
             gpui_component::init(cx);
             cx.set_global(Config::default());
@@ -8956,7 +8976,7 @@ mod gpui_tests {
     fn prompt_ready(
         window: &gpui::WindowHandle<TerminalView>,
         cx: &mut TestAppContext,
-        daemon: &mut UnixStream,
+        daemon: &mut Stream,
     ) {
         DaemonMsg::Prompt {
             active: true,
@@ -8980,7 +9000,7 @@ mod gpui_tests {
     fn alt_screen_ready(
         window: &gpui::WindowHandle<TerminalView>,
         cx: &mut TestAppContext,
-        daemon: &mut UnixStream,
+        daemon: &mut Stream,
     ) {
         DaemonMsg::Output(b"\x1b[?1049h".to_vec())
             .encode(daemon)
@@ -9008,7 +9028,7 @@ mod gpui_tests {
             .encode(&mut daemon)
             .unwrap();
 
-        let report = |status: AgentStatus, daemon: &mut UnixStream| {
+        let report = |status: AgentStatus, daemon: &mut Stream| {
             DaemonMsg::AgentStatus(Some(AgentSessionState {
                 status,
                 message: None,
@@ -9115,7 +9135,7 @@ mod gpui_tests {
         status: crate::core::cli_agent::AgentStatus,
         pane: &gpui::Entity<TerminalView>,
         cx: &mut TestAppContext,
-        daemon: &mut UnixStream,
+        daemon: &mut Stream,
     ) {
         use crate::core::cli_agent::AgentSessionState;
 
@@ -9565,6 +9585,15 @@ mod gpui_tests {
     /// must not have made the promise. Otherwise those paths sit "not answered
     /// yet" for the life of the pane — no underline, and a click that says
     /// nothing, which is the silence this whole path exists to remove.
+    ///
+    /// Unix-only because the path it prints is: `Path::new("/etc/hosts")`
+    /// is not absolute on Windows, so `FileCandidate::paths` measures it
+    /// from the roots rather than letting it stand alone — and a workspace
+    /// that never connected has no roots, so nothing is ever wanted. Which
+    /// is itself the divergence: a Windows tty7 looking at a *remote* Linux
+    /// pane never probes the POSIX paths that pane prints, and so never
+    /// underlines them.
+    #[cfg(unix)]
     #[gpui::test]
     fn a_probe_with_no_host_to_ask_stays_wanted(cx: &mut TestAppContext) {
         let (window, mut daemon) = harness(cx);
@@ -9756,7 +9785,7 @@ mod gpui_tests {
             .unwrap();
     }
 
-    fn next_input(daemon: &mut UnixStream) -> Vec<u8> {
+    fn next_input(daemon: &mut Stream) -> Vec<u8> {
         loop {
             match ClientMsg::read(daemon).expect("client socket stays open") {
                 ClientMsg::Input(bytes) => return bytes,
@@ -9788,7 +9817,7 @@ mod gpui_tests {
         }
     }
 
-    fn next_input_until_timeout(daemon: &mut UnixStream) -> Option<Vec<u8>> {
+    fn next_input_until_timeout(daemon: &mut Stream) -> Option<Vec<u8>> {
         use std::io::ErrorKind;
 
         daemon
@@ -12533,7 +12562,7 @@ mod gpui_tests {
         }
         assert_eq!(seen, "before", "the pre-drop screen is what we relink over");
 
-        let (new_client, mut new_daemon) = UnixStream::pair().unwrap();
+        let (new_client, mut new_daemon) = super::test_stream_pair();
         window
             .update(cx, |view, _, cx| {
                 view.adopt_relink(

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -9282,14 +9282,13 @@ pub(crate) mod test_window {
     }
 
     /// A window carrying `n` quiet tabs, active on the first.
-    #[cfg(unix)]
     pub(crate) fn harness_with_tabs(
         cx: &mut TestAppContext,
         n: usize,
     ) -> (
         Entity<Tty7App>,
         VisualTestContext,
-        Vec<std::os::unix::net::UnixStream>,
+        Vec<crate::daemon::transport::Stream>,
     ) {
         use crate::terminal::view::quiet_test_pane;
         use crate::ui::pane::{Pane, PaneSlot};
@@ -9316,13 +9315,12 @@ pub(crate) mod test_window {
         (app, vcx, streams)
     }
 
-    #[cfg(unix)]
     pub(crate) fn harness_with_pane(
         cx: &mut TestAppContext,
     ) -> (
         Entity<Tty7App>,
         VisualTestContext,
-        std::os::unix::net::UnixStream,
+        crate::daemon::transport::Stream,
     ) {
         use crate::terminal::view::quiet_test_pane;
         use crate::ui::pane::{Pane, PaneSlot};
@@ -9371,7 +9369,6 @@ pub(crate) mod test_window {
     /// another frame 250ms later. So the sleep below is load-bearing too, and
     /// a round that drew nothing is not on its own enough to stop on — a burst
     /// still open is a frame already owed.
-    #[cfg(unix)]
     pub(crate) fn quiesce(vcx: &mut VisualTestContext, cwd: Option<&std::path::Path>) {
         use crate::terminal::git_data::ScmData;
         use crate::terminal::git_status::GitStatusCache;
@@ -9483,7 +9480,7 @@ mod cursor_blink_gpui_tests {
     }
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod ssh_rebuild_gpui_tests {
     use super::test_window::harness_with_pane;
     use crate::core::session::{
@@ -9920,9 +9917,7 @@ mod shell_menu_gpui_tests {
     }
 }
 
-// `harness_with_tabs` hands back the panes' `UnixStream`s, so it exists only
-// on unix — same as `ssh_rebuild_gpui_tests` below it.
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod rename_gpui_tests {
     use gpui::TestAppContext;
 
@@ -10006,7 +10001,7 @@ mod rename_gpui_tests {
 // everything else hidden; a pane nobody has declared — or whose id nobody
 // registered — must err toward displayed, because the failure direction that
 // matters is a visible pane that stops repainting.
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod displayed_gpui_tests {
     use gpui::TestAppContext;
 
@@ -10107,7 +10102,7 @@ mod displayed_gpui_tests {
 
 // Zoom is a tab's view state: it rides with the tab across a switch, while a
 // layout change (drag, split, close) still clears it.
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod zoom_gpui_tests {
     use gpui::TestAppContext;
 
@@ -10155,7 +10150,7 @@ mod zoom_gpui_tests {
 // test config dir and nothing is listening on it — so every forward request
 // fails. That is exactly the case these are about: what the panel and the form
 // are left holding when the far side does not answer.
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod managed_forward_gpui_tests {
     use gpui::TestAppContext;
     use gpui_component::input::InputState;

--- a/src/ui/diff_overlay.rs
+++ b/src/ui/diff_overlay.rs
@@ -2470,13 +2470,17 @@ mod overlay_gpui_tests {
 /// the repository has left. That is what the stale entry below stands for.
 ///
 /// Unix-only, and not for the harness: on Windows the repository root git
-/// reports (`C:/Users/—`, forward slashes, straight out of MSYS2 git) is
-/// not the root the seeded cache below holds, so `scm_epoch` never agrees
-/// with the landing snapshot and the overlay re-probes on every frame —
-/// `load` reaches `Ready` and `loading` goes straight back to `true`,
-/// which is the exact spin this test exists to catch. That is a real
-/// divergence in the SCM layer's path comparisons rather than a test
-/// artefact, so the gate stays until those roots are compared normalised.
+/// reports (`C:/Users/—`, straight out of MSYS2 git) is not the root the
+/// seeded cache below holds. Not for the slash direction — `Path` compares
+/// by component, so `C:/x` and `C:\x` are already equal. The splitter is
+/// the prefix: the seeded root came past `fs::canonicalize`, which spells
+/// it `\\?\C:\Users\—` and makes its prefix component `VerbatimDisk` where
+/// git's answer parses as `Disk`. So `scm_epoch` never agrees with the
+/// landing snapshot and the overlay re-probes on every frame — `load`
+/// reaches `Ready` and `loading` goes straight back to `true`, which is the
+/// exact spin this test exists to catch. That is a real divergence in the
+/// SCM layer's path comparisons rather than a test artefact, so the gate
+/// stays until those roots are keyed by one spelling (#796).
 #[cfg(all(test, unix))]
 mod render_idle_gpui_tests {
     use super::*;

--- a/src/ui/diff_overlay.rs
+++ b/src/ui/diff_overlay.rs
@@ -2191,7 +2191,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod overlay_gpui_tests {
     use super::*;
     use crate::ui::app::test_window;
@@ -2469,8 +2469,14 @@ mod overlay_gpui_tests {
 /// terminal, an editor, a worktree command — and the cached branch is a branch
 /// the repository has left. That is what the stale entry below stands for.
 ///
-/// Unix-gated like every other window harness in this tree: `harness_with_tabs`
-/// hands back a `std::os::unix::net::UnixStream` for the pane.
+/// Unix-only, and not for the harness: on Windows the repository root git
+/// reports (`C:/Users/—`, forward slashes, straight out of MSYS2 git) is
+/// not the root the seeded cache below holds, so `scm_epoch` never agrees
+/// with the landing snapshot and the overlay re-probes on every frame —
+/// `load` reaches `Ready` and `loading` goes straight back to `true`,
+/// which is the exact spin this test exists to catch. That is a real
+/// divergence in the SCM layer's path comparisons rather than a test
+/// artefact, so the gate stays until those roots are compared normalised.
 #[cfg(all(test, unix))]
 mod render_idle_gpui_tests {
     use super::*;

--- a/src/ui/file_tree.rs
+++ b/src/ui/file_tree.rs
@@ -2931,7 +2931,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod render_idle_gpui_tests {
     use super::*;
     use crate::daemon::protocol::DaemonMsg;
@@ -2959,7 +2959,7 @@ mod render_idle_gpui_tests {
     ) -> (
         Entity<Tty7App>,
         VisualTestContext,
-        std::os::unix::net::UnixStream,
+        crate::daemon::transport::Stream,
     ) {
         let (app, mut vcx, mut pane) = test_window::harness_with_pane(cx);
         DaemonMsg::Cwd(root.to_path_buf())
@@ -3558,7 +3558,7 @@ mod render_idle_gpui_tests {
 /// What these cannot reach is the hit test — whether the row under the cursor
 /// is the one that gets the drop is decided by gpui's hitbox stack, and there
 /// is no headless way to put a cursor over a row.
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod drop_gpui_tests {
     use super::render_idle_gpui_tests::{files_panel_on, rows, scratch, serial, settle};
     use super::*;

--- a/src/ui/scm/detail.rs
+++ b/src/ui/scm/detail.rs
@@ -977,13 +977,15 @@ mod tests {
 ///
 /// Still unix-only, and for a reason worth naming rather than a harness
 /// one: on Windows `git rev-parse --show-toplevel` (Git for Windows is
-/// MSYS2) prints `C:/Users/—` with forward slashes, and that string is
-/// what `tty7_core::core::git::probe` stores as `RepoSnapshot::root`.
-/// Every comparison here — and in the SCM cache — is a plain `PathBuf`
-/// equality against a path the OS spelled `C:\Users\`, so the two never
-/// match and the panel never settles on the directory it is already
-/// showing. Taking the gate off needs those roots compared normalised,
-/// the way `ui::path_display` already normalises for display.
+/// MSYS2) prints `C:/Users/—`, and that string is what
+/// `tty7_core::core::git::probe` stores as `RepoSnapshot::root`. The
+/// forward slashes are not what breaks it — `Path` compares by component,
+/// so `C:/x` and `C:\x` are equal. The prefix is: `scratch` below hands the
+/// pane `fs::canonicalize`'s `\\?\C:\Users\—`, whose prefix component is
+/// `VerbatimDisk` where git's answer parses as `Disk`, so the plain
+/// `PathBuf` equalities here — and in the SCM cache — never match and the
+/// panel never settles on the directory it is already showing. Taking the
+/// gate off needs those roots keyed by one spelling (#796).
 #[cfg(all(test, unix))]
 mod detail_gpui_tests {
     use super::*;

--- a/src/ui/scm/detail.rs
+++ b/src/ui/scm/detail.rs
@@ -974,6 +974,16 @@ mod tests {
 /// here — a missing global, a theme token, a slice through the middle of a
 /// character — goes wrong during layout and paint, so these arm the render
 /// probe and insist something was actually drawn.
+///
+/// Still unix-only, and for a reason worth naming rather than a harness
+/// one: on Windows `git rev-parse --show-toplevel` (Git for Windows is
+/// MSYS2) prints `C:/Users/—` with forward slashes, and that string is
+/// what `tty7_core::core::git::probe` stores as `RepoSnapshot::root`.
+/// Every comparison here — and in the SCM cache — is a plain `PathBuf`
+/// equality against a path the OS spelled `C:\Users\`, so the two never
+/// match and the panel never settles on the directory it is already
+/// showing. Taking the gate off needs those roots compared normalised,
+/// the way `ui::path_display` already normalises for display.
 #[cfg(all(test, unix))]
 mod detail_gpui_tests {
     use super::*;
@@ -1043,7 +1053,7 @@ mod detail_gpui_tests {
     ) -> (
         Entity<Tty7App>,
         VisualTestContext,
-        std::os::unix::net::UnixStream,
+        crate::daemon::transport::Stream,
     ) {
         let (app, mut vcx, mut pane) = test_window::harness_with_pane(cx);
         DaemonMsg::Cwd(root.to_path_buf())

--- a/src/ui/scm/graph.rs
+++ b/src/ui/scm/graph.rs
@@ -2286,9 +2286,16 @@ mod render_idle_gpui_tests {
             ));
         }
 
-        let (app, mut vcx, _pane) = test_window::harness_with_pane(cx);
+        // The daemon end is held for the life of the test, the way every other
+        // panel harness holds it. `&mut { _pane }` dropped it on the spot: on
+        // Unix a closed `socketpair` half still delivers the `Cwd` written a
+        // moment earlier, but on Windows the link is a loopback `TcpStream`,
+        // and closing one with the pane's own `Resize` sitting unread on it is
+        // an abortive close — the `Cwd` goes with the connection, and the test
+        // spends its 30s deadline waiting for a cwd that was thrown away.
+        let (app, mut vcx, mut pane) = test_window::harness_with_pane(cx);
         crate::daemon::protocol::DaemonMsg::Cwd(root.clone())
-            .encode(&mut { _pane })
+            .encode(&mut pane)
             .expect("the pane's socket takes the cwd");
         app.update_in(&mut vcx, |app, _, cx| {
             app.right_panel_visible = true;

--- a/src/ui/scm/graph.rs
+++ b/src/ui/scm/graph.rs
@@ -2186,11 +2186,7 @@ mod tests {
 /// way to know is to settle the window and count frames. Same shape as the file
 /// tree's own idle tests, including the serial lock: the render probe is
 /// thread-local and two of these at once would count each other's frames.
-///
-/// `unix` for the same reason `panel.rs`, `detail.rs` and `file_tree.rs` gate
-/// theirs: a real pane means `test_window::harness_with_pane`, and that harness
-/// hands back a `std::os::unix::net::UnixStream`.
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod render_idle_gpui_tests {
     use super::*;
     use crate::ui::app::{render_probe, test_window};

--- a/src/ui/scm/panel.rs
+++ b/src/ui/scm/panel.rs
@@ -2975,10 +2975,13 @@ mod render_idle_gpui_tests {
     }
 
     /// The only test in this module that waits on `repo.root`, and so the
-    /// only one Windows cannot run: git spells that root `C:/Users/—` and
-    /// the pane's own cwd is spelled `C:\Users\`, so the equality below
-    /// never holds there. Its sibling keys off the pane's cwd instead, and
-    /// runs everywhere.
+    /// only one Windows cannot run: git spells that root `C:/Users/—`, which
+    /// parses to a `Disk` prefix, while the pane's cwd came out of `scratch`
+    /// above — `fs::canonicalize`, so `\\?\C:\Users\—` and a `VerbatimDisk`
+    /// prefix — and the equality below never holds between the two. The
+    /// slashes are the red herring here; `Path` compares by component, so
+    /// `C:/x` and `C:\x` are equal. Its sibling keys off the pane's cwd
+    /// instead, and runs everywhere.
     #[cfg(unix)]
     #[gpui::test]
     fn a_settled_source_control_panel_reaches_render_idle(cx: &mut TestAppContext) {

--- a/src/ui/scm/panel.rs
+++ b/src/ui/scm/panel.rs
@@ -2888,7 +2888,7 @@ mod tests {
 /// `default_global`, which fires the global observers whether or not anything
 /// changed, and it is called every frame. A watcher that notified on every one
 /// of those would request a frame from inside a frame and never stop.
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod render_idle_gpui_tests {
     use super::*;
     use crate::daemon::protocol::DaemonMsg;
@@ -2927,7 +2927,7 @@ mod render_idle_gpui_tests {
     ) -> (
         Entity<Tty7App>,
         VisualTestContext,
-        std::os::unix::net::UnixStream,
+        crate::daemon::transport::Stream,
     ) {
         let (app, mut vcx, mut pane) = test_window::harness_with_pane(cx);
         DaemonMsg::Cwd(root.to_path_buf())
@@ -2974,6 +2974,12 @@ mod render_idle_gpui_tests {
         render_probe::draws()
     }
 
+    /// The only test in this module that waits on `repo.root`, and so the
+    /// only one Windows cannot run: git spells that root `C:/Users/—` and
+    /// the pane's own cwd is spelled `C:\Users\`, so the equality below
+    /// never holds there. Its sibling keys off the pane's cwd instead, and
+    /// runs everywhere.
+    #[cfg(unix)]
     #[gpui::test]
     fn a_settled_source_control_panel_reaches_render_idle(cx: &mut TestAppContext) {
         let _serial = serial();

--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -3687,7 +3687,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod gpui_tests {
     use gpui::{Modifiers, TestAppContext};
 

--- a/src/ui/tree_sync.rs
+++ b/src/ui/tree_sync.rs
@@ -3686,7 +3686,6 @@ mod tests {
     /// the window shows one, and the one it could not put up must not come out
     /// of a `Full` diff as `TabClose` — that op deleted from the machine exactly
     /// the tabs a restart had failed to bring back, panes and all (#672).
-    #[cfg(unix)]
     #[gpui::test]
     fn the_next_sync_leaves_a_tab_the_rebuild_could_not_put_up_on_the_machine(
         cx: &mut gpui::TestAppContext,
@@ -3775,7 +3774,6 @@ mod tests {
     /// straight after clears the queue, so by the time a test can look the
     /// ops are gone either way — while `informed` outliving the arrival is
     /// both durable and the thing that made them possible.
-    #[cfg(unix)]
     #[gpui::test]
     fn arriving_at_a_workspace_does_not_prune_what_is_already_in_it(cx: &mut gpui::TestAppContext) {
         let (app, mut vcx, _pane_stream) = crate::ui::app::test_window::harness_with_pane(cx);


### PR DESCRIPTION
## Why

Large blocks of the gpui/UI tests were gated `#[cfg(all(test, unix))]`, so they were silently skipped on the platform tty7 ships on. Three of the gates say in their own doc comments exactly why they exist:

> `unix` for the same reason `panel.rs`, `detail.rs` and `file_tree.rs` gate theirs: a real pane means `test_window::harness_with_pane`, and that harness hands back a `std::os::unix::net::UnixStream`.

That is the whole reason — the *type* of the daemon-side handle, not any Unix behaviour under test. And it stopped being true on 2026-08-28, when #736 gave `quiet_test_pane` a loopback fallback for Windows. The gates were written on 2026-07-29 (#249) and 2026-08-07 (#380); nobody came back for them.

## What changed

`terminal::view::test_stream_pair()` — the `socketpair`/loopback-connect split factored out of `quiet_test_pane`, returning `daemon::transport::Stream` (a `UnixStream` on Unix, a `TcpStream` on Windows). `harness_with_pane`, `harness_with_tabs`, `quiesce`, `quiet_test_ssh_pane` and every downstream harness now name only that portable type, so their gates come off.

No product code is touched; this is test gating only.

## Before / after, on Windows

| `cargo test --bin tty7-app` | tests | harness wall clock |
| --- | --- | --- |
| `origin/main` | 1468 | 3.2 – 3.5 s (4 runs) |
| this branch | 1638 | 16.1 – 17.6 s typical (11 runs); 20.5 s and 26.8 s seen once each |

Measured on Windows 11 / `x86_64-pc-windows-msvc`, warm target dir, default parallelism.

170 tests newly execute. Across eight full runs the only failure seen was the pre-existing `ui::remote_connect::tests::a_routed_auth_prompt_carries_the_machine_that_raised_it` flake, which already ran on Windows before this branch — it fails on `origin/main` too, in 3 of the 4 baseline runs above.

Modules ungated: `terminal::view::gpui_tests` (125), `ui::file_tree` render-idle + drop (17), `ui::switcher::gpui_tests` (14), `ui::app` ssh-rebuild / rename / displayed / zoom / managed-forward (10), `ui::diff_overlay::overlay_gpui_tests` (5), `ui::scm::graph` render-idle (1), `ui::scm::panel` render-idle (1 of 2), plus the two `ui::tree_sync` regressions — including `arriving_at_a_workspace_does_not_prune_what_is_already_in_it`, the guard for the #716 data-loss bug, which had never run on Windows.

## Runtime exposure, and why it is worth it

The suite gets roughly 5× slower on Windows: ~3.3 s → ~16.5 s. That deserves weighing against what CI already says about this step (`.github/workflows/ci.yml:121-136`):

> `cargo test` has no timeout of its own, so one hung test is indistinguishable from a slow suite until the job hits GitHub's six-hour limit. The suite intermittently hangs here — roughly one run in ten, on any branch […] Seen on Windows three times and on Linux once […] The step's honest budget is small: ~75s warm and ~3.5 min when this step also has to compile the test targets […] 20 minutes is pure headroom, so a trip means a hang, not a slow runner.

So, stated plainly: this branch adds ~170 window tests to the Windows run, each of which calls `allow_parking()` and opens a real loopback socket. That is more surface for the existing intermittent hang, and it spends headroom that was sized against a much smaller step. The measured worst case is 26.8 s against a 20-minute cap, so the "a trip means a hang, not a slow runner" reading of that cap still holds — but Windows now has more places to hang than it did, and if that one-in-ten hang starts landing on Windows more often, this branch is the first thing to look at.

The mitigating fact is what these tests now exercise. `transport.rs:371` already sets `Stream = TcpStream` on Windows **in production** — the daemon link a real pane uses on Windows is a loopback TCP socket. Before this branch, the Windows CI run exercised that transport in almost no window-level test; the coverage those tests did have came from a `socketpair` path that ships nowhere. They are slower because they are finally doing what the shipped binary does.

## What stays gated, and why

Two Windows-only **product** divergences turned up. Neither is fixed here, and neither test was adjusted to paper over it — the gate stays, with the reason written at the gate. **Both have since been fixed in separate PRs**; see the follow-up section below.

**1. A POSIX absolute path is not absolute on Windows.** → fixed by #795

`terminal::view::gpui_tests::a_probe_with_no_host_to_ask_stays_wanted` prints `/etc/hosts` into a pane bound to a remote workspace. `Path::new("/etc/hosts").is_absolute()` is `false` on Windows, so `FileCandidate::paths` measures it from the link roots instead of letting it stand alone; a workspace that never connected has no roots, so nothing is ever wanted. The consequence outside the test: **a Windows tty7 looking at a remote Linux pane never probes the POSIX paths that pane prints, and so never underlines them.** `search.rs` already half-knows this — `a_rooted_candidate_is_told_apart_from_one_measured_from_a_root` is `#[cfg(unix)]` with a comment saying exactly that — but the pane path was never followed through.

**2. A repository is keyed by two different spellings of its root.** → fixed by #796

The SCM panel finds the repository and then never settles on it; the diff overlay reaches `DiffLoad::Ready` and `loading` goes straight back to `true`, because `scm_epoch` compares the seeded root against the landing snapshot's root and never agrees. That is a re-probe every frame — the exact spin `diff_overlay::render_idle_gpui_tests` was written to catch, still live on Windows.

Instrumenting it gave `want="\\?\C:\Users\…\tty7-detail-seeded" got=Some("C:/Users/…/tty7-detail-seeded")`, and my first reading blamed the slash direction. That was wrong: `Path` compares by component on Windows, so `C:/x` and `C:\x` are equal. #796's author pinned the actual splitter — the `\\?\` extended-length prefix `fs::canonicalize` returns, which makes the prefix component `VerbatimDisk` where git's answer parses as `Disk`. They also measured the cost of the spin: two `git` processes per lap.

Left gated for the honest reasons (unchanged): `core::cli_install::unix_tests` (symlinks into `/bin`, `PermissionsExt`), `main.rs::tests` (`merge_paths` is itself `#[cfg(unix)]`), `terminal::generator` (`sleep 5`, `printf`, `; exit 1` under a POSIX shell), and the individual symlink/permission tests in `ui::file_copy` and `ui::file_tree`.

## Follow-up: the three gated suites are unblocked by #796

Per #796's author, with that fix in place:

- `ui::diff_overlay::render_idle_gpui_tests` (1) passes on **#796 alone** — nothing needed here.
- `ui::scm::detail::detail_gpui_tests` (5) and `ui::scm::panel::…::a_settled_source_control_panel_reaches_render_idle` (1) pass once each module's `scratch()` helper stops asserting against `fs::canonicalize`'s `\\?\` spelling — a **one-line change in each of two helpers, both of them in this PR's files**: `fn scratch` in `src/ui/scm/detail.rs` and `fn scratch` in `src/ui/scm/panel.rs`. #796 deliberately left them alone, to keep that PR to product code.

With those, all 23 tests this PR leaves gated go green, and the filtered set's runtime drops from 218 s to 23 s.

**Deliberately not done here.** Un-gating them inside #791 would fail CI, because #796 is what makes them pass and #796 has not merged. The un-gating should follow #796 — either as a commit on this branch once #796 lands, or as a small follow-up PR.

## Not in scope

`tty7-core` has 121 more tests behind unix gates (1139 of 1260 run on Windows). Some are genuinely POSIX (`core::proc` shells out to `sleep`/`sh`/`/dev/zero`; the socket-path tests in `daemon::transport`); others look portable in the same way these were — `host::server::tests` (43) builds its pairs with `UnixStream::pair` and `RemoteHost::over_unix`, and both `Duplex for TcpStream` and `RemoteHost::over_tcp` already exist. Left for a separate pass.
