### PR TITLE
feat(ui): make opening a new window a bindable action (#710)

### DIFF
--- a/docs/reference/keyboard-shortcuts.mdx
+++ b/docs/reference/keyboard-shortcuts.mdx
@@ -17,6 +17,7 @@ it shows what *your* copy is bound to. This is the shipped default.
 | Go to Tab 1–9 | <kbd>⌘ 1</kbd>…<kbd>⌘ 9</kbd> | <kbd>Alt 1</kbd>…<kbd>Alt 9</kbd> |
 | New Workspace | <kbd>⌘ ⇧ N</kbd> | <kbd>Ctrl ⇧ N</kbd> |
 | Switch Workspace | <kbd>⌘ ⇧ O</kbd> | <kbd>Ctrl ⇧ O</kbd> |
+| New Window | <kbd>⌘ N</kbd> | — |
 
 ## Panes
 

--- a/src/core/actions.rs
+++ b/src/core/actions.rs
@@ -18,6 +18,7 @@ actions!(
         SelectWorkspace7,
         SelectWorkspace8,
         SelectWorkspace9,
+        NewWindow,
         CloseActiveTab,
         RenameTab,
         NewWorktreeTab,

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1468,6 +1468,22 @@ impl Tty7App {
         crate::ui::windows::refresh_menu(cx);
     }
 
+    /// Opens a second window, on a workspace of its own.
+    ///
+    /// A window on *this* workspace is not the other reading of "new window";
+    /// it is a thing the app cannot hold. `WindowRegistry` is keyed by
+    /// workspace — `window_for`, `app_for`, `unregister` and `rebind` all
+    /// address a window by the workspace it shows — and `windows::open`
+    /// answers a workspace that already has a window by activating it. Asking
+    /// for the current one here would raise the window you are already in.
+    ///
+    /// So this is the same call the switcher makes for "Open in New Window",
+    /// with no workspace named: a fresh one, which is also what a new window
+    /// holds everywhere else it is offered.
+    pub(crate) fn new_window(&self, cx: &mut App) {
+        crate::ui::windows::open(cx, None);
+    }
+
     pub(crate) fn teardown_workspace_forwards(&self, cx: &gpui::App) {
         let Some(route) = self
             .tabs
@@ -4892,6 +4908,7 @@ impl Tty7App {
         match kind {
             NewTab => self.new_tab(window, cx),
             NewWorkspace => self.open_workspace_form(window, cx),
+            NewWindow => self.new_window(cx),
             OpenWorkspacePicker => self.open_switcher(window, cx),
             StopWorkspace => self.stop_workspace(self.workspace, window, cx),
             DeleteWorkspace => self.delete_workspace(self.workspace, window, cx),
@@ -7390,6 +7407,9 @@ impl Render for Tty7App {
                 }))
                 .on_action(cx.listener(|this, _: &NewWorkspace, window, cx| {
                     this.open_workspace_form(window, cx);
+                }))
+                .on_action(cx.listener(|this, _: &NewWindow, _window, cx| {
+                    this.new_window(cx);
                 }))
                 .on_action(cx.listener(|this, _: &CloseActiveTab, window, cx| {
                     if !this.editor_close_active_if_focused(window, cx) {
@@ -10242,5 +10262,87 @@ mod managed_forward_gpui_tests {
             );
             assert!(app.loopback_panel.mf_error.is_some());
         });
+    }
+}
+
+#[cfg(test)]
+mod new_window_action_tests {
+    use crate::core::actions::NewWindow;
+    use crate::core::config::Config;
+    use crate::core::session::Session;
+    use crate::ui::app::Tty7App;
+    use crate::ui::windows::WindowRegistry;
+    use gpui::{AppContext as _, TestAppContext, VisualTestContext};
+
+    /// `NewWindow` has to open a window, not merely exist.
+    ///
+    /// Everything else about the action is a table entry — the `actions!`
+    /// row, the keymap slot, the palette command — and every one of those can
+    /// be there while the action reaches nothing. This drives the real
+    /// dispatch path and then asks the registry, so the assertion is "a second
+    /// window is open, on a workspace of its own, and the first one is still
+    /// here": the same `windows::open` the switcher calls for "Open in New
+    /// Window", with no workspace named.
+    #[gpui::test]
+    fn dispatching_new_window_opens_a_second_window_beside_the_first(cx: &mut TestAppContext) {
+        crate::core::config::pin_test_config_dir();
+        cx.executor().allow_parking();
+        cx.update(|cx| {
+            gpui_component::init(cx);
+            cx.set_global(Config::default());
+            crate::ui::keymap::init(cx);
+            WindowRegistry::init(cx);
+        });
+        let window = cx.add_window(|window, cx| {
+            let app =
+                cx.new(|cx| Tty7App::with_session(None, Some(Session::default()), window, cx));
+            gpui_component::Root::new(app, window, cx)
+        });
+        let app = window
+            .update(cx, |root, _, _| {
+                root.view()
+                    .clone()
+                    .downcast::<Tty7App>()
+                    .ok()
+                    .expect("window root wraps a Tty7App")
+            })
+            .unwrap();
+        // Registered the way an opened window registers itself; without it the
+        // registry cannot tell the two windows apart afterwards.
+        let handle = window.into();
+        let weak = app.downgrade();
+        app.update(cx, |app, cx| {
+            WindowRegistry::register(cx, app.workspace, handle, weak);
+        });
+
+        let mut vcx = VisualTestContext::from_window(handle, cx);
+        vcx.background_executor.run_until_parked();
+        let first = app.update(&mut vcx, |app, _| app.workspace);
+        assert_eq!(
+            vcx.update(|_, cx| WindowRegistry::count(cx)),
+            1,
+            "the harness starts with exactly the one window"
+        );
+
+        vcx.dispatch_action(NewWindow);
+        vcx.background_executor.run_until_parked();
+
+        let open = vcx.update(|_, cx| WindowRegistry::open_windows(cx));
+        assert_eq!(
+            open.len(),
+            2,
+            "NewWindow has to reach windows::open; it opened {} window(s)",
+            open.len()
+        );
+        assert!(
+            open.iter().any(|(id, _)| *id == first),
+            "the window the action was fired from must survive it"
+        );
+        // The registry is keyed by workspace, so a second window on the
+        // current one is not a thing it could tell apart from the first.
+        assert!(
+            open.iter().any(|(id, _)| *id != first),
+            "the new window belongs on a workspace of its own"
+        );
     }
 }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -10345,4 +10345,39 @@ mod new_window_action_tests {
             "the new window belongs on a workspace of its own"
         );
     }
+
+    /// The windowless state is the one `NewWindow` exists for.
+    ///
+    /// `show_tray_icon` is on by default, so closing the last window retires
+    /// tty7 to the tray rather than quitting it: the process is alive, the
+    /// menu bar is still tty7's, and there is nothing on screen. A listener
+    /// that lives only on `Tty7App`'s render root reaches nothing there, and
+    /// the chord that means "give me a window" is the one chord that has to
+    /// answer. `App::dispatch_action` falls through to the global listeners
+    /// when no window is active, which is where `keymap::init` puts this one.
+    #[gpui::test]
+    fn new_window_answers_with_no_window_to_dispatch_it(cx: &mut TestAppContext) {
+        crate::core::config::pin_test_config_dir();
+        cx.executor().allow_parking();
+        cx.update(|cx| {
+            gpui_component::init(cx);
+            cx.set_global(Config::default());
+            crate::ui::keymap::init(cx);
+            WindowRegistry::init(cx);
+            assert_eq!(
+                WindowRegistry::count(cx),
+                0,
+                "the retired-to-tray state this covers has no window in it"
+            );
+            cx.dispatch_action(&NewWindow);
+        });
+        cx.run_until_parked();
+        cx.update(|cx| {
+            assert_eq!(
+                WindowRegistry::count(cx),
+                1,
+                "NewWindow has to reach windows::open with no window to bubble through"
+            );
+        });
+    }
 }

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -1403,6 +1403,7 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         L10nKey::CmdGroupAgents => "Agents",
         L10nKey::CmdGroupApplication => "Application",
         L10nKey::CmdNewTab => "New Tab",
+        L10nKey::CmdNewWindow => "New Window",
         L10nKey::CmdNewWorktreeTab => "New Worktree Tab…",
         L10nKey::CmdNewWorktreeTabSubtitle => "isolated checkout on a fresh branch",
         L10nKey::CmdRenameTab => "Rename Tab…",

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -1460,6 +1460,7 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         L10nKey::CmdGroupAgents => "エージェント",
         L10nKey::CmdGroupApplication => "アプリケーション",
         L10nKey::CmdNewTab => "新しいタブ",
+        L10nKey::CmdNewWindow => "新しいウィンドウ",
         L10nKey::CmdNewWorktreeTab => "新しいワークツリータブ…",
         L10nKey::CmdNewWorktreeTabSubtitle => "新しいブランチでの独立したチェックアウト",
         L10nKey::CmdRenameTab => "タブの名前を変更…",

--- a/src/ui/i18n/mod.rs
+++ b/src/ui/i18n/mod.rs
@@ -1123,6 +1123,7 @@ l10n_keys! {
     CmdGroupAgents,
     CmdGroupApplication,
     CmdNewTab,
+    CmdNewWindow,
     CmdNewWorktreeTab,
     CmdNewWorktreeTabSubtitle,
     CmdRenameTab,

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -1321,6 +1321,7 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         L10nKey::CmdGroupAgents => "Agents",
         L10nKey::CmdGroupApplication => "应用",
         L10nKey::CmdNewTab => "新标签页",
+        L10nKey::CmdNewWindow => "新建窗口",
         L10nKey::CmdNewWorktreeTab => "新建 worktree 标签页…",
         L10nKey::CmdNewWorktreeTabSubtitle => "在全新分支上独立检出",
         L10nKey::CmdRenameTab => "重命名标签页…",

--- a/src/ui/keymap.rs
+++ b/src/ui/keymap.rs
@@ -265,6 +265,16 @@ pub(crate) fn default_bindings() -> Vec<(&'static str, &'static str)> {
     vec![
         ("NewTab", per_platform("secondary-t", "secondary-shift-t")),
         ("NewWorkspace", "secondary-shift-n"),
+        // Cmd+N is what "New Window" means on macOS, and nothing else here
+        // claims it. Off macOS both chords the convention offers are gone:
+        // Ctrl+N is a C0 byte the shell is owed, which
+        // `no_default_binding_sits_on_a_terminal_control_code` fails a build
+        // over, and Ctrl+Shift+N — where that same test says window actions
+        // belong — has been `NewWorkspace` for far longer than this action has
+        // existed. Minting an unguessable third chord would be worse than
+        // shipping unbound: the palette and the Keybindings page both carry
+        // this, so a key is one line of config away.
+        ("NewWindow", per_platform("secondary-n", "")),
         (
             "CloseActiveTab",
             per_platform("secondary-w", "secondary-shift-w"),
@@ -733,6 +743,10 @@ fn authored_entry(action: &str) -> Option<(CommandGroup, String)> {
             CommandGroup::Application,
             t(L10nKey::AppMenuCommandPalette).to_string(),
         ),
+        "NewWindow" => (
+            CommandGroup::Application,
+            t(L10nKey::CmdNewWindow).to_string(),
+        ),
         "OpenSettings" => (
             CommandGroup::Application,
             t(L10nKey::CmdSettings).to_string(),
@@ -1036,6 +1050,7 @@ fn make_binding(action: &str, keystroke: &str) -> Option<KeyBinding> {
         "DeleteWorkspace" => KeyBinding::new(keystroke, DeleteWorkspace, None),
         "RenameWorkspace" => KeyBinding::new(keystroke, RenameWorkspace, None),
         "ToggleSwitcher" => KeyBinding::new(keystroke, ToggleSwitcher, None),
+        "NewWindow" => KeyBinding::new(keystroke, NewWindow, None),
         "CloseActiveTab" => KeyBinding::new(keystroke, CloseActiveTab, None),
         "RenameTab" => KeyBinding::new(keystroke, RenameTab, None),
         "NewWorktreeTab" => KeyBinding::new(keystroke, NewWorktreeTab, None),
@@ -1217,6 +1232,7 @@ mod tests {
         // palette and the docs all say Zoom Pane.
         assert_eq!(action_entry("ToggleMaximizePane").1, "Zoom Pane");
         assert_eq!(action_entry("CloseActiveTab").1, "Close Pane / Tab");
+        assert_eq!(action_entry("NewWindow").1, "New Window");
         assert_eq!(action_entry("ClearScrollback").1, "Clear Scrollback");
         assert_eq!(action_entry("TogglePalette").1, "Command Palette…");
         assert_eq!(action_entry("ToggleSwitcher").1, "Switch Workspace…");
@@ -1228,6 +1244,57 @@ mod tests {
         assert_eq!(action_entry("SelectWorkspace7").0, CommandGroup::Workspaces);
         assert_eq!(action_entry("ToggleSftp").0, CommandGroup::Ssh);
         assert_eq!(action_entry("ForkAgentSessionUp").0, CommandGroup::Agents);
+    }
+
+    #[test]
+    fn new_window_ships_a_chord_only_where_one_is_free() {
+        let mut effective: Vec<(String, String)> = default_bindings()
+            .into_iter()
+            .map(|(a, k)| (a.to_string(), k.to_string()))
+            .collect();
+        let default = effective
+            .iter()
+            .find(|(action, _)| action == "NewWindow")
+            .map(|(_, key)| key.clone())
+            .expect("NewWindow has to be listed here or it cannot be bound at all");
+        assert_eq!(
+            default,
+            if cfg!(target_os = "macos") {
+                "secondary-n"
+            } else {
+                ""
+            },
+            "macOS gets Cmd+N; off macOS this ships unbound on purpose"
+        );
+
+        // Ask the keymap rather than the table. A default can look bound and
+        // dispatch nothing — gpui folds shift into the punctuation glyph, so
+        // `secondary-shift-]` reached no action at all off macOS (#750). An
+        // exact match is also the conflict check: any other action holding
+        // this chord would show up in the list.
+        if !default.is_empty() {
+            assert_eq!(
+                dispatched(&effective, &default, "Terminal"),
+                vec![NewWindow::name_for_type()],
+                "{default} must reach NewWindow, and nothing else may answer it"
+            );
+        }
+
+        // Unbound still has to mean bindable. `set_binding` only writes into
+        // slots this table already has, and `make_binding` is what turns the
+        // name back into a dispatchable binding; miss either and the action
+        // sits on the Keybindings page, takes a key, and does nothing — which
+        // is the whole complaint in #710, not just the missing default.
+        effective
+            .iter_mut()
+            .find(|(action, _)| action == "NewWindow")
+            .expect("found once already")
+            .1 = "ctrl-alt-shift-n".to_string();
+        assert_eq!(
+            dispatched(&effective, "ctrl-alt-shift-n", "Terminal"),
+            vec![NewWindow::name_for_type()],
+            "a chord the user assigns to NewWindow has to reach it"
+        );
     }
 
     #[cfg(target_os = "macos")]

--- a/src/ui/keymap.rs
+++ b/src/ui/keymap.rs
@@ -28,6 +28,16 @@ pub fn init(cx: &mut App) {
     }
     rebuild_keymap(cx);
     cx.on_action(|_: &Quit, cx: &mut App| cx.quit());
+    // On the app rather than on a window, for the same reason `Quit` is: this
+    // is the one action in the table whose whole point is the state where no
+    // window is there to dispatch it. `show_tray_icon` is on by default, so
+    // closing the last window retires tty7 to the tray instead of quitting —
+    // process alive, nothing on screen — and a `NewWindow` that only exists on
+    // a window's render root is dead in exactly the state a New Window chord
+    // is for. `Tty7App`'s own listener still wins wherever there is a window:
+    // gpui runs the window's bubble phase first and returns before the global
+    // one, so the two never both fire.
+    cx.on_action(|_: &NewWindow, cx: &mut App| crate::ui::windows::open(cx, None));
     set_menus(cx);
 }
 

--- a/src/ui/palette.rs
+++ b/src/ui/palette.rs
@@ -22,6 +22,7 @@ pub enum CommandKind {
     RenameWorkspace,
     StopWorkspace,
     DeleteWorkspace,
+    NewWindow,
     SplitRight,
     SplitDown,
     ClosePane,
@@ -124,6 +125,7 @@ impl CommandKind {
             RenameWorkspace => "rename-workspace",
             StopWorkspace => "stop-workspace",
             DeleteWorkspace => "delete-workspace",
+            NewWindow => "new-window",
             SplitRight => "split-right",
             SplitDown => "split-down",
             ClosePane => "close-pane",
@@ -230,6 +232,7 @@ impl CommandKind {
             RenameWorkspace => "RenameWorkspace",
             StopWorkspace => "StopWorkspace",
             DeleteWorkspace => "DeleteWorkspace",
+            NewWindow => "NewWindow",
             SplitRight => "SplitRight",
             SplitDown => "SplitDown",
             ClosePane => "CloseActiveTab",
@@ -565,6 +568,7 @@ impl Command {
         ];
 
         let application = [
+            Command::localized(L10nKey::CmdNewWindow, NewWindow),
             Command::localized(L10nKey::CmdSettings, OpenSettings),
             Command::localized(L10nKey::CmdKeyboardShortcuts, ShowKeyboardShortcuts),
             Command::localized(L10nKey::CmdAboutTty7, About),


### PR DESCRIPTION
Opening a workspace in a new window is reachable exactly one way today: the
switcher, either with the platform modifier held on a row or through that row's
"Open in New Window" menu item. Both land in `crate::ui::windows::open`. Neither
is an action — there is no `NewWindow` in `actions!` — so the capability cannot
be keybound, cannot be found in the command palette, and does not appear on the
Keybindings page at all.

This adds `NewWindow` and wires it the whole way through.

Mirrors #778 (`CloseWindow`, for #773) deliberately: same files, same order, same
registration pattern, same `Cmd*` i18n key style, same `CommandGroup::Application`
placement, same `action_entry` assertion in the vocabulary test. Two actions of
the same family should be indistinguishable in the source. #778 is not in this
branch; whichever lands second rebases.

### What the action does with no argument

`windows::open(cx, None)` — a new window on a workspace of its own.

The other reading, "a second window on the *current* workspace", is not a choice
that was available. `WindowRegistry` is keyed by workspace: `window_for`,
`app_for`, `unregister` and `rebind` all address a window by the workspace it is
showing, and `windows::open` answers a workspace that already has a window by
activating it rather than opening another. Asking for the current workspace from
the current window would raise the window you are already in — a no-op. So the
fresh-workspace reading is the only coherent one, and it is also what New Window
means in every other app that offers the chord.

`reveal_workspace` stays as it is: switching workspaces happens in place, and a
second window remains something you ask for explicitly.

### Default keybinding

**macOS: `Cmd+N`. Off macOS: none, deliberately.**

The conflict check behind that, against `default_bindings()` on every platform:

- `secondary-n` on macOS is free. Nothing in the table claims Cmd+N, and it is
  the platform convention for New Window. `every_default_chord_is_claimed_by_
  exactly_one_action` agrees.
- `secondary-n` off macOS is `Ctrl+N`, which `steals_a_control_code` classifies
  as a C0 byte the shell is owed. `no_default_binding_sits_on_a_terminal_control_
  code` fails the build over it, and correctly — Ctrl+N is next-history.
- `secondary-shift-n` off macOS is `Ctrl+Shift+N` — where that same test's
  message says window actions belong — and it has been `NewWorkspace` on every
  platform for far longer than this action has existed. Moving it would break
  muscle memory for a feature that has shipped.
- Anything else (`alt-shift-n`, `ctrl-alt-n`) is free but unguessable. A default
  nobody would try is worse than no default: it spends a chord and teaches
  nothing.

So off macOS this ships unbound. The action is still listed in
`default_bindings`, which is the only table `set_binding` will write into, so a
key is one line of config or one click on the Keybindings page away — and it is
in the command palette regardless. That is the part of #710 that was actually
broken.

Per the trap in #784/#750 — `secondary-shift-]` was in this table for a chord
that never dispatched off macOS, because gpui folds shift into the punctuation
glyph — the default is not asserted against the table. The test builds a real
`gpui::Keymap` from `action_bindings` and asks it what `Cmd+N` dispatches to.

### Tests

Both ungated (no `#[cfg(unix)]`), both run on Windows:

- `ui::keymap::tests::new_window_ships_a_chord_only_where_one_is_free` — pins the
  per-platform default; where a default exists, asserts through a real keymap
  that it reaches `NewWindow` *and nothing else* (the exact-match is the conflict
  check); then rebinds the slot and asserts a user-assigned chord still
  dispatches, which is what "unbound but bindable" has to mean.
- `ui::app::new_window_action_tests::dispatching_new_window_opens_a_second_window_
  beside_the_first` — dispatches the action for real against a registered window
  and asserts the registry then holds two windows, the original among them, the
  new one on a different workspace. Verified non-vacuous: removing the
  `on_action` listener fails it with `it opened 1 window(s)`.

`cargo test --bin tty7-app` filtered on keymap / palette / i18n / `ui::app::` is
green (29 + 27 + 48 tests), `cargo fmt --check` clean, `clippy` reports nothing
new on the touched files.

### On #710

Not `Fixes #710`. The reporter asked for a Windows taskbar jump list that lists
every workspace and opens the chosen one in a new window — that is COM shell
work with no scaffolding in this repo, and it is not being built here. This is
the small, high-value part: the capability stops being switcher-only and becomes
something you can put on a key. The issue should stay open for the jump list.
