### PR TITLE
test(remote): give each machine in the route-origin tests its own key

### DIFF
--- a/src/ui/remote_connect.rs
+++ b/src/ui/remote_connect.rs
@@ -960,6 +960,7 @@ mod tests {
 
     fn native_spec(user: &str, host: &str, port: u16) -> NativeSshSpec {
         let mut profile = crate::core::ssh_profile::SshProfile::new(host.to_string());
+        profile.host = host.to_string();
         profile.user = user.to_string();
         profile.port = port;
         crate::ui::ssh_connect::build_native_ssh_spec(
@@ -970,6 +971,36 @@ mod tests {
         )
     }
 
+    /// `SshProfile::new` takes a *name*, and the address lives in a separate
+    /// `host` field; every production caller assigns both. `native_spec` used
+    /// to assign only the name, so the spec it handed back addressed nobody
+    /// and `ConnectionKey::from_spec` spelled it `me@:22` — one key for every
+    /// machine in this module that talks to port 22.
+    ///
+    /// `ORIGINS` is keyed by exactly that string, so the two tests below that
+    /// note an origin and read it back were writing to and reading from the
+    /// same slot. Whichever noted last won, and the other was handed the wrong
+    /// machine: 17 failures in 20 runs of this module alone, 6 in 20 of the
+    /// whole binary, and none when either test ran by itself.
+    #[test]
+    fn two_machines_do_not_share_one_route_origin_key() {
+        use crate::daemon::router::RouteTarget;
+
+        let build = RouteTarget::Ssh(Box::new(native_spec("me", "build-box", 22)));
+        let twin = RouteTarget::Ssh(Box::new(native_spec("me", "twin-box", 22)));
+
+        assert_eq!(
+            build.origin_key(),
+            "me@build-box:22",
+            "a route origin key names the machine it dials"
+        );
+        assert_ne!(
+            build.origin_key(),
+            twin.origin_key(),
+            "two machines sharing one key make `note_origin` overwrite the other's"
+        );
+    }
+
     #[test]
     fn a_routed_auth_prompt_carries_the_machine_that_raised_it() {
         let _turn = claim_mailbox();
@@ -978,6 +1009,7 @@ mod tests {
         let route =
             crate::daemon::router::RouteTarget::Ssh(Box::new(native_spec("me", "build-box", 22)));
         note_origin(&route, &target);
+        let origin_key = route.origin_key();
 
         let handle = std::thread::spawn(move || {
             use crate::daemon::router::RouteAuthResponder as _;
@@ -1005,7 +1037,12 @@ mod tests {
             );
             std::thread::sleep(Duration::from_millis(5));
         };
-        assert_eq!(pending.host, target.host_id());
+        assert_eq!(
+            pending.host,
+            target.host_id(),
+            "the prompt names the machine noted under {:?}",
+            origin_key
+        );
         pending.answer(AuthResponse::Secret("hunter2".into()));
         assert_eq!(
             handle.join().unwrap(),


### PR DESCRIPTION
`ui::remote_connect::tests::a_routed_auth_prompt_carries_the_machine_that_raised_it` has been passed over as "a known pre-existing flake" by every agent working in this repo today. It is not a flake. It fails because the test helper that builds its `NativeSshSpec` never spells the host, and two tests in the module then share one `ORIGINS` slot.

## What is actually wrong

`SshProfile::new` takes a **name**; the address lives in a separate `host` field. Every production caller assigns both — `remote_connect::spec_for`, `ssh_connect::open_quick_connect` and `app::parse_ssh_connect` all follow `SshProfile::new(host)` with `profile.host = host`. The test helper dropped that second line:

```rust
fn native_spec(user: &str, host: &str, port: u16) -> NativeSshSpec {
    let mut profile = crate::core::ssh_profile::SshProfile::new(host.to_string());
    profile.user = user.to_string();   // <- profile.host never set
    profile.port = port;
```

So the spec addresses nobody, and `ConnectionKey::from_spec` — `format!("{user}@{host}:{port}")` — spells it `me@:22`. That is the *same string* for every machine in this module on port 22.

`ORIGINS` is keyed by exactly that string. `a_routed_auth_prompt_carries_the_machine_that_raised_it` (build-box) and `a_pane_and_its_workspace_resolve_to_the_same_machine` (twin-box) were each calling `note_origin` into that one shared slot and then reading it back. libtest runs them on different threads; whichever noted last won, and the other was handed the wrong machine's `HostId`. The routed-auth test usually loses, because it spawns a responder thread and waits on the auth mailbox before it reads, while the pane test reads immediately.

## Proof

The origin table at the moment of failure, from a temporary instrumented build that dumped `ORIGINS` into the assertion message:

```
assertion `left == right` failed:
  origins=[("me@:2222", 12106367783589518659),
           ("me@:22",   6831549409032087863),
           ("local-stdio:/opt/tty7-server", 11414125097972604568)]
  left:  HostId(6831549409032087863)   # fnv1a64("ssh-direct:me@twin-box:22")
 right:  HostId(7267374002226354343)   # fnv1a64("ssh-direct:me@build-box:22")
```

An empty host in every key, and the routed-auth test reading twin-box's id out of what should have been build-box's slot. The same collision fires the other way round too — the first suite run of the session failed `a_pane_and_its_workspace_resolve_to_the_same_machine` instead, with `left: build-box, right: twin-box`.

## Failure rates

Measured on Windows 11 against `893172f5`, one build per configuration, counting runs in which the test failed:

| configuration | before | after |
| --- | --- | --- |
| full suite (`tty7-app`) | **6/20 (30%)** | **0/40** |
| this module only (`a_` filter) | **17/20 (85%)** | **0/30** |
| the test alone (`--exact`) | 0/20 | 0/20 |

The isolated column is the tell. Nothing outside this module was ever involved, and no amount of rerunning the test by itself could have shown the defect — which is exactly why it survived as "a flake".

The 85% figure explains the "3 out of 4" reading someone took earlier: the fewer tests share the binary, the more tightly the two colliding tests overlap.

## The fix

One line in the helper, plus a guard.

`two_machines_do_not_share_one_route_origin_key` asserts that a route origin key spells the host it dials and that two machines do not collide. Reverting the one-line fix fails it in 0.00s with `left: "me@:22"`, so it is a real guard and not a restatement.

No retry loop, no sleep, no `#[ignore]`, and no change to `MAILBOX_TURN` — the mailbox arbitration added in #263 was correct and was never the problem here.

## Not a product bug

Worth stating plainly, because the starting hypothesis was that it might be one: **no user-facing path is affected, and no issue is needed.** Only the test helper forgot the field. The three places that build a spec from a real profile all assign `host`, so a routed auth prompt in the app has always named the machine that raised it. Also fixed as a side effect: `a_mismatch_record_resolves_back_to_the_machine_it_is_about` was building its label from the same degenerate `me@:2222` key, so it now exercises the string the product would actually produce.

CI on `main` is green for this test on all platforms, consistent with the diagnosis: the collision needs the two tests to overlap in time, and it loses that race less often on a smaller runner.
