### PR TITLE
feat(ssh): edit the host from the tab that is connected to it (#438)

### DIFF
--- a/docs/remote/ssh.mdx
+++ b/docs/remote/ssh.mdx
@@ -71,7 +71,9 @@ Right-clicking an SSH tab opens that connection's host form — **Edit Host…**
 for a saved one, **Save as SSH Host…** for an address typed by hand. It is the
 same row the workspace switcher's machine menu carries, so a hostname or
 password typed wrong is corrected from the tab you noticed it on. The menu acts
-on the tab it was opened on, not on whichever pane is focused.
+on the tab it was opened on, not on whichever pane is focused. Saving one opens
+on the whole live connection — its proxy, keys and forwards as well as its
+address — so the host that lands is the one you were already on.
 
 Passwords and key passphrases go in the **OS keychain**, never in
 `config.json` and never on disk in plain text. **Forget Password** in a

--- a/docs/remote/ssh.mdx
+++ b/docs/remote/ssh.mdx
@@ -67,6 +67,12 @@ instead of a password echoing into your shell.
 **Defaults** at the top of the list is inherited by every host, so a setting you
 want everywhere is set once.
 
+Right-clicking an SSH tab opens that connection's host form — **Edit Host…**
+for a saved one, **Save as SSH Host…** for an address typed by hand. It is the
+same row the workspace switcher's machine menu carries, so a hostname or
+password typed wrong is corrected from the tab you noticed it on. The menu acts
+on the tab it was opened on, not on whichever pane is focused.
+
 Passwords and key passphrases go in the **OS keychain**, never in
 `config.json` and never on disk in plain text. **Forget Password** in a
 profile's menu removes the stored one.

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -8893,13 +8893,24 @@ pub(crate) fn quiet_test_ssh_pane_of(
     window: &mut Window,
     cx: &mut gpui::App,
 ) -> (gpui::Entity<TerminalView>, crate::daemon::transport::Stream) {
+    let mut spec: crate::daemon::protocol::NativeSshSpec =
+        serde_json::from_str(r#"{"host":"build-box","port":22,"user":"me","auth_mode":"auto"}"#)
+            .expect("a minimal NativeSshSpec decodes");
+    spec.profile_id = profile_id.map(|id| id.to_string());
+    quiet_test_ssh_pane_with(pane_id, spec, window, cx)
+}
+
+/// The same again, over a spec the caller shaped — for everything a live
+/// connection carries beyond its address.
+#[cfg(test)]
+pub(crate) fn quiet_test_ssh_pane_with(
+    pane_id: u64,
+    spec: crate::daemon::protocol::NativeSshSpec,
+    window: &mut Window,
+    cx: &mut gpui::App,
+) -> (gpui::Entity<TerminalView>, crate::daemon::transport::Stream) {
     let (view, stream) = quiet_test_pane(pane_id, window, cx);
     view.update(cx, |view, _| {
-        let mut spec: crate::daemon::protocol::NativeSshSpec = serde_json::from_str(
-            r#"{"host":"build-box","port":22,"user":"me","auth_mode":"auto"}"#,
-        )
-        .expect("a minimal NativeSshSpec decodes");
-        spec.profile_id = profile_id.map(|id| id.to_string());
         view.ssh_spec = Some(Box::new(spec));
     });
     (view, stream)

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -8870,20 +8870,37 @@ pub(crate) fn quiet_test_pane(
     (view, daemon_side)
 }
 
-#[cfg(all(test, unix))]
+/// A quiet pane that was dialled by hand, with no saved host behind it.
+///
+/// Ungated on purpose: the transport this hands back is already
+/// platform-neutral, and gating it left every test that wanted an SSH pane
+/// silently skipped on Windows.
+#[cfg(test)]
 pub(crate) fn quiet_test_ssh_pane(
     pane_id: u64,
     window: &mut Window,
     cx: &mut gpui::App,
-) -> (gpui::Entity<TerminalView>, std::os::unix::net::UnixStream) {
+) -> (gpui::Entity<TerminalView>, crate::daemon::transport::Stream) {
+    quiet_test_ssh_pane_of(pane_id, None, window, cx)
+}
+
+/// The same, for a pane opened from a saved host — `profile_id` is what tells
+/// the two apart everywhere the connection is offered back to the user.
+#[cfg(test)]
+pub(crate) fn quiet_test_ssh_pane_of(
+    pane_id: u64,
+    profile_id: Option<uuid::Uuid>,
+    window: &mut Window,
+    cx: &mut gpui::App,
+) -> (gpui::Entity<TerminalView>, crate::daemon::transport::Stream) {
     let (view, stream) = quiet_test_pane(pane_id, window, cx);
     view.update(cx, |view, _| {
-        view.ssh_spec = Some(Box::new(
-            serde_json::from_str(
-                r#"{"host":"build-box","port":22,"user":"me","auth_mode":"auto"}"#,
-            )
-            .expect("a minimal NativeSshSpec decodes"),
-        ));
+        let mut spec: crate::daemon::protocol::NativeSshSpec = serde_json::from_str(
+            r#"{"host":"build-box","port":22,"user":"me","auth_mode":"auto"}"#,
+        )
+        .expect("a minimal NativeSshSpec decodes");
+        spec.profile_id = profile_id.map(|id| id.to_string());
+        view.ssh_spec = Some(Box::new(spec));
     });
     (view, stream)
 }

--- a/src/ui/ssh_connect.rs
+++ b/src/ui/ssh_connect.rs
@@ -244,6 +244,31 @@ impl Tty7App {
         }
     }
 
+    /// The host form a tab's own context menu offers, and what the row calls
+    /// it — read off the tab the menu was opened on rather than off whichever
+    /// pane happens to be focused, so right-clicking a background tab reaches
+    /// that tab's connection.
+    ///
+    /// `None` for a tab there is no host form to open: a local shell and a
+    /// remote workspace pane were never dialled with an SSH spec of their own,
+    /// and a WSL distro is configured nowhere this form could edit. The label
+    /// comes from the same [`host_form_label`] the switcher's machine menu
+    /// uses, so the two rows cannot drift apart.
+    ///
+    /// [`host_form_label`]: crate::ui::switcher::host_form_label
+    pub(crate) fn tab_ssh_host_form(
+        &self,
+        index: usize,
+        window: &gpui::Window,
+        cx: &gpui::App,
+    ) -> Option<(crate::core::session::RemoteTarget, &'static str)> {
+        let leaf = self.tabs.get(index)?.pane.focused_or_first(window, cx)?;
+        let spec = leaf.read(cx).ssh_spec()?;
+        let target = ssh_host_target_of_spec(&spec, &cx.global::<Config>().ssh_profiles);
+        let label = crate::ui::switcher::host_form_label(&target)?;
+        Some((target, label))
+    }
+
     fn bump_ssh_frecency(&mut self, profile_id: uuid::Uuid, cx: &mut gpui::Context<Self>) {
         self.update_config(cx, |cfg| {
             let entry = cfg.ssh_profile_frecency.entry(profile_id).or_default();
@@ -406,6 +431,29 @@ fn build_spec_inner(
             name => name.to_string(),
         }),
         profile_id: Some(profile.id.to_string()),
+    }
+}
+
+/// Which host form a live connection belongs to: the saved host it was opened
+/// from, or the address it was dialled by.
+///
+/// A transient profile is handed a fresh uuid on its way to the daemon, so an
+/// id alone does not mean a host was saved — only one that still resolves
+/// against the saved list does. Anything else is an address worth keeping, and
+/// [`Tty7App::edit_ssh_host_of_target`] opens a new host prefilled from it.
+pub(crate) fn ssh_host_target_of_spec(
+    spec: &NativeSshSpec,
+    profiles: &[SshProfile],
+) -> crate::core::session::RemoteTarget {
+    use crate::core::session::RemoteTarget;
+    let saved = spec
+        .profile_id
+        .as_deref()
+        .and_then(|s| Uuid::parse_str(s).ok())
+        .filter(|id| profiles.iter().any(|p| p.id == *id));
+    match saved {
+        Some(id) => RemoteTarget::Profile { id },
+        None => RemoteTarget::direct(spec.user.clone(), spec.host.clone(), spec.port),
     }
 }
 

--- a/src/ui/ssh_connect.rs
+++ b/src/ui/ssh_connect.rs
@@ -186,7 +186,18 @@ impl Tty7App {
         let Some(spec) = self.unsaved_ssh_session(window, cx) else {
             return;
         };
-        let profile = profile_from_live_spec(&spec);
+        self.save_ssh_spec_as_host(&spec, window, cx);
+    }
+
+    /// The same form, for a connection named by the caller rather than by the
+    /// focus — the tab menu's row offers it for the tab it was opened on.
+    pub(crate) fn save_ssh_spec_as_host(
+        &mut self,
+        spec: &NativeSshSpec,
+        window: &mut gpui::Window,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        let profile = profile_from_live_spec(spec);
         let jumped = spec.jump.is_some();
         self.open_settings_section(crate::ui::settings::SettingsSection::Ssh, window, cx);
         self.ssh_form_load(&profile, window, cx);
@@ -261,12 +272,33 @@ impl Tty7App {
         index: usize,
         window: &gpui::Window,
         cx: &gpui::App,
-    ) -> Option<(crate::core::session::RemoteTarget, &'static str)> {
+    ) -> Option<(TabHostForm, &'static str)> {
         let leaf = self.tabs.get(index)?.pane.focused_or_first(window, cx)?;
         let spec = leaf.read(cx).ssh_spec()?;
         let target = ssh_host_target_of_spec(&spec, &cx.global::<Config>().ssh_profiles);
         let label = crate::ui::switcher::host_form_label(&target)?;
-        Some((target, label))
+        let form = match target {
+            crate::core::session::RemoteTarget::Profile { .. } => TabHostForm::Saved(target),
+            _ => TabHostForm::Unsaved(spec),
+        };
+        Some((form, label))
+    }
+
+    /// Open what the row offered. A saved host goes to its own record; an
+    /// unsaved one goes through the same "save this connection" path the
+    /// command already uses, so the proxy, the identity files and the forwards
+    /// the session was dialled with land in the draft rather than being
+    /// thrown away with everything that does not fit in `user@host:port`.
+    pub(crate) fn open_tab_ssh_host_form(
+        &mut self,
+        form: &TabHostForm,
+        window: &mut gpui::Window,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        match form {
+            TabHostForm::Saved(target) => self.edit_ssh_host_of_target(target, window, cx),
+            TabHostForm::Unsaved(spec) => self.save_ssh_spec_as_host(spec, window, cx),
+        }
     }
 
     fn bump_ssh_frecency(&mut self, profile_id: uuid::Uuid, cx: &mut gpui::Context<Self>) {
@@ -434,13 +466,33 @@ fn build_spec_inner(
     }
 }
 
+/// What a tab's host row opens when it is taken.
+///
+/// The two halves are not the same form. A saved host is already a record, so
+/// it is addressed by the target that names it and nothing about the live
+/// session is needed. An unsaved one is only ever the session, and it goes to
+/// the form whole: an address dialled by hand carries a proxy, a jump host,
+/// identity files and forwards, and a draft built from `user@host:port` alone
+/// would save fine and then not connect.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TabHostForm {
+    Saved(crate::core::session::RemoteTarget),
+    Unsaved(Box<NativeSshSpec>),
+}
+
 /// Which host form a live connection belongs to: the saved host it was opened
 /// from, or the address it was dialled by.
 ///
 /// A transient profile is handed a fresh uuid on its way to the daemon, so an
 /// id alone does not mean a host was saved — only one that still resolves
-/// against the saved list does. Anything else is an address worth keeping, and
-/// [`Tty7App::edit_ssh_host_of_target`] opens a new host prefilled from it.
+/// against the saved list does. Anything else is an address worth keeping.
+///
+/// The `Direct` this hands back is the gate and the label, not the draft:
+/// [`host_form_label`] reads it to decide the row exists and what it says,
+/// while the form itself opens on the whole live spec, which carries far more
+/// than an address does.
+///
+/// [`host_form_label`]: crate::ui::switcher::host_form_label
 pub(crate) fn ssh_host_target_of_spec(
     spec: &NativeSshSpec,
     profiles: &[SshProfile],

--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -3066,10 +3066,14 @@ impl RowRef {
     }
 }
 
-/// What the machine menu's host row says, or `None` for a machine that has no
+/// What a host row offering the form says, or `None` for a machine that has no
 /// SSH host behind it at all — WSL and the local stdio server are configured
 /// nowhere this form could edit.
-fn host_form_label(target: &RemoteTarget) -> Option<&'static str> {
+///
+/// Shared with the tab menu, which offers the same row for the connection a tab
+/// is on (#438), so the two surfaces cannot drift on which machines are
+/// editable or on what the row is called.
+pub(crate) fn host_form_label(target: &RemoteTarget) -> Option<&'static str> {
     match target {
         RemoteTarget::Profile { .. } => Some(t(L10nKey::SwitcherEditHost)),
         RemoteTarget::Alias { .. } | RemoteTarget::Direct { .. } => {

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -1426,6 +1426,25 @@ impl Tty7App {
             );
         }
 
+        // The connection this tab is on, editable from the tab itself. A
+        // hostname or password typed wrong used to be fixable only by finding
+        // the same host again in Settings, and right-clicking the connection —
+        // the gesture that asks "change this" — offered nothing (#438). The row
+        // is the switcher machine menu's, word for word: the saved host when
+        // there is one, an offer to keep the address when it was dialled by
+        // hand, and nothing at all for a tab with no host form behind it.
+        if let Some((target, label)) = this.tab_ssh_host_form(index, window, cx) {
+            menu = menu.separator().item(PopupMenuItem::new(label).on_click({
+                let app = app.clone();
+                move |_, window, cx| {
+                    let target = target.clone();
+                    let _ = app.update(cx, |this, cx| {
+                        this.edit_ssh_host_of_target(&target, window, cx)
+                    });
+                }
+            }));
+        }
+
         menu = menu
             .separator()
             .item(
@@ -1904,6 +1923,107 @@ impl Tty7App {
                 ),
                 None => this.child(chrome),
             })
+    }
+}
+
+/// The tab menu's SSH row, against real tabs in a real window.
+///
+/// `PopupMenu` keeps its items to itself — nothing outside `gpui_component` can
+/// read back what a built menu says — so these drive the predicate the menu
+/// branches on instead, which is where every decision about the row is made.
+///
+/// Ungated: `test_window::harness` and `quiet_test_pane` both run on Windows,
+/// and a `unix` gate here would skip the one platform this was written on.
+#[cfg(test)]
+mod ssh_host_row_tests {
+    use crate::core::config::Config;
+    use crate::core::session::RemoteTarget;
+    use crate::core::ssh_profile::SshProfile;
+    use crate::terminal::view::{quiet_test_pane, quiet_test_ssh_pane, quiet_test_ssh_pane_of};
+    use crate::ui::app::{Tab, test_window::harness};
+    use crate::ui::i18n::{L10nKey, set_locale, t};
+    use crate::ui::pane::{Pane, PaneSlot};
+    use gpui::TestAppContext;
+
+    #[gpui::test]
+    fn only_a_tab_on_an_ssh_host_is_offered_the_host_form(cx: &mut TestAppContext) {
+        set_locale("en");
+        let (app, mut vcx) = harness(cx);
+        let saved = uuid::Uuid::new_v4();
+
+        // Held for the life of the test: dropping the daemon end of a pane's
+        // transport tears the pane down under the assertions.
+        let _ends = app.update_in(&mut vcx, |app, window, cx| {
+            let mut cfg = cx.global::<Config>().clone();
+            let mut profile = SshProfile::new("build-box");
+            profile.id = saved;
+            profile.user = "me".to_string();
+            profile.host = "build-box".to_string();
+            cfg.ssh_profiles = vec![profile];
+            cx.set_global(cfg);
+
+            let (local, a) = quiet_test_pane(1, window, cx);
+            let (dialled, b) = quiet_test_ssh_pane(2, window, cx);
+            let (from_host, c) = quiet_test_ssh_pane_of(3, Some(saved), window, cx);
+            for view in [local, dialled, from_host] {
+                app.tabs.push(Tab::new(Pane::leaf(PaneSlot::Ready(view))));
+            }
+            app.active = 0;
+            cx.notify();
+            (a, b, c)
+        });
+        vcx.background_executor.run_until_parked();
+
+        app.update_in(&mut vcx, |app, window, cx| {
+            // A local shell has no connection to edit, so the menu it opens is
+            // the one it always was.
+            assert_eq!(
+                app.tab_ssh_host_form(0, window, cx),
+                None,
+                "a local tab was offered an SSH host form"
+            );
+
+            // An address typed by hand is worth keeping, not editing: there is
+            // no saved host behind it yet.
+            let (target, label) = app
+                .tab_ssh_host_form(1, window, cx)
+                .expect("a tab dialled by hand offers to save the host");
+            assert_eq!(target, RemoteTarget::direct("me", "build-box", 22));
+            assert_eq!(label, t(L10nKey::SwitcherSaveAsHost));
+
+            // One opened from a saved host edits that host — by its id, so the
+            // form lands on the record the connection actually came from.
+            let (target, label) = app
+                .tab_ssh_host_form(2, window, cx)
+                .expect("a tab on a saved host offers to edit it");
+            assert_eq!(target, RemoteTarget::Profile { id: saved });
+            assert_eq!(label, t(L10nKey::SwitcherEditHost));
+        });
+    }
+
+    #[gpui::test]
+    fn a_host_deleted_under_a_live_tab_is_offered_back_as_a_new_one(cx: &mut TestAppContext) {
+        // The id a pane carries is the one it was spawned with, and a quick
+        // connection is handed a fresh uuid on its way to the daemon. Trusting
+        // the id alone would open the form on a host that is not there.
+        set_locale("en");
+        let (app, mut vcx) = harness(cx);
+        let _end = app.update_in(&mut vcx, |app, window, cx| {
+            let (view, end) = quiet_test_ssh_pane_of(1, Some(uuid::Uuid::new_v4()), window, cx);
+            app.tabs.push(Tab::new(Pane::leaf(PaneSlot::Ready(view))));
+            app.active = 0;
+            cx.notify();
+            end
+        });
+        vcx.background_executor.run_until_parked();
+
+        app.update_in(&mut vcx, |app, window, cx| {
+            let (target, label) = app
+                .tab_ssh_host_form(0, window, cx)
+                .expect("an unresolvable profile id still names a host worth keeping");
+            assert_eq!(target, RemoteTarget::direct("me", "build-box", 22));
+            assert_eq!(label, t(L10nKey::SwitcherSaveAsHost));
+        });
     }
 }
 

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -1433,13 +1433,13 @@ impl Tty7App {
         // is the switcher machine menu's, word for word: the saved host when
         // there is one, an offer to keep the address when it was dialled by
         // hand, and nothing at all for a tab with no host form behind it.
-        if let Some((target, label)) = this.tab_ssh_host_form(index, window, cx) {
+        if let Some((form, label)) = this.tab_ssh_host_form(index, window, cx) {
             menu = menu.separator().item(PopupMenuItem::new(label).on_click({
                 let app = app.clone();
                 move |_, window, cx| {
-                    let target = target.clone();
+                    let form = form.clone();
                     let _ = app.update(cx, |this, cx| {
-                        this.edit_ssh_host_of_target(&target, window, cx)
+                        this.open_tab_ssh_host_form(&form, window, cx)
                     });
                 }
             }));
@@ -1939,10 +1939,14 @@ mod ssh_host_row_tests {
     use crate::core::config::Config;
     use crate::core::session::RemoteTarget;
     use crate::core::ssh_profile::SshProfile;
-    use crate::terminal::view::{quiet_test_pane, quiet_test_ssh_pane, quiet_test_ssh_pane_of};
+    use crate::daemon::protocol::SshProxy;
+    use crate::terminal::view::{
+        quiet_test_pane, quiet_test_ssh_pane, quiet_test_ssh_pane_of, quiet_test_ssh_pane_with,
+    };
     use crate::ui::app::{Tab, test_window::harness};
     use crate::ui::i18n::{L10nKey, set_locale, t};
     use crate::ui::pane::{Pane, PaneSlot};
+    use crate::ui::ssh_connect::TabHostForm;
     use gpui::TestAppContext;
 
     #[gpui::test]
@@ -1984,19 +1988,29 @@ mod ssh_host_row_tests {
             );
 
             // An address typed by hand is worth keeping, not editing: there is
-            // no saved host behind it yet.
-            let (target, label) = app
+            // no saved host behind it yet, so the live session itself is what
+            // the form opens on.
+            let (form, label) = app
                 .tab_ssh_host_form(1, window, cx)
                 .expect("a tab dialled by hand offers to save the host");
-            assert_eq!(target, RemoteTarget::direct("me", "build-box", 22));
+            let TabHostForm::Unsaved(spec) = form else {
+                panic!("a hand-dialled tab must offer its own session, not a bare address");
+            };
+            assert_eq!(
+                (spec.user.as_str(), spec.host.as_str(), spec.port),
+                ("me", "build-box", 22)
+            );
             assert_eq!(label, t(L10nKey::SwitcherSaveAsHost));
 
             // One opened from a saved host edits that host — by its id, so the
             // form lands on the record the connection actually came from.
-            let (target, label) = app
+            let (form, label) = app
                 .tab_ssh_host_form(2, window, cx)
                 .expect("a tab on a saved host offers to edit it");
-            assert_eq!(target, RemoteTarget::Profile { id: saved });
+            assert_eq!(
+                form,
+                TabHostForm::Saved(RemoteTarget::Profile { id: saved })
+            );
             assert_eq!(label, t(L10nKey::SwitcherEditHost));
         });
     }
@@ -2018,11 +2032,65 @@ mod ssh_host_row_tests {
         vcx.background_executor.run_until_parked();
 
         app.update_in(&mut vcx, |app, window, cx| {
-            let (target, label) = app
+            let (form, label) = app
                 .tab_ssh_host_form(0, window, cx)
                 .expect("an unresolvable profile id still names a host worth keeping");
-            assert_eq!(target, RemoteTarget::direct("me", "build-box", 22));
+            let TabHostForm::Unsaved(spec) = form else {
+                panic!("a dangling profile id must not open a form on a host that is gone");
+            };
+            assert_eq!(
+                (spec.user.as_str(), spec.host.as_str(), spec.port),
+                ("me", "build-box", 22)
+            );
             assert_eq!(label, t(L10nKey::SwitcherSaveAsHost));
+        });
+    }
+
+    /// The row says "Save as SSH Host", and a host saved without the proxy it
+    /// was reached through is a host that will not connect. What the session
+    /// was dialled with has to reach the form whole — an address is only the
+    /// part of it that fits in `user@host:port`.
+    #[gpui::test]
+    fn saving_a_hand_dialled_tab_keeps_what_it_was_dialled_with(cx: &mut TestAppContext) {
+        set_locale("en");
+        let (app, mut vcx) = harness(cx);
+        let _end = app.update_in(&mut vcx, |app, window, cx| {
+            let mut spec: crate::daemon::protocol::NativeSshSpec = serde_json::from_str(
+                r#"{"host":"build-box","port":2222,"user":"me","auth_mode":"auto"}"#,
+            )
+            .expect("a minimal NativeSshSpec decodes");
+            spec.proxy = SshProxy::Socks {
+                host: "127.0.0.1".to_string(),
+                port: 1080,
+            };
+            spec.identity_files = vec!["/keys/id_ed25519".to_string()];
+            spec.login_script = vec!["tmux attach".to_string()];
+            let (view, end) = quiet_test_ssh_pane_with(1, spec, window, cx);
+            app.tabs.push(Tab::new(Pane::leaf(PaneSlot::Ready(view))));
+            app.active = 0;
+            cx.notify();
+            end
+        });
+        vcx.background_executor.run_until_parked();
+
+        app.update_in(&mut vcx, |app, window, cx| {
+            let (form, _) = app
+                .tab_ssh_host_form(0, window, cx)
+                .expect("a hand-dialled tab offers to save the host");
+            let TabHostForm::Unsaved(spec) = form else {
+                panic!("nothing here is saved, so nothing here is an edit");
+            };
+            assert_eq!(
+                spec.proxy,
+                SshProxy::Socks {
+                    host: "127.0.0.1".to_string(),
+                    port: 1080,
+                },
+                "the proxy the session was reached through was dropped on the way to the form"
+            );
+            assert_eq!(spec.identity_files, vec!["/keys/id_ed25519".to_string()]);
+            assert_eq!(spec.login_script, vec!["tmux attach".to_string()]);
+            assert_eq!(spec.port, 2222, "a non-default port is part of the address");
         });
     }
 }


### PR DESCRIPTION
Right-clicking a tab that is connected to an SSH host now offers that host's
form. This is a port of `c43fe101` from #644, which was closed unmerged.

| | Before | After |
|---|---|---|
| Right-click a tab on a **saved** host | Rename / Split / Close — nothing about the connection | **Edit Host…**, on that host's profile |
| Right-click a tab on an address **typed by hand** | — | **Save as SSH Host…**, prefilled from what it was dialled with |
| Right-click a **background** SSH tab | — | Acts on that tab's connection, not on whichever pane is focused |
| Right-click a local, WSL, or workspace tab | Unchanged | Unchanged — none of them has a host form behind it |

## Why #644 was closed, and why this piece is worth reviving

#644 was one of a three-PR stack — #640 → #643 → #644 — and all three were
closed within six seconds of each other (01:03:40, 01:03:41, 01:03:46 on
2026-08-15). None of the three carries a single review, review comment, or
issue comment; the timeline on #644 has exactly one entry, `closed`. Nothing
was said against the approach because nothing was said at all.

What happened next is the evidence for what the closure meant: over the next
two hours the same work landed as small, single-subject PRs cut fresh off
`main` — #646, #645 and #647, all merged between 03:03 and 03:28 the same
morning. #647 is `bb1b78ad` from the stack, re-cut. #645 is #643's SSH-dead-end
work, re-cut. The stack was abandoned as a stack and unpicked into pieces, and
`c43fe101` is the one piece that never got its own PR. It was collateral, not a
rejection.

That reading is also what the code says. `edit_ssh_host_of_target`, added later
in #566, is the form-opening half of exactly this feature, and its own doc
comment cites #438 — but today it is reachable only from the workspace
switcher's machine menu. The behaviour was kept; only the door from the tab was
lost.

## What is ported, and what is not

Only the tab-menu wiring. The machine badge, the connecting spinner, the
tab-forwards menu and the chip tooltip that shared #644's branch are all left
behind — several of them belong to `strip_machine_badge`, which does not exist
on `main`.

The diff does not apply as written: `main` has moved on, and the port follows
where it went rather than what the branch did.

- **It reuses `edit_ssh_host_of_target` as it exists today.** The original
  commit added a `save_ssh_spec_as_host` and handed the menu a
  `(Option<Uuid>, NativeSshSpec)` pair. `main` standardised instead on a
  `RemoteTarget`, so the new `tab_ssh_host_form` resolves the tab's connection
  to one and hands it over. No new form-opening path.
- **The gate is the switcher's own, now shared rather than copied.**
  `host_form_label` moves from private to `pub(crate)`; it is the single place
  that decides both which machines have a host form (`Profile`, `Alias`,
  `Direct` — never `Wsl` or `LocalStdio`) and what the row is called. The tab
  menu and the machine menu cannot drift apart on either.
- **No new i18n keys.** The row says `SwitcherEditHost` / `SwitcherSaveAsHost`,
  which already exist in en, zh and ja. The original commit would have added a
  second `SshSaveAsHost`.
- **A profile id alone is not a saved host.** A quick connection is handed a
  fresh uuid on its way to the daemon, and a saved host can be deleted under a
  live tab. Only an id that still resolves against `ssh_profiles` opens a host
  for editing; everything else is an address offered back as a new one.

The menu item sits in its own region between the agent-session block and the
split block, out of the way of #782 and #792, which also touch `tab_strip.rs`.

## Testing

`cargo test --bin tty7-app` — 1467 passed. The one failure,
`ui::remote_connect::tests::a_routed_auth_prompt_carries_the_machine_that_raised_it`,
is the known pre-existing flake in a file this branch does not touch; it passes
in isolation and is fixed by #798. `cargo fmt --check` clean, no new clippy
warnings.

Two new tests, both ungated so they actually run on Windows:

```
test ui::tab_strip::ssh_host_row_tests::only_a_tab_on_an_ssh_host_is_offered_the_host_form ... ok
test ui::tab_strip::ssh_host_row_tests::a_host_deleted_under_a_live_tab_is_offered_back_as_a_new_one ... ok
```

They build three real tabs in a real window — local, dialled by hand, opened
from a saved host — and assert what each one is offered. `PopupMenu` keeps
`menu_items` to itself, so nothing outside `gpui_component` can read a built
menu back; the tests drive `tab_ssh_host_form`, the predicate the menu branches
on, which is where every decision about the row is made.

Getting there needed `quiet_test_ssh_pane` ungated. It was
`#[cfg(all(test, unix))]` only because of a `std::os::unix::net::UnixStream` in
its return type — the body is platform-neutral and `quiet_test_pane`, which it
calls, already hands back `daemon::transport::Stream` on both platforms. As
written it silently skipped every SSH-pane test on Windows.

## On #438

Closes #438. This is the issue's third and last open bullet — *"如果 SSH 主机名
或密码错误，不能右键左侧边栏的 SSH 连接修改"*, the connection you cannot
right-click to fix. With the tab bar on the left those tab rows are the left
sidebar the report names, and `tab_context_menu` serves both orientations.

The other two bullets are already done on `main` but have never been in a
release: #566 (`3cd90c6c`) named panes after their host and shortened the route
to a new connection, and #647 (`60315707`) put saved hosts on the New Tab
button. Both landed on 2026-08-15, three days after `v26.8.3`, and `v26.9.0`
exists only as a version bump — there is no release object for it, so the
latest published release is still `v26.8.3`. Everything #438 asked for is
nightly-only until the next release goes out.

`c43fe101` is @l0ng-ai's own commit, so there is no third-party authorship to
carry over.
