### PR TITLE
fix(deps): restore the lockfile edges #799's merge walked back

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -309,7 +309,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -911,7 +911,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2148,7 +2148,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2186,7 +2186,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -2438,7 +2438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3243,7 +3243,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.20",
- "windows 0.58.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -4101,7 +4101,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5246,7 +5246,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5302,7 +5302,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5525,7 +5525,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6950,7 +6950,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7661,7 +7661,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8439,7 +8439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8565,7 +8565,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8967,7 +8967,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9434,7 +9434,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9946,7 +9946,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10790,7 +10790,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11541,7 +11541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
The merge for #799 re-resolved `Cargo.lock` and pointed twenty consumers at older copies of dependencies that were already in the tree for other crates. No `version =` line moved, so nothing shows up in the usual scan of a lockfile diff — what changed is which copy each consumer points at:

| consumer | was | became |
| --- | --- | --- |
| `anstyle-query`, `anstyle-wincon`, `dirs-sys`, `errno`, `miow`, `muda`, `nu-ansi-term`, `quinn-udp`, `rustix`, `socket2`, `stacker`, `tempfile`, `tray-icon`, `uds_windows`, `winreg` (15) | `windows-sys 0.61.2` | `windows-sys 0.60.2` |
| `winapi-util` | `windows-sys 0.61.2` | `windows-sys 0.48.0` |
| `gpu-allocator` | `windows 0.62.2` | `windows 0.58.0` |
| `iana-time-zone` | `windows-core 0.62.2` | `windows-core 0.58.0` |
| `dlib` | `libloading 0.8.9` | `libloading 0.7.4` |
| `bindgen` | `itertools 0.13.0` | `itertools 0.11.0` |

Visible with:

```
git diff 081e191b^ 081e191b -- Cargo.lock | grep -E '^[-+] "(windows-sys|windows|windows-core|libloading|itertools) '
```

Nothing in that PR asked for the re-resolution. Its only dependency change was the gpui fork rev (`d99a40a5` → `ece710e3`), and the range it moves over touches one file, `crates/gpui/src/elements/list.rs`, and no manifest. Nothing since — including the `async_zip` bump in cb710c4d — has touched these edges, so they are still backwards on `main` today.

## What this does

Points those twenty edges back at the versions they held before #799. Lockfile only: no manifest, no source.

Every version already in the lock stays in the lock. `windows-sys 0.60.2` is still there for `notify 8.2.0` (which pins `^0.60.1`), and the older `windows` / `windows-core` / `libloading` / `itertools` copies still serve their own consumers. So this removes no duplicate builds; it only stops the newer copies being compiled alongside older ones for crates that had already moved on.

## Verification

- The diff is exactly 20 changed lines, one per consumer, and nothing else.
- Diffing this lockfile against the pre-#799 one (`081e191b^`) leaves only the legitimate `async_zip` bump from cb710c4d and the packages added since (`binrw`, `binrw_derive`, `array-init`, `owo-colors`, `async_zip 0.0.19`).
- `cargo metadata --locked` accepts the result and does not want to rewrite it, which is what CI's `--locked` builds check.
- `cargo tree --locked --target all -i windows-sys@0.60.2` now reports a single consumer, `notify v8.2.0`.

I deliberately did not reach for `cargo update` here. `cargo update -p windows-sys@0.60.2 --precise 0.61.2` cannot work, because `notify 8.2.0` legitimately requires `^0.60.1`; and `cargo update --recursive` over the twenty consumers drags in 31 unrelated version bumps (`futures-*`, `sval*`, `crossbeam-*`, `flate2`/`miniz_oxide`/`zlib-rs`, …). Re-pointing exactly the regressed edges keeps the change reviewable and reversible.
