### PR TITLE
style(ui): flatten the inline controls and give tooltips a real shortcut slot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "gpui-component"
 version = "0.5.2"
-source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#070d1a28cec5130bf7c4c7895683595d488155b8"
+source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#51a6925955adda598c9363915a06eae6de5dd8df"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -3436,7 +3436,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-assets"
 version = "0.5.1"
-source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#070d1a28cec5130bf7c4c7895683595d488155b8"
+source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#51a6925955adda598c9363915a06eae6de5dd8df"
 dependencies = [
  "anyhow",
  "gpui",
@@ -3450,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-macros"
 version = "0.5.1"
-source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#070d1a28cec5130bf7c4c7895683595d488155b8"
+source = "git+https://github.com/l0ng-ai/gpui-component?branch=tty7#51a6925955adda598c9363915a06eae6de5dd8df"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/ui/home.rs
+++ b/src/ui/home.rs
@@ -140,11 +140,20 @@ fn snap_to_separator(tail: &str) -> &str {
     }
 }
 
-pub(crate) fn key_hint(action: &str, cx: &App) -> Option<String> {
+/// The first keystroke bound to `action`, as a `Keystroke`.
+///
+/// `key_hint` below formats one of these into text. Callers that hand the
+/// chord to a `Tooltip` want the stroke itself: a `Kbd` built from it renders
+/// as a shortcut — a step down in size and colour from the label — where a
+/// formatted string can only be concatenated onto the end of one.
+pub(crate) fn key_stroke(action: &str, cx: &App) -> Option<Keystroke> {
     let spec = crate::ui::keymap::effective_key(action, cx)?;
     let first = spec.split_whitespace().next()?;
-    let stroke = Keystroke::parse(first).ok()?;
-    Some(Kbd::format(&stroke))
+    Keystroke::parse(first).ok()
+}
+
+pub(crate) fn key_hint(action: &str, cx: &App) -> Option<String> {
+    Some(Kbd::format(&key_stroke(action, cx)?))
 }
 
 fn home_shortcut_label(action: &str, closed: Option<&str>) -> String {

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -4,7 +4,7 @@ use gpui::{
     div, img, prelude::*, px, relative, rgb,
 };
 use gpui_component::InteractiveElementExt as _;
-use gpui_component::button::{Button, ButtonVariants as _};
+use gpui_component::button::{Button, ButtonCustomVariant, ButtonVariants as _};
 use gpui_component::color_picker::{ColorPicker, ColorPickerState};
 use gpui_component::input::{Input, InputEvent, InputState};
 use gpui_component::link::Link;
@@ -215,8 +215,21 @@ fn ui_scale(cx: &App) -> f32 {
     cx.global::<Config>().ui_font_size / UI_FONT_SIZE_DEFAULT
 }
 
+/// How wide a control in the right-hand column is.
+///
+/// One number for the whole of settings, across every sub-page. It used to be
+/// three: text fields took 260, sliders 240 and dropdowns 180, each picked
+/// where it was written. Every row still ended on the same right edge, so on
+/// any one page the difference read as controls that had been aligned
+/// carelessly rather than as controls of different kinds — and moving between
+/// Appearance and Terminal, where the mix differs, the column visibly changed
+/// width. 260 is the widest of the three because it is the one with a
+/// requirement behind it: a font name or a shell path has to be readable
+/// without being truncated.
+const FIELD_W: f32 = 260.;
+
 /// Width a settings row needs before its label and its control fit side by
-/// side: a 260px control, the `gap_8` between them, and enough left for a
+/// side: a [`FIELD_W`] control, the `gap_8` between them, and enough left for a
 /// description to read as prose rather than as a column of words.
 const STACK_ROW_BELOW: f32 = 500.;
 
@@ -2333,7 +2346,7 @@ impl Tty7App {
         let font_dropdown = |state: &Entity<SelectState<SearchableVec<String>>>| {
             Select::new(state)
                 .small()
-                .w(px(180.))
+                .w(px(FIELD_W))
                 .h(control_h)
                 .search_placeholder(crate::ui::i18n::t(crate::ui::i18n::L10nKey::SearchFonts))
                 .menu_max_h(px(224.))
@@ -2349,7 +2362,7 @@ impl Tty7App {
             .into_any_element();
         let language_control = Select::new(&language_select)
             .small()
-            .w(px(180.))
+            .w(px(FIELD_W))
             .h(control_h)
             .menu_max_h(px(224.))
             .into_any_element();
@@ -2482,7 +2495,7 @@ impl Tty7App {
         let opacity_control = h_flex()
             .items_center()
             .gap_3()
-            .w(px(240.))
+            .w(px(FIELD_W))
             .max_w_full()
             .child(div().flex_1().child(Slider::new(&slider)))
             .child(
@@ -2511,7 +2524,7 @@ impl Tty7App {
             {
                 Some(select) => Select::new(&select)
                     .small()
-                    .w(px(180.))
+                    .w(px(FIELD_W))
                     .h(px(24.))
                     .menu_max_h(px(224.))
                     .into_any_element(),
@@ -2639,7 +2652,7 @@ impl Tty7App {
             let image_control = h_flex()
                 .items_center()
                 .gap_2()
-                .w(px(240.))
+                .w(px(FIELD_W))
                 .child(
                     Button::new("pick-theme-image")
                         .label(if image.is_some() {
@@ -2675,7 +2688,7 @@ impl Tty7App {
                 let control = h_flex()
                     .items_center()
                     .gap_3()
-                    .w(px(240.))
+                    .w(px(FIELD_W))
                     .child(div().flex_1().child(Slider::new(&slider)))
                     .child(
                         div()
@@ -4334,7 +4347,7 @@ impl Tty7App {
                     t(L10nKey::SettingsName),
                     t(L10nKey::SettingsNameDesc),
                     div()
-                        .w(px(260.))
+                        .w(px(FIELD_W))
                         .max_w_full()
                         .child(Input::new(&form.name).small())
                         .into_any_element(),
@@ -4376,7 +4389,7 @@ impl Tty7App {
                     t(L10nKey::SettingsUser),
                     t(L10nKey::SettingsUserDesc),
                     div()
-                        .w(px(260.))
+                        .w(px(FIELD_W))
                         .max_w_full()
                         .child(Input::new(&form.user).small())
                         .into_any_element(),
@@ -4393,7 +4406,7 @@ impl Tty7App {
                     // width, the way the other long-form pickers on this page do.
                     Select::new(&form.auth_select)
                         .small()
-                        .w(px(260.))
+                        .w(px(FIELD_W))
                         .max_w_full()
                         .into_any_element(),
                     cx,
@@ -4493,7 +4506,7 @@ impl Tty7App {
                     t(L10nKey::SettingsJumpHostDesc),
                     v_flex()
                         .gap_1()
-                        .w(px(260.))
+                        .w(px(FIELD_W))
                         .max_w_full()
                         .child(Input::new(&form.jump).small())
                         .when_some(error, |col, line| col.child(line))
@@ -4761,7 +4774,7 @@ impl Tty7App {
                 label.to_string(),
                 desc.to_string(),
                 div()
-                    .w(px(260.))
+                    .w(px(FIELD_W))
                     .max_w_full()
                     .child(Input::new(input).small())
                     .into_any_element(),
@@ -4788,7 +4801,7 @@ impl Tty7App {
                 desc.to_string(),
                 v_flex()
                     .gap_1()
-                    .w(px(260.))
+                    .w(px(FIELD_W))
                     .max_w_full()
                     .child(Input::new(input).small())
                     .when_some(line, |col, line| col.child(line))
@@ -5122,13 +5135,25 @@ impl Tty7App {
         let program_picker = crate::ui::tab_strip::hit_target(
             Button::new("shell-program-detected")
                 .icon(IconName::ChevronDown)
-                .ghost()
+                // No fill in any state, so it reads the way `Select` draws its
+                // own chevron: a mark inside the field, not a control sitting
+                // on top of one. `ghost` gave it a filled rounded rectangle
+                // while the menu was open, and `hit_target` sizes it to the
+                // 24px accessibility floor — which is exactly the field's inner
+                // height, so that fill met the border top and bottom and looked
+                // like a patch stuck over the field's right end. The field's
+                // own border and the tooltip carry the affordance.
+                .custom(ButtonCustomVariant::new(cx).foreground(muted_fg))
                 .xsmall(),
         )
         .disabled(shells.is_empty())
         .tooltip(t(L10nKey::SettingsShellDetected))
         .dropdown_menu_with_anchor(gpui::Anchor::TopRight, move |menu, _window, _cx| {
-            let mut menu = menu.min_w(px(200.));
+            // As wide as the field it drops out of. Anchored `TopRight` on a
+            // chevron that sits *inside* the field, a 200px menu hung off the
+            // field's right half with its left edge 110px in from the field's
+            // own — a menu that looked like it belonged to something else.
+            let mut menu = menu.min_w(px(FIELD_W));
             let pick = |program: String| {
                 let app = picker_app.clone();
                 let input = picker_input.clone();
@@ -5157,7 +5182,7 @@ impl Tty7App {
             menu
         });
         let program_control = div()
-            .w(px(260.))
+            .w(px(FIELD_W))
             .max_w_full()
             .child(Input::new(&program_input).small().suffix(program_picker))
             .into_any_element();
@@ -5173,7 +5198,7 @@ impl Tty7App {
             .then(|| field_error(t(L10nKey::SettingsArgumentsInvalid), cx));
         let args_control = v_flex()
             .gap_1()
-            .w(px(260.))
+            .w(px(FIELD_W))
             .max_w_full()
             .child(Input::new(&args_input).small())
             .when_some(args_error, |this, line| this.child(line))
@@ -5215,7 +5240,7 @@ impl Tty7App {
                 .then(|| field_error(t(L10nKey::SettingsWdPathInvalid), cx));
             v_flex()
                 .gap_1()
-                .w(px(260.))
+                .w(px(FIELD_W))
                 .max_w_full()
                 .child(Input::new(&wd_path_input).small())
                 .when_some(wd_path_error, |this, line| this.child(line))
@@ -5436,7 +5461,7 @@ impl Tty7App {
         let scroll_control = h_flex()
             .items_center()
             .gap_3()
-            .w(px(240.))
+            .w(px(FIELD_W))
             .max_w_full()
             .child(div().flex_1().child(Slider::new(&scroll_slider)))
             .child(
@@ -6955,7 +6980,7 @@ impl Tty7App {
             http_proxy_invalid.then(|| field_error(t(L10nKey::SettingsAppHttpProxyInvalid), cx));
         let http_proxy_control = v_flex()
             .gap_1()
-            .w(px(260.))
+            .w(px(FIELD_W))
             .max_w_full()
             .child(Input::new(&http_proxy_input).small())
             .when_some(http_proxy_error, |this, line| this.child(line))

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -1027,7 +1027,7 @@ impl Tty7App {
                         cx,
                     )
                     .rounded_lg()
-                    .tooltip(crate::ui::tab_strip::chord_hint(
+                    .tooltip_element(crate::ui::tab_strip::chord_tooltip(
                         t(L10nKey::TabTooltipHideSidebar),
                         "ToggleLeftPanel",
                         cx,

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -5,7 +5,9 @@ use gpui::{
 };
 use gpui_component::button::{Button, ButtonCustomVariant, ButtonVariants as _};
 use gpui_component::input::Input;
+use gpui_component::kbd::Kbd;
 use gpui_component::menu::{ContextMenuExt as _, DropdownMenu as _, PopupMenu, PopupMenuItem};
+use gpui_component::tooltip::Tooltip;
 use gpui_component::{ActiveTheme as _, Icon, IconName, Selectable as _, Sizable as _, h_flex};
 use unicode_segmentation::UnicodeSegmentation as _;
 
@@ -512,11 +514,25 @@ impl Render for DragTab {
 /// What a chrome tile says on hover: what it does, then the chord that does it.
 /// The tile's own name is no use as a tooltip — the workspace head already
 /// wears it as its label.
-pub(crate) fn chord_hint(what: &str, action: &str, cx: &gpui::App) -> SharedString {
-    match crate::ui::home::key_hint(action, cx) {
-        Some(keys) => SharedString::from(format!("{what}  {keys}")),
-        None => SharedString::from(what.to_string()),
-    }
+///
+/// This used to be `chord_hint`, which pasted the two together into one string
+/// — `"Hide sidebar  \u{2318}B"` — and handed that to `Button::tooltip`. Inside the
+/// card the chord then wore the label's own size and colour, so the tooltip
+/// read as one odd sentence rather than as a name with a shortcut beside it.
+/// `Tooltip` has a `key_binding` slot that already renders a chord the way a
+/// chord should look — set apart on the right, a size down, in
+/// `muted_foreground` — and all that was missing was a way to hand `Button` a
+/// built tooltip instead of a string, which is what `tooltip_element` is for.
+pub(crate) fn chord_tooltip(
+    what: impl Into<SharedString>,
+    action: &str,
+    cx: &gpui::App,
+) -> impl Fn(&mut Window, &mut App) -> gpui::Entity<Tooltip> + 'static {
+    let what: SharedString = what.into();
+    // Resolved now, while there is a `cx`: the builder below runs on hover, and
+    // is handed only the window it is drawing into.
+    let kbd = crate::ui::home::key_stroke(action, cx).map(Kbd::new);
+    move |_window, cx| cx.new(|_| Tooltip::new(what.clone()).key_binding(kbd.clone()))
 }
 
 pub(crate) fn chrome_tile_variant(cx: &gpui::App) -> ButtonCustomVariant {
@@ -1014,7 +1030,7 @@ impl Tty7App {
                     .w_full()
                     .h(px(30.))
                     .rounded_md()
-                    .tooltip(chord_hint(
+                    .tooltip_element(chord_tooltip(
                         t(L10nKey::HomeSwitchWorkspace),
                         "ToggleSwitcher",
                         cx,
@@ -1078,7 +1094,7 @@ impl Tty7App {
                         cx,
                     )
                     .rounded_lg()
-                    .tooltip(chord_hint(
+                    .tooltip_element(chord_tooltip(
                         match panel_open {
                             true => t(L10nKey::TabTooltipHideDetailPanel),
                             false => t(L10nKey::TabTooltipShowDetailPanel),
@@ -1318,7 +1334,7 @@ impl Tty7App {
     /// tab surface, and so it says something about the tabs you are *not*
     /// looking at — the zoom outlives a switch away from them.
     pub(crate) fn zoom_mark(&self, id: impl Into<gpui::ElementId>, cx: &App) -> gpui::AnyElement {
-        let tip = chord_hint(t(L10nKey::TabTooltipZoomed), "ToggleMaximizePane", cx);
+        let tip = chord_tooltip(t(L10nKey::TabTooltipZoomed), "ToggleMaximizePane", cx);
         div()
             .id(id)
             .flex_shrink_0()
@@ -1328,9 +1344,10 @@ impl Tty7App {
             .size(px(16.))
             .text_color(cx.theme().muted_foreground)
             .child(Icon::new(IconName::Maximize).size(px(11.)))
-            .tooltip(move |window, cx| {
-                gpui_component::tooltip::Tooltip::new(tip.clone()).build(window, cx)
-            })
+            // Not a `Button`, so this one goes through gpui's own `tooltip`
+            // rather than `tooltip_element` — but it is the same builder, and
+            // the chord lands in the same slot the chrome tiles use.
+            .tooltip(move |window, cx| tip(window, cx).into())
             .into_any_element()
     }
 
@@ -1397,7 +1414,7 @@ impl Tty7App {
             // come through here were the ones left silent. The chord is worth
             // more here than anywhere else in the row: it is the way back to
             // opening a tab without reading a menu first.
-            .tooltip(chord_hint(t(L10nKey::AppMenuNewTab), "NewTab", cx))
+            .tooltip_element(chord_tooltip(t(L10nKey::AppMenuNewTab), "NewTab", cx))
             // Built when the menu opens, not when the strip draws: this
             // closure runs once per press, and again after each dismissal.
             .dropdown_menu(move |menu, window, cx| {
@@ -1991,7 +2008,7 @@ impl Tty7App {
                             cx,
                         )
                         .rounded_lg()
-                        .tooltip(chord_hint(
+                        .tooltip_element(chord_tooltip(
                             t(L10nKey::TabTooltipShowSidebar),
                             "ToggleLeftPanel",
                             cx,

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -780,6 +780,16 @@ pub(crate) fn apply_theme(mut window: Option<&mut Window>, cx: &mut App) {
     // give primary buttons, and the thumb to `primary_foreground`, which on a
     // dark theme is a black disc on a dark page. Side by side on one settings
     // page the two controls disagreed about what a set value looks like.
+    //
+    // Both were tried on `primary` — the neutral ramp the segmented controls
+    // and the sidebar's selected page are drawn from — to settle a complaint
+    // that the accent pills were the only saturated things on a screen of
+    // greys. Reverted on sight: a dark-grey "on" against a light-grey "off" is
+    // not a large enough step to read at a glance down a column of rows, and a
+    // switch whose state you have to look twice at has lost the one job it has.
+    // If the mismatch with the segmented controls is worth closing, it has to
+    // close from the other end — by giving *them* some accent — not by taking
+    // it away from here.
     t.tokens.slider_bar = Hsla::from(rgb(m.accent)).into();
     t.tokens.slider_thumb = Hsla::from(rgb(knob)).into();
 
@@ -805,6 +815,18 @@ pub(crate) fn apply_theme(mut window: Option<&mut Window>, cx: &mut App) {
     t.scrollbar_show = ScrollbarShow::Scrolling;
 
     t.radius = px(8.);
+
+    // Flat controls, floating panels. `Theme::shadow` gates exactly one thing —
+    // the `shadow_xs` an inline control (button, input, select trigger,
+    // checkbox, radio, slider knob) paints under itself — and never the drop
+    // shadow on a menu, tooltip or popover, which every one of those draws
+    // unconditionally. Left on, every field and button in the window carried a
+    // faint lift that nothing else here has: this chrome separates surfaces with
+    // low-contrast fills and hairlines, so a control sitting a millimetre above
+    // the panel was the one place claiming depth, and it read as a rendering
+    // artefact rather than as a material. Panels that really do float keep
+    // their shadow.
+    t.shadow = false;
 
     let sidebar_bg = Hsla::from(rgb(m.sidebar));
     let sidebar_sel = rgb(surfaces.sidebar.selected);
@@ -881,6 +903,14 @@ pub(crate) fn apply_theme(mut window: Option<&mut Window>, cx: &mut App) {
     }
 }
 
+/// Every switch in the window, built here so the on-state has one definition.
+///
+/// The accent is load-bearing, not decoration. Without `.color()` a switch's
+/// on-state falls to `tokens.primary`, a dark neutral, and against the light
+/// neutral of the off-state that is too small a step to read while scanning a
+/// column of rows — you end up checking the thumb's position on each one. It
+/// was tried that way and reverted; see the slider-bar note in `apply_theme`
+/// for the other half of the pair.
 pub(crate) fn switch(id: impl Into<gpui::ElementId>, cx: &App) -> gpui_component::switch::Switch {
     let accent = cx.global::<presets::ActiveAccent>().0;
     gpui_component::switch::Switch::new(id).color(Hsla::from(rgb(accent)))


### PR DESCRIPTION
Pulls the widgets tty7 borrows from gpui-component onto the same design language as the chrome around them, and fixes three things on the settings page that made its right-hand column look assembled rather than laid out.

Pairs with l0ng-ai/gpui-component@51a6925 on the `tty7` branch; the pin moves with it.

## Before / After

| | Before | After |
|---|---|---|
| Buttons, inputs, select triggers, checkboxes, slider knobs | Each painted a faint `shadow_xs` under itself | Flat. Menus, tooltips and popovers keep their drop shadow |
| Medium/Large button label | 16px — a step above the window's body size | 14px, the body size |
| Labelled button side padding | 16 / 12 / 4 | 12 / 10 / 6, off the chrome's own 12px content inset |
| Focused input border | Full `ring` — near-black on light, near-white on dark | `ring` at 50%: the edge still changes, the field no longer jumps to the front |
| Chrome tile tooltip, e.g. Hide sidebar | `Hide sidebar  ⌘B` in one string, chord in the label's own size and colour | Label, then the chord set apart on the right, a size down, in `muted_foreground` |
| Tooltip card | 6px radius pinned, full-strength border, 2px vertical padding | Theme radius, hairline border, 4px vertical padding |
| Select dropdown panel | Sat on `tokens.background` — the window's own fill | `popover`, with `PopupMenu`'s radius, shadow and 5px inset |
| Slider rail | 6px against a 16px knob | 4px, thumb offset moved to match |
| Settings right column width | 260 (fields) / 240 (sliders) / 180 (dropdowns) | One `FIELD_W` = 260 |
| Program row's shell picker | `ghost` button — filled a rounded rectangle at the field's exact inner height while open | No fill in any state, like `Select`'s own chevron |
| That picker's menu | `min_w(200)`, anchored `TopRight` on a chevron inside the field → left edge 110px in from the field's | As wide as the field it drops out of |

## Why

Two of these are worth spelling out.

**The shadow.** `Theme::shadow` gates exactly one thing: the `shadow_xs` an inline control paints under itself. It never touches the drop shadow on a menu, tooltip or popover — those are unconditional. This chrome separates surfaces with low-contrast fills and hairlines, so with it on, every field and button was the one thing on screen claiming depth.

**The chord.** `Tooltip` has always had a `key_binding` slot that renders a shortcut as a shortcut. `chord_hint` bypassed it by concatenating, because `Button::tooltip` only took a `SharedString`. gpui-component's `Button` had a `tooltip_builder` field that was declared, initialised and read in `render` but that nothing could write to; the companion PR adds the setter, and `chord_hint` becomes `chord_tooltip`.

## Not changed, deliberately

The switch and slider keep their accent colour. Both were tried on the neutral ramp the segmented controls and the sidebar's selected row use, so that the settings page would say "current value" one way instead of two — and a dark-grey *on* against a light-grey *off* turned out not to be a large enough step to read while scanning down a column of rows. Reverted on sight, with the reasoning recorded in `theme.rs` so it does not get tried a third time. Closing that mismatch, if it is worth closing, has to come from giving the segmented controls some accent rather than taking it away here.

## Lockfile

Three lines: the `gpui-component` source pin, on all three crates from the fork.

It was briefly wider. Bumping the pin made cargo re-converge the same twenty dependency edges #802 exists to restore, so the two PRs overlapped on those lines. #802 landed first — it is scoped to exactly that and its body carries the reasoning — and rebasing on top of it left only the pin here, since git saw both sides setting the same lines to the same values.

## Testing

- `cargo build -p tty7` and `cargo fmt -p tty7 --check` clean, rebased on current `main`.
- `cargo clippy -p gpui-component` clean on the fork side.
- Manual pass in an isolated dev instance (`--config-dir /tmp/t7dev`): hovered the chrome tiles for the tooltip and chord; walked the Terminal and Appearance settings pages for the flattened controls, the column width and the Program row's picker menu; confirmed the segmented controls, context menus and the command palette were untouched.
- Rebased onto `main` at `bfabe053`. The rebase applied cleanly but did not compile: #782 landed a new `chord_hint` call site for the zoomed-tab mark while this branch was renaming that function. It now goes through `chord_tooltip` like the rest — it is a plain `div().tooltip()` rather than a `Button`, so it uses gpui's own tooltip hook with the same builder.
- No behaviour outside rendering changed, so no new unit tests. `key_hint` keeps its signature and its callers; `key_stroke` is the same lookup one step earlier.