### PR TITLE
fix(ui): give an agent's mark one colour, not one per draw site

### DIFF
--- a/crates/tty7-core/src/core/cli_agent.rs
+++ b/crates/tty7-core/src/core/cli_agent.rs
@@ -460,6 +460,25 @@ impl CLIAgent {
         }
     }
 
+    /// The colour the agent's mark is drawn in.
+    ///
+    /// SVG assets render as a single-colour mask, so whatever `fill` the file
+    /// carries is thrown away and the colour has to come from here. It lives
+    /// next to [`Self::accent_rgb`] rather than at either draw site because
+    /// there are two of those — the tab avatar and the tray icon — and a mark
+    /// that answers differently depending on which one is asking is the same
+    /// agent wearing two faces.
+    ///
+    /// White for every mark that is a silhouette sitting on its brand colour.
+    /// TraeCode is the one whose mark is the coloured half of the pair, on an
+    /// accent that is deliberately black.
+    pub fn icon_rgb(self) -> u32 {
+        match self {
+            CLIAgent::TraeCode => 0x32F08C,
+            _ => 0xFFFFFF,
+        }
+    }
+
     pub fn icon_path(self) -> &'static str {
         match self {
             CLIAgent::Claude => "icons/agents/claude.svg",

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -1301,14 +1301,11 @@ impl Tty7App {
                         gpui::svg()
                             .path(agent.icon_path())
                             .size(px(size * 0.54))
-                            // SVG assets are rendered as a single-colour mask.
-                            // TraeCode's black field comes from the avatar, and
-                            // its brand mark uses the official green.
-                            .text_color(if agent == crate::core::cli_agent::CLIAgent::TraeCode {
-                                gpui::rgb(0x32F08C)
-                            } else {
-                                gpui::rgb(0xFFFFFF)
-                            }),
+                            // SVG assets render as a single-colour mask, so
+                            // the mark's colour comes from the agent rather
+                            // than from the file. The tray icon reads the same
+                            // answer.
+                            .text_color(gpui::rgb(agent.icon_rgb())),
                     )
                     .when_some(dot, |b, dot| b.child(dot))
                     .tooltip(move |window, cx| {

--- a/src/ui/tray/icon.rs
+++ b/src/ui/tray/icon.rs
@@ -81,7 +81,15 @@ pub(super) fn agent_avatar(
     let glyph_size = (s * 0.60).round() as u32;
     let mut glyph = tiny_skia::Pixmap::new(glyph_size, glyph_size)?;
     resvg::render(&tree, fit_center(&tree, glyph_size), &mut glyph.as_mut());
-    recolor(&mut glyph, (0xFF, 0xFF, 0xFF));
+    // Not a hard-coded white: a mark whose brand colour *is* the mark —
+    // TraeCode's green on a black disc — comes out here as a white silhouette
+    // while the tab avatar draws it green, which is the same agent wearing two
+    // faces. `icon_rgb` is the one answer both draw sites read.
+    let mark = agent.icon_rgb();
+    recolor(
+        &mut glyph,
+        ((mark >> 16) as u8, (mark >> 8) as u8, mark as u8),
+    );
     let offset = ((SIZE - glyph_size) / 2) as i32;
     pixmap.draw_pixmap(
         offset,
@@ -296,6 +304,38 @@ mod tests {
                 agent.display_name()
             );
             assert_ne!(idle.data(), waiting.data());
+        }
+    }
+
+    /// The tab avatar and the tray icon draw the same mark, so they have to
+    /// draw it in the same colour.
+    ///
+    /// The tray used to recolour every glyph white regardless. That is
+    /// invisible for the nineteen agents whose mark *is* a white silhouette on
+    /// a brand-coloured disc, and wrong for the one whose mark carries the
+    /// colour itself: TraeCode came out white here while the tab strip drew it
+    /// green. Reading `icon_rgb` at both sites is what keeps one agent from
+    /// having two faces, and this asserts the tray actually reads it.
+    #[test]
+    fn the_tray_draws_each_mark_in_the_agents_own_colour() {
+        for agent in CLIAgent::ALL {
+            let avatar = agent_avatar(agent, AgentStatus::Idle).unwrap();
+            let mark = agent.icon_rgb();
+            let want = ((mark >> 16) as u8, (mark >> 8) as u8, mark as u8);
+            // Fully opaque only: the anti-aliased rim of the glyph is a blend
+            // of the mark and the disc under it and is nobody's brand colour.
+            let solid: std::collections::HashSet<_> = avatar
+                .pixels()
+                .iter()
+                .filter(|p| p.alpha() == 0xFF)
+                .map(|p| (p.red(), p.green(), p.blue()))
+                .collect();
+            assert!(
+                solid.contains(&want),
+                "{} should draw its mark in {want:?}; the solid colours on its \
+                 avatar are {solid:?}",
+                agent.display_name()
+            );
         }
     }
 


### PR DESCRIPTION
Follow-up to #807. Two places draw an agent's mark, and each decided its colour on its own.

| | Before | After |
|---|---|---|
| TraeCode on a tab | Green mark (`#32F08C`) on a black disc | Unchanged |
| TraeCode in the tray, when it needs input | **White** mark on the same black disc | Green, matching the tab |
| Every other agent, either place | White silhouette on its brand colour | Unchanged |

## Why it split

SVG assets render as a single-colour mask, so the `fill="#32F08C"` inside `traecli.svg` never reaches the screen — the colour has to come from code. #807 supplied it at the one draw site it touched:

```rust
// src/ui/tab_strip.rs
.text_color(if agent == CLIAgent::TraeCode { rgb(0x32F08C) } else { rgb(0xFFFFFF) })
```

The other site, `src/ui/tray/icon.rs`, has always said `recolor(&mut glyph, (0xFF, 0xFF, 0xFF))`. That was invisible for the nineteen agents whose mark *is* a white silhouette, so nothing before now had a reason to notice that "what colour is this mark" had no home on `CLIAgent` at all — only `accent_rgb` (the disc) and `icon_path` (the file) did.

## What changed

`CLIAgent::icon_rgb` joins `accent_rgb`, and both draw sites read it. The `if` in the tab strip goes away, which also means the next agent whose mark carries its own colour is one match arm rather than a second branch in a render closure.

## Testing

`cargo fmt --all --check` clean.

`the_tray_draws_each_mark_in_the_agents_own_colour` walks `CLIAgent::ALL`, renders the tray avatar, and asserts its fully-opaque pixels contain that agent's `icon_rgb`. Opaque only, because the glyph's anti-aliased rim is a blend of the mark and the disc beneath it. Against the old hard-coded white this test fails on TraeCode; it is what stops a future agent from being coloured at one draw site alone.

No local compile: this machine is down to 44G free and the worktree would rebuild the full dependency tree for a three-line substitution, so the build is left to CI. No GUI verification (project rule).