### PR TITLE
feat(chrome): show the window's buttons only under the pointer

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -337,6 +337,34 @@ fn strip_band(viewport: Size<Pixels>, pad: Edges<Pixels>) -> Bounds<Pixels> {
 
 pub(crate) const WINDOW_MARK_SIZE: f32 = 20.;
 
+/// A transparent sheet that answers one question: is the pointer inside the
+/// box it covers. Lay it over a region as that region's *last* child and read
+/// the flag to reveal chrome only while the pointer is there.
+///
+/// The obvious way to write this is `group_hover` on the region itself, and it
+/// does not work. Group hover asks whether the group's *hitbox* is the one
+/// under the pointer, and gpui's hit test stops at the first `occlude()`d
+/// element it meets on the way down. Tab chips and the chrome tiles are all
+/// occluding, so the region stopped counting as hovered the instant the
+/// pointer reached the very button it was revealing, and the button vanished
+/// from under the cursor. Painted last, this sheet's own hitbox sits in front
+/// of all of them, and it blocks nothing — it is not opaque, so the rows,
+/// chips and tiles underneath keep their clicks, cursors and tooltips.
+pub(crate) fn hover_sheet(id: &'static str, flag: &Rc<Cell<bool>>) -> gpui::Stateful<gpui::Div> {
+    use gpui::{InteractiveElement as _, StatefulInteractiveElement as _};
+    let flag = flag.clone();
+    gpui::div()
+        .id(id)
+        .absolute()
+        .inset_0()
+        .on_hover(move |over, window, _cx| {
+            if flag.get() != *over {
+                flag.set(*over);
+                window.refresh();
+            }
+        })
+}
+
 pub(crate) fn title_bar_drag(
     row: gpui::Stateful<gpui::Div>,
     key: &'static str,
@@ -835,6 +863,13 @@ pub struct Tty7App {
     pub(crate) editor: crate::ui::code_editor::EditorPanelState,
     pub(crate) sidebar_width: Rc<Cell<f32>>,
     pub(crate) sidebar_dragging: Rc<Cell<bool>>,
+    /// Whether the pointer is over the sidebar, the tab strip and the right
+    /// panel's own title bar. The chrome tiles in each — new tab, the two
+    /// panel toggles, the app menu — are drawn only while its own flag is set,
+    /// so a window nobody is pointing at carries no buttons at all.
+    pub(crate) sidebar_chrome_hover: Rc<Cell<bool>>,
+    pub(crate) strip_chrome_hover: Rc<Cell<bool>>,
+    pub(crate) panel_chrome_hover: Rc<Cell<bool>>,
     /// How much width a settings row will actually get, measured once per
     /// render. `settings_row` is called from page builders that never see the
     /// window, and the answer differs per page — the SSH page spends a host
@@ -1452,6 +1487,9 @@ impl Tty7App {
             editor,
             sidebar_width: Rc::new(Cell::new(sidebar_width)),
             sidebar_dragging: Rc::new(Cell::new(false)),
+            sidebar_chrome_hover: Rc::new(Cell::new(false)),
+            strip_chrome_hover: Rc::new(Cell::new(false)),
+            panel_chrome_hover: Rc::new(Cell::new(false)),
             settings_row_width: Cell::new(f32::MAX),
             settings_viewport_w: Cell::new(f32::MAX),
             settings_hit_anchored: Cell::new(false),

--- a/src/ui/right_panel.rs
+++ b/src/ui/right_panel.rs
@@ -441,9 +441,14 @@ impl Tty7App {
                     .items_center()
                     .gap(px(2.))
                     .pl(px(tile_trailing_inset()))
+                    .relative()
                     .children(self.right_panel_tabs(cx))
                     .child(div().flex_1())
-                    .child(self.window_chrome(window, cx))
+                    .child(self.window_chrome(self.panel_chrome_hover.get(), window, cx))
+                    .child(crate::ui::app::hover_sheet(
+                        "panel-chrome-hover",
+                        &self.panel_chrome_hover,
+                    ))
                 }))
                 .child(body)
                 .children(self.sftp_transfers_footer(cx))

--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -1135,6 +1135,9 @@ impl Tty7App {
             );
         }
 
+        // Empty chrome until the pointer is over the rail: these two tiles are
+        // the only thing between a resting window and a bare column of tabs.
+        let chrome_shown = self.sidebar_chrome_hover.get();
         let controls = h_flex()
             .flex_shrink_0()
             .h(px(TITLE_BAR_HEIGHT))
@@ -1157,24 +1160,29 @@ impl Tty7App {
                 div()
                     .occlude()
                     .flex_shrink_0()
+                    .when(!chrome_shown, |tile| tile.invisible())
                     .child(self.new_tab_button("sidebar-add", cx)),
             )
             .child(
-                div().occlude().flex_shrink_0().child(
-                    crate::ui::tab_strip::chrome_tile(
-                        Button::new("sidebar-collapse")
-                            .icon(Icon::empty().path("icons/panel-left.svg")),
-                        false,
-                        cx,
-                    )
-                    .rounded_lg()
-                    .tooltip_element(crate::ui::tab_strip::chord_tooltip(
-                        t(L10nKey::TabTooltipHideSidebar),
-                        "ToggleLeftPanel",
-                        cx,
-                    ))
-                    .on_click(cx.listener(|this, _, _window, cx| this.toggle_left_panel(cx))),
-                ),
+                div()
+                    .occlude()
+                    .flex_shrink_0()
+                    .when(!chrome_shown, |tile| tile.invisible())
+                    .child(
+                        crate::ui::tab_strip::chrome_tile(
+                            Button::new("sidebar-collapse")
+                                .icon(Icon::empty().path("icons/panel-left.svg")),
+                            false,
+                            cx,
+                        )
+                        .rounded_lg()
+                        .tooltip_element(crate::ui::tab_strip::chord_tooltip(
+                            t(L10nKey::TabTooltipHideSidebar),
+                            "ToggleLeftPanel",
+                            cx,
+                        ))
+                        .on_click(cx.listener(|this, _, _window, cx| this.toggle_left_panel(cx))),
+                    ),
             );
         // The tile inside asks for `w_full`, and a percentage is only a width
         // while some box above it has a real one. This row used to have none of
@@ -1345,6 +1353,10 @@ impl Tty7App {
                     )),
             )
             .child(handle)
+            .child(crate::ui::app::hover_sheet(
+                "sidebar-chrome-hover",
+                &self.sidebar_chrome_hover,
+            ))
     }
 
     /// What the sidebar row hid: the full title, the full branch and diff

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -1074,13 +1074,18 @@ impl Tty7App {
         )
     }
 
+    /// The trailing chrome tiles. `shown` is the pointer being over the bar
+    /// they sit in: they are laid out either way, and only painted while it
+    /// holds, so revealing them never shifts anything beside them.
     pub(crate) fn window_chrome(
         &self,
+        shown: bool,
         window: &Window,
         cx: &mut Context<Self>,
     ) -> impl IntoElement + use<> {
         let panel_open = self.right_panel_open(cx);
         h_flex()
+            .when(!shown, |row| row.invisible())
             .flex_shrink_0()
             .items_center()
             .gap(px(2.))
@@ -2036,6 +2041,9 @@ impl Tty7App {
             .flex_shrink_0()
             .child(self.new_tab_button("tab-add", cx));
 
+        // Same bargain the sidebar's own tiles keep: present in the layout,
+        // painted only while the pointer is on the bar.
+        let strip_chrome_shown = self.strip_chrome_hover.get();
         let rail_collapsed = !show_chips && !self.left_panel_open(cx);
         let left_group = rail_collapsed.then(|| {
             h_flex()
@@ -2053,37 +2061,48 @@ impl Tty7App {
                             .child(mark),
                     )
                 })
+                // The logo above stays put: it is the window's mark, not a
+                // control, and a window that loses its identity when nobody is
+                // pointing at it reads as a different window.
                 .child(
                     div()
                         .occlude()
                         .flex_shrink_0()
+                        .when(!strip_chrome_shown, |tile| tile.invisible())
                         .child(self.new_tab_button("titlebar-add-collapsed", cx)),
                 )
                 .child(
-                    div().occlude().flex_shrink_0().child(
-                        chrome_tile(
-                            Button::new("titlebar-expand-sidebar")
-                                .icon(Icon::empty().path("icons/panel-left.svg")),
-                            false,
-                            cx,
-                        )
-                        .rounded_lg()
-                        .tooltip_element(chord_tooltip(
-                            t(L10nKey::TabTooltipShowSidebar),
-                            "ToggleLeftPanel",
-                            cx,
-                        ))
-                        .on_click(cx.listener(|this, _, _window, cx| this.toggle_left_panel(cx))),
-                    ),
+                    div()
+                        .occlude()
+                        .flex_shrink_0()
+                        .when(!strip_chrome_shown, |tile| tile.invisible())
+                        .child(
+                            chrome_tile(
+                                Button::new("titlebar-expand-sidebar")
+                                    .icon(Icon::empty().path("icons/panel-left.svg")),
+                                false,
+                                cx,
+                            )
+                            .rounded_lg()
+                            .tooltip_element(chord_tooltip(
+                                t(L10nKey::TabTooltipShowSidebar),
+                                "ToggleLeftPanel",
+                                cx,
+                            ))
+                            .on_click(
+                                cx.listener(|this, _, _window, cx| this.toggle_left_panel(cx)),
+                            ),
+                        ),
                 )
         });
 
         let panel_open = self.right_panel_open(cx);
-        let right_chrome =
-            (!panel_open || !cfg!(target_os = "macos")).then(|| self.window_chrome(window, cx));
+        let right_chrome = (!panel_open || !cfg!(target_os = "macos"))
+            .then(|| self.window_chrome(strip_chrome_shown, window, cx));
 
         h_flex()
             .id("tab-strip")
+            .relative()
             .items_center()
             .gap_1p5()
             .when(show_chips, |this| this.w(strip_w))
@@ -2105,6 +2124,10 @@ impl Tty7App {
                 ),
                 None => this.child(chrome),
             })
+            .child(crate::ui::app::hover_sheet(
+                "strip-chrome-hover",
+                &self.strip_chrome_hover,
+            ))
     }
 }
 


### PR DESCRIPTION
Reveals the window's chrome tiles only while the pointer is over the bar they belong to, so a window nobody is using is just tabs and terminal.

| | Before | After |
|---|---|---|
| Sidebar's new-tab and collapse tiles | Always painted | Painted while the pointer is anywhere over the sidebar |
| Trailing right-panel and app-menu tiles | Always painted | Painted while the pointer is over the tab strip (or, on macOS with the panel open, over the panel's own title bar) |
| Collapsed rail's new-tab and expand tiles | Always painted | Painted while the pointer is over the tab strip |
| Window mark (Linux/Windows logo) | Always painted | Unchanged — it identifies the window, it is not a control |
| Layout when a group is hidden | — | Unchanged: the tiles keep their place and only lose their paint, so revealing them shifts nothing |

## Why not `group_hover`

The obvious implementation is `.group()` on each region with `.group_hover(|s| s.visible())` on the tiles, and it breaks in a way that is worth recording.

Group hover asks whether the *group's hitbox* is the one under the pointer, and gpui's hit test stops at the first occluding element it meets (`window.rs`, `HitboxBehavior::BlockMouse` → `break`). Tab chips and the chrome tiles are all `occlude()`d, so the region stopped counting as hovered the instant the pointer reached the very button it was revealing: the button vanished from under the cursor.

Dropping `occlude()` from the tiles is not the way out either. They sit on top of the title bar's `window_control_area(Drag)`, and Windows resolves `WM_NCHITTEST` against the **whole** hit list rather than the truncated hover prefix — an unoccluded tile would leave the drag hitbox in that list, turning the button into draggable chrome that no longer takes clicks.

So the reveal is a hover flag, in the shape this codebase already uses for pane grips (`pane_drag::reveal_band`): a transparent `hover_sheet` laid over each region as its **last** child. Painted last, its own hitbox sits in front of everything in the region, and it is not opaque, so the rows, chips and tiles underneath keep their clicks, cursors and tooltips.

```mermaid
flowchart LR
    P([pointer]) --> S["hover_sheet<br/>(painted last, not opaque)"]
    S -->|sets| F["Rc&lt;Cell&lt;bool&gt;&gt;<br/>on Tty7App"]
    F -->|read at render| T["chrome tiles<br/>.invisible() while false"]
    S -.->|"hit test continues<br/>(no BlockMouse)"| U["rows, chips, tiles<br/>clicks · cursors · tooltips"]
```

Three flags, one per bar: `sidebar_chrome_hover`, `strip_chrome_hover`, `panel_chrome_hover`.

## Testing

- `cargo test -p tty7` — 1845 passed, 0 failed.
- `cargo fmt --all --check` clean.
- Manual acceptance in an isolated dev instance (`--config-dir /tmp/t7dev`) on macOS: tiles absent with the pointer in the terminal, present on entering each bar, and stable — no flicker — with the pointer resting on a tile itself, which is the failure mode `group_hover` produced. Sidebar resize, tab drag-reorder and the tab context menu unaffected.
