### PR TITLE
fix(daemon): let the reap wait for a seat that is coming back

### DIFF
--- a/crates/tty7-core/src/daemon/singleton.rs
+++ b/crates/tty7-core/src/daemon/singleton.rs
@@ -205,6 +205,19 @@ pub fn holder_pid() -> Option<u32> {
 /// colliding with it is told `Taken` — accepted for the same reason: every
 /// caller is a reap that has just confirmed the seat's holder dead, and a
 /// spawn follows on each of those paths.
+///
+/// It waits [`SEAT_RELEASE_GRACE`] for the seat rather than reading one
+/// `EWOULDBLOCK` as "still held", because a seat whose holder has just died is
+/// not free the same instant the reap sees the death. The kernel releases the
+/// lock while tearing the process down, and any descriptor a `fork` in that
+/// process left behind — every `Command::spawn` duplicates them, and BSD
+/// `flock` counts an inherited descriptor as another reference to the one lock
+/// rather than a second lock — keeps it referenced until that child execs.
+/// Giving up on the first refusal left the dead holder's pid in the file for
+/// good: nothing revisits it, and the next pre-recording build to hold the
+/// seat would make that number — by then possibly reused — read as the holder.
+/// The same patience `a_reference_a_forking_neighbour_left_behind_does_not_lose_the_seat`
+/// records for the claim side.
 #[cfg(unix)]
 pub fn clear_record_if_free() {
     use std::os::unix::io::AsRawFd as _;
@@ -213,6 +226,7 @@ pub fn clear_record_if_free() {
     let Ok(file) = File::options().write(true).open(&path) else {
         return;
     };
+    let deadline = std::time::Instant::now() + SEAT_RELEASE_GRACE;
     loop {
         if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
             let _ = file.set_len(0);
@@ -221,10 +235,24 @@ pub fn clear_record_if_free() {
         }
         match std::io::Error::last_os_error().raw_os_error() {
             Some(libc::EINTR) => continue,
+            // A live holder that outlasts the grace keeps its record, which is
+            // the whole point of asking the kernel rather than the caller.
+            Some(libc::EWOULDBLOCK) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(RETRY_INTERVAL);
+            }
             _ => return,
         }
     }
 }
+
+/// How long the seat gets to come back after its holder was confirmed dead.
+/// Long enough for a teardown and a neighbour's `fork`/`exec` window, short
+/// enough to sit on a reap path that runs before the first window exists.
+#[cfg(unix)]
+const SEAT_RELEASE_GRACE: std::time::Duration = std::time::Duration::from_millis(500);
+
+#[cfg(unix)]
+const RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
 
 #[cfg(not(unix))]
 pub fn clear_record_if_free() {}
@@ -468,6 +496,40 @@ mod tests {
             );
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
+    }
+
+    /// The reap's half of the patience the claim side already has: a seat
+    /// whose holder has just been killed is not free the same instant the
+    /// reap sees the death, and one refusal used to end the attempt for good
+    /// — nothing revisits the file, so the dead holder's pid stayed in it.
+    ///
+    /// The 50ms reference here is what a `Command::spawn` on another thread
+    /// does between `fork` and `exec`, done deterministically; a real teardown
+    /// spends the same kind of moment releasing the descriptor.
+    #[cfg(unix)]
+    #[test]
+    fn clearing_the_record_waits_out_a_seat_that_is_about_to_come_back() {
+        let (dir, _guard) = pin_dir("clear-waits");
+        let path = dir.join("daemon.lock");
+        let seat = match claim_within(PATIENCE) {
+            Claim::Held(s) => s,
+            other => panic!("the claim must be granted, got {other:?}"),
+        };
+        let inherited = unsafe { libc::dup(held_fd().expect("the seat records its descriptor")) };
+        assert!(inherited >= 0, "dup the seat descriptor");
+        drop(seat);
+        let released = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            unsafe { libc::close(inherited) };
+        });
+        // One call, no retry loop of its own: waiting is the function's job.
+        clear_record_if_free();
+        let cleared = std::fs::read_to_string(&path).unwrap();
+        released.join().expect("the reference is let go");
+        assert_eq!(
+            cleared, "",
+            "a record whose seat comes back within the grace must be cleared"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes the flaky `reap_stranded_clears_a_seat_holder_with_no_pidfile` on macOS CI — it reddened #812, which touches nothing near the daemon.

| | Before | After |
|---|---|---|
| `clear_record_if_free` meets a locked seat | Gives up on the first `EWOULDBLOCK` | Retries for 500ms, then gives up |
| Record of a holder that has just died | Often kept forever — nothing revisits the file | Cleared once the kernel releases the lock |
| Record of a holder that is still alive | Kept | Kept — unchanged; the truncation still happens only while the kernel says the seat is free |
| Cost on the reap path | — | Up to 500ms, and only when the seat is genuinely still taken |

## Why it failed

A seat is not free the same instant its holder is confirmed dead. The kernel releases the lock while tearing the process down, and any descriptor a `fork` left behind keeps it referenced a moment longer: BSD `flock` counts an inherited descriptor as **another reference to the one lock**, not a second lock, and every `Command::spawn` duplicates the descriptors of the process it forks from.

This module already knows that — it is what `claim_within` and `a_reference_a_forking_neighbour_left_behind_does_not_lose_the_seat` are about on the claim side, and what `the_held_seat_names_its_holder_and_a_free_seat_names_nobody` polls around. `clear_record_if_free` was the one path with no patience, and it is the one nothing revisits: the reap calls it once, so a refusal left the dead holder's pid in the file permanently — where a later pre-recording build holding the seat would make that number, by then possibly reused for an unrelated process, read as the holder.

```mermaid
sequenceDiagram
    participant R as reap
    participant K as kernel
    participant L as daemon.lock
    R->>K: SIGTERM holder
    K-->>R: holder no longer alive
    Note over K: teardown still releasing<br/>the descriptor (and any<br/>a fork left behind)
    R->>L: flock LOCK_EX|LOCK_NB
    L-->>R: EWOULDBLOCK
    Note over R: before — give up;<br/>dead pid stays forever
    Note over R: after — retry up to 500ms,<br/>clear as soon as the seat is back
```

## Testing

- New guard: `clearing_the_record_waits_out_a_seat_that_is_about_to_come_back` — holds a duplicated seat descriptor, releases it after 50ms (what a neighbour's `fork`/`exec` window does, made deterministic), and asserts one `clear_record_if_free` call waits it out.
- Measured both ways: with the grace set to zero the new test fails with exactly the assertion CI reported (`left: "<pid>", right: ""`).
- `cargo test -p tty7-core` (1258) and `cargo test -p tty7-server` (incl. all 5 `daemon_reap` cases) pass locally on macOS; `cargo fmt --all --check` clean.
