### PR TITLE
perf(ssh): prove the remote server once per connection, not once per pane (#695)

### DIFF
--- a/crates/tty7-core/src/daemon/install/mod.rs
+++ b/crates/tty7-core/src/daemon/install/mod.rs
@@ -1341,37 +1341,135 @@ fn connection_label(conn: &SshConnection) -> String {
     conn.key().as_str().to_string()
 }
 
+/// What one SSH connection's server probe proved, kept so that the panes after
+/// the first one do not pay for proving it again.
+///
+/// `Installer::run` is four to six serial round trips — `uname -sm`, an SFTP
+/// realpath for the home directory, an SFTP stat, a control probe that spawns
+/// the server binary, and `check_running_build`, which walks `/proc/<pid>/exe`
+/// with a `readlink` per PID (or shells out to `ps` where there is no `/proc`).
+/// That is a fair price once for a machine and an absurd one per pane: issue
+/// #695 is a user watching `connecting to ...` for ten seconds every time they
+/// open a tab on a host tty7 was already connected to and already serving. The
+/// SSH connection itself is reused, so none of that wait is handshake cost.
+///
+/// Deliberately not a global map keyed by host, the way [`wsl`]'s is. A distro
+/// name is the whole identity of a WSL target, but an SSH connection can die
+/// and be replaced under the same key, and a note about the previous link must
+/// not answer for the next one. Keying by connection generation *is* keeping
+/// the note on the connection — see `SshConnection::proved_server`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProvedServer {
+    /// The server binary the probe settled on, which is what the route runs.
+    pub binary: String,
+    /// The build mismatch the probe found, if it found one.
+    ///
+    /// Kept because the warning is raised inside `Installer::run`, and the
+    /// whole point of the memo is that `run` does not happen again: without
+    /// this, only the first pane on a connection would ever hear that a
+    /// different build is serving the machine, and every pane after it — every
+    /// window, since a connection outlives one — would attach in silence. That
+    /// is the one way memoizing could quietly cancel the version check, so it
+    /// is the one thing the note carries besides the path.
+    pub mismatch: Option<MismatchedRemoteDaemon>,
+}
+
+impl ProvedServer {
+    fn from_report(report: InstallReport) -> ProvedServer {
+        ProvedServer {
+            binary: report.paths.binary,
+            mismatch: report.mismatch,
+        }
+    }
+}
+
+/// Answer from the note if there is one, otherwise prove it and leave a note.
+///
+/// Two rules the callers depend on:
+///
+/// - A failed probe is not remembered. `prove` returning an error leaves the
+///   slot exactly as it found it, so a host that was briefly unreachable, or an
+///   install the user declined once, is retried by the next pane rather than
+///   pinned into permanent failure for the life of the connection.
+/// - A remembered mismatch is re-filed on every hit. Each route carries its own
+///   mismatch sink (`RouteSetup::mismatches`), drained into a prompt as the
+///   route is set up, so re-filing is what makes the *n*th pane's client hear
+///   what the first pane's probe found.
+fn proved_or_prove(
+    slot: &mut Option<ProvedServer>,
+    prove: impl FnOnce() -> io::Result<ProvedServer>,
+) -> io::Result<String> {
+    if let Some(known) = slot.as_ref() {
+        if let Some(mismatch) = known.mismatch.clone() {
+            record_remote_mismatches(vec![mismatch]);
+        }
+        return Ok(known.binary.clone());
+    }
+    let proved = prove()?;
+    let binary = proved.binary.clone();
+    *slot = Some(proved);
+    Ok(binary)
+}
+
 pub fn ensure_remote_server(conn: &Arc<SshConnection>) -> io::Result<String> {
     let host = connection_label(conn);
     ensure_remote_server_labeled(conn, &host)
 }
 
 pub fn ensure_remote_server_labeled(conn: &Arc<SshConnection>, host: &str) -> io::Result<String> {
-    let ops = ssh_ops::SshRemoteOps::new(conn.clone());
-    let fetch = default_fetcher();
-    let confirm = install_confirm();
-    let source = BundledOrRelease::discover(fetch.as_ref());
-    let report = Installer::with_source(&ops, &source, confirm.as_ref(), host).run()?;
-    log::info!(
-        "remote {host}: {} at {} ({}{})",
-        if report.installed {
-            "installed tty7-server"
-        } else {
-            "tty7-server already present"
-        },
-        report.paths.binary,
-        if report.launched {
-            "daemon launched"
-        } else {
-            "daemon already running"
-        },
-        if report.mismatch.is_some() {
-            ", build mismatch recorded"
-        } else {
-            ""
-        },
-    );
-    Ok(report.paths.binary)
+    // The lock is held across the probe, not just across the read: two panes
+    // opening at once on a cold connection would otherwise both install, and
+    // the loser would be uploading over the very file the winner is renaming
+    // into place. Waiting out an install is what the second pane wants to do
+    // anyway — it needs the same answer.
+    let mut slot = conn.proved_server();
+    if let Some(known) = slot.as_ref() {
+        log::debug!(
+            "remote {host}: tty7-server was already proved at {} on this connection",
+            known.binary,
+        );
+    }
+    proved_or_prove(&mut slot, || {
+        let ops = ssh_ops::SshRemoteOps::new(conn.clone());
+        let fetch = default_fetcher();
+        let confirm = install_confirm();
+        let source = BundledOrRelease::discover(fetch.as_ref());
+        let report = Installer::with_source(&ops, &source, confirm.as_ref(), host).run()?;
+        log::info!(
+            "remote {host}: {} at {} ({}{})",
+            if report.installed {
+                "installed tty7-server"
+            } else {
+                "tty7-server already present"
+            },
+            report.paths.binary,
+            if report.launched {
+                "daemon launched"
+            } else {
+                "daemon already running"
+            },
+            if report.mismatch.is_some() {
+                ", build mismatch recorded"
+            } else {
+                ""
+            },
+        );
+        Ok(ProvedServer::from_report(report))
+    })
+}
+
+/// Drop what we thought we knew about a connection's server, so that the next
+/// `ensure_remote_server` on it proves the whole thing again.
+///
+/// Three callers, and between them they are the memo's correctness argument:
+/// [`restart_remote_daemon`] and [`replace_remote_server`], which change which
+/// build is serving the machine and therefore what the note claims, and the
+/// router, which calls this when a routed link closes without the remote ever
+/// sending a byte — the only way a path that has stopped working is found out.
+/// A reconnect needs no caller at all: the note lives on the connection, and a
+/// new connection has none.
+pub fn forget_remote_server(conn: &SshConnection) {
+    *conn.proved_server() = None;
 }
 
 pub fn restart_remote_daemon(conn: &Arc<SshConnection>) -> io::Result<()> {
@@ -1379,6 +1477,11 @@ pub fn restart_remote_daemon(conn: &Arc<SshConnection>) -> io::Result<()> {
     let ops = ssh_ops::SshRemoteOps::new(conn.clone());
     let fetch = default_fetcher();
     let confirm = install_confirm();
+    // Forget first, not afterwards: this deliberately changes what is running
+    // over there, which is most of what the note claims, and a restart that
+    // fails halfway must leave the next pane looking rather than trusting a
+    // note written before the upheaval.
+    forget_remote_server(conn);
     Installer::new(&ops, fetch.as_ref(), confirm.as_ref(), host).restart_daemon()?;
     Ok(())
 }
@@ -1389,6 +1492,7 @@ pub fn replace_remote_server(conn: &Arc<SshConnection>) -> io::Result<()> {
     let fetch = default_fetcher();
     let confirm = install_confirm();
     let source = BundledOrRelease::discover(fetch.as_ref());
+    forget_remote_server(conn);
     Installer::with_source(&ops, &source, confirm.as_ref(), host).replace()?;
     Ok(())
 }

--- a/crates/tty7-core/src/daemon/install/mod.rs
+++ b/crates/tty7-core/src/daemon/install/mod.rs
@@ -1461,15 +1461,46 @@ pub fn ensure_remote_server_labeled(conn: &Arc<SshConnection>, host: &str) -> io
 /// Drop what we thought we knew about a connection's server, so that the next
 /// `ensure_remote_server` on it proves the whole thing again.
 ///
-/// Three callers, and between them they are the memo's correctness argument:
-/// [`restart_remote_daemon`] and [`replace_remote_server`], which change which
-/// build is serving the machine and therefore what the note claims, and the
-/// router, which calls this when a routed link closes without the remote ever
-/// sending a byte — the only way a path that has stopped working is found out.
-/// A reconnect needs no caller at all: the note lives on the connection, and a
-/// new connection has none.
+/// The router's call, and between it and [`while_changing_the_server`] they are
+/// the memo's correctness argument: this one is made when a routed link closes
+/// without the remote ever sending a byte — the only way a path that has stopped
+/// working is found out — and that one covers [`restart_remote_daemon`] and
+/// [`replace_remote_server`], which change which build is serving the machine
+/// and therefore what the note claims. A reconnect needs no caller at all: the
+/// note lives on the connection, and a new connection has none.
+///
+/// Takes the lock and gives it straight back, so it is safe to call from the
+/// reactor — unlike anything that holds it across a probe or a replace.
 pub fn forget_remote_server(conn: &SshConnection) {
     *conn.proved_server() = None;
+}
+
+/// Run something that changes which server is running over there, with the note
+/// dropped first and its lock held for the whole operation.
+///
+/// Forget first, not afterwards: both callers deliberately change what is
+/// running over there, which is most of what the note claims, and one that
+/// fails halfway must leave the next pane looking rather than trusting a note
+/// written before the upheaval.
+///
+/// Held throughout for the same reason `ensure_remote_server` holds it across
+/// its probe. A pane opening while a replace is in flight would otherwise probe
+/// against a half-moved binary — installing over the very upload this call is
+/// renaming into place, or filing the outgoing daemon as the mismatch — and
+/// then *keep* that answer for the life of the connection, where before the
+/// memo it cost that one pane and no other. Waiting the replace out is what the
+/// pane wants anyway: the answer it is asking for is the one this call is in
+/// the business of changing.
+///
+/// The note is cleared inside the guard rather than by calling
+/// [`forget_remote_server`], which wants this same non-reentrant lock.
+fn while_changing_the_server(
+    conn: &SshConnection,
+    change: impl FnOnce() -> io::Result<()>,
+) -> io::Result<()> {
+    let mut slot = conn.proved_server();
+    *slot = None;
+    change()
 }
 
 pub fn restart_remote_daemon(conn: &Arc<SshConnection>) -> io::Result<()> {
@@ -1477,13 +1508,10 @@ pub fn restart_remote_daemon(conn: &Arc<SshConnection>) -> io::Result<()> {
     let ops = ssh_ops::SshRemoteOps::new(conn.clone());
     let fetch = default_fetcher();
     let confirm = install_confirm();
-    // Forget first, not afterwards: this deliberately changes what is running
-    // over there, which is most of what the note claims, and a restart that
-    // fails halfway must leave the next pane looking rather than trusting a
-    // note written before the upheaval.
-    forget_remote_server(conn);
-    Installer::new(&ops, fetch.as_ref(), confirm.as_ref(), host).restart_daemon()?;
-    Ok(())
+    while_changing_the_server(conn, || {
+        Installer::new(&ops, fetch.as_ref(), confirm.as_ref(), host).restart_daemon()?;
+        Ok(())
+    })
 }
 
 pub fn replace_remote_server(conn: &Arc<SshConnection>) -> io::Result<()> {
@@ -1492,9 +1520,10 @@ pub fn replace_remote_server(conn: &Arc<SshConnection>) -> io::Result<()> {
     let fetch = default_fetcher();
     let confirm = install_confirm();
     let source = BundledOrRelease::discover(fetch.as_ref());
-    forget_remote_server(conn);
-    Installer::with_source(&ops, &source, confirm.as_ref(), host).replace()?;
-    Ok(())
+    while_changing_the_server(conn, || {
+        Installer::with_source(&ops, &source, confirm.as_ref(), host).replace()?;
+        Ok(())
+    })
 }
 
 #[cfg(feature = "remote-install")]

--- a/crates/tty7-core/src/daemon/install/tests.rs
+++ b/crates/tty7-core/src/daemon/install/tests.rs
@@ -2453,4 +2453,72 @@ mod proving_the_server_once_per_connection {
             "the next pane proves it again the long way"
         );
     }
+
+    /// What `restart_remote_daemon` and `replace_remote_server` do to the note:
+    /// drop it before they start, so that one which fails halfway leaves the
+    /// next pane looking instead of trusting a note written before the upheaval.
+    #[tokio::test]
+    async fn a_change_that_failed_halfway_leaves_no_note() {
+        use crate::daemon::ssh::test_support::{Exec, FakeSshd};
+
+        let sshd = FakeSshd::connect(Exec::Exits, None).await;
+        *sshd.conn.proved_server() = Some(ProvedServer {
+            binary: BINARY.to_string(),
+            mismatch: None,
+        });
+
+        let failed = while_changing_the_server(&sshd.conn, || {
+            Err(io::Error::other("the daemon would not stop"))
+        })
+        .expect_err("the change failed");
+        assert!(format!("{failed}").contains("would not stop"));
+        assert_eq!(
+            sshd.conn.remembered_server(),
+            None,
+            "the note went first, so the next pane proves it again"
+        );
+    }
+
+    /// And they hold the lock while they run: a pane that arrives in the middle
+    /// of a replace waits for it rather than proving a binary the replace is in
+    /// the middle of moving — and then keeping that answer for the life of the
+    /// connection.
+    #[tokio::test]
+    async fn a_pane_arriving_mid_change_waits_for_it() {
+        use crate::daemon::ssh::test_support::{Exec, FakeSshd};
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let sshd = FakeSshd::connect(Exec::Exits, None).await;
+        let proved = Arc::new(AtomicBool::new(false));
+        let mut pane = None;
+
+        while_changing_the_server(&sshd.conn, || {
+            let conn = sshd.conn.clone();
+            let raced = proved.clone();
+            pane = Some(std::thread::spawn(move || {
+                *conn.proved_server() = Some(ProvedServer {
+                    binary: "/home/me/.tty7/bin/proved-mid-change".to_string(),
+                    mismatch: None,
+                });
+                raced.store(true, Ordering::SeqCst);
+            }));
+            // Long enough for the other thread to reach the lock. It cannot
+            // pass it, so this can only fail if the lock is not being held.
+            std::thread::sleep(Duration::from_millis(50));
+            assert!(
+                !proved.load(Ordering::SeqCst),
+                "a pane must not write a note while the server is being changed"
+            );
+            Ok(())
+        })
+        .expect("the change itself succeeded");
+
+        pane.expect("the pane raced")
+            .join()
+            .expect("it got through");
+        assert!(
+            proved.load(Ordering::SeqCst),
+            "and it goes through as soon as the change is done"
+        );
+    }
 }

--- a/crates/tty7-core/src/daemon/install/tests.rs
+++ b/crates/tty7-core/src/daemon/install/tests.rs
@@ -59,6 +59,10 @@ struct FakeRemote {
     /// a login shell that could not read the script, which is the shape the
     /// no-`/proc` bug took on every Mac.
     stop_fails: bool,
+    /// SFTP metadata reads — the realpath behind `home_dir` and every `stat`.
+    /// The journal carries commands and writes; these are the other half of
+    /// what a probe spends on the wire, and #695 is a count of both.
+    sftp_reads: Mutex<usize>,
 }
 
 impl FakeRemote {
@@ -87,6 +91,7 @@ impl FakeRemote {
             speaks: Mutex::new(HashMap::new()),
             installed_speaks: Some(ours()),
             stop_fails: false,
+            sftp_reads: Mutex::new(0),
         }
     }
 
@@ -183,10 +188,28 @@ impl FakeRemote {
             .filter(|j| !matches!(j, Journal::Exec(_)))
             .collect()
     }
+
+    /// The commands this remote was asked to run, in order.
+    fn execs(&self) -> Vec<String> {
+        self.journal()
+            .into_iter()
+            .filter_map(|j| match j {
+                Journal::Exec(cmd) => Some(cmd),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Everything that would have crossed the wire: commands, SFTP metadata
+    /// reads, and the writes an install makes.
+    fn round_trips(&self) -> usize {
+        self.journal().len() + *self.sftp_reads.lock().unwrap()
+    }
 }
 
 impl RemoteOps for FakeRemote {
     fn home_dir(&self) -> Result<String, String> {
+        *self.sftp_reads.lock().unwrap() += 1;
         Ok(HOME.to_string())
     }
 
@@ -290,6 +313,7 @@ impl RemoteOps for FakeRemote {
     }
 
     fn stat(&self, path: &str) -> Result<Option<RemoteStat>, String> {
+        *self.sftp_reads.lock().unwrap() += 1;
         Ok(self.file(path).map(|f| RemoteStat {
             size: f.bytes.len() as u64,
             mode: f.mode,
@@ -2255,4 +2279,178 @@ fn replacing_overwrites_a_published_binary_that_does_not_serve_us() {
         remote.writes()
     );
     assert!(!release.fetched().is_empty(), "which means downloading it");
+}
+
+/// The probe every pane used to pay for, and the note that spares the second
+/// one — issue #695. See [`ProvedServer`].
+mod proving_the_server_once_per_connection {
+    use super::*;
+
+    /// A warm machine: this build's server is installed and already serving.
+    /// Every pane after the first on a connection to it finds exactly this.
+    fn warm() -> FakeRemote {
+        FakeRemote::new().with_previous_install().serving(BINARY)
+    }
+
+    fn prove(remote: &FakeRemote, user: &FakeUser, host: &str) -> io::Result<ProvedServer> {
+        let release = FakeRelease::new();
+        Ok(ProvedServer::from_report(
+            installer(remote, &release, user, host).run()?,
+        ))
+    }
+
+    /// The measurement the issue asks for, from the fake's own books: what the
+    /// first pane on a connection spends, and what the second one spends after
+    /// it. The chain is asserted by name rather than by count so that a probe
+    /// growing a step is a failure here and not a slow tab somewhere.
+    #[test]
+    fn the_second_pane_on_a_connection_spends_nothing() {
+        let remote = warm();
+        let user = FakeUser::approving();
+        let mut slot = None;
+
+        let first = proved_or_prove(&mut slot, || prove(&remote, &user, "me@warm-box:22"))
+            .expect("the server is there and serving");
+        assert_eq!(first, BINARY);
+        assert_eq!(
+            remote.execs(),
+            vec![
+                "uname -sm".to_string(),
+                format!("{} --stdio --bridge < /dev/null", shell_quote(BINARY)),
+                RUNNING_EXE_COMMAND.to_string(),
+            ],
+            "the probe: what to install, is a daemon answering, and what build is serving"
+        );
+        assert_eq!(
+            remote.round_trips(),
+            5,
+            "three commands and two SFTP reads — the realpath for $HOME and the stat"
+        );
+
+        let paid = remote.round_trips();
+        let second = proved_or_prove(&mut slot, || {
+            panic!("the second pane must not probe again");
+        })
+        .expect("the note answers");
+        assert_eq!(second, BINARY);
+        assert_eq!(
+            remote.round_trips(),
+            paid,
+            "the second pane pays nothing for what the first one proved"
+        );
+    }
+
+    /// A transient failure must not pin every later pane on the connection into
+    /// the same failure. Nothing is written to the note unless the probe got
+    /// all the way through, so the next pane goes and asks again.
+    #[test]
+    fn a_probe_that_failed_is_not_remembered() {
+        let remote = FakeRemote::new();
+        let user = FakeUser::declining();
+        let mut slot = None;
+
+        let refused = proved_or_prove(&mut slot, || prove(&remote, &user, "me@shy-box:22"))
+            .expect_err("the user said no");
+        assert!(
+            format!("{refused}").contains("was not confirmed"),
+            "the refusal is the install prompt's, not something else: {refused}"
+        );
+        assert_eq!(slot, None, "a failure leaves the slot exactly as it was");
+        assert_eq!(user.asked().len(), 1);
+
+        let _ = proved_or_prove(&mut slot, || prove(&remote, &user, "me@shy-box:22"));
+        assert_eq!(
+            user.asked().len(),
+            2,
+            "the pane after a refusal asks again rather than inheriting the refusal"
+        );
+    }
+
+    /// The one thing memoizing could quietly cancel: the version check. The
+    /// probe is what notices that a different build is serving the machine, and
+    /// the note has to keep filing that warning for the panes that never run
+    /// the probe — each route drains its own sink, so a warning filed only once
+    /// would reach only the first pane's client.
+    #[test]
+    fn a_remembered_mismatch_is_filed_again_for_every_pane() {
+        let (remote, legacy) = FakeRemote::new().with_legacy_install("26.7.4");
+        let remote = remote.serving(&legacy).speaking(
+            &legacy,
+            RemoteProtocol {
+                control: CONTROL - 1,
+                protocol: PROTOCOL,
+                build: "26.7.4".to_string(),
+            },
+        );
+        let user = FakeUser::approving();
+        let mut slot = None;
+
+        let first_route: Arc<Mutex<Vec<MismatchedRemoteDaemon>>> = Arc::new(Mutex::new(Vec::new()));
+        with_mismatch_sink(first_route.clone(), || {
+            proved_or_prove(&mut slot, || prove(&remote, &user, "me@old-box:22"))
+                .expect("an old daemon is kept, not a failure")
+        });
+        assert_eq!(
+            first_route.lock().unwrap().len(),
+            1,
+            "the probe found the mismatch"
+        );
+
+        let spent = remote.round_trips();
+        let second_route: Arc<Mutex<Vec<MismatchedRemoteDaemon>>> =
+            Arc::new(Mutex::new(Vec::new()));
+        with_mismatch_sink(second_route.clone(), || {
+            proved_or_prove(&mut slot, || panic!("the note answers this one")).expect("remembered")
+        });
+
+        let filed = second_route.lock().unwrap().clone();
+        assert_eq!(filed.len(), 1, "the second pane's client hears it too");
+        assert_eq!(filed[0].running_version.as_deref(), Some("26.7.4"));
+        assert_eq!(filed[0].wanted_version, VERSION);
+        assert_eq!(
+            remote.round_trips(),
+            spent,
+            "and hears it without a round trip"
+        );
+    }
+
+    /// The wiring, over a real SSH connection: `ensure_remote_server` reads the
+    /// note off the connection it was handed, and `forget_remote_server` takes
+    /// it away again. The fake sshd counts session channels, so "no round trip"
+    /// is measured here rather than argued.
+    #[tokio::test]
+    async fn a_proved_connection_answers_the_next_pane_off_the_wire() {
+        use crate::daemon::ssh::test_support::{Exec, FakeSshd};
+
+        let sshd = FakeSshd::connect(Exec::Exits, None).await;
+        assert_eq!(
+            sshd.conn.remembered_server(),
+            None,
+            "a new link knows nothing"
+        );
+
+        *sshd.conn.proved_server() = Some(ProvedServer {
+            binary: BINARY.to_string(),
+            mismatch: None,
+        });
+        assert_eq!(
+            ensure_remote_server(&sshd.conn).expect("the note answers"),
+            BINARY
+        );
+        assert_eq!(
+            sshd.opened(),
+            0,
+            "a proved connection opens no channel for the next pane"
+        );
+        assert_eq!(sshd.conn.remembered_server().as_deref(), Some(BINARY));
+
+        // What `replace_remote_server`, `restart_remote_daemon` and a routed
+        // link that closed without answering all do before they act.
+        forget_remote_server(&sshd.conn);
+        assert_eq!(
+            sshd.conn.remembered_server(),
+            None,
+            "the next pane proves it again the long way"
+        );
+    }
 }

--- a/crates/tty7-core/src/daemon/router.rs
+++ b/crates/tty7-core/src/daemon/router.rs
@@ -622,6 +622,25 @@ async fn drive(local: Stream, header: &RouteHeader) -> io::Result<()> {
         log::info!("wsl:{distro}: the bridge closed without answering; proving it again next time");
         crate::daemon::install::wsl::forget_wsl_server(distro);
     }
+    // The same reasoning over SSH, where the note is the one this connection's
+    // probe left behind. `exec` on a session channel succeeds whatever the
+    // command turns out to be, so a server binary that has been deleted or
+    // moved since the probe proved it is discovered exactly here, by a link
+    // that opened and then said nothing. Forget it and the next pane on this
+    // connection pays for a fresh probe once; leave it and every pane on the
+    // connection repeats the same silent failure.
+    if let (RouteTarget::Ssh(_), Some(conn)) = (&header.target, conn.as_ref())
+        && header.server_command.is_none()
+        && !copied
+            .as_ref()
+            .is_ok_and(|(_, from_remote)| *from_remote > 0)
+    {
+        log::info!(
+            "ssh {}: the routed link closed without answering; proving the server again next time",
+            conn.key().as_str(),
+        );
+        crate::daemon::install::forget_remote_server(conn);
+    }
 
     let (to_remote, to_local) = copied?;
     log::debug!("routed connection closed after {to_remote} up / {to_local} down bytes");

--- a/crates/tty7-core/src/daemon/router.rs
+++ b/crates/tty7-core/src/daemon/router.rs
@@ -639,7 +639,15 @@ async fn drive(local: Stream, header: &RouteHeader) -> io::Result<()> {
             "ssh {}: the routed link closed without answering; proving the server again next time",
             conn.key().as_str(),
         );
-        crate::daemon::install::forget_remote_server(conn);
+        // Off this thread, which is the one polling the route: the note's lock
+        // is also the connection's install gate, so a pane that is mid-probe or
+        // a replace that is mid-upload holds it for as long as that takes, and
+        // waiting here would keep the client's half of a link that is already
+        // gone open for the same span. Landing after whatever holds it is right
+        // either way — a note written by a probe that started before this link
+        // failed is exactly as suspect as the one it replaced.
+        let conn = conn.clone();
+        tokio::task::spawn_blocking(move || crate::daemon::install::forget_remote_server(&conn));
     }
 
     let (to_remote, to_local) = copied?;

--- a/crates/tty7-core/src/daemon/ssh/session.rs
+++ b/crates/tty7-core/src/daemon/ssh/session.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex, Weak};
 use russh::client::Msg;
 use russh::{Channel, ChannelMsg};
 
+use crate::daemon::install::ProvedServer;
 use crate::daemon::protocol::WinSize;
 use crate::daemon::remote_link::RemoteEntry;
 
@@ -230,6 +231,9 @@ pub struct SshConnection {
     remote_forwards: RemoteForwardTable,
     alive: AtomicBool,
     remote_entry: tokio::sync::Mutex<Option<RemoteEntry>>,
+    /// What this connection's server probe proved, once it has. See
+    /// [`SshConnection::proved_server`].
+    proved_server: Mutex<Option<ProvedServer>>,
 }
 
 impl SshConnection {
@@ -244,6 +248,7 @@ impl SshConnection {
             remote_forwards,
             alive: AtomicBool::new(true),
             remote_entry: tokio::sync::Mutex::new(None),
+            proved_server: Mutex::new(None),
         })
     }
 
@@ -332,6 +337,38 @@ impl SshConnection {
 
     pub async fn set_remote_entry(&self, entry: RemoteEntry) {
         *self.remote_entry.lock().await = Some(entry);
+    }
+
+    /// Where this connection's server was proved to be, and the lock that
+    /// makes the second pane wait for the first rather than prove it again.
+    ///
+    /// The memo lives on the connection rather than beside its key, and that
+    /// is the whole of the invalidation story for a reconnect: a dropped or
+    /// evicted link is a dropped `SshConnection`, and the one dialled in its
+    /// place starts with an empty slot. Nothing has to remember to forget.
+    /// What does have to remember is anything that changes the server *over
+    /// there* while the link stays up — see
+    /// [`crate::daemon::install::forget_remote_server`].
+    ///
+    /// A blocking `Mutex` on purpose: the probe behind it is a chain of
+    /// blocking SSH round trips run on a blocking thread, and a pane that
+    /// arrives mid-install wants to wait for that install rather than start a
+    /// second one.
+    pub(crate) fn proved_server(&self) -> std::sync::MutexGuard<'_, Option<ProvedServer>> {
+        self.proved_server
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Where this connection's server was last proved to be, or `None` if the
+    /// next pane would have to go and ask — including while it is being asked,
+    /// since this never waits. A hint for callers deciding whether a failure is
+    /// worth re-proving; the answer itself comes from `ensure_remote_server`.
+    pub fn remembered_server(&self) -> Option<String> {
+        self.proved_server
+            .try_lock()
+            .ok()
+            .and_then(|slot| slot.as_ref().map(|proved| proved.binary.clone()))
     }
 
     pub async fn add_remote_forward(


### PR DESCRIPTION
Closes the performance half of #695. The macOS-server half shipped in v26.9.1 and is untouched.

## What changed

Every route called `ensure_remote_server` unconditionally (`crates/tty7-core/src/daemon/ssh/mod.rs:323`), so every pane re-ran the full installer probe on a connection that was already up and already serving. The probe is now run once per SSH connection, and the answer is kept on the `SshConnection` itself.

| | before | after |
| --- | --- | --- |
| first pane on a connection | 3 commands + 2 SFTP reads | unchanged |
| every pane after it, same connection | 3 commands + 2 SFTP reads | **0** |
| after a reconnect | 3 + 2 | 3 + 2 (new connection, empty note) |
| after `replace`/`restart` | 3 + 2 | 3 + 2 (note dropped first) |

The three commands, in order, are `uname -sm`; the control probe `'…/tty7-server-c<n>p<n>' --stdio --bridge < /dev/null`, which spawns the server binary over there; and `RUNNING_EXE_COMMAND`, which walks `/proc/[0-9]*` with a `readlink` per PID and falls back to `ps -xwwo` where there is no `/proc`. The two SFTP reads are the realpath for `$HOME` and the stat of the binary. All five are serial, and all five happened before the pane's own channel was opened.

## Why

`crates/tty7-core/src/daemon/install/mod.rs:1344` (`ensure_remote_server`) → `Installer::run` → `uname`, `home_dir`, `stat`, `ensure_daemon`'s control probe, `check_running_build` (`:1034`). The SSH connection is reused across panes, so this was never handshake cost — it was probe cost paid again per pane. WSL hit the same wall in #479 and solved it with `remembered_wsl_server` (`crates/tty7-core/src/daemon/install/wsl.rs:606`, consulted by the router at `:789`); this gives SSH the same shape.

The one difference from WSL, and the reason the note is not a global map: a distro name is the whole identity of a WSL target, but an SSH connection can die and be replaced under the same `ConnectionKey`. Keeping the note on the `SshConnection` *is* keying it by connection generation, so a reconnect invalidates it structurally rather than by anyone remembering to.

## How the memo is invalidated

This is the part worth reviewing.

1. **Reconnect** — structural, no caller. The note lives in `SshConnection::proved_server` (`daemon/ssh/session.rs`); a dead or evicted link is a dropped `SshConnection`, and the one dialled in its place starts empty.
2. **`replace_remote_server` and `restart_remote_daemon`** — `forget_remote_server(conn)` runs *before* the operation, not after, so a restart that fails halfway leaves the next pane looking rather than trusting a note written before the upheaval. (Same ordering as `wsl::restart_wsl_daemon`.)
3. **A routed link that closed without the remote sending a byte** — `daemon/router.rs`, right beside the WSL clause that already does this. `exec` on a session channel succeeds whatever the command turns out to be, so a binary deleted or moved since the probe is discovered exactly there; the next pane pays for one fresh probe instead of every pane repeating a silent failure.
4. **A build mismatch is never skipped.** The note carries the `MismatchedRemoteDaemon` the probe found and **re-files it on every hit**. The warning is raised inside `Installer::run`, and each route drains its own sink (`RouteSetup::mismatches`) into a `RoutePrompt::Mismatch`; without re-filing, only the first pane on a connection would ever hear that a different build is serving the machine, and every window opened after it would attach in silence. This is the answer to "memoizing must not silently skip the version check" — the check's *finding* is what survives, not just its verdict.
5. **A failed probe is not remembered at all.** The slot is written only when the probe got all the way through, so a host that was briefly unreachable, or an install the user declined once, is retried by the next pane rather than pinned into permanent failure for the life of the connection.

What the note deliberately does *not* cache: `installed`, `launched`, `confirmed` from `InstallReport`. Those describe an event, not a state, and re-serving them to a later pane would only make the log lie. It caches the binary path and the mismatch, nothing else.

The lock is held across the probe rather than only across the read. Two panes opening at once on a cold connection would otherwise both install, with the loser uploading over the very file the winner is renaming into place; waiting out an install is what the second pane wants to do anyway, since it needs the same answer.

## Testing

Run on Windows 11, against `crates/tty7-core` only (`AWS_LC_SYS_PREBUILT_NASM=1 cargo test -p tty7-core`): **1165 passed, 0 failed, 3 ignored**, including the four new tests. `cargo fmt` clean; `cargo clippy -p tty7-core --tests` produces no new warnings (the ones it does produce are pre-existing and in untouched files).

New tests, in `daemon::install::tests::proving_the_server_once_per_connection`:

- `the_second_pane_on_a_connection_spends_nothing` — the measurement. `FakeRemote` now counts SFTP metadata reads as well as commands, so the test asserts the first pane's chain **by name** (`uname -sm`, the `--stdio --bridge` control probe, `RUNNING_EXE_COMMAND`) and its total of 5 round trips, then asserts the second pane adds 0 — its `prove` closure panics if it is ever called.
- `a_probe_that_failed_is_not_remembered` — a declined install is asked again by the next pane.
- `a_remembered_mismatch_is_filed_again_for_every_pane` — an old daemon serving the machine; the second route's own sink receives the mismatch, with no round trip.
- `a_proved_connection_answers_the_next_pane_off_the_wire` — the wiring, over a real SSH connection to the in-process `FakeSshd`: with a note in place, `ensure_remote_server` opens **0 session channels**, and `forget_remote_server` empties the note.

**Not verified, and not verifiable here:** wall-clock improvement against a real remote host. This machine is Windows with no Linux/macOS host to connect to, so the round-trip counts above come from the fake remote's own books rather than from a stopwatch on a real link. The user's ~10 s figure is still unattributed: this removes five serial round trips per pane, and on a link where one round trip costs what #454 measured (3.3 s) that is most of it, but nobody has yet timed the real thing. Also unexercised by tests: the router's forget-on-silent-link clause, which needs a live routed link to reach.

https://claude.ai/code/session_01UUyWQXzcBAoBzaSX8pc7nU
