### PR TITLE
docs: why a nested shell stops reporting its cwd (#698)

### DIFF
--- a/docs/reference/shell-integration.mdx
+++ b/docs/reference/shell-integration.mdx
@@ -90,8 +90,9 @@ To get integration into that shell, make it the shell tty7 starts:
   does *not* — those lines are typed into the session after the shell is
   already up, so they nest like anything else. Neither does `exec zsh` from
   your `.bashrc`: it replaces the process tty7 set up.
-- **A local pane.** Set `shell` in [config](/reference/configuration), and
-  leave `args` out — arguments you write turn the injection off.
+- **A local pane.** Set **Settings → Terminal → Shell → Program** (or `shell`
+  in [config](/reference/configuration)), and leave **Arguments** empty —
+  arguments you write turn the injection off.
 
 [If the Files panel stopped following a nested shell →](/reference/troubleshooting#the-directory-stopped-following-my-shell)
 

--- a/docs/reference/shell-integration.mdx
+++ b/docs/reference/shell-integration.mdx
@@ -23,7 +23,8 @@ removes itself from the equation if you run the same shell elsewhere.
 | **Remote panes** | The same three POSIX shells, bootstrapped over the SSH connection. Toggle per profile with **Settings → SSH → Session → Shell integration**. |
 
 `TTY7_SHELL_INTEGRATION` is set once it is active, and guards against a second
-injection when shells nest.
+injection when shells nest. It does not put the integration *into* a nested
+shell — [shells you start yourself](#shells-you-start-yourself) have none.
 
 <Note>
   A shell launched with arguments *you* wrote — `shell.args`, or a
@@ -51,9 +52,47 @@ it just falls back to less precise sources:
 
 - Ghost suggestions, the completion menu, and <kbd>⌃ R</kbd>'s fuzzy history
 - "Command finished" notifications and the failure marks in history search
-- Exact working-directory tracking (tty7 falls back to inspecting the process)
+- Exact working-directory tracking
 
 Panes, splits, scrollback, search, SSH, and the CLI are unaffected.
+
+The working-directory fallback is worth knowing in detail, because it is not
+available everywhere. Where tty7 can see the pane's processes it reads the
+foreground one's own working directory instead — a local pane on macOS or
+Linux, or a pane in a remote workspace, where the `tty7-server` on that host
+does the reading. It is a poll, not a report: it is sampled while the pane is
+producing output, at most twice a second, so it can trail a `cd` until the
+pane writes something again. A local pane on **Windows** and a pane connected
+to an **SSH host** have no fallback at all — on the far end of an `ssh` there
+is no process table to read, so a shell that does not report its directory
+leaves the pane showing the last directory that did.
+
+## Shells you start yourself
+
+The injection happens when the pane's shell is *launched*. Type `zsh` at a
+bash prompt — or `bash`, or `sh`, or `docker exec … sh` — and that second
+shell is a new process, launched by your shell rather than by tty7. It emits no
+prompt marks and no `OSC 7`, and the pane keeps showing the directory the
+outer shell last reported until you exit back to it.
+
+On your own machine this is usually invisible, because prompt frameworks
+report the directory themselves: oh-my-zsh does it from
+`omz_termsupport_cwd` in `lib/termsupport.zsh`. **Over SSH it is not.** That
+file returns early when `SSH_CLIENT` or `SSH_TTY` is set, so on a remote host
+a zsh you started by hand reports nothing at all, and neither does tty7.
+
+To get integration into that shell, make it the shell tty7 starts:
+
+- **A remote host.** tty7 asks the host for `$SHELL` when it connects and
+  bootstraps that shell, so `chsh -s /bin/zsh` (then reconnect) is what
+  switches it. A login script under **Advanced → Session** that runs `zsh`
+  does *not* — those lines are typed into the session after the shell is
+  already up, so they nest like anything else. Neither does `exec zsh` from
+  your `.bashrc`: it replaces the process tty7 set up.
+- **A local pane.** Set `shell` in [config](/reference/configuration), and
+  leave `args` out — arguments you write turn the injection off.
+
+[If the file panel stopped following a nested shell →](/reference/troubleshooting#the-directory-stopped-following-my-shell)
 
 ## Per-pane history
 

--- a/docs/reference/shell-integration.mdx
+++ b/docs/reference/shell-integration.mdx
@@ -19,8 +19,9 @@ removes itself from the equation if you run the same shell elsewhere.
 | **bash** | An rcfile that sources your own first. |
 | **fish** | A `-C` init command. |
 | **PowerShell** | An encoded init command that wraps your existing `prompt` function and PSReadLine's line reader. |
+| **nushell** | A `--config` wrapper whose `config.nu` sources yours first, then adds tty7's hooks. Local panes only. |
 | **WSL** *(Windows)* | The distro's shell is bootstrapped with the same scripts. |
-| **Remote panes** | The same three POSIX shells, bootstrapped over the SSH connection. Toggle per profile with **Settings → SSH → Session → Shell integration**. |
+| **Remote panes** | The same three POSIX shells, bootstrapped over the SSH connection. Toggle per profile with **Settings → SSH →** a profile **→ Advanced → Session → Shell integration**. |
 
 `TTY7_SHELL_INTEGRATION` is set once it is active, and guards against a second
 injection when shells nest. It does not put the integration *into* a nested
@@ -92,7 +93,7 @@ To get integration into that shell, make it the shell tty7 starts:
 - **A local pane.** Set `shell` in [config](/reference/configuration), and
   leave `args` out — arguments you write turn the injection off.
 
-[If the file panel stopped following a nested shell →](/reference/troubleshooting#the-directory-stopped-following-my-shell)
+[If the Files panel stopped following a nested shell →](/reference/troubleshooting#the-directory-stopped-following-my-shell)
 
 ## Per-pane history
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -84,6 +84,75 @@ If they do nothing at all in a particular pane, the shell there probably has no
 [shell integration](/reference/shell-integration) — nushell, elvish, xonsh and
 friends run fine but do not get the prompt layer.
 
+## The directory stopped following my shell
+
+The file panel, new splits, and the sidebar's repo grouping all follow the
+directory the pane's shell reports (`OSC 7`). If the pane is frozen on one
+directory while you `cd` around, something in the pane is not reporting it.
+
+The usual cause is a shell you started by hand. tty7 injects its
+[shell integration](/reference/shell-integration) into the shell it launches
+for the pane, and nothing else: run `zsh` at a bash prompt and that nested
+shell has none. Locally you rarely notice, because oh-my-zsh reports the
+directory itself — but its `lib/termsupport.zsh` begins with
+
+```zsh
+if [[ -n "$INSIDE_EMACS" || -n "$SSH_CLIENT" || -n "$SSH_TTY" ]]; then
+  return
+fi
+```
+
+so over SSH, where sshd sets those, oh-my-zsh does not define the reporter at
+all. A nested zsh on a remote host therefore reports nothing, from either
+side, and the pane keeps showing wherever the outer shell was.
+
+**Make it the shell tty7 starts.** On the remote host:
+
+```sh
+chsh -s /bin/zsh      # then reconnect
+```
+
+tty7 asks the host for `$SHELL` at connect time and bootstraps *that* shell,
+so this is what moves the integration into your zsh — oh-my-zsh keeps working
+beside it. Starting `zsh` from a login script, or `exec zsh` from your
+`.bashrc`, does not help: both run after (or instead of) the shell tty7 set
+up.
+
+**Or report the directory yourself.** If you cannot change the login shell,
+add this to the remote `~/.zshrc` — it restores directory tracking only, not
+prompt marks or command status:
+
+```zsh
+# Report the working directory to tty7 (OSC 7).
+autoload -Uz add-zsh-hook
+__tty7_cwd() { printf '\e]7;file://%s%s\a' "${HOST:-localhost}" "${PWD//\%/%25}" }
+add-zsh-hook precmd __tty7_cwd
+```
+
+It is safe to leave in place afterwards: when tty7 *is* integrating that
+shell, the two hooks simply report the same directory twice. The bash
+equivalent is `PROMPT_COMMAND`:
+
+```bash
+__tty7_cwd() { printf '\e]7;file://%s%s\a' "${HOSTNAME:-localhost}" "${PWD//%/%25}"; }
+PROMPT_COMMAND="__tty7_cwd${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+```
+
+Two other reasons a pane never reports its directory:
+
+- **The shell is one tty7 does not integrate.** Locally: zsh, bash, fish,
+  PowerShell, nushell. Over SSH: zsh, bash, fish. A remote host whose
+  `$SHELL` is anything else gets no bootstrap, silently.
+- **You gave the shell your own arguments** in `shell` or a `custom_shells`
+  entry, which turns the injection off by design.
+
+Where tty7 can see the pane's processes it falls back to reading the
+foreground process's working directory, which is why an unintegrated shell in
+a **remote workspace** mostly keeps up — that fallback is a poll, though,
+sampled while the pane produces output, so it can lag a `cd` until the pane
+writes again. There is no such fallback for an **SSH pane** (the processes are
+on the far end) or for a local pane on **Windows**.
+
 ## <kbd>⌥ B</kbd> types `∫` instead of moving a word
 
 That is macOS's default. Turn on **Settings → Input → Keyboard → Option (⌥) acts

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -81,12 +81,12 @@ shell:
 - **Settings → Input → Prompt → History search**
 
 If they do nothing at all in a particular pane, the shell there probably has no
-[shell integration](/reference/shell-integration) — nushell, elvish, xonsh and
-friends run fine but do not get the prompt layer.
+[shell integration](/reference/shell-integration) — elvish, xonsh and friends
+run fine but do not get the prompt layer.
 
 ## The directory stopped following my shell
 
-The file panel, new splits, and the sidebar's repo grouping all follow the
+The Files panel, new splits, and the sidebar's repo grouping all follow the
 directory the pane's shell reports (`OSC 7`). If the pane is frozen on one
 directory while you `cd` around, something in the pane is not reporting it.
 
@@ -94,7 +94,8 @@ The usual cause is a shell you started by hand. tty7 injects its
 [shell integration](/reference/shell-integration) into the shell it launches
 for the pane, and nothing else: run `zsh` at a bash prompt and that nested
 shell has none. Locally you rarely notice, because oh-my-zsh reports the
-directory itself — but its `lib/termsupport.zsh` begins with
+directory itself — but the cwd reporter sits at the end of its
+`lib/termsupport.zsh`, behind
 
 ```zsh
 if [[ -n "$INSIDE_EMACS" || -n "$SSH_CLIENT" || -n "$SSH_TTY" ]]; then
@@ -102,9 +103,10 @@ if [[ -n "$INSIDE_EMACS" || -n "$SSH_CLIENT" || -n "$SSH_TTY" ]]; then
 fi
 ```
 
-so over SSH, where sshd sets those, oh-my-zsh does not define the reporter at
-all. A nested zsh on a remote host therefore reports nothing, from either
-side, and the pane keeps showing wherever the outer shell was.
+so over SSH, where sshd sets those, sourcing stops there and the reporter is
+never defined — only the title hooks above that line still run. A nested zsh
+on a remote host therefore reports nothing, from either side, and the pane
+keeps showing wherever the outer shell was.
 
 **Make it the shell tty7 starts.** On the remote host:
 
@@ -140,9 +142,9 @@ PROMPT_COMMAND="__tty7_cwd${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
 
 Two other reasons a pane never reports its directory:
 
-- **The shell is one tty7 does not integrate.** Locally: zsh, bash, fish,
-  PowerShell, nushell. Over SSH: zsh, bash, fish. A remote host whose
-  `$SHELL` is anything else gets no bootstrap, silently.
+- **The shell is not one tty7 integrates.** It injects into zsh, bash, fish,
+  PowerShell and nushell locally, and into zsh, bash and fish over SSH — a
+  remote host whose `$SHELL` is anything else gets no bootstrap, silently.
 - **You gave the shell your own arguments** in `shell` or a `custom_shells`
   entry, which turns the injection off by design.
 


### PR DESCRIPTION
Docs for #698: a shell you start by hand inside a pane has no shell integration, and over SSH oh-my-zsh will not cover for it either.

## What changed

`docs/reference/shell-integration.mdx`

- New **Shells you start yourself** section: the injection happens when the pane's shell is launched, so a `zsh` typed at a bash prompt is a new process with no prompt marks and no `OSC 7`; how to make it the shell tty7 starts (`chsh` on a remote host, `shell` in config locally); why a login script and `exec zsh` from `.bashrc` do not count.
- The "what turns off without it" bullet used to say "tty7 falls back to inspecting the process". That overpromises, so it now says where the fallback exists (local macOS/Linux panes and remote-workspace panes), where it does not (SSH panes, Windows panes), and that it is an output-driven poll capped at twice a second rather than a report.

`docs/reference/troubleshooting.mdx`

- New entry **"The directory stopped following my shell"**, phrased as the symptom rather than the cause: the nested-shell rule, the oh-my-zsh SSH guard quoted from its own source, the `chsh` fix, and a four-line `precmd` snippet for a host where the login shell cannot be changed (plus the bash `PROMPT_COMMAND` equivalent). Also lists the two other ways a pane ends up with no cwd source: a shell tty7 does not integrate, and a `shell`/`custom_shells` entry with user-written args.

No code. See "What I deliberately left alone".

## Why

Two facts combine, and neither is visible from inside the app.

1. tty7 injects only into the login shell it starts itself. `daemon/ssh/mod.rs` probes the remote `$SHELL` (`remote::PROBE_COMMAND`) and execs that shell with `remote::bootstrap_command()` — zsh via a throwaway `ZDOTDIR`, bash via `--rcfile`. The reporter's remote login shell is bash, so bash is what gets integrated; a `zsh` typed afterwards is a separate process nothing injected into.
2. oh-my-zsh normally papers over that with its own `OSC 7` reporter, but `lib/termsupport.zsh` returns early when `SSH_CLIENT` or `SSH_TTY` is set (line 125 of the current master), so over SSH it never defines it.

I reproduced both halves myself in WSL Ubuntu-24.04 (zsh 5.9, oh-my-zsh master, stock template `.zshrc` in a throwaway `$HOME`), running the real `remote::bootstrap_command()` output — dumped from this tree — inside a `script(1)` pty, with `SSH_TTY`/`SSH_CLIENT`/`SSH_CONNECTION` as the only variable between runs. The bash bootstrap, then `zsh` by hand, then `cd /var`, `cd /usr`:

```
ssh env set                        ssh env unset
@OSC 133;C;zsh                     @OSC 133;C;zsh
@OSC 133;D;0    <- nothing between @OSC 7;file://thomas/etc
@OSC 7;file://thomas/etc           @OSC 7;file://thomas/var
                                   @OSC 7;file://thomas/usr
                                   @OSC 133;D;0
```

That is the maintainer's rows C and D, independently. The remedies in the docs were run the same way: the `precmd` snippet in `~/.zshrc` restores `OSC 7` from the nested zsh over SSH (including `/tmp/a b`), and, with the zsh bootstrap in play, it coexists with the injected integration by reporting the same directory twice per prompt. The bash `PROMPT_COMMAND` line was checked separately, including a `%` in the path (`/tmp/pct%dir` → `pct%25dir`, which `parse_osc7` decodes back).

**On the issue's second half ("with tty7-server installed it mostly works, but feels unstable").** The code offers a mechanism. In a remote workspace the daemon runs on the remote host, so its panes are local PTYs and `daemon/pane.rs::foreground_cwd` can read `/proc/<foreground pgid>/cwd`; `apply_probed_cwd` only declines for panes it considers remote, which a remote-workspace pane is not. That is why an unintegrated nested zsh tracks at all there — but the probe runs only inside the pane's output path, forced by an `OSC 133` prompt mark or otherwise throttled to `REMOTE_CONTEXT_POLL_INTERVAL` (500 ms). A nested shell emits no prompt marks, so its `cd` is picked up only if the redraw happens to land outside the throttle window; otherwise the panel keeps the old directory until the pane writes again, which is usually the echo of the user's next keystroke. "Mostly works, sometimes lags, no obvious trigger" is what that would feel like. I did not build a fix: it is a Linux-only daemon path I cannot exercise from this machine, for a symptom nobody has reproduced yet. It is written down in the docs and here so it can be aimed at properly if the reporter confirms the shape.

## What I deliberately left alone

- **Propagating the integration into nested shells.** For zsh it would mean keeping an exported `ZDOTDIR` alive for the whole session, which reaches every zsh in it — scripts included — and the remote bootstrap deletes its throwaway directory at the first prompt precisely because an SSH session has no reliable exit hook. A `ZDOTDIR` that outlives its directory is worse than the bug: the nested shell would lose the user's own config, not just tty7's hooks. (Checked in WSL that today's bootstrap does *not* do this — `unset ZDOTDIR` inside the redirector drops the export attribute, so nothing leaks to children and a nested zsh loads the user's real `.zshrc` with oh-my-zsh intact.) For bash there is no equivalent hook at all: `BASH_ENV` is non-interactive only.
- **A UI hint.** "This pane has never reported a cwd" would not fire on the reported bug, where the pane has a cwd — a stale one from the outer shell. Something honest is possible (the `OSC 133;C` payload names the command, so the daemon does know a shell is in the foreground with no `D` yet), but it is GUI work in the root crate, and I could not run the app here to see whether it reads as help or as noise.

## Testing

- `cargo test -p tty7-core --lib shell_integration` — 51 passed, 0 failed (nothing in this PR touches code; run to confirm the tree was clean after a temporary bootstrap-dump test used for the repro was removed).
- WSL Ubuntu-24.04 reproduction, four `script(1)` runs, described above: bash bootstrap with and without the SSH environment; the zsh snippet under SSH with the bash bootstrap and again with the zsh bootstrap; the bash `PROMPT_COMMAND` snippet with a `%` path.
- Docs are `.mdx` only — not rendered through Mintlify here. No new pages, so `docs.json` is untouched; the one new cross-link (`/reference/troubleshooting#the-directory-stopped-following-my-shell`) matches the new heading.
- **Not verified:** anything against a real CentOS 7 host or a real sshd — `SSH_TTY`/`SSH_CLIENT` were injected by hand to stand in for what sshd sets, and the bootstrap ran under a local pty rather than over an SSH channel. The "unstable with tty7-server" mechanism above is read from the code, not observed.

https://claude.ai/code/session_01UUyWQXzcBAoBzaSX8pc7nU
