### PR TITLE
fix: the three remaining items of #716 — the misdirected rename, the missing adopt verb, the absent tree backup

### DIFF
--- a/crates/tty7-cli/src/cli.rs
+++ b/crates/tty7-cli/src/cli.rs
@@ -407,7 +407,7 @@ pub enum TabCmd {
         ws: Option<String>,
     },
 
-    #[command(about = "Add a tab with a fresh shell")]
+    #[command(about = "Add a tab with a fresh shell, or around a pane already running")]
     New {
         #[arg(value_name = "WORKSPACE")]
         ws: Option<String>,
@@ -417,6 +417,20 @@ pub enum TabCmd {
             help = "Working directory for the tab's shell"
         )]
         cwd: Option<String>,
+
+        // The recovery half of `pane ls --all`. Until this existed, a pane that
+        // came out from under its tab — an interrupted `run`, or a client that
+        // closed tabs whose shells were still alive (#716) — could only be
+        // listed and killed. The shell is fine; it just has no tab, and
+        // `TabCreate` has always been able to take an existing pane id.
+        #[arg(
+            long,
+            value_name = "%PANE",
+            help = "Re-home a pane that is already running instead of spawning a shell — \
+                    for the orphans `tty7 pane ls --all` lists. Defaults the workspace to \
+                    the one the pane was spawned for"
+        )]
+        pane: Option<String>,
     },
 
     #[command(about = "Close a tab and every pane in it")]
@@ -742,7 +756,12 @@ mod tests {
         ));
         assert!(matches!(
             parse(&["tty7", "tab", "new", "api", "--cwd", "C:\\proj"]).command,
-            Some(Command::Tab(TabCmd::New { ws: Some(w), cwd: Some(c) })) if w == "api" && c == "C:\\proj"
+            Some(Command::Tab(TabCmd::New { ws: Some(w), cwd: Some(c), pane: None }))
+                if w == "api" && c == "C:\\proj"
+        ));
+        assert!(matches!(
+            parse(&["tty7", "tab", "new", "--pane", "%37"]).command,
+            Some(Command::Tab(TabCmd::New { ws: None, cwd: None, pane: Some(p) })) if p == "%37"
         ));
         assert!(matches!(
             parse(&["tty7", "tab", "close", "@7"]).command,

--- a/crates/tty7-cli/src/commands.rs
+++ b/crates/tty7-cli/src/commands.rs
@@ -81,7 +81,9 @@ pub fn execute(cli: Cli, ctx: &Context, backend: &mut dyn Backend) -> Result<Out
         Some(Command::Capture(args)) => capture(args, ctx, backend),
         Some(Command::Procs { target }) => procs(target.as_deref(), ctx, backend),
         Some(Command::Tab(TabCmd::Ls { ws })) => tab_ls(ws.as_deref(), ctx, backend),
-        Some(Command::Tab(TabCmd::New { ws, cwd })) => tab_new(ws.as_deref(), cwd, ctx, backend),
+        Some(Command::Tab(TabCmd::New { ws, cwd, pane })) => {
+            tab_new(ws.as_deref(), cwd, pane.as_deref(), ctx, backend)
+        }
         Some(Command::Tab(TabCmd::Close { tab })) => tab_close(&tab, backend),
         Some(Command::Tab(TabCmd::Rename { tab, name })) => tab_rename(&tab, name, backend),
         Some(Command::Tab(TabCmd::Move { tab, index })) => tab_move(&tab, index, backend),
@@ -668,12 +670,19 @@ fn tab_ls(explicit: Option<&str>, ctx: &Context, backend: &mut dyn Backend) -> R
 fn tab_new(
     explicit: Option<&str>,
     cwd: Option<String>,
+    adopt: Option<&str>,
     ctx: &Context,
     backend: &mut dyn Backend,
 ) -> Result<Outcome> {
     let machine = fetch_machine(backend)?;
-    let id = resolve_ws(explicit, ctx, &machine)?;
-    let pane = backend.spawn_shell(id, cwd.clone())?;
+    let (id, pane, cwd) = match adopt {
+        Some(spec) => adopt_pane(spec, explicit, cwd, ctx, &machine, backend)?,
+        None => {
+            let id = resolve_ws(explicit, ctx, &machine)?;
+            let pane = backend.spawn_shell(id, cwd.clone())?;
+            (id, pane, cwd)
+        }
+    };
     let tab = match backend.control(ControlRequest::TabCreate {
         workspace: id,
         at: None,
@@ -693,6 +702,83 @@ fn tab_new(
         format!("%{pane}"),
         json!({ "tab": tab.id.to_string(), "pane": pane }),
     )
+}
+
+/// Works out which workspace a pane that is already running goes into, and what
+/// to seed the tab around it with.
+///
+/// The seed is rebuilt from the **live pane registry**, not from the tree, and
+/// that is the whole design of this verb. `tab_close` retains the panes it
+/// orphaned out of `m.panes` at the same moment it drops the tab, so by the
+/// time anyone wants a pane back the tree has forgotten its record — its cwd,
+/// its title, the shell it was started with. The registry still has the pane,
+/// because the pane is still running; it is the only place left that knows
+/// anything about it.
+///
+/// What the registry does not carry is `ssh_spec`, `agent` or `shell`, so a
+/// re-homed pane is seeded without them. That costs nothing while the shell
+/// lives — the tab is a view onto a pty that is already there — and only shows
+/// up if the pane later dies and something tries to restore it from the seed.
+/// Reconstructing those from a running pty is a separate problem; a tab you can
+/// see and close beats a shell nobody can reach.
+fn adopt_pane(
+    spec: &str,
+    explicit: Option<&str>,
+    cwd: Option<String>,
+    ctx: &Context,
+    machine: &Machine,
+    backend: &mut dyn Backend,
+) -> Result<(WorkspaceId, u64, Option<String>)> {
+    let pane = address::parse_pane(spec)?;
+    let running = backend.list_panes()?;
+    let info = running
+        .iter()
+        .find(|info| info.pane_id == pane)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "no pane %{pane} is running on this machine — \
+                 `tty7 pane ls --all` lists every pane the server holds"
+            )
+        })?;
+    if let Ok(holder) = resolve::workspace_of_pane(machine, pane) {
+        bail!(
+            "%{pane} is already in a tab of workspace {} — `tty7 pane split` adds \
+             to that tab, and `tty7 tab new --pane` is for panes no tab holds",
+            resolve::short_id(&holder.id)
+        );
+    }
+    // A pane the tree still knows nothing about, addressed with no workspace,
+    // goes back to the one it was spawned for: that is what `pane ls --all`
+    // prints as its owner, and the shell being recovered from is by definition
+    // not inside tty7, so `$TTY7_WS` is not going to answer here.
+    let id = match (explicit, ctx.ws.as_deref()) {
+        (None, None) => owner_of(info, machine).ok_or_else(|| {
+            anyhow::anyhow!(
+                "%{pane} does not name a workspace that still exists — \
+                 say which one to re-home it into: `tty7 tab new <workspace> --pane %{pane}`"
+            )
+        })?,
+        _ => resolve_ws(explicit, ctx, machine)?,
+    };
+    // The recorded cwd is a courtesy for a later restore, not something the
+    // running shell is moved to; an explicit `--cwd` overrides it.
+    let cwd = cwd.or_else(|| {
+        info.cwd
+            .as_ref()
+            .map(|dir| dir.display().to_string())
+            .filter(|dir| !dir.is_empty())
+    });
+    Ok((id, pane, cwd))
+}
+
+/// The workspace a pane was spawned for, if it is still on this machine.
+fn owner_of(info: &tty7_core::daemon::protocol::PaneInfo, machine: &Machine) -> Option<WorkspaceId> {
+    let owner = info.owner.as_deref()?;
+    machine
+        .workspaces
+        .iter()
+        .find(|ws| ws.id.to_string() == owner)
+        .map(|ws| ws.id)
 }
 
 fn tab_close(tab: &str, backend: &mut dyn Backend) -> Result<Outcome> {
@@ -818,8 +904,9 @@ fn pane_ls_all(backend: &mut dyn Backend) -> Result<Outcome> {
     let mut human = output::registry_table(&running, &|pane| holder(pane).map(|ws| ws.to_string()));
     if orphans > 0 {
         human.push_str(&format!(
-            "\n{orphans} pane(s) held by no workspace — `tty7 pane close %<id>` stops one, \
-             `tty7 pane close --orphans` stops all of them\n"
+            "\n{orphans} pane(s) held by no workspace — `tty7 tab new --pane %<id>` puts one \
+             back in a tab, `tty7 pane close %<id>` stops one, `tty7 pane close --orphans` \
+             stops all of them\n"
         ));
     }
     report(human, json!({ "panes": panes, "orphans": orphans }))
@@ -2058,6 +2145,135 @@ mod tests {
             backend.spawned,
             vec![(api.id, Some("C:\\elsewhere".to_string()))]
         );
+    }
+
+    /// The recovery verb from #716. The pane is running and no tab holds it;
+    /// the tab is built around it and no new shell is started.
+    #[test]
+    fn tab_new_with_a_pane_re_homes_an_orphan_instead_of_spawning() {
+        let mut backend = mock();
+        let api = backend.machine.workspaces[0].clone();
+        let mut orphan = pane_info(37, Some(&api.id.to_string()));
+        orphan.cwd = Some("C:\\work".into());
+        backend.registry = vec![orphan];
+        backend
+            .replies
+            .push_back(ReplyOk::TabTree(Box::new(Tab::leaf(37))));
+
+        let out = run_cli(
+            &["tty7", "tab", "new", "--pane", "%37"],
+            &Context::default(),
+            &mut backend,
+        );
+
+        assert_eq!(
+            backend.control_calls[1],
+            ControlRequest::TabCreate {
+                workspace: api.id,
+                at: None,
+                pane: PaneSeed {
+                    pane: 37,
+                    // Rebuilt from the registry: the tree dropped this pane's
+                    // record when the tab holding it closed.
+                    cwd: Some("C:\\work".into()),
+                    ssh_spec: None,
+                    agent: None,
+                    shell: None,
+                },
+                tab: None,
+            },
+            "with no workspace named, the pane goes back to the one it was spawned for"
+        );
+        assert!(
+            backend.spawned.is_empty(),
+            "re-homing must not start a second shell — the point is the one still running"
+        );
+        assert_eq!(human(out), "%37");
+    }
+
+    #[test]
+    fn tab_new_with_a_pane_takes_an_explicit_workspace_and_cwd() {
+        let mut backend = mock();
+        let web = backend.machine.workspaces[1].id;
+        backend.registry = vec![pane_info(37, None)];
+        backend
+            .replies
+            .push_back(ReplyOk::TabTree(Box::new(Tab::leaf(37))));
+
+        run_cli(
+            &["tty7", "tab", "new", "web", "--pane", "%37", "--cwd", "C:\\else"],
+            &Context::default(),
+            &mut backend,
+        );
+
+        assert_eq!(
+            backend.control_calls[1],
+            ControlRequest::TabCreate {
+                workspace: web,
+                at: None,
+                pane: PaneSeed {
+                    pane: 37,
+                    cwd: Some("C:\\else".into()),
+                    ssh_spec: None,
+                    agent: None,
+                    shell: None,
+                },
+                tab: None,
+            },
+            "a pane with no owner still re-homes wherever it is told to"
+        );
+    }
+
+    #[test]
+    fn tab_new_refuses_a_pane_that_is_not_running() {
+        let mut backend = mock();
+        let error = execute(
+            cli(&["tty7", "tab", "new", "api", "--pane", "%99"]),
+            &Context::default(),
+            &mut backend,
+        )
+        .expect_err("a pane the server does not hold cannot be re-homed");
+        assert!(
+            error.to_string().contains("no pane %99 is running"),
+            "{error:#}"
+        );
+        assert!(
+            !backend
+                .control_calls
+                .iter()
+                .any(|call| matches!(call, ControlRequest::TabCreate { .. })),
+            "and nothing is written to the tree"
+        );
+    }
+
+    /// A pane a tab already holds is not an orphan, and putting it in a second
+    /// tab would leave the tree with one pane in two places.
+    #[test]
+    fn tab_new_refuses_a_pane_a_tab_already_holds() {
+        let mut backend = mock();
+        backend.registry = vec![pane_info(2, None)];
+        let error = execute(
+            cli(&["tty7", "tab", "new", "api", "--pane", "%2"]),
+            &Context::default(),
+            &mut backend,
+        )
+        .expect_err("%2 is in a tab of api");
+        assert!(error.to_string().contains("already in a tab"), "{error:#}");
+    }
+
+    /// The listing is where an orphan is found, so it is where the way out of
+    /// being one has to be written down.
+    #[test]
+    fn pane_ls_all_points_at_the_way_back_as_well_as_the_way_out() {
+        let mut backend = mock();
+        backend.registry = vec![pane_info(37, None)];
+        let out = human(run_cli(
+            &["tty7", "pane", "ls", "--all"],
+            &Context::default(),
+            &mut backend,
+        ));
+        assert!(out.contains("tty7 tab new --pane %<id>"), "{out}");
+        assert!(out.contains("tty7 pane close --orphans"), "{out}");
     }
 
     #[test]

--- a/crates/tty7-cli/src/commands.rs
+++ b/crates/tty7-cli/src/commands.rs
@@ -772,7 +772,10 @@ fn adopt_pane(
 }
 
 /// The workspace a pane was spawned for, if it is still on this machine.
-fn owner_of(info: &tty7_core::daemon::protocol::PaneInfo, machine: &Machine) -> Option<WorkspaceId> {
+fn owner_of(
+    info: &tty7_core::daemon::protocol::PaneInfo,
+    machine: &Machine,
+) -> Option<WorkspaceId> {
     let owner = info.owner.as_deref()?;
     machine
         .workspaces
@@ -2201,7 +2204,9 @@ mod tests {
             .push_back(ReplyOk::TabTree(Box::new(Tab::leaf(37))));
 
         run_cli(
-            &["tty7", "tab", "new", "web", "--pane", "%37", "--cwd", "C:\\else"],
+            &[
+                "tty7", "tab", "new", "web", "--pane", "%37", "--cwd", "C:\\else",
+            ],
             &Context::default(),
             &mut backend,
         );

--- a/crates/tty7-core/src/core/machine.rs
+++ b/crates/tty7-core/src/core/machine.rs
@@ -1304,12 +1304,9 @@ fn backup_path(path: &Path, generation: usize) -> PathBuf {
 /// Returns `Ok(())` when there was nothing to do: no tree yet, or the newest
 /// generation is younger than `spacing`.
 fn keep_a_generation(path: &Path, spacing: Duration) -> io::Result<()> {
-    let bytes = match std::fs::read(path) {
-        Ok(bytes) => bytes,
-        // Nothing has been written yet, so there is no previous generation.
-        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
-        Err(e) => return Err(e),
-    };
+    // Asked before the tree is read: this runs on every persist and answers
+    // "nothing to do" on almost all of them, so reading the whole document
+    // first would be a full read per write for one copy every five minutes.
     let newest = backup_path(path, 0);
     let too_soon = std::fs::metadata(&newest)
         .and_then(|meta| meta.modified())
@@ -1318,6 +1315,12 @@ fn keep_a_generation(path: &Path, spacing: Duration) -> io::Result<()> {
     if too_soon {
         return Ok(());
     }
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        // Nothing has been written yet, so there is no previous generation.
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e),
+    };
     // Oldest first, so nothing is overwritten before it has been moved down.
     // A generation that is not there yet simply has nothing to move.
     for generation in (1..BACKUP_GENERATIONS).rev() {
@@ -2701,8 +2704,12 @@ mod tests {
         let store = MachineStore::open(&path);
 
         let ws = store.workspace_create(None, None, None).unwrap();
-        store.tab_create(ws.id, None, seed(1, "/work"), None, None).unwrap();
-        store.tab_create(ws.id, None, seed(2, "/work"), None, None).unwrap();
+        store
+            .tab_create(ws.id, None, seed(1, "/work"), None, None)
+            .unwrap();
+        store
+            .tab_create(ws.id, None, seed(2, "/work"), None, None)
+            .unwrap();
 
         let kept = backup_path(&path, 0);
         assert!(

--- a/crates/tty7-core/src/core/machine.rs
+++ b/crates/tty7-core/src/core/machine.rs
@@ -26,6 +26,28 @@ pub const FACT_FLUSH_INTERVAL: Duration = Duration::from_secs(2);
 #[cfg(test)]
 pub const FACT_FLUSH_INTERVAL: Duration = Duration::from_secs(600);
 
+/// How many earlier generations of the machine tree are kept beside it.
+///
+/// Bounded on purpose: the tree is rewritten whole on every mutation, so an
+/// unbounded history would be a new file every few seconds forever. Three is
+/// what the spacing below has to work with.
+const BACKUP_GENERATIONS: usize = 3;
+
+/// How far apart those generations are taken.
+///
+/// The point of the spacing is that "the previous write" is worthless as a
+/// backup here. The tree is written whole on every mutation, and the failure
+/// worth recovering from arrives as a burst — #716 emptied a workspace with
+/// nineteen `TabClose`s in a row, each of them a persist. A backup taken on
+/// every write would have rolled the damage through all three generations
+/// before anyone looked. Spaced out, the oldest generation is a quarter of an
+/// hour of history, which is longer than any burst.
+///
+/// Note that "previous good" cannot mean "the last document that parsed":
+/// an emptied tree parses perfectly and is exactly what you want to recover
+/// *from*. Age is the only signal available here, so age is what is used.
+const BACKUP_SPACING: Duration = Duration::from_secs(300);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct TabId(uuid::Uuid);
@@ -1116,6 +1138,15 @@ impl MachineStore {
         if let Some(parent) = self.path.parent() {
             std::fs::create_dir_all(parent)?;
         }
+        // Before the overwrite, never after: the backup is the document about
+        // to be replaced. A failure here is not a reason to stop writing the
+        // new one — a machine with no backup still has to keep working.
+        if let Err(e) = keep_a_generation(&self.path, BACKUP_SPACING) {
+            log::warn!(
+                "could not keep an earlier generation of {}: {e}",
+                self.path.display()
+            );
+        }
         crate::core::config::write_atomic_private(&self.path, &bytes)
     }
 
@@ -1210,22 +1241,94 @@ fn load_machine(path: &Path) -> Machine {
         Err(e) => {
             log::warn!("could not read {}; quarantining it: {e}", path.display());
             crate::core::config::quarantine_by_rename(path);
-            return Machine::default();
+            return load_a_backup(path).unwrap_or_default();
         }
     };
-    match serde_json::from_str::<Machine>(crate::core::config::strip_bom(&text)) {
-        Ok(mut machine) => {
-            for pane in &mut machine.panes {
-                pane.live = false;
-            }
-            machine
-        }
+    match parse_machine(&text) {
+        Ok(machine) => machine,
         Err(e) => {
             log::warn!("{} does not parse ({e}); quarantining it", path.display());
             crate::core::config::quarantine(path);
-            Machine::default()
+            load_a_backup(path).unwrap_or_default()
         }
     }
+}
+
+fn parse_machine(text: &str) -> serde_json::Result<Machine> {
+    let mut machine = serde_json::from_str::<Machine>(crate::core::config::strip_bom(text))?;
+    for pane in &mut machine.panes {
+        pane.live = false;
+    }
+    Ok(machine)
+}
+
+/// The newest kept generation that still parses.
+///
+/// Only reached when the live document is gone or unreadable — a tree that
+/// parses is always preferred to a backup, however empty it turns out to be.
+/// This is the automatic half of [`keep_a_generation`]; the manual half is a
+/// human copying a `.bak` over `machine.json`, which is why the files are
+/// plain JSON under obvious names.
+fn load_a_backup(path: &Path) -> Option<Machine> {
+    (0..BACKUP_GENERATIONS).find_map(|generation| {
+        let kept = backup_path(path, generation);
+        let machine = parse_machine(&std::fs::read_to_string(&kept).ok()?).ok()?;
+        log::warn!("recovered the machine tree from {}", kept.display());
+        Some(machine)
+    })
+}
+
+/// Where generation `n` of `path` is kept — `machine.json.bak` for the newest,
+/// `machine.json.bak.1` and `.bak.2` behind it.
+fn backup_path(path: &Path, generation: usize) -> PathBuf {
+    let name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(MACHINE_FILE);
+    match generation {
+        0 => path.with_file_name(format!("{name}.bak")),
+        n => path.with_file_name(format!("{name}.bak.{n}")),
+    }
+}
+
+/// Rotates the document currently at `path` into the backup ring, if the ring's
+/// newest entry is at least `spacing` old.
+///
+/// The live file is never renamed, only read: at every point in this function
+/// `path` still holds a complete document, so a crash part-way through costs at
+/// most one *backup* generation and never the tree itself. The new generation
+/// lands through `write_atomic_private`, which writes a sibling temporary and
+/// renames it into place — so a reader never sees a half-written `.bak` either,
+/// and the 0600 the live tree is written under is the mode the copies get.
+///
+/// Returns `Ok(())` when there was nothing to do: no tree yet, or the newest
+/// generation is younger than `spacing`.
+fn keep_a_generation(path: &Path, spacing: Duration) -> io::Result<()> {
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        // Nothing has been written yet, so there is no previous generation.
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e),
+    };
+    let newest = backup_path(path, 0);
+    let too_soon = std::fs::metadata(&newest)
+        .and_then(|meta| meta.modified())
+        .map(|at| at.elapsed().unwrap_or_default() < spacing)
+        .unwrap_or(false);
+    if too_soon {
+        return Ok(());
+    }
+    // Oldest first, so nothing is overwritten before it has been moved down.
+    // A generation that is not there yet simply has nothing to move.
+    for generation in (1..BACKUP_GENERATIONS).rev() {
+        let from = backup_path(path, generation - 1);
+        match std::fs::rename(&from, backup_path(path, generation)) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
+    }
+    crate::core::config::write_atomic_private(&newest, &bytes)
 }
 
 static OBSERVED: Mutex<Option<Arc<MachineStore>>> = Mutex::new(None);
@@ -2566,6 +2669,119 @@ mod tests {
             std::fs::read_to_string(&aside).unwrap(),
             "{\"workspaces\":[]}",
             "moved aside byte-for-byte, ready for a hand repair"
+        );
+    }
+
+    /// One tree with `tabs` tabs in it, written out the way `persist` writes.
+    fn document(tabs: u64) -> Vec<u8> {
+        let machine = Machine {
+            workspaces: vec![Workspace {
+                tabs: (0..tabs).map(Tab::leaf).collect(),
+                ..Workspace::default()
+            }],
+            panes: Vec::new(),
+        };
+        serde_json::to_vec_pretty(&machine).unwrap()
+    }
+
+    fn tabs_in(path: &Path) -> usize {
+        let text = std::fs::read_to_string(path).expect("a generation must be there to read");
+        parse_machine(&text).expect("and it must parse").workspaces[0]
+            .tabs
+            .len()
+    }
+
+    /// A machine tree is written whole on every mutation, so the write that
+    /// loses the layout also erases the only copy of it (#716). One generation
+    /// back is the least that makes a bad write survivable by hand.
+    #[test]
+    fn the_document_being_replaced_is_kept_beside_it() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(MACHINE_FILE);
+        let store = MachineStore::open(&path);
+
+        let ws = store.workspace_create(None, None, None).unwrap();
+        store.tab_create(ws.id, None, seed(1, "/work"), None, None).unwrap();
+        store.tab_create(ws.id, None, seed(2, "/work"), None, None).unwrap();
+
+        let kept = backup_path(&path, 0);
+        assert!(
+            kept.exists(),
+            "the second write has a first write to keep: {}",
+            kept.display()
+        );
+        assert_eq!(
+            tabs_in(&kept),
+            0,
+            "and what it kept is the document that write replaced"
+        );
+    }
+
+    /// The whole reason the generations are spaced. The failure this came from
+    /// arrived as a burst — nineteen `TabClose`s, nineteen persists, seconds
+    /// apart — and a ring that rotated on every write would have held three
+    /// copies of the damage by the time anyone looked at it.
+    #[test]
+    fn a_burst_of_writes_cannot_roll_the_history_away() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(MACHINE_FILE);
+        std::fs::write(&path, document(19)).unwrap();
+        keep_a_generation(&path, Duration::ZERO).unwrap();
+
+        for remaining in (0..19).rev() {
+            std::fs::write(&path, document(remaining)).unwrap();
+            keep_a_generation(&path, BACKUP_SPACING).unwrap();
+        }
+
+        assert_eq!(tabs_in(&path), 0, "the burst emptied the live tree");
+        assert_eq!(
+            tabs_in(&backup_path(&path, 0)),
+            19,
+            "and the kept generation is from before it, not from one write ago"
+        );
+    }
+
+    #[test]
+    fn the_ring_keeps_three_generations_and_no_more() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(MACHINE_FILE);
+
+        for tabs in 1..=6 {
+            std::fs::write(&path, document(tabs)).unwrap();
+            keep_a_generation(&path, Duration::ZERO).unwrap();
+        }
+
+        assert_eq!(tabs_in(&backup_path(&path, 0)), 6);
+        assert_eq!(tabs_in(&backup_path(&path, 1)), 5);
+        assert_eq!(tabs_in(&backup_path(&path, 2)), 4);
+        assert!(
+            !backup_path(&path, 3).exists(),
+            "the ring is bounded; a tree rewritten every few seconds must not \
+             grow a file per write forever"
+        );
+    }
+
+    /// The automatic half of the recovery. A tree that parses always wins —
+    /// including an empty one, which is why the manual `.bak` copy still
+    /// matters — but a tree that does not parse used to mean starting over.
+    #[test]
+    fn a_tree_that_does_not_parse_is_loaded_from_the_newest_backup() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(MACHINE_FILE);
+        std::fs::write(&path, document(3)).unwrap();
+        keep_a_generation(&path, Duration::ZERO).unwrap();
+        std::fs::write(&path, b"{ not json").unwrap();
+
+        let store = MachineStore::open(&path);
+
+        assert_eq!(
+            store.machine().workspaces[0].tabs.len(),
+            3,
+            "the layout comes back from the kept generation"
+        );
+        assert!(
+            path.with_extension("json.corrupt").exists(),
+            "and the unparseable document is still kept for inspection"
         );
     }
 

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -270,9 +270,21 @@ resolve it immediately before use. A full tab UUID also works: `@<uuid>`.
 |---|---|---|
 | `tab ls [WORKSPACE]` | Tabs of a workspace | `{"workspace","tabs":[{"ordinal","id","name","label","agent","group","panes":[…]}]}` |
 | `tab new [WORKSPACE] [--cwd DIR]` | Add a tab with a fresh shell | `{"tab","pane"}` |
+| `tab new [WORKSPACE] --pane %PANE` | Add a tab around a pane already running | `{"tab","pane"}` |
 | `tab close @TAB` | Close the tab and every pane in it | `{"closed"}` |
 | `tab rename @TAB NAME` | Name or rename | `{"tab","name"}` |
 | `tab move @TAB INDEX` | Reposition within its workspace | `{"tab","to"}` |
+
+`--pane` re-homes instead of spawning: it builds the tab around a pane the
+server is already running, which is how an orphan gets back on screen. Only a
+pane no tab holds is accepted — use `pane split` to add to a tab that exists.
+With no `WORKSPACE` and no `TTY7_WS`, the pane goes back to the workspace it was
+spawned for, which is the `owner` that `pane ls --all` prints. The seed is
+rebuilt from the pane registry, so the tab gets the pane's recorded cwd (unless
+`--cwd` overrides it) but not the shell or SSH spec the pane started with: the
+tree drops a pane's record when the tab holding it closes, and the registry is
+what is left. That only matters if the shell later dies, since a restore would
+then have nothing to restore from.
 
 `GROUP` is the heading the GUI's sidebar files the tab under, shown by its last
 segment. Read-only from here: with the default repo grouping the GUI recomputes
@@ -298,6 +310,11 @@ a stand-in.
 of the workspace that may attach to the pane (absent when none may), and
 `orphan: true` means no workspace holds it. An interrupted `run` leaves orphans
 here, as does a `ws rm` that reported panes it could not hang up.
+
+An orphan is not necessarily rubbish — its shell may still be doing real work —
+so there are two ways out of the list. `tab new --pane %<id>` puts one back into
+a tab, which is the recovery path when the panes came out from under a workspace
+rather than out of an interrupted `run`. `pane close` is the other.
 
 `--orphans` is the reaper for exactly those. It closes what `pane ls --all`
 lists as orphaned and nothing else — panes a workspace holds are untouched —

--- a/src/ui/tree_sync.rs
+++ b/src/ui/tree_sync.rs
@@ -2909,7 +2909,8 @@ mod tests {
             assert_eq!(parked.name, "deploy");
             assert_eq!(
                 parked.workspace, ws,
-                "and it is parked against the workspace it was typed for, so a window                  that walks into a different one cannot spend it (#716)"
+                "and it is parked against the workspace it was typed for, so a window \
+                 that walks into a different one cannot spend it (#716)"
             );
         });
     }

--- a/src/ui/tree_sync.rs
+++ b/src/ui/tree_sync.rs
@@ -843,6 +843,38 @@ enum SyncPhase {
     Primed(WsMirror),
 }
 
+/// A name the user typed, and the workspace they typed it for.
+///
+/// The workspace id is the whole point. Parked on its own, a name is just "the
+/// last thing somebody typed into a create form", and `settle_chosen_name` had
+/// no way to tell a workspace it had named into existence from one the window
+/// had since walked into — so it renamed whichever workspace the window
+/// happened to land on (#716). Carrying the id it was chosen for makes that
+/// question answerable.
+#[derive(Clone, Debug)]
+struct ChosenName {
+    /// The workspace on the machine — `tree_workspace_id`, not the client's own
+    /// id — that this name was typed for.
+    workspace: WorkspaceId,
+    name: String,
+}
+
+/// How the workspace a pull answered for got there.
+///
+/// The name a user types belongs to a create. When one runs — this client's, or
+/// a create of its own that raced it and won with a rolled codename — the typed
+/// name is owed and goes out as a rename if the machine came back with anything
+/// else (#618, #604). When the workspace was simply already on the machine,
+/// nothing was created, the window walked into somebody else's workspace, and
+/// the name it is called is its own.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Arrival {
+    /// A create ran for this workspace as part of this pull.
+    Created,
+    /// The workspace was on the machine before this window asked for it.
+    Adopted,
+}
+
 struct WsState {
     sync: SyncPhase,
     queue: VecDeque<ControlRequest>,
@@ -917,7 +949,7 @@ struct WsState {
     /// names it whatever `fresh_workspace_name` rolled (#618). Consumed by
     /// `start_prime`, which spends it instead of the generated name, and
     /// cleared by `finish_prime` once the machine has confirmed a name.
-    chosen_name: Option<String>,
+    chosen_name: Option<ChosenName>,
     /// Whether this window has already been told why it opened empty.
     ///
     /// The retry is as quiet as the failure was, so a window whose machine
@@ -1213,6 +1245,10 @@ fn unsendable(request: &ControlRequest, why: &str) {
 /// A window already synced with its machine has no create coming, so there is
 /// nothing to ride along with and the rename goes out as usual.
 pub(crate) fn name_new_workspace(cx: &mut App, client_ws: WorkspaceId, name: String) {
+    // Read before the state is borrowed, and read *now* rather than at settle
+    // time: this is the moment the user named a particular workspace, and it is
+    // the only moment at which the pairing is certain.
+    let workspace = tree_workspace_id(cx, client_ws);
     // A window tree-sync has never heard of is as unprimed as one it is
     // priming right now: either way the create is still ahead of us.
     let state = cx
@@ -1221,7 +1257,7 @@ pub(crate) fn name_new_workspace(cx: &mut App, client_ws: WorkspaceId, name: Str
         .entry(client_ws)
         .or_default();
     if matches!(state.sync, SyncPhase::Unprimed { .. }) {
-        state.chosen_name = Some(name);
+        state.chosen_name = Some(ChosenName { workspace, name });
         return;
     }
     rename_workspace(cx, client_ws, Some(name));
@@ -1234,7 +1270,8 @@ pub(crate) fn chosen_name_for(cx: &mut App, client_ws: WorkspaceId) -> Option<St
     cx.default_global::<TreeSync>()
         .windows
         .get(&client_ws)
-        .and_then(|state| state.chosen_name.clone())
+        .and_then(|state| state.chosen_name.as_ref())
+        .map(|chosen| chosen.name.clone())
 }
 
 pub(crate) fn rename_workspace(cx: &mut App, client_ws: WorkspaceId, name: Option<String>) {
@@ -1281,7 +1318,9 @@ fn start_prime(cx: &mut App, client_ws: WorkspaceId) {
             cx.default_global::<TreeSync>()
                 .windows
                 .get(&client_ws)
-                .and_then(|state| state.chosen_name.clone())
+                .and_then(|state| state.chosen_name.as_ref())
+                .filter(|chosen| chosen.workspace == machine_ws)
+                .map(|chosen| chosen.name.clone())
                 .unwrap_or_else(|| fresh_workspace_name(cx, host))
         });
         let outcome = cx
@@ -1329,38 +1368,69 @@ pub(crate) fn fresh_workspace_name(cx: &App, host: HostId) -> String {
 ///
 /// `answered` is the machine's answer. A chosen name it read back was spent by
 /// the create that carried it, and there is nothing left to do. One it did not
-/// means the create never ran — the workspace was already there, or the other
-/// create won the race with a stale idea of the name — so it goes out as the
-/// rename it has become. Either way the name is owed only once.
+/// means the create ran under a different name — this client's create lost the
+/// race to a create of its own that had rolled a codename before the user had
+/// finished typing — so it goes out as the rename it has become (#618, #604).
+/// Either way the name is owed only once.
+///
+/// `arrival` is what stops that override from firing at a workspace nobody
+/// asked to create. A name is spent only on a create it actually rode along
+/// with: the workspace it was typed for, and a pull that had to make that
+/// workspace. Walking into a workspace the machine already had renamed it to
+/// whatever the arriving client had parked — which is how a remote client's
+/// login name ended up on somebody else's workspace (#716).
+///
+/// A name that does not match this arrival is left parked rather than dropped.
+/// Two pulls run at once when a window opens a workspace (`start_prime`'s and
+/// `hydrate`'s) and only one of them creates; taking the name on the adopting
+/// one would let the loser of that race swallow it before the winner could
+/// spend it, which is the #618 regression this is trying not to reintroduce.
+/// A parked name outlives nothing: `forget` drops the whole state when the
+/// window leaves the workspace.
 fn settle_chosen_name(
     cx: &mut App,
     client_ws: WorkspaceId,
     answered: Option<String>,
+    arrival: Arrival,
 ) -> Option<String> {
-    let chosen = cx
-        .default_global::<TreeSync>()
-        .windows
-        .get_mut(&client_ws)
-        .and_then(|state| state.chosen_name.take());
-    match chosen {
-        Some(chosen) if answered.as_deref() == Some(chosen.as_str()) => answered,
-        Some(chosen) => {
-            rename_workspace(cx, client_ws, Some(chosen.clone()));
-            Some(chosen)
+    let machine_ws = tree_workspace_id(cx, client_ws);
+    let Some(state) = cx.default_global::<TreeSync>().windows.get_mut(&client_ws) else {
+        return answered;
+    };
+    let owed = state
+        .chosen_name
+        .as_ref()
+        .is_some_and(|chosen| chosen.workspace == machine_ws && arrival == Arrival::Created);
+    if !owed {
+        if let Some(parked) = &state.chosen_name {
+            log::debug!(
+                "workspace {client_ws}: keeping the name {} answered, not the parked \
+                 '{}' — nothing was created here",
+                answered.as_deref().unwrap_or("<unnamed>"),
+                parked.name
+            );
         }
-        None => answered,
+        return answered;
     }
+    let chosen = state.chosen_name.take().expect("checked just above").name;
+    if answered.as_deref() == Some(chosen.as_str()) {
+        return answered;
+    }
+    rename_workspace(cx, client_ws, Some(chosen.clone()));
+    Some(chosen)
 }
 
 fn pull_or_create(
     client: &ControlClient,
     machine_ws: WorkspaceId,
     fresh: String,
-) -> io::Result<(WsMirror, Option<String>)> {
+) -> io::Result<(WsMirror, Option<String>, Arrival)> {
     match client.call(ControlRequest::WorkspaceTree {
         workspace: machine_ws,
     }) {
-        Ok(ReplyOk::WorkspaceTree(ws)) => Ok(primed(*ws)),
+        // The tree answered, so nothing was created here — this window walked
+        // into a workspace that was already on the machine.
+        Ok(ReplyOk::WorkspaceTree(ws)) => Ok(primed(*ws, Arrival::Adopted)),
         Ok(other) => Err(io::Error::other(format!(
             "WorkspaceTree answered {other:?}"
         ))),
@@ -1369,7 +1439,7 @@ fn pull_or_create(
                 name: Some(fresh),
                 workspace: Some(machine_ws),
             })? {
-                ReplyOk::WorkspaceTree(ws) => Ok(primed(*ws)),
+                ReplyOk::WorkspaceTree(ws) => Ok(primed(*ws, Arrival::Created)),
                 other => Err(io::Error::other(format!(
                     "WorkspaceCreate answered {other:?}"
                 ))),
@@ -1379,13 +1449,14 @@ fn pull_or_create(
     }
 }
 
-fn primed(ws: Workspace) -> (WsMirror, Option<String>) {
+fn primed(ws: Workspace, arrival: Arrival) -> (WsMirror, Option<String>, Arrival) {
     (
         WsMirror {
             tabs: ws.tabs,
             active: ws.active_tab,
         },
         ws.name,
+        arrival,
     )
 }
 
@@ -1393,7 +1464,7 @@ fn finish_prime(
     cx: &mut App,
     client_ws: WorkspaceId,
     epoch: u64,
-    outcome: io::Result<(WsMirror, Option<String>)>,
+    outcome: io::Result<(WsMirror, Option<String>, Arrival)>,
 ) {
     let Some(state) = cx.default_global::<TreeSync>().windows.get_mut(&client_ws) else {
         return;
@@ -1404,12 +1475,12 @@ fn finish_prime(
     }
     let was_dirty = matches!(state.sync, SyncPhase::Unprimed { dirty: true, .. });
     let landed = match outcome {
-        Ok((mirror, name)) => {
+        Ok((mirror, name, arrival)) => {
             state.informed |= mirror.tabs.is_empty();
             // The machine answered, which is the only thing the retry was
             // waiting to find out, so the next failure starts its backoff over.
             state.rehydrate_attempts = 0;
-            let landed = (mirror.tabs.clone(), mirror.active, name);
+            let landed = (mirror.tabs.clone(), mirror.active, name, arrival);
             state.sync = SyncPhase::Primed(mirror);
             landed
         }
@@ -1429,7 +1500,7 @@ fn finish_prime(
     );
     // The pull above is the only place this window will hear the workspace's
     // name — it is left out of the deltas its own create raises (#604).
-    let name = settle_chosen_name(cx, client_ws, landed.2);
+    let name = settle_chosen_name(cx, client_ws, landed.2, landed.3);
     crate::ui::machine_mirror::MachineMirrors::note_workspace_name(cx, host, machine_ws, name);
     if !was_dirty {
         return;
@@ -1855,7 +1926,9 @@ fn hydrate_with(cx: &mut App, client_ws: WorkspaceId, adopt: Adopt, showing: Vec
             cx.default_global::<TreeSync>()
                 .windows
                 .get(&client_ws)
-                .and_then(|state| state.chosen_name.clone())
+                .and_then(|state| state.chosen_name.as_ref())
+                .filter(|chosen| chosen.workspace == machine_ws)
+                .map(|chosen| chosen.name.clone())
         });
         let outcome = cx
             .background_executor()
@@ -2005,9 +2078,13 @@ fn pull_workspace(
     client: &ControlClient,
     machine_ws: WorkspaceId,
     chosen: Option<String>,
-) -> io::Result<(Machine, WsMirror, Session)> {
+) -> io::Result<(Machine, WsMirror, Session, Arrival)> {
+    // The workspace was on the machine before this pull touched it: adopted,
+    // whatever name anyone has parked for it.
     let mut machine = match layout_of(machine_get(client)?, machine_ws) {
-        Ok(pulled) => return Ok(pulled),
+        Ok((machine, mirror, session)) => {
+            return Ok((machine, mirror, session, Arrival::Adopted));
+        }
         Err(machine) => machine,
     };
     // The whole tree is already in hand, so the taken names can be read
@@ -2033,9 +2110,19 @@ fn pull_workspace(
         Ok(ReplyOk::WorkspaceTree(created)) => {
             machine.workspaces.retain(|w| w.id != created.id);
             machine.workspaces.push(*created);
-            Ok((machine, WsMirror::default(), Session::default()))
+            Ok((
+                machine,
+                WsMirror::default(),
+                Session::default(),
+                Arrival::Created,
+            ))
         }
-        Ok(_) => Ok((machine, WsMirror::default(), Session::default())),
+        Ok(_) => Ok((
+            machine,
+            WsMirror::default(),
+            Session::default(),
+            Arrival::Created,
+        )),
         // Losing this create is not a failed hydration. Opening a remote
         // workspace runs two pulls at once — this one and `start_prime`'s —
         // and both create when the tree they read did not hold it yet, so the
@@ -2054,8 +2141,14 @@ fn pull_workspace(
                 "workspace {machine_ws} could not be created ({refused}); reading the tree \
                  again in case something else created it first"
             );
+            // Still `Created`, and deliberately: a create did run for this
+            // workspace a moment ago, it just was not this one. That is the
+            // race #618 came from — the winner rolled a codename before the
+            // user had finished typing — and the typed name is owed against it.
             match machine_get(client) {
-                Ok(machine) => layout_of(machine, machine_ws).map_err(|_| refused),
+                Ok(machine) => layout_of(machine, machine_ws)
+                    .map(|(machine, mirror, session)| (machine, mirror, session, Arrival::Created))
+                    .map_err(|_| refused),
                 Err(_) => Err(refused),
             }
         }
@@ -2091,7 +2184,7 @@ fn finish_hydration(
     client_ws: WorkspaceId,
     epoch: u64,
     adopt: Adopt,
-    outcome: io::Result<(Machine, WsMirror, Session)>,
+    outcome: io::Result<(Machine, WsMirror, Session, Arrival)>,
 ) {
     if settle_hydration(cx, client_ws, epoch, adopt, outcome) {
         open_parked_path(cx, client_ws);
@@ -2107,7 +2200,7 @@ fn settle_hydration(
     client_ws: WorkspaceId,
     epoch: u64,
     adopt: Adopt,
-    outcome: io::Result<(Machine, WsMirror, Session)>,
+    outcome: io::Result<(Machine, WsMirror, Session, Arrival)>,
 ) -> bool {
     let current = cx
         .default_global::<TreeSync>()
@@ -2118,7 +2211,7 @@ fn settle_hydration(
         log::debug!("workspace {client_ws}: dropping a superseded hydration");
         return false;
     }
-    let (machine, mirror, session) = match outcome {
+    let (machine, mirror, session, arrival) = match outcome {
         Ok(pulled) => pulled,
         Err(e) => {
             let failures = cx
@@ -2144,7 +2237,7 @@ fn settle_hydration(
         .find(|w| w.id == machine_ws)
         .and_then(|w| w.name.clone());
     crate::ui::machine_mirror::MachineMirrors::install(cx, host, machine);
-    let name = settle_chosen_name(cx, client_ws, answered);
+    let name = settle_chosen_name(cx, client_ws, answered, arrival);
     crate::ui::machine_mirror::MachineMirrors::note_workspace_name(cx, host, machine_ws, name);
     let machine_was_empty = mirror.tabs.is_empty();
     let was_dirty = {
@@ -2809,12 +2902,14 @@ mod tests {
 
             name_new_workspace(cx, ws, "deploy".into());
 
+            let parked = cx.default_global::<TreeSync>().windows[&ws]
+                .chosen_name
+                .clone()
+                .expect("the name rides along with the create instead of chasing it");
+            assert_eq!(parked.name, "deploy");
             assert_eq!(
-                cx.default_global::<TreeSync>().windows[&ws]
-                    .chosen_name
-                    .as_deref(),
-                Some("deploy"),
-                "the name rides along with the create instead of chasing it"
+                parked.workspace, ws,
+                "and it is parked against the workspace it was typed for, so a window                  that walks into a different one cannot spend it (#716)"
             );
         });
     }
@@ -2831,7 +2926,7 @@ mod tests {
                 cx,
                 ws,
                 epoch,
-                Ok((WsMirror::default(), Some("deploy".into()))),
+                Ok((WsMirror::default(), Some("deploy".into()), Arrival::Created)),
             );
 
             assert!(
@@ -2848,12 +2943,17 @@ mod tests {
         });
     }
 
-    /// The other branch of `pull_or_create`: the workspace was already on the
-    /// machine, so the pull answered and the create never ran — nobody was ever
-    /// offered the typed name. It has to go out as a rename, and it has to beat
-    /// the name the pull came back with, which #604 wired straight to the chip.
+    /// A create ran and came back under a different name — this window's create
+    /// lost the race to the other pull's, which had rolled a codename before
+    /// the user finished typing. The typed name is still owed and still has to
+    /// beat what the pull answered with, which is #618 and the chip #604 wired.
+    ///
+    /// Reshaped from `a_workspace_the_machine_already_had_still_takes_the_typed_name`,
+    /// which asserted this override for *every* answer, adopted workspaces
+    /// included. The override is right; the blanket was not (#716) — see the
+    /// test below for the half that was wrong.
     #[gpui::test]
-    fn a_workspace_the_machine_already_had_still_takes_the_typed_name(
+    fn a_create_that_answered_with_another_name_still_takes_the_typed_one(
         cx: &mut gpui::TestAppContext,
     ) {
         cx.update(|cx| {
@@ -2864,7 +2964,11 @@ mod tests {
                 cx,
                 ws,
                 epoch,
-                Ok((WsMirror::default(), Some("keen-marten".into()))),
+                Ok((
+                    WsMirror::default(),
+                    Some("keen-marten".into()),
+                    Arrival::Created,
+                )),
             );
 
             assert!(
@@ -2876,7 +2980,73 @@ mod tests {
             assert_eq!(
                 crate::ui::machine_mirror::display_name(cx, &view).as_deref(),
                 Some("deploy"),
-                "the name the user typed outranks the one the pull answered with"
+                "the name the user typed outranks the one the create answered with"
+            );
+        });
+    }
+
+    /// The other half of that split, and #716's second failure. A client
+    /// opening a workspace that was already on the machine renamed it to
+    /// whatever that client had parked — a workspace holding nineteen panes
+    /// came back named after the arriving user. Nothing was created here, so
+    /// nothing is owed: the workspace keeps the name it has.
+    #[gpui::test]
+    fn a_workspace_the_window_walked_into_keeps_its_own_name(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let (ws, view) = primed_window(cx, Some("sher1"));
+            let epoch = cx.default_global::<TreeSync>().windows[&ws].epoch;
+
+            finish_prime(
+                cx,
+                ws,
+                epoch,
+                Ok((
+                    WsMirror::default(),
+                    Some("keen-marten".into()),
+                    Arrival::Adopted,
+                )),
+            );
+
+            assert_eq!(
+                crate::ui::machine_mirror::display_name(cx, &view).as_deref(),
+                Some("keen-marten"),
+                "the machine's name stands; an arriving client does not rename it"
+            );
+        });
+    }
+
+    /// The identity check, independently of how the pull arrived. A name typed
+    /// for one workspace must not be spendable on another even when a create
+    /// did run: the pairing is what makes the name mean anything.
+    #[gpui::test]
+    fn a_name_typed_for_another_workspace_is_never_spent_here(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let (ws, view) = primed_window(cx, Some("deploy"));
+            cx.default_global::<TreeSync>()
+                .windows
+                .get_mut(&ws)
+                .expect("primed just above")
+                .chosen_name = Some(ChosenName {
+                workspace: WorkspaceId::new(),
+                name: "deploy".into(),
+            });
+            let epoch = cx.default_global::<TreeSync>().windows[&ws].epoch;
+
+            finish_prime(
+                cx,
+                ws,
+                epoch,
+                Ok((
+                    WsMirror::default(),
+                    Some("keen-marten".into()),
+                    Arrival::Created,
+                )),
+            );
+
+            assert_eq!(
+                crate::ui::machine_mirror::display_name(cx, &view).as_deref(),
+                Some("keen-marten"),
+                "a name owed to another workspace is not this one's to take"
             );
         });
     }
@@ -2906,7 +3076,12 @@ mod tests {
                 ws,
                 epoch,
                 Adopt::IfEmpty,
-                Ok((pulled, WsMirror::default(), Session::default())),
+                Ok((
+                    pulled,
+                    WsMirror::default(),
+                    Session::default(),
+                    Arrival::Created,
+                )),
             );
 
             assert_eq!(
@@ -2923,6 +3098,46 @@ mod tests {
         });
     }
 
+    /// The same window arriving at a workspace it did not make, which is the
+    /// path #716 came in through: `switch_workspace` orders the hydration, the
+    /// pull finds the workspace already there, and the name parked on the
+    /// window used to land on it as a rename.
+    #[gpui::test]
+    fn a_hydration_that_adopted_leaves_the_name_it_found(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            crate::ui::windows::WindowRegistry::init(cx);
+            let (ws, view) = primed_window(cx, Some("sher1"));
+            let epoch = cx.default_global::<TreeSync>().windows[&ws].epoch;
+            let pulled = Machine {
+                workspaces: vec![tty7_core::core::machine::Workspace {
+                    id: ws,
+                    name: Some("keen-marten".into()),
+                    ..Default::default()
+                }],
+                panes: Vec::new(),
+            };
+
+            settle_hydration(
+                cx,
+                ws,
+                epoch,
+                Adopt::IfEmpty,
+                Ok((
+                    pulled,
+                    WsMirror::default(),
+                    Session::default(),
+                    Arrival::Adopted,
+                )),
+            );
+
+            assert_eq!(
+                crate::ui::machine_mirror::display_name(cx, &view).as_deref(),
+                Some("keen-marten"),
+                "walking in is not naming"
+            );
+        });
+    }
+
     /// A window with no name owed reads whatever the machine says, which is
     /// the whole of #604 and must survive the arbitration above.
     #[gpui::test]
@@ -2935,7 +3150,11 @@ mod tests {
                 cx,
                 ws,
                 epoch,
-                Ok((WsMirror::default(), Some("keen-marten".into()))),
+                Ok((
+                    WsMirror::default(),
+                    Some("keen-marten".into()),
+                    Arrival::Created,
+                )),
             );
 
             assert_eq!(
@@ -2973,7 +3192,10 @@ mod tests {
             dirty: false,
             priming: true,
         };
-        state.chosen_name = chosen.map(str::to_string);
+        state.chosen_name = chosen.map(|name| ChosenName {
+            workspace: ws,
+            name: name.to_string(),
+        });
         (ws, view)
     }
 
@@ -3492,7 +3714,11 @@ mod tests {
                 cx,
                 ws,
                 epoch,
-                Ok((WsMirror::default(), Some("keen-marten".to_string()))),
+                Ok((
+                    WsMirror::default(),
+                    Some("keen-marten".to_string()),
+                    Arrival::Created,
+                )),
             );
 
             assert_eq!(
@@ -3548,7 +3774,12 @@ mod tests {
 
             // The machine answered. Whatever it was, it is over.
             unprimed(cx);
-            finish_prime(cx, ws, epoch, Ok((WsMirror::default(), None)));
+            finish_prime(
+                cx,
+                ws,
+                epoch,
+                Ok((WsMirror::default(), None, Arrival::Created)),
+            );
             assert_eq!(
                 attempts(cx),
                 0,
@@ -4028,7 +4259,12 @@ mod tests {
                 state.sync = SyncPhase::Primed(advanced.clone());
             }
 
-            finish_prime(cx, ws, stale_epoch, Ok((WsMirror::default(), None)));
+            finish_prime(
+                cx,
+                ws,
+                stale_epoch,
+                Ok((WsMirror::default(), None, Arrival::Created)),
+            );
 
             match &cx.default_global::<TreeSync>().windows[&ws].sync {
                 SyncPhase::Primed(mirror) => assert_eq!(


### PR DESCRIPTION
The three items #716 has left after `adb3feb5`/#728 fixed the tab-tree overwrite.
Item 1 is not touched here — it is fixed at `main` and has
`arriving_at_a_workspace_does_not_prune_what_is_already_in_it` standing on it.

## What changed

| | Before | After |
|---|---|---|
| A window arriving at a workspace the machine already had | the name parked on it is sent as a rename and beats the machine's — the workspace comes back called after the arriving client | the workspace keeps its own name; the parked name stays parked |
| A create that answered under a rolled codename | the typed name wins (#618/#604) | unchanged — the typed name still wins |
| A name parked for workspace A, settled for workspace B | spent on B | never spent on B |
| An orphaned pane | `pane close %N` or `pane close --orphans`, both of which kill it | `tab new --pane %N` builds a tab around it and puts it back on screen |
| `pane ls --all` footer | names only the two ways to kill | names the way back first, then the two ways to kill |
| `machine.json` | overwritten atomically, previous document gone | previous generations kept beside it (`.bak`, `.bak.1`, `.bak.2`), spaced ≥5 min apart |
| `machine.json` unreadable or unparseable at load | quarantined, start from an empty tree | quarantined, then loaded from the newest generation that parses |

## Why

**The rename (item 2).** `settle_chosen_name` had two facts to work with: a
parked string, and the name the machine answered with. Neither says which
workspace the name was meant for, or whether anything was created at all — so
"the machine came back saying something else" covered both *a create that rolled
a codename before the user finished typing* (#618, where the override is right)
and *walking into somebody else's workspace* (#716, where it is not). The parked
name now carries the workspace id it was typed for, and `pull_or_create` /
`pull_workspace` now report `Arrival::Created` vs `Arrival::Adopted`. The name is
spent only when both agree.

Losing the create race still counts as `Created`: a create did run for that
workspace a moment ago, it just was not this one, and its rolled codename is
exactly what #618 exists to beat. A name that does not match is left parked
rather than dropped — opening a workspace runs two pulls at once and only one of
them creates, so taking the name on the adopting one would let the loser of that
race swallow it before the winner could spend it. `forget` clears the state when
the window leaves, so nothing outlives its workspace.

`a_workspace_the_machine_already_had_still_takes_the_typed_name` is reshaped, not
deleted: what it was really pinning is the create that answers under another
name, and that is still asserted under a name that says so. The half it asserted
wrongly is now pinned the other way, once through `finish_prime` and once
through `settle_hydration` — the path the report came in through.

**The adopt verb (item 3).** `ControlRequest::TabCreate` has always taken a
`PaneSeed` with a pane id in it, so the mechanism existed; the verb did not. The
part that needed designing is where the seed comes from. `tab_close` retains the
panes it orphaned out of `m.panes` at the same moment it drops the tab, so
reading the seed off the tree would work for an interrupted `run` and fail for
exactly the case this verb exists for. It is rebuilt from the live pane registry
instead — the same list `pane ls --all` walks, and the only thing left that knows
anything about the pane. `ssh_spec`, `agent` and `shell` are therefore not
recovered; the registry never carried them. They cost nothing while the shell
lives, and only matter if the pane later dies and something tries to restore it.

Two refusals rather than a guess: a pane the server is not running, and a pane a
tab already holds (that is what `pane split` is for; accepting it would put one
pane in two places in the tree). With no workspace named, the pane goes back to
its recorded `owner` — `$TTY7_WS` cannot help, because a shell recovering from
this is by definition not inside tty7.

**The backup (item 4).** `persist` is atomic, so the file is never torn, but the
document it replaces is simply gone — and the tree is rewritten whole on every
mutation, so the write that loses a layout erases the only copy of it. That is
what turned item 1 from an annoyance into a lost afternoon.

Two things decide whether a backup ring is worth anything here. "Previous good"
cannot mean "the last document that parsed": an emptied tree parses perfectly and
is exactly the state you want to recover *from*, so validity is no signal. Age is
the only signal available, so the ring is spaced — a generation is taken only
when the newest is ≥5 minutes old. Without that, #716's burst of nineteen
`TabClose`s (nineteen persists, seconds apart) would have rolled three copies of
the damage through the whole ring. Three generations is where it stops, so a file
rewritten every few seconds does not grow a history without bound.

And the rotation has to be atomic itself, or it is worse than nothing. The live
file is never renamed, only read: at every point in `keep_a_generation` the tree
is still complete at its own path, and the new generation lands through
`write_atomic_private` — which also means the copies inherit the 0600 the live
tree is written under rather than widening anything. A crash mid-rotation costs
at most one backup generation and never the tree.

## Deliberately not done

- **A GUI Adopt button on the switcher's orphan rows.** Not the one-line
  counterpart to the CLI verb it looks like: the row lists orphans machine-wide
  while a window speaks for one workspace, and a pane may only be attached by
  the workspace that owns it, so the button has to decide where the tab goes
  before it can build one. Its own piece of work.
- **The daemon-side half of item 2.** As with the tab-tree fix in #728, this is
  client-side: the daemon still executes a `WorkspaceRename` from any client
  without asking whether that client has ever pulled the tree, so an older build
  can still do this to a machine running current `main`.

## Testing

Run on Windows 11, from a directory outside the worktree tree with
`--manifest-path`, because a shared dev `[patch]` at
`.claude/worktrees/.cargo/config.toml` points gpui-component at a vendored clone
that predates `Button::tooltip_element` and breaks the root crate from any agent
worktree. `Cargo.lock` is unmodified on this branch.

- `cargo test -p tty7-core` — 1165 passed, 0 failed. Includes the four new
  backup tests: `the_document_being_replaced_is_kept_beside_it`,
  `a_burst_of_writes_cannot_roll_the_history_away`,
  `the_ring_keeps_three_generations_and_no_more`,
  `a_tree_that_does_not_parse_is_loaded_from_the_newest_backup`.
- `cargo test -p tty7-cli` — 143 passed, 0 failed, including the CLI e2e binary
  (which drives a real `tty7-server`). Five new tests cover the adopt verb, its
  two refusals, the owner default, and the footer.
- `cargo test --bin tty7-app` — 1817 passed, 0 failed, 2 ignored. All 58
  non-`cfg(unix)` `tree_sync` tests pass, including the three new name tests.
- `cargo clippy --all-targets` — no new warnings attributable to this diff.
- `cargo fmt` clean.

**Not verified on this machine:** the `#[cfg(unix)]` `tree_sync` tests (the ones
built on `harness_with_pane`, which includes #728's own regression test) and the
`cfg(unix)` `tty7-core` remote_link/router tests do not compile or run on
Windows. CI covers those on Linux/macOS. Nothing in this diff was exercised
against a real remote client end-to-end — the item-2 change is pinned by unit
tests over `finish_prime` and `settle_hydration` rather than by a live SSH
reproduction.

https://claude.ai/code/session_01UUyWQXzcBAoBzaSX8pc7nU
