### PR TITLE
fix(daemon): stop a replay claiming a prompt a running program contradicts (#711)

### DIFF
--- a/crates/tty7-core/src/daemon/pane.rs
+++ b/crates/tty7-core/src/daemon/pane.rs
@@ -2097,11 +2097,33 @@ impl DaemonPane {
         subscriber: Sender<DaemonMsg>,
         allow_remote_clipboard_write: bool,
     ) -> u64 {
+        // Asked before the state lock, not under it: the probe takes the pty
+        // master's lock, and every other caller that holds both takes them in
+        // this order.
+        let foreground_command = self.has_foreground_command();
         let mut st = self.state.lock().unwrap();
-        let epoch =
-            attach_subscriber_with_permissions(&mut st, subscriber, allow_remote_clipboard_write);
+        let epoch = attach_subscriber_with_permissions(
+            &mut st,
+            subscriber,
+            allow_remote_clipboard_write,
+            foreground_command,
+        );
         self.gate.reset();
         epoch
+    }
+
+    /// Whether something other than the pane's own shell owns the terminal.
+    ///
+    /// Answered by the kernel (`tcgetpgrp`), not by the pane's stored shell
+    /// state, which is why it can contradict `st.shell.at_prompt` — see
+    /// [`replayed_at_prompt`]. A pane with no pty to ask (native ssh, and
+    /// every pane on Windows, where the pty has no foreground process group)
+    /// answers "no", which is what the live suppression already assumes.
+    fn has_foreground_command(&self) -> bool {
+        match &self.backend {
+            PaneBackend::Pty(pty) => foreground_command_running(&pty.master, pty.shell_pid),
+            PaneBackend::NativeSsh(_) => false,
+        }
     }
 
     pub fn detach(&self, epoch: u64) -> bool {
@@ -2115,8 +2137,9 @@ impl DaemonPane {
     }
 
     pub fn observe(&self, observer: Sender<DaemonMsg>, gate: Arc<OutputGate>) -> u64 {
+        let foreground_command = self.has_foreground_command();
         let mut st = self.state.lock().unwrap();
-        observe_subscriber(&mut st, observer, gate)
+        observe_subscriber(&mut st, observer, gate, foreground_command)
     }
 
     pub fn unobserve(&self, observer_id: u64) {
@@ -2575,7 +2598,14 @@ impl ReplayRing {
     }
 }
 
-fn replay_state(st: &PaneState, subscriber: &Sender<DaemonMsg>) {
+/// Everything a client needs to rebuild the pane's screen and status, in the
+/// order it has to be applied.
+///
+/// `foreground_command` is the answer to "does a program other than the shell
+/// own the terminal right now?", asked of the pty rather than of the pane's
+/// stored state. It gates the prompt report, and that gate is not cosmetic —
+/// see [`replayed_at_prompt`].
+fn replay_state(st: &PaneState, subscriber: &Sender<DaemonMsg>, foreground_command: bool) {
     st.ring.replay(subscriber);
     if let Some(cwd) = &st.cwd {
         let _ = subscriber.send(DaemonMsg::Cwd(cwd.clone()));
@@ -2583,7 +2613,7 @@ fn replay_state(st: &PaneState, subscriber: &Sender<DaemonMsg>) {
     if st.shell.active {
         let _ = subscriber.send(DaemonMsg::Prompt {
             active: st.shell.active,
-            at_prompt: st.shell.at_prompt,
+            at_prompt: replayed_at_prompt(st, foreground_command),
             last_exit: st.shell.last_exit_code,
         });
     }
@@ -2601,9 +2631,39 @@ fn replay_state(st: &PaneState, subscriber: &Sender<DaemonMsg>) {
     }
 }
 
+/// Whether a replay may tell the client the pane is sitting at a shell prompt.
+///
+/// `st.shell.at_prompt` is only ever as fresh as the last OSC 133 mark the pane
+/// produced, and a mark can stay the last word for hours: a shell that printed
+/// its prompt (`133;B`) and then handed the terminal to a full-screen program
+/// which emits no `133;C` of its own leaves the flag set for as long as that
+/// program runs. The live path already declines to believe such a mark — the
+/// reader drops `at_prompt` from any prompt mark that arrives while a
+/// foreground command owns the pty — but the replay re-asserted the stored
+/// value with no check at all.
+///
+/// That gap is what #711 is. A client that hears "at a prompt" scrubs the TUI
+/// modes it finds in its grid, the alternate screen included, on the reasoning
+/// that no full-screen program can own a pane whose shell is prompting. On a
+/// replay the alternate screen it finds is the one the ring *just rebuilt*, so
+/// the scrub swaps it away and leaves the primary screen underneath: the shell
+/// banner and the command line the pane was born with. The program is still
+/// there, still painting differential updates, now into a grid that no longer
+/// holds what those updates are differences from — which is why the pane came
+/// back as a few fragments on an empty screen, and why only a resize (a real
+/// `SIGWINCH`, a real repaint) put it back.
+///
+/// Asking the pty closes the gap without costing the scrub its purpose: when
+/// the shell really is prompting, no command is in the foreground, the report
+/// goes out unchanged, and a genuinely stranded alt screen (an `ssh` that died
+/// mid-`vim`) still heals on reattach.
+fn replayed_at_prompt(st: &PaneState, foreground_command: bool) -> bool {
+    st.shell.at_prompt && !foreground_command
+}
+
 #[cfg(test)]
 fn attach_subscriber(st: &mut PaneState, subscriber: Sender<DaemonMsg>) -> u64 {
-    attach_subscriber_with_permissions(st, subscriber, false)
+    attach_subscriber_with_permissions(st, subscriber, false, false)
 }
 
 /// The one place a pane's clipboard permission is decided. A pane that carries
@@ -2617,10 +2677,11 @@ fn attach_subscriber_with_permissions(
     st: &mut PaneState,
     subscriber: Sender<DaemonMsg>,
     allow_remote_clipboard_write: bool,
+    foreground_command: bool,
 ) -> u64 {
     st.subscriber_epoch += 1;
     set_clipboard_permission(st, allow_remote_clipboard_write);
-    replay_state(st, &subscriber);
+    replay_state(st, &subscriber, foreground_command);
     st.subscriber = Some(subscriber);
     st.subscriber_epoch
 }
@@ -2629,9 +2690,10 @@ fn observe_subscriber(
     st: &mut PaneState,
     observer: Sender<DaemonMsg>,
     gate: Arc<OutputGate>,
+    foreground_command: bool,
 ) -> u64 {
     st.observer_seq += 1;
-    replay_state(st, &observer);
+    replay_state(st, &observer, foreground_command);
     // The replay just queued the whole ring into this channel. Charge it, or
     // the first budget check would read zero while a full scrollback is already
     // sitting there unread — an observer that never drains would be allowed a
@@ -4755,6 +4817,90 @@ mod tests {
         assert!(rx.try_recv().is_err());
     }
 
+    /// Issue #711. A pane whose shell printed its prompt and then handed the
+    /// terminal to a full-screen program keeps `at_prompt` set for as long as
+    /// that program runs — nothing clears the flag but a `133;C` the program
+    /// has no reason to send. The live path already refuses to believe a
+    /// prompt mark that arrives while a foreground command owns the pty; the
+    /// replay used to re-assert the stored value regardless.
+    ///
+    /// What the client does with "at a prompt" is scrub the TUI modes it finds
+    /// in its grid — the alternate screen first (`\x1b[?1049l`) — because a
+    /// prompting shell means no full-screen program can own the pane. On a
+    /// replay that alternate screen is the one the ring just rebuilt, so the
+    /// scrub swapped it away and left the primary screen underneath: the shell
+    /// banner and the command line the pane was born with, with the program
+    /// still painting differential updates into a grid that no longer holds
+    /// what they are differences from.
+    #[test]
+    fn a_replay_does_not_claim_a_prompt_while_a_program_owns_the_pane() {
+        let mut st = test_state(true);
+        // The shell prompted, then `claude` took the terminal and entered the
+        // alternate screen. No `133;C` ever arrived, so the flag still stands.
+        st.shell = ShellState {
+            active: true,
+            at_prompt: true,
+            last_exit_code: Some(0),
+            command: None,
+        };
+        st.ring.append(b"\x1b[?1049h\x1b[2Jthe agent's screen");
+
+        let (tx, rx) = mpsc::channel();
+        attach_subscriber_with_permissions(&mut st, tx, false, true);
+
+        let replayed = drain(&rx);
+        let prompt = replayed
+            .iter()
+            .find_map(|msg| match msg {
+                DaemonMsg::Prompt {
+                    active, at_prompt, ..
+                } => Some((*active, *at_prompt)),
+                _ => None,
+            })
+            .expect("shell integration is on, so the replay reports the prompt state");
+        assert_eq!(
+            prompt,
+            (true, false),
+            "a pane with a program in the foreground is not at a prompt, whatever the last \
+             OSC 133 mark said; claiming otherwise costs the client the screen the ring just \
+             replayed"
+        );
+    }
+
+    /// The other half of the same gate, and the reason it is a gate rather
+    /// than a deletion: an `ssh` that died mid-`vim` leaves `?1049h` in the
+    /// ring with no `?1049l` behind it, and the host shell's next prompt is
+    /// the only thing that says the alternate screen is stale. With nothing in
+    /// the foreground the report goes out as it always did, and a re-attach
+    /// still heals that pane.
+    #[test]
+    fn a_replay_still_reports_a_prompt_when_the_shell_owns_the_pane() {
+        let mut st = test_state(true);
+        st.shell = ShellState {
+            active: true,
+            at_prompt: true,
+            last_exit_code: Some(0),
+            command: None,
+        };
+        st.ring.append(b"\x1b[?1049hstranded alt screen");
+
+        let (tx, rx) = mpsc::channel();
+        attach_subscriber_with_permissions(&mut st, tx, false, false);
+
+        assert!(
+            drain(&rx).iter().any(|msg| matches!(
+                msg,
+                DaemonMsg::Prompt {
+                    active: true,
+                    at_prompt: true,
+                    ..
+                }
+            )),
+            "with no foreground command the stored prompt state is the truth, and the client \
+             needs it to leave a stranded alternate screen"
+        );
+    }
+
     #[test]
     fn attach_replays_initial_cwd_even_before_shell_reports_osc7() {
         let mut st = test_state(true);
@@ -4804,7 +4950,7 @@ mod tests {
         drain(&controller_rx);
 
         let (observer_tx, observer_rx) = mpsc::channel();
-        let id = observe_subscriber(&mut st, observer_tx, Arc::new(OutputGate::new()));
+        let id = observe_subscriber(&mut st, observer_tx, Arc::new(OutputGate::new()), false);
         assert_eq!(
             st.subscriber_epoch, epoch,
             "observing must not bump the controller epoch"
@@ -4843,7 +4989,7 @@ mod tests {
         drain(&first_rx);
 
         let (observer_tx, observer_rx) = mpsc::channel();
-        observe_subscriber(&mut st, observer_tx, Arc::new(OutputGate::new()));
+        observe_subscriber(&mut st, observer_tx, Arc::new(OutputGate::new()), false);
         drain(&observer_rx);
 
         let (second_tx, second_rx) = mpsc::channel();
@@ -4875,7 +5021,7 @@ mod tests {
     fn a_gone_observer_is_pruned_on_the_next_broadcast() {
         let mut st = test_state(true);
         let (observer_tx, observer_rx) = mpsc::channel();
-        observe_subscriber(&mut st, observer_tx, Arc::new(OutputGate::new()));
+        observe_subscriber(&mut st, observer_tx, Arc::new(OutputGate::new()), false);
         drop(observer_rx);
 
         notify(&mut st, DaemonMsg::Output(b"x".to_vec()));
@@ -4893,7 +5039,7 @@ mod tests {
         drain(&controller_rx);
 
         let (observer_tx, observer_rx) = mpsc::channel();
-        observe_subscriber(&mut st, observer_tx, Arc::new(OutputGate::new()));
+        observe_subscriber(&mut st, observer_tx, Arc::new(OutputGate::new()), false);
         drain(&observer_rx);
 
         let pane_gate = OutputGate::new();
@@ -4932,7 +5078,7 @@ mod tests {
         let mut st = test_state(true);
         let (observer_tx, observer_rx) = mpsc::channel();
         let observer_gate = Arc::new(OutputGate::new());
-        observe_subscriber(&mut st, observer_tx, observer_gate.clone());
+        observe_subscriber(&mut st, observer_tx, observer_gate.clone(), false);
         drain(&observer_rx);
 
         let pane_gate = OutputGate::new();
@@ -4989,6 +5135,7 @@ mod tests {
             &mut with_observer_only.lock().unwrap(),
             observer_tx,
             Arc::new(OutputGate::new()),
+            false,
         );
         drain(&observer_rx);
         let (dead_tx, dead_rx) = mpsc::channel();
@@ -5009,7 +5156,7 @@ mod tests {
         {
             let mut st = with_both.lock().unwrap();
             attach_subscriber(&mut st, controller_tx);
-            observe_subscriber(&mut st, observer_tx, Arc::new(OutputGate::new()));
+            observe_subscriber(&mut st, observer_tx, Arc::new(OutputGate::new()), false);
         }
         drain(&controller_rx);
         drain(&observer_rx);
@@ -5507,7 +5654,7 @@ mod tests {
         let mut st = test_state(true);
         st.clipboard_write_from_spec = Some(true);
         let (tx, _rx) = mpsc::channel();
-        attach_subscriber_with_permissions(&mut st, tx, false);
+        attach_subscriber_with_permissions(&mut st, tx, false, false);
         assert!(st.allow_remote_clipboard_write);
 
         // And a profile that says no is not something an attaching client can
@@ -5515,17 +5662,17 @@ mod tests {
         let mut st = test_state(true);
         st.clipboard_write_from_spec = Some(false);
         let (tx, _rx) = mpsc::channel();
-        attach_subscriber_with_permissions(&mut st, tx, true);
+        attach_subscriber_with_permissions(&mut st, tx, true, false);
         assert!(!st.allow_remote_clipboard_write);
 
         // A pane with no spec of its own — everything on a remote
         // `tty7-server` — is exactly as permitted as its controller says.
         let mut st = test_state(true);
         let (tx, _rx) = mpsc::channel();
-        attach_subscriber_with_permissions(&mut st, tx, true);
+        attach_subscriber_with_permissions(&mut st, tx, true, false);
         assert!(st.allow_remote_clipboard_write);
         let (tx, _rx) = mpsc::channel();
-        attach_subscriber_with_permissions(&mut st, tx, false);
+        attach_subscriber_with_permissions(&mut st, tx, false, false);
         assert!(!st.allow_remote_clipboard_write);
     }
 
@@ -5538,8 +5685,8 @@ mod tests {
         let (observer_tx, observer_rx) = mpsc::channel();
         {
             let mut st = state.lock().unwrap();
-            attach_subscriber_with_permissions(&mut st, controller_tx, true);
-            observe_subscriber(&mut st, observer_tx, Arc::new(OutputGate::new()));
+            attach_subscriber_with_permissions(&mut st, controller_tx, true, false);
+            observe_subscriber(&mut st, observer_tx, Arc::new(OutputGate::new()), false);
         }
         drain(&controller_rx);
         drain(&observer_rx);

--- a/src/terminal/remote.rs
+++ b/src/terminal/remote.rs
@@ -3158,6 +3158,90 @@ mod replay_tests {
         drop(daemon);
     }
 
+    /// Issue #711: what a prompt report costs a replay that ended inside the
+    /// alternate screen.
+    ///
+    /// A re-attach replays the pane's ring and then the pane's *state*, and
+    /// the state ends with the shell's prompt status. `active && at_prompt`
+    /// makes the reader scrub the TUI modes it finds in the grid, alternate
+    /// screen first — see `prompt_report_scrubs_stale_tui_modes`, which is the
+    /// case that is meant to reach it: a program that died without its
+    /// `?1049l` leaves the grid stranded on a screen nothing owns, and the
+    /// shell's next prompt is what proves it stale.
+    ///
+    /// On a replay the alternate screen the scrub finds is the one the ring
+    /// just rebuilt, and `?1049l` does not undo it — it swaps it away. The
+    /// grid is left holding the primary screen underneath: the banner and the
+    /// command line the pane was born with, which is exactly what #711's
+    /// reporter photographed. The client cannot tell the two apart from the
+    /// frame, so the daemon decides — it declines to claim a prompt while a
+    /// foreground command owns the pty (`daemon::pane::replayed_at_prompt`).
+    /// Both halves of that contract are pinned here, from the side that pays
+    /// for it.
+    #[test]
+    fn a_replayed_prompt_report_decides_whether_the_alternate_screen_survives() {
+        crate::core::config::pin_test_config_dir();
+
+        // A re-attach, as the daemon writes one: the shell's banner on the
+        // primary screen, the agent's alternate screen drawn over it, then the
+        // pane's stored state. The trailing `Output` is a barrier — frames are
+        // applied in order, so a grid that holds it has already been through
+        // the prompt report, and neither half can pass on a race.
+        let replayed_pane = |at_prompt: bool| {
+            let (client_side, mut daemon) = socket_pair();
+            let term = RemoteTerminal::from_stream(client_side, TermSize::new(80, 24)).unwrap();
+            DaemonMsg::Size(ws(80, 24)).encode(&mut daemon).unwrap();
+            DaemonMsg::Snapshot(
+                b"BIRTH-BANNER\r\nMac:Accounts joe$ claude --resume --fork-session\r\n".to_vec(),
+            )
+            .encode(&mut daemon)
+            .unwrap();
+            DaemonMsg::Snapshot(b"\x1b[?1049h\x1b[2J\x1b[HAGENT-SCREEN\r\n".to_vec())
+                .encode(&mut daemon)
+                .unwrap();
+            DaemonMsg::Prompt {
+                active: true,
+                at_prompt,
+                last_exit: Some(0),
+            }
+            .encode(&mut daemon)
+            .unwrap();
+            DaemonMsg::Output(b"REPORT-APPLIED\r\n".to_vec())
+                .encode(&mut daemon)
+                .unwrap();
+            let text = settled(&term, &["REPORT-APPLIED"]);
+            drop(daemon);
+            text
+        };
+
+        // A program owns the pane, so the replay reports no prompt and the
+        // screen the ring rebuilt is the screen the pane shows.
+        let text = replayed_pane(false);
+        assert!(
+            text.contains("REPORT-APPLIED"),
+            "the barrier never arrived, so nothing below is tested; grid held:\n{text}"
+        );
+        assert!(
+            text.contains("AGENT-SCREEN"),
+            "a replay that does not claim a prompt must leave the alternate screen it \
+             rebuilt alone; grid held:\n{text}"
+        );
+
+        // The same replay under the stale claim: the scrub swaps the agent's
+        // screen away, and what the pane comes back showing is the banner it
+        // was born with. That is #711.
+        let text = replayed_pane(true);
+        assert!(
+            !text.contains("AGENT-SCREEN"),
+            "a prompt report still has to scrub a stranded alternate screen, or the daemon's \
+             gate is load-bearing for nothing; grid held:\n{text}"
+        );
+        assert!(
+            text.contains("BIRTH-BANNER"),
+            "what the scrub leaves is the primary screen underneath; grid held:\n{text}"
+        );
+    }
+
     // ---- The switch, end to end, with a real daemon pane ----------------
     //
     // Everything above drives the client half against a scripted daemon. This


### PR DESCRIPTION
Fixes #711 — a pane that comes back from a workspace switch showing only the shell banner and the line it was born with, with the agent still running above the blanks.

## What it is

Not a lost replay. The ring arrives whole and is applied; the client throws the result away three frames later.

`replay_state` closes an attach with the pane's shell state, and a client that hears `active && at_prompt` runs `stale_mode_resets` over its grid — `\x1b[?1049l` first. For a **live** report that is right, and it is why the scrub exists (2a74e538): a prompting shell cannot have a full-screen program under it, so a `?1049h` still set is residue from one that died without its `?1049l` (an `ssh` dropped mid-`vim`), and the reset is the repair.

For a **replayed** report it is wrong. The alternate screen the scrub finds is the one the ring has just rebuilt, and `?1049l` does not undo a stale mode — it swaps a live screen away and restores the primary screen underneath, which for an agent pane is exactly the banner and the launch command. The program is never told. It carries on with differential updates, into a grid that no longer holds what they are differences from.

The claim comes from `st.shell.at_prompt`, which is only as fresh as the pane's last OSC 133 mark. A shell that printed `133;B` and then handed the terminal to a program that sends no `133;C` of its own leaves it set for the life of that program. The live path already refuses such a mark — `spawn_reader` drops `at_prompt` from any prompt mark that arrives while a foreground command owns the pty (the `foreground_running()` guard in `pane.rs`). The replay was the one place that re-asserted the stored value unchecked.

The replay now asks the pty the same question, once, before it takes the state lock. `has_foreground_command()` → `tcgetpgrp` against the shell's pid; a prompt is reported only when nothing but the shell owns the terminal.

## Why

Every symptom in the report falls out of it, and only out of it:

- **The exact survivors.** `\x1b[?1049l` leaves the primary screen. For this pane that is the birth output and nothing else — which is why what came back reads as "the first replay segment": same bytes, different reason. Replayed into a real grid the shape is line-for-line the screenshot — banner, blank line, zsh notice, prompt + command, a screenful of nothing, then one fragment of the status line where the agent's next differential update lands.
- **Nothing else in the tree emits it.** `\x1b[?1049l` reaches a client's grid from exactly one place, `stale_mode_resets`, reachable only from `DaemonMsg::Prompt { active: true, at_prompt: true }`. `Term::reset_state()` is `adopt_relink`, which local panes never take; `restore_preamble`'s copy is written at spawn-with-restore, into a pane whose shell is new. So the pane had `at_prompt` set while the agent was in the alternate screen — that is a deduction from the screenshot, not a guess.
- **Why a resize fixed it and a tab switch did not**, and why it had to be repeated per tab: a resize is the only thing that reaches the child. New geometry → `SIGWINCH` → full repaint, into whichever buffer the client is now showing. A tab switch reports geometry the daemon already has.
- **Why the tests in #789 pass.** They cover the replay path with no full-screen program and no shell state; the frame that does the damage is never sent in any of them.

What is *not* established: which mark left the flag set in that particular session. The suppression covers a mark arriving during a program, not a `true` recorded before one starts, and every route to that (a `133;C` that never came, a `133;D` from something other than the shell, a value carried through a daemon handoff, a pane where the probe cannot answer) ends at the same fix — the daemon knows a program owns the pty and should not say otherwise.

## Interaction with #828

#828 (open, for #774) makes this sharper rather than conflicting with it: it has `replay_state` re-send the pane's folded terminal modes — `?1049h` included — *ahead* of the ring, so replayed frames land in the buffer they were drawn for. The trailing prompt report then takes that straight back off. Both changes touch `replay_state`; the textual overlap is a few adjacent lines. After #828 the alternate screen is present at replay time for more panes (including those whose `?1049h` has aged out of the 8 MiB ring), so this gate matters for more of them.

## Testing

Run and green:

- `cargo test -p tty7-core` — 1163 passed, 0 failed. Two new tests in `daemon::pane`:
  - `a_replay_does_not_claim_a_prompt_while_a_program_owns_the_pane` — the regression. Confirmed to fail on the old behaviour (`left: (true, true)`, `right: (true, false)`) by reverting the gate and re-running.
  - `a_replay_still_reports_a_prompt_when_the_shell_owns_the_pane` — the self-heal the scrub exists for, pinned so the gate cannot become a deletion.
- `cargo test --bin tty7-app replay_tests::` — 7 passed, 0 failed, including the five from #789. One new test, `a_replayed_prompt_report_decides_whether_the_alternate_screen_survives`, drives the client over a real socket pair and a real grid: the same replay with `at_prompt: false` keeps the agent's screen, with `at_prompt: true` loses it and comes back holding the banner. That second half is #711 reproduced end to end on the client side.
- `cargo fmt --all -- --check`, `cargo clippy -p tty7-core --all-targets` — nothing new.

Not verified here (Windows machine):

- **The fix's effect on a live pane.** `foreground_command_running` is `tcgetpgrp` under `#[cfg(unix)]`; on Windows it always answers "no", so the gate is inert locally and cannot be exercised against a real pty. The unit test drives the flag directly. The reporter's case — local pty, `bash` running `claude` — is where it takes effect.
- **The `#[cfg(unix)]` modules** in `src/terminal/remote.rs` and `src/ui/tree_sync.rs`. CI runs them; they were not run here.
- **The GUI.** Not launched, per this machine's rules.

One environment note: the root crate does not build from an agent worktree because of a shared dev `[patch]` in `.claude/worktrees/.cargo/config.toml` pointing gpui-component at a stale vendored clone. The runs above were driven with `--manifest-path` from outside that tree; `Cargo.lock` is unmodified in this branch.

## What this does not do

It does not force a repaint, nudge the geometry, or otherwise stand in for the resize the reporter found. If a grid still ends up on the wrong screen after this, the pane will still look wrong — which is the point: the remaining failure would stay visible rather than being papered over.

https://claude.ai/code/session_01UUyWQXzcBAoBzaSX8pc7nU
