### PR TITLE
feat(panel): keep the panel's chrome tiles and underline the current tab

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -863,13 +863,13 @@ pub struct Tty7App {
     pub(crate) editor: crate::ui::code_editor::EditorPanelState,
     pub(crate) sidebar_width: Rc<Cell<f32>>,
     pub(crate) sidebar_dragging: Rc<Cell<bool>>,
-    /// Whether the pointer is over the sidebar, the tab strip and the right
-    /// panel's own title bar. The chrome tiles in each — new tab, the two
-    /// panel toggles, the app menu — are drawn only while its own flag is set,
-    /// so a window nobody is pointing at carries no buttons at all.
+    /// Whether the pointer is over the sidebar and over the tab strip. The
+    /// chrome tiles in each — new tab, the panel toggles, the app menu — are
+    /// drawn only while its own flag is set, so a window nobody is pointing at
+    /// carries no buttons at all. The right panel's own title bar is the
+    /// exception: its tiles are always painted while the panel is open.
     pub(crate) sidebar_chrome_hover: Rc<Cell<bool>>,
     pub(crate) strip_chrome_hover: Rc<Cell<bool>>,
-    pub(crate) panel_chrome_hover: Rc<Cell<bool>>,
     /// How much width a settings row will actually get, measured once per
     /// render. `settings_row` is called from page builders that never see the
     /// window, and the answer differs per page — the SSH page spends a host
@@ -1489,7 +1489,6 @@ impl Tty7App {
             sidebar_dragging: Rc::new(Cell::new(false)),
             sidebar_chrome_hover: Rc::new(Cell::new(false)),
             strip_chrome_hover: Rc::new(Cell::new(false)),
-            panel_chrome_hover: Rc::new(Cell::new(false)),
             settings_row_width: Cell::new(f32::MAX),
             settings_viewport_w: Cell::new(f32::MAX),
             settings_hit_anchored: Cell::new(false),

--- a/src/ui/right_panel.rs
+++ b/src/ui/right_panel.rs
@@ -429,8 +429,14 @@ impl Tty7App {
                         .id("right-panel-titlebar-drag")
                         .flex_none()
                         .h(px(crate::ui::app::TITLE_BAR_HEIGHT))
+                        // `sidebar_border`, the lighter of the two hairline
+                        // tiers and the one the panel's own left edge is drawn
+                        // in. It rules the tiles off from the content below,
+                        // which on macOS starts directly under them: the title
+                        // row that carries this line on other platforms is not
+                        // drawn here.
                         .border_b_1()
-                        .border_color(cx.theme().transparent);
+                        .border_color(cx.theme().sidebar_border);
                     crate::ui::app::window_move_gesture(
                         row,
                         "right-panel-titlebar-drag",
@@ -444,12 +450,18 @@ impl Tty7App {
                     .relative()
                     .children(self.right_panel_tabs(cx))
                     .child(div().flex_1())
-                    .child(self.window_chrome(self.panel_chrome_hover.get(), window, cx))
-                    .child(crate::ui::app::hover_sheet(
-                        "panel-chrome-hover",
-                        &self.panel_chrome_hover,
-                    ))
+                    // Always painted, unlike the sidebar's and the strip's:
+                    // the tab tiles beside them are already there whenever the
+                    // panel is open, so hiding just these two left a row that
+                    // grew two buttons on hover and read as a glitch.
+                    .child(self.window_chrome(true, window, cx))
                 }))
+                // Air under the rule, so the first row of content is not
+                // sitting on the line. On the other platforms the title row
+                // holds this line and its own text keeps that distance; here
+                // the tiles are in the window's title bar and the content
+                // would start against the hairline.
+                .children(cfg!(target_os = "macos").then(|| div().flex_none().h(px(8.))))
                 .child(body)
                 .children(self.sftp_transfers_footer(cx))
                 .child(handle)

--- a/src/ui/right_panel.rs
+++ b/src/ui/right_panel.rs
@@ -639,6 +639,12 @@ impl Tty7App {
                 this.child(
                     h_flex()
                         .flex_shrink_0()
+                        // Full height, so the current tile's underline — pinned
+                        // to the bottom of its own box — lands on the rule that
+                        // closes this row, the way it does on macOS. Without it
+                        // the tiles are only as tall as a glyph and the bar
+                        // floats a few pixels above the line.
+                        .h_full()
                         .items_center()
                         .gap(px(2.))
                         .when(has_trailing, |this| this.ml(px(6.)))

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -1182,53 +1182,55 @@ impl Tty7App {
         .into_iter()
         .map(|(tab, icon, label_key)| {
             let current = active_tab == tab;
+            let tile = chrome_tile_marked(
+                Button::new(("right-panel-tab", tab as usize)).icon(icon),
+                current,
+                cx,
+            )
+            .rounded_lg()
+            .tooltip(match (tab, changed) {
+                (RightPanelTab::Scm, Some(n)) => {
+                    SharedString::from(format!("{} · {n}", t(label_key)))
+                }
+                _ => SharedString::from(t(label_key)),
+            })
+            // A tile for another tab switches to it; the lit one puts
+            // the panel away, the way an activity bar behaves
+            // everywhere else. Pressing it used to do nothing at all
+            // — a dead click on the one control in the row that looks
+            // like it should undo itself. (These tiles only exist
+            // while the panel is open, so `ToggleRightPanel` and the
+            // chrome tile beside them are still what brings it back.)
+            .on_click(cx.listener(move |this, _, window, cx| {
+                match this.right_panel_open(cx) && this.right_panel_tab == tab {
+                    true => {
+                        this.toggle_right_panel(cx);
+                        // These tiles live inside the panel, so
+                        // closing from one destroys the element that
+                        // holds the focus and leaves it nowhere —
+                        // and a keymap whose bindings are scoped to a
+                        // focused thing goes quiet with it, so the
+                        // ⌘J that would undo this did nothing at all.
+                        // Hand the terminal back what it lost.
+                        this.focus_active(window, cx);
+                    }
+                    false => this.set_right_panel_tab(tab, cx),
+                }
+            }));
             div()
-                .occlude()
                 .flex_shrink_0()
                 // Full height and `relative` so the bar below can be pinned to
                 // the row's own bottom edge, where it lands on the hairline
                 // that closes the row rather than floating under the glyph.
+                // The `occlude` that keeps a press from dragging the window
+                // stays on the tile: grown to the whole row it would take the
+                // few pixels above and below each glyph out of the drag
+                // region and hand them to nothing.
                 .h_full()
                 .relative()
                 .flex()
                 .items_center()
-                .child(
-                    chrome_tile_marked(
-                        Button::new(("right-panel-tab", tab as usize)).icon(icon),
-                        current,
-                        cx,
-                    )
-                    .rounded_lg()
-                    .tooltip(match (tab, changed) {
-                        (RightPanelTab::Scm, Some(n)) => {
-                            SharedString::from(format!("{} · {n}", t(label_key)))
-                        }
-                        _ => SharedString::from(t(label_key)),
-                    })
-                    // A tile for another tab switches to it; the lit one puts
-                    // the panel away, the way an activity bar behaves
-                    // everywhere else. Pressing it used to do nothing at all
-                    // — a dead click on the one control in the row that looks
-                    // like it should undo itself. (These tiles only exist
-                    // while the panel is open, so `ToggleRightPanel` and the
-                    // chrome tile beside them are still what brings it back.)
-                    .on_click(cx.listener(move |this, _, window, cx| {
-                        match this.right_panel_open(cx) && this.right_panel_tab == tab {
-                            true => {
-                                this.toggle_right_panel(cx);
-                                // These tiles live inside the panel, so
-                                // closing from one destroys the element that
-                                // holds the focus and leaves it nowhere —
-                                // and a keymap whose bindings are scoped to a
-                                // focused thing goes quiet with it, so the
-                                // ⌘J that would undo this did nothing at all.
-                                // Hand the terminal back what it lost.
-                                this.focus_active(window, cx);
-                            }
-                            false => this.set_right_panel_tab(tab, cx),
-                        }
-                    })),
-                )
+                .child(div().occlude().flex_shrink_0().child(tile))
                 // Narrower than the tile so it reads as underlining the glyph
                 // rather than as the edge of a box around it.
                 .children(current.then(|| {

--- a/src/ui/tab_strip.rs
+++ b/src/ui/tab_strip.rs
@@ -593,6 +593,22 @@ pub(crate) fn chrome_tile(button: Button, selected: bool, cx: &gpui::App) -> But
     chrome_tile_sized(button, TILE_SIZE, TILE_GLYPH, selected, cx)
 }
 
+/// A chrome tile whose current state is said with a rule under it rather than
+/// with a fill: the ink still steps up to full strength, the pill never
+/// appears, and the caller draws the bar.
+///
+/// The fill is what an activity bar of three tiles cannot afford. It is the
+/// same grey block the hover state paints, so the lit tab and the tile under
+/// the pointer read as the same thing, and it sits in a title bar where every
+/// other tile is a bare glyph.
+pub(crate) fn chrome_tile_marked(button: Button, current: bool, cx: &gpui::App) -> Button {
+    button
+        .custom(chrome_tile_variant_for(current, cx))
+        .with_size(px(TILE_GLYPH / BUTTON_ICON_SCALE))
+        .w(px(TILE_SIZE))
+        .h(px(TILE_SIZE))
+}
+
 /// How wide the two chrome tiles at the trailing end of the title bar are, with
 /// the padding around them.
 pub(crate) fn trailing_chrome_tiles_w() -> f32 {
@@ -1165,13 +1181,21 @@ impl Tty7App {
         ]
         .into_iter()
         .map(|(tab, icon, label_key)| {
+            let current = active_tab == tab;
             div()
                 .occlude()
                 .flex_shrink_0()
+                // Full height and `relative` so the bar below can be pinned to
+                // the row's own bottom edge, where it lands on the hairline
+                // that closes the row rather than floating under the glyph.
+                .h_full()
+                .relative()
+                .flex()
+                .items_center()
                 .child(
-                    chrome_tile(
+                    chrome_tile_marked(
                         Button::new(("right-panel-tab", tab as usize)).icon(icon),
-                        active_tab == tab,
+                        current,
                         cx,
                     )
                     .rounded_lg()
@@ -1205,6 +1229,18 @@ impl Tty7App {
                         }
                     })),
                 )
+                // Narrower than the tile so it reads as underlining the glyph
+                // rather than as the edge of a box around it.
+                .children(current.then(|| {
+                    div()
+                        .absolute()
+                        .bottom_0()
+                        .left(px(6.))
+                        .right(px(6.))
+                        .h(px(2.))
+                        .rounded_t(px(1.))
+                        .bg(cx.theme().foreground)
+                }))
                 .into_any_element()
         })
         .collect()


### PR DESCRIPTION
Three fixes to the right panel's own chrome on macOS, where the panel draws its
title bar itself instead of handing the row to `panel_title`.

| | Before | After |
|---|---|---|
| Panel toggle and app menu, panel open | Drawn only while the pointer is over the panel's title bar | Always drawn, like the tab tiles beside them |
| Under that row | No rule; content started against the tiles | A hairline in `sidebar_border`, then 8px of air |
| Current tab | Grey pill behind the glyph | Ink steps up, and a 2px bar sits under the glyph on the hairline |

## Why

The two trailing tiles were on the same hover flag as the sidebar's and the tab
strip's, but they share a row with three tiles that are always painted, so the
row grew two buttons when the pointer entered it. The pill said "current" with
the same grey the hover state paints, so the lit tab and the tile under the
pointer read alike.

The rule uses the lighter hairline tier, `sidebar_border`, the one the panel's
left edge is already drawn in, and a theme test keeps that tier lighter than
`border` in every preset.

## Scope

macOS only for the first two: on Windows and Linux the tab tiles live in
`panel_title`, which already draws its own rule and keeps content off it with
its own text. The underline is in `right_panel_tabs`, so it applies everywhere
those tiles are drawn.

`chrome_tile_marked` is `chrome_tile` without the selected fill: the custom
variant still steps the ink up for the current tile, and the caller draws the
bar.

## Testing

- `cargo build -p tty7` and `cargo fmt --check` clean.
- Looked at it in an isolated dev instance (`--config-dir /tmp/t7dev`): tiles
  stay put with the pointer outside the panel, the hairline reads as a hairline
  rather than a border, and the Source Control tab carries the bar while the
  other two are quiet.
- No behavior changed, so no tests added.

https://claude.ai/code/session_01VuYUPiDEhQX6aQ4WQZbEGn
