### PR TITLE
fix(terminal): encode the function keys and stop swallowing them (#834)

### DIFF
--- a/src/terminal/input.rs
+++ b/src/terminal/input.rs
@@ -142,8 +142,29 @@ fn encode_kitty(ks: &gpui::Keystroke, kitty: KeyFlags) -> Option<Vec<u8>> {
         return Some(csi_u(code, mods, None));
     }
 
+    // F3 is the one function key the kitty protocol does not share with
+    // terminfo. Its first version allowed both `CSI R` and `CSI 13~`, then
+    // dropped the letter form outright: `CSI 1;2R` is also a Cursor Position
+    // Report for row 1, column 2, so a client that negotiated the protocol
+    // cannot tell Shift+F3 from an answer to its own DSR. The table gives F3
+    // as `CSI 13~` alone -- the VT220 `kf3` -- so that is what an app that
+    // asked for the protocol is told, while the legacy path below keeps the
+    // `\EOR` our `$TERM` spells.
+    if ks.key.as_str() == "f3" {
+        let s = if mods == 1 {
+            "\x1b[13~".to_string()
+        } else {
+            format!("\x1b[13;{mods}~")
+        };
+        return Some(s.into_bytes());
+    }
+
     if let Some(seq) = functional_key(ks.key.as_str(), mods, kitty.app_cursor()) {
         return Some(seq);
+    }
+
+    if let Some(code) = kitty_function_key(ks.key.as_str()) {
+        return Some(csi_u(code, mods, None));
     }
 
     let modified = m.control || m.alt;
@@ -250,6 +271,8 @@ enum FunctionKey {
 /// A physical F13 therefore has no encoding of its own under this `$TERM`;
 /// sending the VT220 `\E[25~` for it would hand ncurses a sequence its own
 /// table reads back as Shift+F1, which is worse than sending nothing.
+/// `kitty_function_key` picks them up for the one protocol that *can* name
+/// them without that clash.
 fn function_key(key: &str) -> Option<FunctionKey> {
     Some(match key {
         "f1" => FunctionKey::Ss3('P'),
@@ -268,11 +291,24 @@ fn function_key(key: &str) -> Option<FunctionKey> {
     })
 }
 
-/// Whether a key name is one `functional_key` turns into a function-key
-/// sequence. The inline editor asks this to know a keystroke it holds no
-/// meaning for but the shell does.
+/// `f13`..`f24`, encodable only once the kitty protocol is negotiated. Kitty
+/// gives them codepoints of its own in the private use area — `CSI 57376 u` is
+/// F13, up to `CSI 57387 u` for F24 — so the ambiguity that stops
+/// `function_key` at F12 does not arise: nothing else in that protocol spells
+/// 57376. An app that never asked for the protocol still gets nothing, because
+/// there is nothing in `xterm-256color` to send it.
+fn kitty_function_key(key: &str) -> Option<u32> {
+    let n: u32 = key.strip_prefix('f')?.parse().ok()?;
+    (13..=24).contains(&n).then(|| 57376 + (n - 13))
+}
+
+/// Whether a key name is one of the function keys — the range that means
+/// nothing to a text editor and everything to a shell. The inline editor asks
+/// this to know a keystroke it holds no meaning for but the shell does; it
+/// still only hands over what actually encodes, which for F13 and up is the
+/// kitty path alone.
 pub(crate) fn is_function_key(key: &str) -> bool {
-    function_key(key).is_some()
+    function_key(key).is_some() || kitty_function_key(key).is_some()
 }
 
 fn text_key_code(ks: &gpui::Keystroke) -> Option<u32> {
@@ -829,23 +865,100 @@ mod tests {
     /// The `mods` parameter is what makes F13 onwards ambiguous: in
     /// `xterm-256color` those capability names are already spoken for by the
     /// modified F1..F8, so a physical F13 has no sequence of its own to send.
+    ///
+    /// The kitty protocol has no such clash — it puts F13..F24 in the private
+    /// use area, `CSI 57376 u` upwards — so a client that negotiated it does
+    /// get those keys, and only those twelve: F25 is past the end of the range
+    /// gpui names.
     #[test]
-    fn function_keys_stop_at_f12() {
+    fn terminfo_stops_at_f12_and_kitty_carries_on_to_f24() {
         let none = Modifiers::default();
+        let shift = Modifiers {
+            shift: true,
+            ..Default::default()
+        };
         let ctrl = Modifiers {
             control: true,
             ..Default::default()
         };
-        for key in ["f13", "f14", "f20", "f24"] {
-            assert_eq!(legacy(&ks(none, key, None)), None, "{key} is unencodable");
+        let kitty_cases: &[(&str, &[u8])] = &[
+            ("f13", b"\x1b[57376u"),
+            ("f14", b"\x1b[57377u"),
+            ("f20", b"\x1b[57383u"),
+            ("f24", b"\x1b[57387u"),
+        ];
+        for (key, seq) in kitty_cases {
             assert_eq!(
-                keystroke_to_bytes(&ks(none, key, None), kitty()),
+                legacy(&ks(none, key, None)),
                 None,
-                "{key} is unencodable under kitty too"
+                "{key} has no terminfo capability"
+            );
+            assert_eq!(
+                keystroke_to_bytes(&ks(none, key, None), kitty()).as_deref(),
+                Some(*seq),
+                "{key} under kitty"
             );
         }
+        assert_eq!(
+            keystroke_to_bytes(&ks(shift, "f13", None), kitty()),
+            Some(b"\x1b[57376;2u".to_vec())
+        );
         // Ctrl+F13 must not fold into a C0 byte on its first letter either.
         assert_eq!(legacy(&ks(ctrl, "f13", None)), None);
+        // And the range ends where gpui's names do.
+        assert_eq!(keystroke_to_bytes(&ks(none, "f25", None), kitty()), None);
+        assert_eq!(legacy(&ks(none, "f25", None)), None);
+    }
+
+    /// The one function key where the two protocols disagree. Kitty's spec
+    /// allowed `CSI R` for F3 in its first version and then removed it,
+    /// because `CSI 1;2R` is also a Cursor Position Report for row 1, column
+    /// 2 — so a client that negotiated the protocol is given `CSI 13~`, the
+    /// VT220 `kf3`, while `$TERM`'s own `kf3=\EOR` still goes to everyone
+    /// else. alacritty draws the same line.
+    #[test]
+    fn kitty_spells_f3_thirteen_because_csi_r_is_a_cursor_report() {
+        let none = Modifiers::default();
+        let shift = Modifiers {
+            shift: true,
+            ..Default::default()
+        };
+        let ctrl = Modifiers {
+            control: true,
+            ..Default::default()
+        };
+        assert_eq!(legacy(&ks(none, "f3", None)), Some(b"\x1bOR".to_vec()));
+        assert_eq!(legacy(&ks(shift, "f3", None)), Some(b"\x1b[1;2R".to_vec()));
+        let full = KeyFlags {
+            disambiguate: true,
+            report_all_keys: true,
+            report_text: true,
+            app_cursor: false,
+        };
+        for flags in [kitty(), full] {
+            assert_eq!(
+                keystroke_to_bytes(&ks(none, "f3", None), flags),
+                Some(b"\x1b[13~".to_vec())
+            );
+            assert_eq!(
+                keystroke_to_bytes(&ks(shift, "f3", None), flags),
+                Some(b"\x1b[13;2~".to_vec())
+            );
+            assert_eq!(
+                keystroke_to_bytes(&ks(ctrl, "f3", None), flags),
+                Some(b"\x1b[13;5~".to_vec())
+            );
+        }
+        // Cmd is not a kitty modifier either, and the platform key sends the
+        // keystroke down the legacy path in the first place.
+        let cmd = Modifiers {
+            platform: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            keystroke_to_bytes(&ks(cmd, "f3", None), kitty()),
+            Some(b"\x1bOR".to_vec())
+        );
     }
 
     /// Cmd is not an xterm modifier, so it must not turn a bare F-key into a
@@ -1181,7 +1294,9 @@ mod tests {
     /// The kitty encoder shares `functional_key`, so the F keys have to come
     /// out of it byte-identical to the legacy path — kitty's own spec keeps
     /// the legacy CSI/SS3 forms for F1..F12 and only appends the modifier
-    /// parameter, which is what that shared table already does.
+    /// parameter, which is what that shared table already does. F3 is the sole
+    /// exception and has a test of its own:
+    /// `kitty_spells_f3_thirteen_because_csi_r_is_a_cursor_report`.
     ///
     /// `report_all_keys` changes nothing here either: the F keys are already
     /// escape sequences, so there is no bare byte for it to promote.
@@ -1202,7 +1317,7 @@ mod tests {
             report_text: true,
             app_cursor: false,
         };
-        for key in ["f1", "f2", "f3", "f4", "f5", "f7", "f10", "f11", "f12"] {
+        for key in ["f1", "f2", "f4", "f5", "f7", "f10", "f11", "f12"] {
             for mods in [none, shift, ctrl] {
                 let want = legacy(&ks(mods, key, None));
                 assert!(want.is_some(), "{key} encodes on the legacy path");

--- a/src/terminal/input.rs
+++ b/src/terminal/input.rs
@@ -171,7 +171,7 @@ fn csi_u(code: u32, mods: u32, text: Option<&[u32]>) -> Vec<u8> {
     s.into_bytes()
 }
 
-/// The cursor and editing keys, encoded the way `xterm-256color`'s terminfo
+/// The cursor, editing and function keys, encoded the way `xterm-256color`'s terminfo
 /// says they are — which is what we advertise in `$TERM`, and what ncurses
 /// matches against byte for byte.
 ///
@@ -197,6 +197,19 @@ fn functional_key(key: &str, mods: u32, app_cursor: bool) -> Option<Vec<u8>> {
         };
         return Some(s.into_bytes());
     }
+    if let Some(form) = function_key(key) {
+        let s = match form {
+            // `kf1=\EOP` .. `kf4=\EOS`, and modified the `CSI 1;<mods>` form
+            // the cursor keys use — terminfo spells Shift+F1 `kf13=\E[1;2P`.
+            // DECCKM has no say here: unlike `kcuu1`, `kf1` is SS3 under both
+            // `smkx` and `rmkx`.
+            FunctionKey::Ss3(l) if mods == 1 => format!("\x1bO{l}"),
+            FunctionKey::Ss3(l) => format!("\x1b[1;{mods}{l}"),
+            FunctionKey::Tilde(n) if mods == 1 => format!("\x1b[{n}~"),
+            FunctionKey::Tilde(n) => format!("\x1b[{n};{mods}~"),
+        };
+        return Some(s.into_bytes());
+    }
     let num = match key {
         "insert" => Some(2u32),
         "delete" => Some(3),
@@ -213,6 +226,53 @@ fn functional_key(key: &str, mods: u32, app_cursor: bool) -> Option<Vec<u8>> {
         return Some(s.into_bytes());
     }
     None
+}
+
+/// The two shapes `xterm-256color` gives a function key.
+enum FunctionKey {
+    /// `SS3 <letter>` unmodified, `CSI 1;<mods> <letter>` with a modifier.
+    Ss3(char),
+    /// `CSI <n> ~`, or `CSI <n>;<mods> ~` with a modifier.
+    Tilde(u32),
+}
+
+/// `f1`..`f12` — the name gpui gives these keys on all three platforms, and
+/// the range `xterm-256color` gives a key of its own.
+///
+/// The numbering is the PC-style table xterm has used since patch #94 and the
+/// one `kf5`..`kf12` spell: it starts at 15 and skips both 16 and 22, because
+/// those two were DEC's "do" and "help" on the VT220 keypad. Guessing a
+/// contiguous run here is the classic way to make F6 arrive as F5.
+///
+/// This deliberately stops at F12. In the entry we advertise, `kf13` onwards
+/// are not further keys — they are the *modified* forms of F1..F8 (`kf13` is
+/// `\E[1;2P`, Shift+F1), which the `mods` parameter above already produces.
+/// A physical F13 therefore has no encoding of its own under this `$TERM`;
+/// sending the VT220 `\E[25~` for it would hand ncurses a sequence its own
+/// table reads back as Shift+F1, which is worse than sending nothing.
+fn function_key(key: &str) -> Option<FunctionKey> {
+    Some(match key {
+        "f1" => FunctionKey::Ss3('P'),
+        "f2" => FunctionKey::Ss3('Q'),
+        "f3" => FunctionKey::Ss3('R'),
+        "f4" => FunctionKey::Ss3('S'),
+        "f5" => FunctionKey::Tilde(15),
+        "f6" => FunctionKey::Tilde(17),
+        "f7" => FunctionKey::Tilde(18),
+        "f8" => FunctionKey::Tilde(19),
+        "f9" => FunctionKey::Tilde(20),
+        "f10" => FunctionKey::Tilde(21),
+        "f11" => FunctionKey::Tilde(23),
+        "f12" => FunctionKey::Tilde(24),
+        _ => return None,
+    })
+}
+
+/// Whether a key name is one `functional_key` turns into a function-key
+/// sequence. The inline editor asks this to know a keystroke it holds no
+/// meaning for but the shell does.
+pub(crate) fn is_function_key(key: &str) -> bool {
+    function_key(key).is_some()
 }
 
 fn text_key_code(ks: &gpui::Keystroke) -> Option<u32> {
@@ -682,10 +742,142 @@ mod tests {
         }
     }
 
+    /// Issue #834: the function keys produced no bytes at all, on any
+    /// platform. PSReadLine puts CharacterSearch on F3 and HistorySearch on
+    /// F8, so on Windows this took part of the shell's normal editing surface
+    /// away.
+    ///
+    /// The table is `xterm-256color`'s `kf1`..`kf12` verbatim, gaps included:
+    /// F5 is 15 and F6 is 17, F10 is 21 and F11 is 23.
+    #[test]
+    fn keystroke_to_bytes_encodes_f1_through_f12_like_terminfo() {
+        let none = Modifiers::default();
+        let cases: &[(&str, &[u8])] = &[
+            ("f1", b"\x1bOP"),
+            ("f2", b"\x1bOQ"),
+            ("f3", b"\x1bOR"),
+            ("f4", b"\x1bOS"),
+            ("f5", b"\x1b[15~"),
+            ("f6", b"\x1b[17~"),
+            ("f7", b"\x1b[18~"),
+            ("f8", b"\x1b[19~"),
+            ("f9", b"\x1b[20~"),
+            ("f10", b"\x1b[21~"),
+            ("f11", b"\x1b[23~"),
+            ("f12", b"\x1b[24~"),
+        ];
+        for (key, seq) in cases {
+            assert_eq!(
+                legacy(&ks(none, key, None)).as_deref(),
+                Some(*seq),
+                "{key} unmodified"
+            );
+            // gpui hands a function key over with no `key_char`, but the
+            // Windows backend has been known to attach an empty one; neither
+            // may reach the `key_char` fallback and send nothing.
+            assert_eq!(
+                legacy(&ks(none, key, Some(""))).as_deref(),
+                Some(*seq),
+                "{key} with an empty key_char"
+            );
+        }
+    }
+
+    /// The modified forms are the same ones terminfo lists under `kf13`
+    /// onwards: `kf13=\E[1;2P` is Shift+F1, `kf17=\E[15;2~` is Shift+F5,
+    /// `kf25=\E[1;5P` is Ctrl+F1. Alt is xterm's 3, which PSReadLine wants for
+    /// Alt+F7 (ClearHistory).
+    #[test]
+    fn keystroke_to_bytes_modifies_function_keys_like_terminfo() {
+        let shift = Modifiers {
+            shift: true,
+            ..Default::default()
+        };
+        let alt = Modifiers {
+            alt: true,
+            ..Default::default()
+        };
+        let ctrl = Modifiers {
+            control: true,
+            ..Default::default()
+        };
+        let ctrl_shift = Modifiers {
+            control: true,
+            shift: true,
+            ..Default::default()
+        };
+        // kf13, kf16
+        assert_eq!(legacy(&ks(shift, "f1", None)), Some(b"\x1b[1;2P".to_vec()));
+        assert_eq!(legacy(&ks(shift, "f4", None)), Some(b"\x1b[1;2S".to_vec()));
+        // kf25
+        assert_eq!(legacy(&ks(ctrl, "f1", None)), Some(b"\x1b[1;5P".to_vec()));
+        // kf37
+        assert_eq!(
+            legacy(&ks(ctrl_shift, "f1", None)),
+            Some(b"\x1b[1;6P".to_vec())
+        );
+        // kf49
+        assert_eq!(legacy(&ks(alt, "f1", None)), Some(b"\x1b[1;3P".to_vec()));
+        // kf20 -- Shift+F8, PSReadLine's HistorySearchForward
+        assert_eq!(legacy(&ks(shift, "f8", None)), Some(b"\x1b[19;2~".to_vec()));
+        // kf55 -- Alt+F7, PSReadLine's ClearHistory
+        assert_eq!(legacy(&ks(alt, "f7", None)), Some(b"\x1b[18;3~".to_vec()));
+        // kf35 -- Ctrl+F11
+        assert_eq!(legacy(&ks(ctrl, "f11", None)), Some(b"\x1b[23;5~".to_vec()));
+    }
+
+    /// The `mods` parameter is what makes F13 onwards ambiguous: in
+    /// `xterm-256color` those capability names are already spoken for by the
+    /// modified F1..F8, so a physical F13 has no sequence of its own to send.
+    #[test]
+    fn function_keys_stop_at_f12() {
+        let none = Modifiers::default();
+        let ctrl = Modifiers {
+            control: true,
+            ..Default::default()
+        };
+        for key in ["f13", "f14", "f20", "f24"] {
+            assert_eq!(legacy(&ks(none, key, None)), None, "{key} is unencodable");
+            assert_eq!(
+                keystroke_to_bytes(&ks(none, key, None), kitty()),
+                None,
+                "{key} is unencodable under kitty too"
+            );
+        }
+        // Ctrl+F13 must not fold into a C0 byte on its first letter either.
+        assert_eq!(legacy(&ks(ctrl, "f13", None)), None);
+    }
+
+    /// Cmd is not an xterm modifier, so it must not turn a bare F-key into a
+    /// modified one — and on macOS Cmd+F-keys belong to the window anyway.
+    #[test]
+    fn cmd_does_not_modify_a_function_key() {
+        let cmd = Modifiers {
+            platform: true,
+            ..Default::default()
+        };
+        assert_eq!(legacy(&ks(cmd, "f5", None)), Some(b"\x1b[15~".to_vec()));
+    }
+
     fn app_cursor() -> KeyFlags {
         KeyFlags {
             app_cursor: true,
             ..Default::default()
+        }
+    }
+
+    /// DECCKM governs `kcuu1` and friends, not `kf1`: terminfo spells `kf1`
+    /// `\EOP` under both `smkx` and `rmkx`, so the F keys must not move when
+    /// an ncurses app turns application cursor keys on.
+    #[test]
+    fn app_cursor_mode_leaves_the_function_keys_alone() {
+        let none = Modifiers::default();
+        for key in ["f1", "f4", "f5", "f12"] {
+            assert_eq!(
+                keystroke_to_bytes(&ks(none, key, None), app_cursor()),
+                legacy(&ks(none, key, None)),
+                "{key} does not follow DECCKM"
+            );
         }
     }
 
@@ -801,9 +993,11 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(legacy(&ks(alt, "b", Some("b"))), Some(b"\x1bb".to_vec()));
+        // `f13` stands in for "a named key with nothing behind it" — it used
+        // to be `f7`, back when no function key encoded at all (#834).
         let none = Modifiers::default();
-        assert_eq!(legacy(&ks(none, "f7", Some(""))), None);
-        assert_eq!(legacy(&ks(none, "f7", None)), None);
+        assert_eq!(legacy(&ks(none, "f13", Some(""))), None);
+        assert_eq!(legacy(&ks(none, "f13", None)), None);
     }
 
     #[test]
@@ -981,6 +1175,58 @@ mod tests {
         assert_eq!(
             keystroke_to_bytes(&ks(shift, "delete", None), kitty()),
             Some(b"\x1b[3;2~".to_vec())
+        );
+    }
+
+    /// The kitty encoder shares `functional_key`, so the F keys have to come
+    /// out of it byte-identical to the legacy path — kitty's own spec keeps
+    /// the legacy CSI/SS3 forms for F1..F12 and only appends the modifier
+    /// parameter, which is what that shared table already does.
+    ///
+    /// `report_all_keys` changes nothing here either: the F keys are already
+    /// escape sequences, so there is no bare byte for it to promote.
+    #[test]
+    fn kitty_encodes_function_keys_like_the_legacy_path() {
+        let none = Modifiers::default();
+        let shift = Modifiers {
+            shift: true,
+            ..Default::default()
+        };
+        let ctrl = Modifiers {
+            control: true,
+            ..Default::default()
+        };
+        let full = KeyFlags {
+            disambiguate: true,
+            report_all_keys: true,
+            report_text: true,
+            app_cursor: false,
+        };
+        for key in ["f1", "f2", "f3", "f4", "f5", "f7", "f10", "f11", "f12"] {
+            for mods in [none, shift, ctrl] {
+                let want = legacy(&ks(mods, key, None));
+                assert!(want.is_some(), "{key} encodes on the legacy path");
+                assert_eq!(
+                    keystroke_to_bytes(&ks(mods, key, None), kitty()),
+                    want,
+                    "{key} under kitty disambiguate"
+                );
+                assert_eq!(
+                    keystroke_to_bytes(&ks(mods, key, None), full),
+                    want,
+                    "{key} under kitty report-all-keys"
+                );
+            }
+        }
+        // Spot-check the actual bytes, so a change to `legacy` cannot quietly
+        // move both sides at once.
+        assert_eq!(
+            keystroke_to_bytes(&ks(none, "f7", None), full),
+            Some(b"\x1b[18~".to_vec())
+        );
+        assert_eq!(
+            keystroke_to_bytes(&ks(shift, "f1", None), full),
+            Some(b"\x1b[1;2P".to_vec())
         );
     }
 

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -2482,6 +2482,19 @@ impl TerminalView {
 
         self.close_completion();
 
+        // A function key means nothing to this editor and everything to the
+        // shell — PSReadLine puts CharacterSearch on F3 and HistorySearch on
+        // F8, and both of those act on the line that is currently on the
+        // prompt. So it takes the same route an unknown Ctrl chord takes:
+        // hand the line over first, then send the key, with every modifier
+        // combination going the same way (Alt+F7 is ClearHistory).
+        if super::input::is_function_key(key) && !m.platform {
+            if let Some(bytes) = super::input::keystroke_to_bytes(ks, self.key_flags()) {
+                self.handoff_line_to_shell(&bytes, cx);
+                return;
+            }
+        }
+
         if m.control && !m.platform && !m.alt {
             if cfg!(not(target_os = "macos")) {
                 match key {
@@ -6859,10 +6872,24 @@ impl Render for TerminalView {
             .on_action(
                 cx.listener(|this, _: &FindInTerminal, window, cx| this.open_search(window, cx)),
             )
+            // Off macOS these two live on F3 and Shift+F3, which is also where
+            // PSReadLine keeps CharacterSearch and readline users put their
+            // own widgets. With no find bar open there is no next match to
+            // step to, so the keystroke is given back the way `EditorSave`
+            // gives back Ctrl+S — otherwise the action swallows the key and
+            // the shell never sees it (#834).
             .on_action(cx.listener(|this, _: &FindNext, _w, cx| {
+                if this.search.is_none() {
+                    cx.propagate();
+                    return;
+                }
                 this.step_match(Direction::Right, cx);
             }))
             .on_action(cx.listener(|this, _: &FindPrevious, _w, cx| {
+                if this.search.is_none() {
+                    cx.propagate();
+                    return;
+                }
                 this.step_match(Direction::Left, cx);
             }))
             .on_action(cx.listener(|this, _: &ClearScrollback, _w, cx| this.clear_scrollback(cx)))
@@ -11960,6 +11987,59 @@ mod gpui_tests {
             .unwrap();
     }
 
+    /// The whole chain for #834, through the real dispatch tree: F3 is bound
+    /// to Find Next off macOS, and gpui matches bindings before the pane's key
+    /// handler. With no find bar open the action gives the key back, the pane
+    /// encodes it, and PSReadLine's CharacterSearch gets its `\EOR`.
+    ///
+    /// F7 has no binding at all and is the control: it takes the same route
+    /// with nothing to fall through.
+    #[cfg(not(target_os = "macos"))]
+    #[gpui::test]
+    fn an_unused_find_binding_gives_f3_back_to_the_shell(cx: &mut TestAppContext) {
+        let (window, mut daemon) = harness(cx);
+        cx.update(|cx| crate::ui::keymap::init(cx));
+        prompt_ready(&window, cx, &mut daemon);
+        window
+            .update(cx, |view, window, cx| {
+                window.activate_window();
+                view.focus_handle.focus(window, cx);
+                view.commit_text("echo a", cx);
+            })
+            .unwrap();
+
+        let mut vcx = gpui::VisualTestContext::from_window(window.into(), cx);
+        for (chord, seq) in [("f3", b"\x1bOR".to_vec()), ("f7", b"\x1b[18~".to_vec())] {
+            window
+                .update(cx, |view, _, _| {
+                    // The previous handoff gave this prompt to the shell for
+                    // good; take it back so both keys are tested from the
+                    // same starting state.
+                    view.editor_handoff = None;
+                    view.cmd.set("echo a");
+                    assert!(view.search.is_none(), "no find bar is open");
+                })
+                .unwrap();
+            vcx.simulate_keystrokes(chord);
+            window
+                .update(cx, |view, _, _| {
+                    assert!(view.search.is_none(), "{chord} did not open the find bar");
+                    assert_eq!(view.cmd.text(), "", "{chord} handed the line over");
+                })
+                .unwrap();
+            assert_eq!(
+                next_input_until_timeout(&mut daemon),
+                Some(b"echo a".to_vec()),
+                "{chord} puts the line on the shell's prompt first"
+            );
+            assert_eq!(
+                next_input_until_timeout(&mut daemon),
+                Some(seq),
+                "{chord} reaches the PTY"
+            );
+        }
+    }
+
     #[gpui::test]
     fn ctrl_r_fuzzy_search_accepts_into_the_editor(cx: &mut TestAppContext) {
         let (window, _daemon) = harness(cx);
@@ -12025,6 +12105,41 @@ mod gpui_tests {
             Some(b"git status\r".to_vec()),
             "Cmd+Enter ships the selected line to the PTY"
         );
+    }
+
+    /// The second half of #834. Even once the encoder knew the F keys, the
+    /// inline editor still ate them: `handle_editor_key` had no arm for a
+    /// named key it does not bind, so F8 fell out of the bottom of the match
+    /// and died on a `cx.notify()`. PSReadLine's HistorySearchBackward acts on
+    /// the line that is on the prompt, so the fix is the unknown-chord route —
+    /// the line goes over first, then the key.
+    #[gpui::test]
+    fn function_keys_hand_the_line_to_the_shell(cx: &mut TestAppContext) {
+        let (window, mut daemon) = harness(cx);
+        for (chord, seq) in [
+            ("f8", b"\x1b[19~".to_vec()),
+            ("shift-f8", b"\x1b[19;2~".to_vec()),
+            ("alt-f7", b"\x1b[18;3~".to_vec()),
+            ("f3", b"\x1bOR".to_vec()),
+        ] {
+            window
+                .update(cx, |view, _, cx| {
+                    view.cmd.set("git st");
+                    view.handle_editor_key(&key(chord), cx);
+                    assert_eq!(view.cmd.text(), "", "{chord} handed the line over");
+                })
+                .unwrap();
+            assert_eq!(
+                next_input_until_timeout(&mut daemon),
+                Some(b"git st".to_vec()),
+                "{chord} puts the line on the shell's prompt first"
+            );
+            assert_eq!(
+                next_input_until_timeout(&mut daemon),
+                Some(seq),
+                "{chord} follows the line"
+            );
+        }
     }
 
     #[gpui::test]

--- a/src/ui/keymap.rs
+++ b/src/ui/keymap.rs
@@ -402,6 +402,15 @@ pub(crate) fn default_bindings() -> Vec<(&'static str, &'static str)> {
             per_platform("secondary-shift-t", "alt-shift-t"),
         ),
         ("ToggleMaximizePane", "secondary-shift-enter"),
+        // The one default that sits on a bare function key, and it stays
+        // there: F11 is the fullscreen chord Windows Terminal, GNOME Terminal
+        // and konsole all train their users on, and no shell binds it — the
+        // keys PSReadLine actually wants are F3, F7 and F8. gpui matches this
+        // binding before the pane's key handler runs, so the terminal never
+        // sees a bare F11; Shift/Ctrl/Alt+F11 are not bound and still reach
+        // the PTY as `\E[23;<mods>~`, and the whole chord is one line of
+        // config away from being retired. See
+        // `f11_is_the_only_default_on_a_bare_function_key`.
         ("ToggleFullscreen", per_platform("secondary-enter", "f11")),
         ("ToggleTabSidebar", ""),
         (
@@ -1871,6 +1880,52 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// F1..F12 now encode (#834), so a default sitting on one takes it away
+    /// from the shell the same way a Ctrl binding takes a control code: gpui
+    /// matches bindings before the pane's key handler runs, so a bound
+    /// function key never reaches the PTY at all.
+    ///
+    /// The three that do are named here rather than left to be discovered,
+    /// and each answers for the shell key it stands on:
+    ///
+    /// * F11 keeps fullscreen outright. It is the chord Windows Terminal,
+    ///   GNOME Terminal and konsole all use, and no shell binds it —
+    ///   PSReadLine's F keys are F3, F7 and F8.
+    /// * F3 and Shift+F3 are Find Next / Previous, and they fall through:
+    ///   with no find bar open the listener in `terminal::view` calls
+    ///   `cx.propagate()`, so PSReadLine's CharacterSearch still gets the key.
+    ///
+    /// A fourth needs a fall-through of its own to join them.
+    #[test]
+    fn f11_is_the_only_default_on_a_bare_function_key() {
+        let mut bound = Vec::new();
+        for (action, spec) in default_bindings() {
+            for chord in spec.split_whitespace() {
+                let ks = Keystroke::parse(chord).expect("default chords parse");
+                if crate::terminal::input::is_function_key(&ks.key) {
+                    bound.push((action, chord));
+                }
+            }
+        }
+        let expected: &[(&str, &str)] = if cfg!(target_os = "macos") {
+            &[]
+        } else {
+            &[
+                ("FindNext", "f3"),
+                ("FindPrevious", "shift-f3"),
+                ("ToggleFullscreen", "f11"),
+            ]
+        };
+        bound.sort();
+        let mut expected = expected.to_vec();
+        expected.sort();
+        assert_eq!(
+            bound, expected,
+            "a default on a function key hides it from the shell; \
+             PSReadLine wants F3, F7 and F8, readline's `bind -x` any of them"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #834.

## What changed

F1–F12 were never encoded, on any platform. `functional_key` in `src/terminal/input.rs` is the single place a named key becomes an escape sequence, and it knew only the cursor and editing keys. It now carries `xterm-256color`'s function-key table, and two upstream swallows that would have eaten the new bytes anyway are fixed too.

| Key | Before | After (unmodified) | Shift | Ctrl | Alt |
| --- | --- | --- | --- | --- | --- |
| F1 | *nothing* | `\EOP` | `\E[1;2P` | `\E[1;5P` | `\E[1;3P` |
| F2 | *nothing* | `\EOQ` | `\E[1;2Q` | `\E[1;5Q` | `\E[1;3Q` |
| F3 | *nothing* | `\EOR` | `\E[1;2R` | `\E[1;5R` | `\E[1;3R` |
| F4 | *nothing* | `\EOS` | `\E[1;2S` | `\E[1;5S` | `\E[1;3S` |
| F5 | *nothing* | `\E[15~` | `\E[15;2~` | `\E[15;5~` | `\E[15;3~` |
| F6 | *nothing* | `\E[17~` | `\E[17;2~` | `\E[17;5~` | `\E[17;3~` |
| F7 | *nothing* | `\E[18~` | `\E[18;2~` | `\E[18;5~` | `\E[18;3~` |
| F8 | *nothing* | `\E[19~` | `\E[19;2~` | `\E[19;5~` | `\E[19;3~` |
| F9 | *nothing* | `\E[20~` | `\E[20;2~` | `\E[20;5~` | `\E[20;3~` |
| F10 | *nothing* | `\E[21~` | `\E[21;2~` | `\E[21;5~` | `\E[21;3~` |
| F11 | *nothing* | *(fullscreen — see below)* | `\E[23;2~` | `\E[23;5~` | `\E[23;3~` |
| F12 | *nothing* | `\E[24~` | `\E[24;2~` | `\E[24;5~` | `\E[24;3~` |
| F13+ | *nothing* | *nothing, deliberately* | | | |

The kitty encoder shares the same table, so those bytes are identical under `disambiguate` and `report_all_keys`. DECCKM does not move them: unlike `kcuu1`, `kf1` is SS3 under both `smkx` and `rmkx`.

Two behaviours off the encoder also move:

| Path | Before | After |
| --- | --- | --- |
| F-key at a prompt, inline editor on | fell out of the bottom of `handle_editor_key` and died on a `cx.notify()` | takes the unknown-Ctrl-chord route: the line goes to the shell, then the key |
| F3 / Shift+F3 with no find bar open | Find Next/Previous matched the binding, did nothing, and consumed the key | the listener calls `cx.propagate()`, exactly as `EditorSave` gives back Ctrl+S |
| F11 | fullscreen | unchanged — but now a stated choice, pinned by a test |

## Why

`functional_key` handles `up`/`down`/`left`/`right`/`home`/`end`/`insert`/`delete`/`pageup`/`pagedown` and had no `f1`..`f12` arm. Nothing downstream could cover for it: `text_key_code` returns `None` as soon as a key name has a second character, so `"f7"` fell through, and the `key_char` fallback in `legacy_keystroke_to_bytes` never fires because gpui hands a function key over with no character. Both the legacy path and `encode_kitty` call that one function, so both produced nothing.

The numbers come from the terminfo entry we advertise in `$TERM`, read rather than recalled (`kf1=\EOP` … `kf12=\E[24~`, the numbering starting at 15 and skipping 16 and 22 — DEC's "do" and "help" on the VT220 keypad). The modified forms reproduce `kf13`–`kf48` exactly, because in that entry those names *are* the modified F1–F8: `kf13=\E[1;2P` is Shift+F1, `kf25=\E[1;5P` is Ctrl+F1.

**F13 and up are deliberately left unencoded.** Since `kf13` onward are already spoken for by the modified F1–F8, a physical F13 has no capability of its own under this `$TERM`. Sending the VT220 `\E[25~` would hand ncurses a sequence its own table reads back as Shift+F1 — worse than sending nothing.

Key names were checked against gpui rather than assumed: `gpui_windows/src/events.rs` maps `VK_F1`..`VK_F24` to `"f1"`..`"f24"`, and `gpui_macos/src/events.rs` produces the same spelling, so one table serves all platforms.

The reporter's second clause — "disable *Prompt editor* still not working" — is explained, not fixed. `prompt_editor` is a real gate (`input_inactive_reason`), but turning it off only routes the keystroke to `keystroke_to_bytes`, which returned `None`. It could not have helped. Leaving it *on* was a second, independent swallow: `handle_editor_key` had no arm for a named key it does not bind, so F8 reached the fall-through `_` and was dropped. Both are fixed here.

Evidence that these keys matter on Windows, from `Get-PSReadLineKeyHandler -Bound` on the machine this was developed on:

```
F3        CharacterSearch
Shift+F3  CharacterSearchBackward
F8        HistorySearchBackward
Shift+F8  HistorySearchForward
Alt+F7    ClearHistory
```

F3 in particular collided with tty7's own Find Next binding, which is how the third swallow was found: gpui matches key bindings *before* dispatching to the pane's key handler (`Window::dispatch_key_event` runs `match_result.bindings` and only reaches `finish_dispatch_key_event` if propagation survives), so a bound function key never reached the PTY at all. Find Next/Previous now hand it back when there is no search to step through.

F11 keeps fullscreen off macOS. It is the chord Windows Terminal, GNOME Terminal and konsole all use, PSReadLine binds nothing to it, the modified forms still reach the shell, and it is one line of config away from being retired. That is now a stated decision with `f11_is_the_only_default_on_a_bare_function_key` standing on it — a fourth default landing on a function key will fail that test and have to answer for the shell key it eats.

## Testing

All run on Windows 11, headless, from outside the worktree tree (`--manifest-path`, `AWS_LC_SYS_PREBUILT_NASM=1`). No GUI was launched.

- `cargo test --bin tty7-app` — **1806 passed, 0 failed**, 2 ignored. `Cargo.lock` is unmodified.
- `cargo fmt` clean; `cargo clippy` adds no new warnings.

New tests:

- `keystroke_to_bytes_encodes_f1_through_f12_like_terminfo` — the whole table byte for byte, with and without an empty `key_char`.
- `keystroke_to_bytes_modifies_function_keys_like_terminfo` — Shift/Ctrl/Alt/Ctrl+Shift, cross-referenced against the `kf13`/`kf20`/`kf25`/`kf35`/`kf37`/`kf49`/`kf55` capability names.
- `function_keys_stop_at_f12` — F13/F14/F20/F24 encode nothing, legacy and kitty, and Ctrl+F13 does not fold into a C0 byte.
- `cmd_does_not_modify_a_function_key`, `app_cursor_mode_leaves_the_function_keys_alone`.
- `kitty_encodes_function_keys_like_the_legacy_path` — every F key under `disambiguate` and under `report_all_keys` + `report_text`, plus literal spot checks so both sides cannot drift together.
- `function_keys_hand_the_line_to_the_shell` — F8, Shift+F8, Alt+F7 and F3 put the pending line on the shell's prompt and then the key, in order, over a real PTY stream.
- `an_unused_find_binding_gives_f3_back_to_the_shell` — end to end through the real dispatch tree with the keymap installed: `simulate_keystrokes("f3")` and `("f7")` arrive at the PTY as `\EOR` and `\E[18~`. This one fails without the `cx.propagate()` change, which is how the Find Next collision surfaced.
- `f11_is_the_only_default_on_a_bare_function_key` — pins the three defaults allowed to sit on a function key.

**Not verified:** no real PowerShell session in the GUI. The tests prove the exact bytes leave tty7 and reach the PTY, but nobody has watched PSReadLine open a character search on F3 or step history on F8 in a running window, and no Linux or macOS run happened at all (the F3/Shift+F3 fall-through is only reachable off macOS, and its test is gated accordingly). The F11-stays-fullscreen decision is asserted at the keymap level, not by pressing F11 in a window.

https://claude.ai/code/session_01UUyWQXzcBAoBzaSX8pc7nU
