### PR TITLE
fix(sidebar): lift a lone row's branch onto its group header too

### DIFF
--- a/src/ui/tab_sidebar.rs
+++ b/src/ui/tab_sidebar.rs
@@ -422,9 +422,14 @@ impl Tty7App {
             // column they were also the loudest thing in it. Read off every
             // row the group counts rather than the ones it draws, so a folded
             // group still names its branch.
+            //
+            // A lone row is no exception. Its branch describes the same repo
+            // the heading above it names, and leaving it down there gave a
+            // one-tab group a shape no other group in the column has: a
+            // bare heading over a two-line row. It lifts like any other.
             let shared_git: Option<SharedGit> = section.name.as_ref().and_then(|_| {
                 let rows = &visible_by_section[group_ix];
-                if rows.len() < 2 {
+                if rows.is_empty() {
                     return None;
                 }
                 // Only rows that *have* a status get a vote. A tab that was


### PR DESCRIPTION
A group with a single tab now shows its branch and diff counts on the group header, the same as a group with several tabs already did.

| | Before | After |
|---|---|---|
| Group with 2+ tabs on one branch | Branch + counts on the group header, rows stay one line | unchanged |
| Group with exactly 1 tab in a repo | Bare heading, branch + counts on a second line under the row | Branch + counts on the group header, row is one line |
| Group with 1 tab outside a repo | Heading, row's second line carries the compressed cwd | unchanged |
| Click target for the counts | Row's counts open the diff overlay | Header's counts open it, activating the group's tab first |

## Why

The rule that lifts a shared branch onto the header required at least two rows, on the reasoning that four copies of the same branch describe the repo rather than the tabs. That reasoning holds for one copy as well: the lone row's branch names the same repo as the heading directly above it. The threshold also gave a one-tab group a shape no other group in the column has, a bare heading over a two-line row, so the column stopped lining up as tabs came and went.

## Testing

- `cargo build -p tty7`
- `cargo test -p tty7 --bin tty7-app ui::tab_sidebar`, 31 passing
- Not verified in the running app. The visible change is one group's layout in the sidebar.

https://claude.ai/code/session_01E4EPKzHg1fm9HMmHkUYpER
