### PR TITLE
fix(daemon): clear the dead TUI's input modes on restore (#850)

### DIFF
--- a/crates/tty7-core/src/daemon/pane.rs
+++ b/crates/tty7-core/src/daemon/pane.rs
@@ -1348,12 +1348,19 @@ pub fn retitle(title: &str) -> Vec<u8> {
 /// in the common case: the primary buffer still holds the pre-`vim` scrollback
 /// from earlier in the same snapshot.
 ///
+/// The same argument reaches further than the four resets it started with, and
+/// [`INPUT_MODE_RESETS`] is the rest of it: a snapshot that ends inside a
+/// full-screen program replays that program's `?1002h` and nothing to undo it,
+/// and the emulator then reports every pointer move into a shell that never
+/// asked (#850).
+///
 /// On Windows it ends by scrolling the restored screen out of the viewport
 /// ([`SCROLL_RESTORED_AWAY`]), which is a correctness requirement rather than a
 /// matter of taste — see that constant.
 pub fn restore_preamble(banner: Option<&str>) -> Vec<u8> {
     let mut out = Vec::new();
     out.extend_from_slice(b"\x1b[?1049l\x1b[?25h\x1b[?7h\x1b[0m");
+    out.extend_from_slice(INPUT_MODE_RESETS);
     if let Some(banner) = banner.map(str::trim).filter(|b| !b.is_empty()) {
         out.extend_from_slice(b"\r\n\x1b[2m\xe2\x94\x80\xe2\x94\x80 ");
         // A newline inside the banner would be a client writing multiple lines
@@ -1366,6 +1373,45 @@ pub fn restore_preamble(banner: Option<&str>) -> Vec<u8> {
     }
     out
 }
+
+/// Turn off every mode that makes a terminal *send* bytes on its own, or encode
+/// keys in a way the incoming shell cannot read.
+///
+/// A restored pane is a snapshot of a dead process replayed at a brand-new
+/// shell. The process that switched these on was killed by a hangup with no
+/// grace period, so it never emitted its own `l` counterparts, and the snapshot
+/// was photographed before it could have anyway. What is left is a byte stream
+/// whose last word on mouse reporting is "on", replayed verbatim into an
+/// emulator that obeys it: the pointer crossing the pane types SGR reports into
+/// the shell's line, and the line grows for as long as the pointer is there
+/// (#850).
+///
+/// Unconditional on purpose. The state to land in is not "whatever the dead
+/// program had" but a constant — the new shell asked for none of these, and it
+/// is not running yet, so there is nothing here to preserve. Switching off a
+/// mode that is already off is a no-op in every emulator, which makes the blunt
+/// version the one that cannot fail: a fold over the snapshot's bytes that
+/// misreads one sequence leaves the mode on and the bug exactly as it is today.
+///
+/// - `9`/`1000`/`1002`/`1003` are the mouse reporting level, `1005`/`1006`/
+///   `1015`/`1016` its encodings. Our own emulator knows `1000`, `1002`, `1003`,
+///   `1005` and `1006` and ignores the rest; `9`, `1015` and `1016` are here for
+///   the terminals downstream of a CLI consumer replaying the same ring, which
+///   do know them.
+/// - `1004` is focus reporting — the other mode that makes the terminal write
+///   into the pty unprompted, on every window activation.
+/// - `2004` is bracketed paste: a paste into a shell that does not know the
+///   protocol arrives with `ESC[200~` typed around it.
+/// - `1` is DECCKM, which sends the arrow keys as `ESC O A` instead of `ESC[A`.
+/// - `CSI = 0 ; 1 u` sets the kitty keyboard flags to none, the same reset
+///   `stale_mode_resets` in the client uses.
+///
+/// Deliberately absent: `1007` (alternate scroll), which this emulator has *on*
+/// by default, so clearing it would walk away from the default rather than back
+/// to it; and `2026` (synchronised update), which the client's processor closes
+/// out itself the moment a replayed frame ends inside one.
+pub const INPUT_MODE_RESETS: &[u8] = b"\x1b[?9l\x1b[?1000l\x1b[?1002l\x1b[?1003l\
+\x1b[?1005l\x1b[?1006l\x1b[?1015l\x1b[?1016l\x1b[?1004l\x1b[?2004l\x1b[?1l\x1b[=0;1u";
 
 /// Push the restored screen into the client's scrollback and put the cursor
 /// back at the top-left, so the incoming shell starts on a blank viewport.
@@ -3798,6 +3844,95 @@ mod tests {
         assert!(text.contains("\x1b[?7h"), "put autowrap back");
         assert!(text.contains("\x1b[0m"), "drop any colour left mid-run");
         assert!(text.contains("this shell is new"));
+
+        // #850: the same argument, for the modes that make the terminal talk
+        // back. The snapshot ends inside a program that enabled mouse
+        // reporting and was killed before it could disable it, so replaying it
+        // leaves the emulator reporting every pointer move into a shell that
+        // never asked — the line fills with SGR reports as long as the pointer
+        // is over the pane. Focus reporting writes unprompted for the same
+        // reason; bracketed paste and DECCKM mangle what the user types.
+        for (seq, what) in [
+            ("\x1b[?9l", "X10 mouse reporting"),
+            ("\x1b[?1000l", "click reporting"),
+            ("\x1b[?1002l", "cell-motion reporting"),
+            ("\x1b[?1003l", "all-motion reporting"),
+            ("\x1b[?1005l", "the UTF-8 mouse encoding"),
+            ("\x1b[?1006l", "the SGR mouse encoding"),
+            ("\x1b[?1015l", "the urxvt mouse encoding"),
+            ("\x1b[?1016l", "the SGR-pixel mouse encoding"),
+            ("\x1b[?1004l", "focus reporting"),
+            ("\x1b[?2004l", "bracketed paste"),
+            ("\x1b[?1l", "application cursor keys"),
+            ("\x1b[=0;1u", "the kitty keyboard flags"),
+        ] {
+            assert!(
+                text.contains(seq),
+                "the preamble has to turn {what} off: the process that turned it \
+                 on was killed by a hangup with no grace period and never sent \
+                 its own reset, so the replay's last word on it is `on`"
+            );
+        }
+
+        // Not reset: alternate scroll is on in a default terminal, so clearing
+        // it would leave the pane further from the default than it started.
+        assert!(
+            !text.contains("\x1b[?1007l"),
+            "?1007 defaults to on; resetting it walks away from the default"
+        );
+    }
+
+    /// Whether the stream's last word on a private mode is `h`, `l`, or
+    /// nothing — which is all a client's emulator ends up remembering of it.
+    fn last_mode_switch(stream: &[u8], mode: &str) -> Option<u8> {
+        let last = |needle: Vec<u8>| {
+            stream
+                .windows(needle.len())
+                .rposition(|w| w == needle.as_slice())
+        };
+        let on = last(format!("\x1b[?{mode}h").into_bytes());
+        let off = last(format!("\x1b[?{mode}l").into_bytes());
+        match (on, off) {
+            (Some(h), Some(l)) => Some(if h > l { b'h' } else { b'l' }),
+            (Some(_), None) => Some(b'h'),
+            (None, Some(_)) => Some(b'l'),
+            (None, None) => None,
+        }
+    }
+
+    /// Issue #850, along the whole chain rather than at the preamble alone: a
+    /// snapshot is a raw byte stream, it seeds the restored pane's ring
+    /// verbatim, and the client feeds it straight to its parser. So a snapshot
+    /// whose last word on mouse reporting is `h` puts the *client* into mouse
+    /// reporting, against a shell that never asked, and every pointer move
+    /// over the pane is typed into its line as an SGR report.
+    #[test]
+    fn a_ring_restored_from_a_full_screen_snapshot_ends_with_reporting_off() {
+        let size = ws(80, 24);
+        // What the photograph of a pane running `claude`, `vim` or `btop`
+        // actually holds. There is no epilogue: `DaemonPane::kill` is a hangup
+        // with no grace period, so the program never sent its own `?1002l`,
+        // and the snapshot was taken before it could have anyway.
+        let snapshot = crate::daemon::scrollback::Segment {
+            size,
+            bytes: b"\x1b[?1049h\x1b[?1002h\x1b[?1003h\x1b[?1006h\x1b[?1004h\
+\x1b[?2004hframe one\x1b[Hframe two"
+                .to_vec(),
+        };
+        let mut ring = ReplayRing::seeded(vec![snapshot], size);
+        ring.append(&restore_preamble(Some("the shell below is new")));
+        let replayed = ring.flatten();
+
+        for mode in [
+            "1000", "1002", "1003", "1005", "1006", "1004", "2004", "1049",
+        ] {
+            assert_eq!(
+                last_mode_switch(&replayed, mode),
+                Some(b'l'),
+                "a client replaying this ring ends with ?{mode} still on, which is \
+                 what types SGR reports into the restored shell (#850)"
+            );
+        }
     }
 
     /// The ConPTY constraint, from the daemon's side. A pane whose shell runs


### PR DESCRIPTION
Closes #850.

A pane restored after a server stop came back with the killed program's mouse
reporting still on. Every pointer move over it was typed into the new shell's
line as an SGR report, and the line grew for as long as the pointer stayed
there. `Ctrl-C` cleared the line but not the cause.

## What changed

`restore_preamble` — the bytes the daemon appends after the replayed segments,
which already exist to keep the dead pane's leftovers away from the incoming
shell — now also turns off the modes that make a terminal *send* something on
its own, or encode keys in a way a plain shell cannot read:

| | Before | After |
|---|---|---|
| Alternate screen, cursor, autowrap, SGR | Reset | Reset |
| Mouse reporting (`9`/`1000`/`1002`/`1003`) | Left on | Reset |
| Mouse encodings (`1005`/`1006`/`1015`/`1016`) | Left on | Reset |
| Focus reporting (`1004`) | Left on | Reset |
| Bracketed paste (`2004`) | Left on | Reset |
| Application cursor keys (`1`, DECCKM) | Left on | Reset |
| Kitty keyboard flags | Left on | Reset (`CSI = 0 ; 1 u`) |
| Alternate scroll (`1007`) | Left alone | Left alone — a default terminal has it *on* |
| Synchronised update (`2026`) | Left alone | Left alone — the client's processor closes it out |

One crate, one function, one new constant. Nothing in the client changed.

## Why

The reporter's chain holds at every link; I read each one rather than taking it
on trust.

- The snapshot is a raw byte stream, not a rendered grid. `scrollback.rs`'s own
  module doc says so ("These bytes include whatever was echoed into the pane"),
  and `encode` writes the segment bytes verbatim.
- Those bytes seed the restored pane's ring unchanged:
  `ReplayRing::seeded(restore.segments, size)` in `DaemonPane::spawn` copies
  each segment straight into the ring.
- The client parses them: `DaemonMsg::Snapshot(bytes)` in `src/terminal/remote.rs`
  calls `processor.advance(&mut *term, &bytes)`. So `?1002h` in a snapshot is not
  a description of a screen, it is an instruction, and it is executed a second
  time — against a shell that never asked for it. `TerminalView::mouse_mode`
  then reads `TermMode::MOUSE_MODE` off that emulator and writes reports into the
  pty.
- Nothing undoes it. `ClientMsg::Shutdown` photographs the panes and *then* kills
  them, and `DaemonPane::kill` is a hangup with no grace period, so the program
  never emits its own `?1002l` — and the snapshot predates the kill regardless.
- `restore_preamble` is appended *after* the seeded segments, and its doc comment
  already states the principle it stopped short of applying. The test at
  `the_restore_preamble_hands_the_new_shell_a_terminal_it_can_use` locked in the
  short list, exactly as reported.

**Which of the two options, and why the blunt one.** The issue offers extending
the preamble's reset string, or folding the snapshot's bytes and clearing only
what is still on at the end of the replay, and prefers the fold. I took the
first, deliberately.

The fold's precision is essential on the re-attach path #828 serves — there the
pane is still alive, and re-sending a mode the program had turned off would be
wrong. It buys nothing here, because here the target state is a constant rather
than a discovery. The process that set these modes is dead; the shell the
preamble is handed to is brand new, has not written a byte at the moment the
preamble is appended to the ring, and asked for none of them. There is no
outcome in which a restored pane should come back with mouse reporting on.

And the risk is not symmetric. Turning off a mode that is already off is a no-op
in every emulator, so the unconditional version cannot fail to clear a mode. A
fold that misparses one sequence — a mode set split across a segment boundary, a
family it does not track (the kitty keyboard stack is not a DEC private mode and
`core::term_modes` does not model it), a divergence between it and alacritty's
parser — leaves the mode on and reproduces today's bug silently. The cost of
being blunt is about sixty bytes appended once per restored pane, into an 8 MiB
ring.

The unconditional version also keeps this fix free of #828, which matters for
merge order — see below.

## Dependency and merge order relative to #828

**None. This does not depend on #828 and can merge before or after it, in either
order.** It is based on `main`, not on `fix/774-pty-source-and-replayed-modes`.

I read that branch before deciding. Option 2 would have wanted its
`core::term_modes` tracker and I would then have based on it; taking option 1
means I need nothing from it, so coupling a user-visible fix to an unmerged PR
would have bought only queueing.

The two changes are mirror images and do not conflict in intent: #828 re-sends
the modes that are still on for a pane that is *alive* and whose ring dropped
them; this clears the modes a *dead* pane left behind. They also do not conflict
textually — #828 touches `replay_state` and `PaneState`, this touches
`restore_preamble` and its tests. And they do not fight at runtime: #828's fold
starts empty for a pane adopted across a daemon restart (its own "Not in this
PR" says so), so a restored pane gets no mode frame from it, and this preamble is
the only thing speaking for that pane's modes.

## Testing

Run here, on Windows:

- `cargo test -p tty7-core --lib` — 1158 passed, 4 failed. The four are
  `daemon::remote_link` (3) and `daemon::router` (1), which fail the same way on
  a clean tree.
- `cargo test -p tty7-core --lib daemon::pane` — 103 passed, 0 failed.
- Both new/updated assertions were confirmed to *fail* on the previous preamble:
  with `INPUT_MODE_RESETS` commented out,
  `the_restore_preamble_hands_the_new_shell_a_terminal_it_can_use` and
  `a_ring_restored_from_a_full_screen_snapshot_ends_with_reporting_off` both go
  red, the latter with "a client replaying this ring ends with ?1000 still on".
- `cargo clippy -p tty7-core --lib --all-targets` — no warning on any line this
  diff added or moved; the crate's existing 56 are untouched.
- `cargo fmt --all` clean. `Cargo.lock` is unmodified.

Not verified here:

- **The reporter's own repro.** It needs stopping and restarting the server,
  which would disturb a live session on this machine, so it was not run. What is
  asserted instead is the byte stream a client would be handed: the second test
  builds the real restored ring from a snapshot that ends inside a full-screen
  program and checks that its last word on every reporting mode is `l`.
- **The root crate.** Nothing in `src/` changed, and it was not built. Note that
  `src/terminal/remote.rs`'s existing `a_restored_screen_leaves_the_new_shell_the_viewport_conpty_thinks_it_has`
  already replays `restore_preamble`'s output through the real alacritty parser
  on Windows, so CI exercises the new bytes end to end there without a new test.
- **Whether a downstream terminal honours `9`, `1015` and `1016`.** Our own
  emulator ignores those three; they are in the string for the terminals a CLI
  consumer replaying the same ring writes into.

https://claude.ai/code/session_01UUyWQXzcBAoBzaSX8pc7nU
