### PR TITLE
fix(ui): remember the focused pane as focus arrives, not at switch time (#843)

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -3543,9 +3543,7 @@ impl Tty7App {
             view.read(cx).run_command_line(&cmd);
         }
         let slot = PaneSlot::Ready(view.clone());
-        self.tabs
-            .iter_mut()
-            .any(|tab| tab.pane.replace_leaf(slot_id, slot.clone()));
+        replace_leaf_in(&mut self.tabs, slot_id, slot.clone());
         if was_focused {
             self.focus_leaf(&slot, window, cx);
         }
@@ -3749,14 +3747,11 @@ impl Tty7App {
                 return;
             }
         };
-        for tab in &mut self.tabs {
-            if tab
-                .pane
-                .replace_leaf(dead.entity_id(), PaneSlot::Ready(fresh.clone()))
-            {
-                break;
-            }
-        }
+        replace_leaf_in(
+            &mut self.tabs,
+            dead.entity_id(),
+            PaneSlot::Ready(fresh.clone()),
+        );
         self.maximized = None;
         self.focus_leaf(&PaneSlot::Ready(fresh), window, cx);
         self.save_session(cx);
@@ -8665,6 +8660,30 @@ fn remember_leaf_in(tabs: &mut [Tab], leaf: gpui::EntityId) {
     }
 }
 
+/// Put `new` where the slot `old` named stood, carrying that tab's focus
+/// memory across with it.
+///
+/// The memory has to move because the id it holds does not survive the swap.
+/// Focus arriving in a pane that is still coming up is recorded against the
+/// *pending* slot — that is why connecting slots are watched at all — and that
+/// slot's id dies the moment the pane lands. Left behind, the memory names an
+/// entity no tab holds, `focus_target` falls through `leaf_matching_or_first`,
+/// and the tab comes back to its first leaf: #843 again, one landing later.
+///
+/// Nothing else writes the answer down in that case. `land_pane` re-focuses
+/// the pane it built only when the pending slot still held focus, and with
+/// focus off the panes the switch-away sample has nothing to read either.
+fn replace_leaf_in(tabs: &mut [Tab], old: gpui::EntityId, new: PaneSlot) {
+    for tab in tabs.iter_mut() {
+        if tab.pane.replace_leaf(old, new.clone()) {
+            if tab.last_focused == Some(old) {
+                tab.last_focused = Some(new.entity_id());
+            }
+            break;
+        }
+    }
+}
+
 /// Repaint the chrome that marks the focused pane, and record the leaf as the
 /// one its tab returns to (#843).
 ///
@@ -11125,7 +11144,7 @@ mod close_window_action_tests {
 /// #843: which pane a tab comes back to.
 #[cfg(test)]
 mod tab_focus_memory_tests {
-    use super::{Pane, PaneSlot, Tab, remember_leaf_in};
+    use super::{Pane, PaneSlot, Tab, remember_leaf_in, replace_leaf_in};
     use crate::ui::pending_pane::{PendingPane, PendingSpawn};
     use gpui::{
         AppContext as _, Axis, Context, Entity, IntoElement, Render, Styled as _, TestAppContext,
@@ -11288,5 +11307,114 @@ mod tab_focus_memory_tests {
             Some(b.entity_id()),
             "a stranger's arrival leaves the tab's own answer alone"
         );
+    }
+
+    /// A pane focused while it was still coming up is remembered under its
+    /// *pending* slot, and that id dies the moment the pane lands in its
+    /// place. The memory has to come along with the swap, or the landing is
+    /// itself what puts the tab back on its first leaf.
+    ///
+    /// What lands here is another slot rather than a running pane: the swap has
+    /// to move an id from one slot to another, and which kind of slot arrived
+    /// is no part of the question.
+    #[gpui::test]
+    fn a_landing_pane_inherits_what_its_pending_slot_was_told(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_, _| Blank);
+        let (a, connecting, landed, other) = window
+            .update(cx, |_, _, cx| (leaf(cx), leaf(cx), leaf(cx), leaf(cx)))
+            .unwrap();
+        let mut tabs = vec![two_pane_tab(&a, &connecting)];
+
+        // Focus arrives while the pane is still connecting, then the pane it
+        // was waiting for lands in that slot.
+        remember_leaf_in(&mut tabs, connecting.entity_id());
+        replace_leaf_in(
+            &mut tabs,
+            connecting.entity_id(),
+            PaneSlot::Connecting(landed.clone()),
+        );
+
+        assert_eq!(
+            tabs[0].focus_target().map(|l| l.entity_id()),
+            Some(landed.entity_id()),
+            "#843: the memory follows the pane, not the slot it arrived in"
+        );
+
+        // A landing somewhere else in the tab is not an answer to this
+        // question and does not touch it.
+        replace_leaf_in(&mut tabs, a.entity_id(), PaneSlot::Connecting(other));
+        assert_eq!(
+            tabs[0].focus_target().map(|l| l.entity_id()),
+            Some(landed.entity_id()),
+            "another pane landing leaves the tab's answer alone"
+        );
+    }
+
+    /// The wiring, end to end. `watch_pane_focus` is the subscription that
+    /// writes the record, and a real round trip through `activate` has to come
+    /// back to the pane focus last arrived in — with focus off the panes well
+    /// before the switch was made, which is the moment the switch-away sample
+    /// cannot see (#843).
+    #[gpui::test]
+    fn a_tab_switch_returns_to_the_pane_focus_arrived_in(cx: &mut TestAppContext) {
+        use super::{test_window::harness, watch_pane_focus};
+        use crate::terminal::view::quiet_test_pane;
+
+        let (app, mut vcx) = harness(cx);
+        let (left, right, elsewhere, _held) = app.update_in(&mut vcx, |app, window, cx| {
+            let (left, left_stream) = quiet_test_pane(1, window, cx);
+            let (right, right_stream) = quiet_test_pane(2, window, cx);
+            let (only, only_stream) = quiet_test_pane(3, window, cx);
+            app.tabs.push(Tab::new(Pane::split_node(
+                Axis::Horizontal,
+                0.5,
+                Pane::leaf(PaneSlot::Ready(left.clone())),
+                Pane::leaf(PaneSlot::Ready(right.clone())),
+            )));
+            app.tabs.push(Tab::new(Pane::leaf(PaneSlot::Ready(only))));
+            app.active = 0;
+            // The subscription every spawn path registers for the pane it
+            // built.
+            for view in [&left, &right] {
+                let handle = view.read(cx).focus_handle.clone();
+                watch_pane_focus(&handle, view.entity_id(), window, cx);
+            }
+            cx.notify();
+            (
+                left,
+                right,
+                cx.focus_handle(),
+                (left_stream, right_stream, only_stream),
+            )
+        });
+        vcx.background_executor.run_until_parked();
+
+        // The reader clicks into the right-hand pane.
+        app.update_in(&mut vcx, |_, window, cx| {
+            let handle = right.read(cx).focus_handle.clone();
+            handle.focus(window, cx);
+        });
+        vcx.background_executor.run_until_parked();
+
+        // Focus then leaves the panes altogether — a palette closing, the tab
+        // strip, the switcher's own search input — before the tab is left.
+        app.update_in(&mut vcx, |_, window, cx| elsewhere.focus(window, cx));
+        vcx.background_executor.run_until_parked();
+
+        app.update_in(&mut vcx, |app, window, cx| app.activate(1, window, cx));
+        vcx.background_executor.run_until_parked();
+        app.update_in(&mut vcx, |app, window, cx| app.activate(0, window, cx));
+        vcx.background_executor.run_until_parked();
+
+        app.update_in(&mut vcx, |_, window, cx| {
+            assert!(
+                right.read(cx).focus_handle.is_focused(window),
+                "#843: the tab has to come back to the pane the reader was in"
+            );
+            assert!(
+                !left.read(cx).focus_handle.is_focused(window),
+                "and not to the first leaf"
+            );
+        });
     }
 }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -3455,6 +3455,16 @@ impl Tty7App {
         }
     }
 
+    /// Sample which pane holds focus right now and record it against the
+    /// active tab.
+    ///
+    /// A sample only ever writes the truth, but it can only write it when
+    /// there is one to read: with focus one handle off the panes it finds no
+    /// leaf and leaves the field alone. That is why it is no longer the only
+    /// writer (see [`Tty7App::remember_focused_leaf`]) — it stays because the
+    /// callers below want the answer settled at a named moment, before a pane
+    /// is detached or a tab is torn down and the layout stops being able to
+    /// answer at all.
     pub(crate) fn remember_active_pane(&mut self, window: &Window, cx: &App) {
         let active = self.active;
         if let Some(tab) = self.tabs.get_mut(active) {
@@ -3462,6 +3472,24 @@ impl Tty7App {
                 tab.last_focused = Some(leaf.entity_id());
             }
         }
+    }
+
+    /// Record `leaf` as the pane its tab comes back to, as focus arrives in it.
+    ///
+    /// Sampling at switch time asks which leaf holds focus *at that instant*,
+    /// and by then focus is routinely somewhere else: the switcher's own
+    /// search input, a palette that just closed, the tab strip, a pane
+    /// restored and never clicked. The sample then wrote nothing and the tab
+    /// kept a stale pane — or the `None` it was born with — and came back to
+    /// its first leaf instead of the one the reader was working in (#843).
+    ///
+    /// Focus-in is the one moment that knows the answer without having to
+    /// guess when to look, so it is the primary writer now. The tab is found
+    /// by the leaf rather than assumed to be the active one: a pane dragged
+    /// into another tab is focused after the move, and it is the tab holding
+    /// it now that has to remember it.
+    pub(crate) fn remember_focused_leaf(&mut self, leaf: gpui::EntityId) {
+        remember_leaf_in(&mut self.tabs, leaf);
     }
 
     fn focus_leaf(&self, leaf: &PaneSlot, window: &mut Window, cx: &mut App) {
@@ -8525,6 +8553,8 @@ pub(crate) fn new_terminal(
         },
     )
     .detach();
+    let handle = pending.read(cx).focus_handle.clone();
+    watch_pane_focus(&handle, pending.entity_id(), window, cx);
     start_pane_spawn(pending.clone(), window, cx);
     Ok(PaneSlot::Connecting(pending))
 }
@@ -8590,7 +8620,8 @@ fn build_terminal_view(
     )
     .detach();
     watch_open_file_requests(&view, window, cx);
-    watch_pane_focus(&view, window, cx);
+    let handle = view.read(cx).focus_handle.clone();
+    watch_pane_focus(&handle, view.entity_id(), window, cx);
     view
 }
 
@@ -8618,13 +8649,42 @@ fn watch_open_file_requests(
     .detach();
 }
 
-fn watch_pane_focus(view: &Entity<TerminalView>, window: &mut Window, cx: &mut Context<Tty7App>) {
-    let handle = view.read(cx).focus_handle.clone();
+/// Record `leaf` as the pane the tab holding it comes back to.
+///
+/// Which tab that is gets asked of the layout rather than assumed to be the
+/// active one: a pane dragged into another tab takes focus with it, and it is
+/// the tab holding it now whose memory the arrival should change. A leaf no
+/// tab holds — one that has just closed, or arrived after its slot went away —
+/// is recorded nowhere.
+fn remember_leaf_in(tabs: &mut [Tab], leaf: gpui::EntityId) {
+    let held = tabs
+        .iter_mut()
+        .find(|tab| tab.pane.leaves().iter().any(|l| l.entity_id() == leaf));
+    if let Some(tab) = held {
+        tab.last_focused = Some(leaf);
+    }
+}
+
+/// Repaint the chrome that marks the focused pane, and record the leaf as the
+/// one its tab returns to (#843).
+///
+/// Every leaf is watched, connecting slots included: a pane can be focused
+/// while it is still coming up, and if the tab is left in that moment the
+/// answer has to already be written down.
+fn watch_pane_focus(
+    handle: &gpui::FocusHandle,
+    leaf: gpui::EntityId,
+    window: &mut Window,
+    cx: &mut Context<Tty7App>,
+) {
     let app = cx.weak_entity();
     window
-        .on_focus_in(&handle, cx, move |_window, cx| {
+        .on_focus_in(handle, cx, move |_window, cx| {
             if let Some(app) = app.upgrade() {
-                app.update(cx, |_, cx| cx.notify());
+                app.update(cx, |app, cx| {
+                    app.remember_focused_leaf(leaf);
+                    cx.notify();
+                });
             }
         })
         .detach();
@@ -8656,7 +8716,8 @@ pub(crate) fn new_terminal_native(
     )
     .detach();
     watch_open_file_requests(&view, window, cx);
-    watch_pane_focus(&view, window, cx);
+    let handle = view.read(cx).focus_handle.clone();
+    watch_pane_focus(&handle, view.entity_id(), window, cx);
     Ok(view)
 }
 
@@ -11057,6 +11118,175 @@ mod close_window_action_tests {
             cx.update(|cx| WindowRegistry::open_windows(cx).is_empty()),
             "the close has to run the same cleanup the red button runs, \
              which is what takes the window out of the registry"
+        );
+    }
+}
+
+/// #843: which pane a tab comes back to.
+#[cfg(test)]
+mod tab_focus_memory_tests {
+    use super::{Pane, PaneSlot, Tab, remember_leaf_in};
+    use crate::ui::pending_pane::{PendingPane, PendingSpawn};
+    use gpui::{
+        AppContext as _, Axis, Context, Entity, IntoElement, Render, Styled as _, TestAppContext,
+        Window, div,
+    };
+
+    /// A window has to exist for focus to live in, but nothing this file asks
+    /// is about what a pane paints.
+    struct Blank;
+    impl Render for Blank {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div().size_full()
+        }
+    }
+
+    /// A leaf that owns a real focus handle without owning a shell. Focus
+    /// tracking asks the slot, not the terminal behind it, so a connecting
+    /// pane answers every question here exactly as a running one would — and
+    /// connecting panes are watched for focus now too, so this is not a
+    /// stand-in for the case under test but one of its cases.
+    fn leaf(cx: &mut Context<Blank>) -> Entity<PendingPane> {
+        cx.new(|cx| {
+            PendingPane::new(
+                "test",
+                PendingSpawn {
+                    workspace: None,
+                    working_directory: None,
+                    restore_pane: None,
+                    shell: None,
+                    agent: None,
+                    agent_session_id: None,
+                    agent_launch_argv: None,
+                    owner: None,
+                    font_size: 14.,
+                },
+                cx,
+            )
+        })
+    }
+
+    fn two_pane_tab(a: &Entity<PendingPane>, b: &Entity<PendingPane>) -> Tab {
+        Tab::new(Pane::split_node(
+            Axis::Horizontal,
+            0.5,
+            Pane::Leaf(PaneSlot::Connecting(a.clone())),
+            Pane::Leaf(PaneSlot::Connecting(b.clone())),
+        ))
+    }
+
+    fn one_pane_tab(a: &Entity<PendingPane>) -> Tab {
+        Tab::new(Pane::Leaf(PaneSlot::Connecting(a.clone())))
+    }
+
+    /// The mechanism behind the report: `remember_active_pane`'s sample asks
+    /// which leaf holds focus *at that instant*, and a switch begun with focus
+    /// one handle away — the switcher's own search input, a palette closing,
+    /// the tab strip — finds no leaf and has nothing to write. This is why the
+    /// sample cannot be the only writer, and it is pinned here so that a change
+    /// making `focused_leaf` tolerant would have to argue with a test rather
+    /// than silently make this fix look unnecessary.
+    #[gpui::test]
+    fn a_switch_begun_off_the_panes_samples_nothing(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_, _| Blank);
+        let (a, b, elsewhere) = window
+            .update(cx, |_, _, cx| (leaf(cx), leaf(cx), cx.focus_handle()))
+            .unwrap();
+        let tab = two_pane_tab(&a, &b);
+
+        window
+            .update(cx, |_, window, cx| {
+                let on_b = b.read(cx).focus_handle.clone();
+                window.focus(&on_b, cx);
+                assert_eq!(
+                    tab.pane.focused_leaf(window, cx).map(|l| l.entity_id()),
+                    Some(b.entity_id()),
+                    "with focus in the pane the sample would have found it"
+                );
+
+                window.focus(&elsewhere, cx);
+                assert!(
+                    tab.pane.focused_leaf(window, cx).is_none(),
+                    "one handle off the pane and the switch-away sample has \
+                     nothing to write"
+                );
+            })
+            .unwrap();
+    }
+
+    /// So focus-in writes instead, and the tab comes back to the pane focus
+    /// was last in even though it had wandered off the panes before the switch
+    /// ever started.
+    #[gpui::test]
+    fn a_tab_comes_back_to_the_pane_focus_was_last_in(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_, _| Blank);
+        let (a, b) = window.update(cx, |_, _, cx| (leaf(cx), leaf(cx))).unwrap();
+        let mut tabs = vec![two_pane_tab(&a, &b)];
+        assert_eq!(
+            tabs[0].focus_target().map(|l| l.entity_id()),
+            Some(a.entity_id()),
+            "a tab nobody has worked in yet still opens on its first leaf"
+        );
+
+        // The reader clicks into the right-hand pane: focus arrives, and that
+        // is the moment the tab is told.
+        remember_leaf_in(&mut tabs, b.entity_id());
+
+        // Focus then leaves the panes — the switcher opens, a palette closes —
+        // and the tab is switched away from. `remember_active_pane` finds no
+        // focused leaf and writes nothing, which is now harmless.
+        assert_eq!(
+            tabs[0].focus_target().map(|l| l.entity_id()),
+            Some(b.entity_id()),
+            "#843: the tab has to come back to the pane the reader was in"
+        );
+    }
+
+    /// A pane dragged into another tab is focused where it lands, so the
+    /// arrival has to change that tab's memory and not the one it left — the
+    /// reason the tab is found by the leaf rather than taken to be the active
+    /// one.
+    #[gpui::test]
+    fn a_moved_pane_is_remembered_by_the_tab_that_holds_it_now(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_, _| Blank);
+        let (a, b, c) = window
+            .update(cx, |_, _, cx| (leaf(cx), leaf(cx), leaf(cx)))
+            .unwrap();
+        // Tab 0 is the active one and holds `a`; `b` and `c` live in tab 1.
+        let mut tabs = vec![one_pane_tab(&a), two_pane_tab(&b, &c)];
+
+        remember_leaf_in(&mut tabs, c.entity_id());
+
+        assert_eq!(
+            tabs[1].focus_target().map(|l| l.entity_id()),
+            Some(c.entity_id()),
+            "the tab holding the focused pane is the one that remembers it"
+        );
+        assert_eq!(
+            tabs[0].focus_target().map(|l| l.entity_id()),
+            Some(a.entity_id()),
+            "and no other tab's memory is touched"
+        );
+    }
+
+    /// A pane that arrives after its slot has gone — a spawn landing on a
+    /// closed tab, a leaf killed mid-flight — belongs to no tab, and must not
+    /// leave a memory behind for the first tab that happens to be looked at.
+    #[gpui::test]
+    fn a_leaf_no_tab_holds_is_recorded_nowhere(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_, _| Blank);
+        let (a, b, gone) = window
+            .update(cx, |_, _, cx| (leaf(cx), leaf(cx), leaf(cx)))
+            .unwrap();
+        let mut tabs = vec![two_pane_tab(&a, &b)];
+
+        remember_leaf_in(&mut tabs, b.entity_id());
+        remember_leaf_in(&mut tabs, gone.entity_id());
+
+        assert_eq!(
+            tabs[0].focus_target().map(|l| l.entity_id()),
+            Some(b.entity_id()),
+            "a stranger's arrival leaves the tab's own answer alone"
         );
     }
 }


### PR DESCRIPTION
Closes #843.

## What changed

`Tab::last_focused` is now written as focus **arrives** in a pane, not sampled as the tab is switched **away** from.

- `remember_leaf_in(tabs, leaf)` (new, `src/ui/app.rs`) records a leaf against the tab that holds it — found by asking the layout, not by assuming the active tab.
- `watch_pane_focus` (`src/ui/app.rs:8674`) now calls it. That subscription already existed: it was registered for every terminal view to repaint the chrome that marks the focused pane, and only called `cx.notify()`. It takes a `FocusHandle` + leaf id now instead of an `Entity<TerminalView>`, so connecting slots get watched too (`new_terminal`).
- `remember_active_pane` is unchanged apart from a doc comment explaining why it stays.

No new subscriptions, no new lifetimes, no new fields, no schema change.

## Why

The reporter's diagnosis holds up. Two pieces of it are pinned by tests written against unmodified code, where both passed before any change:

1. `Pane::focused_leaf` (`src/ui/pane.rs:938`) is true only while the handle holds window focus, so one handle off the panes and `remember_active_pane` (`src/ui/app.rs:3468`) has nothing to write and leaves the field alone.
2. A tab that was never sampled while a pane held focus returns its first leaf via `leaf_matching_or_first` (`src/ui/pane.rs:223`).

The window that makes this common is wider than the report says. `close_switcher` (`src/ui/switcher.rs:669`) calls `focus_active` before `activate` runs, so a switch made through the switcher first *restores* focus to `focus_target()` — which, if the field was stale or `None`, is the first leaf — and `remember_active_pane` then samples that first leaf and writes it down as the answer. The sample-only design does not just fail to record the right pane there; it cements the wrong one.

### Fix shape, and the ones rejected

The report suggested subscribing to focus events on each pane's focus handle, and flagged the ongoing cost and the lifetime that comes with it. That cost is already sunk — `watch_pane_focus` has been subscribing to exactly that event for every pane all along — so the change is to give an existing callback one more line rather than to add a subscription. It also settles the lifetime question the report raised: the subscription is created where the view is, and "which tab" is resolved at focus time from the live layout, so a pane that moves between tabs needs no bookkeeping at all.

Rejected:

- **Record on focus-out instead.** Focus-out tells you a pane lost focus, which is not the same question. The pane to come back to is the last one that *had* focus, and focus-in names it directly. Focus-out also fires with an empty current path when the window is deactivated (`window.rs:2679`), which would need guarding for no gain.
- **Have the switch-away path fall back to the pane it last knew rather than skipping the write.** This is a no-op: skipping the write already leaves the last known value in place. The failure is that the last known value was never correct.
- **Prefer a most-recently-active leaf recorded elsewhere.** Checked before building on it. `last_used` exists on `Tab` (`src/ui/app.rs:470`) to order the switcher's MRU tab column; there is no per-leaf equivalent anywhere in the tree. No timestamp field was invented to satisfy the suggestion, and once focus-in is authoritative there is nothing left for one to break a tie about.

### The restore case, deliberately not fixed

A restored tab whose panes were never clicked still opens on its first leaf. That is a different hole — persistence, not a focus race — and closing it needs a leaf identity that survives a restart. `SessionTab` (`crates/tty7-core/src/core/session.rs:49`) carries none, and an ordinal into the restored tree is not one either: `session_to_pane` drops leaves that cannot be respawned, which shifts every index after them. Within a session the hole is one keystroke deep — the first time a restored tab is looked at, `focus_active` focuses a pane and the new path records it — so this is a separate feature, not a loose end.

Also left alone: if a connecting pane is focused, focus moves to something that is not a pane, and the pane then lands, `land_pane` sees `was_focused == false` and the tab's memory names an entity that no longer exists, falling back to the first leaf. Narrow, and not reachable by a test without a headless `Tty7App`.

## Testing

Run on Windows 11, from outside the worktree tree to skip the shared dev `[patch]`:

- `cargo test --bin tty7-app` — **1801 passed, 0 failed, 2 ignored**. `Cargo.lock` unmodified.
- `cargo clippy --bin tty7-app --all-targets` — no new warnings; the one hit inside the touched region (`app.rs:3470`, `collapsible_if` in `remember_active_pane`'s body) predates this change and is untouched.
- `cargo fmt` run.

Four new `#[gpui::test]`s in `ui::app::tab_focus_memory_tests`, driving real `gpui` focus in a test window over real `PaneSlot`s (connecting slots — they own the same focus handles, and they are one of the cases under test now):

- `a_switch_begun_off_the_panes_samples_nothing` — pins the mechanism: `focused_leaf` finds the pane with focus in it and finds nothing one handle away. Written first, against unmodified code, where it passed.
- `a_tab_comes_back_to_the_pane_focus_was_last_in` — the fix.
- `a_moved_pane_is_remembered_by_the_tab_that_holds_it_now` — the write goes to the holding tab, not the active one, and no other tab is touched.
- `a_leaf_no_tab_holds_is_recorded_nowhere`.

**Not verified here:**

- The wiring itself — that gpui's focus-in actually reaches `remember_focused_leaf` — is not under test. `Tty7App` has no headless harness in this repo, and building one is out of scope for a one-line callback change. The evidence it fires is that the same callback has been repainting the focused-pane chrome for every pane all along.
- No GUI run. Another session and the user's live session share this machine, and a test window steals the keyboard and pointer.
- The `#[cfg(unix)]` test modules under `src/ui/` do not compile on Windows and did not run. CI runs them.

https://claude.ai/code/session_01UUyWQXzcBAoBzaSX8pc7nU
