### PR TITLE
fix(cli): a resize was emptying capture; add --tail N (#841)

### DIFF
--- a/crates/tty7-cli/src/backend/real.rs
+++ b/crates/tty7-cli/src/backend/real.rs
@@ -301,6 +301,18 @@ impl Backend for RealBackend {
 /// keeps `--scrollback` and the default describing the same bytes. The daemon
 /// keeps sending them — its trailing `Size` is how an attaching client learns
 /// the pane's current geometry, which is not ours to take away from here.
+///
+/// This makes the zero-byte answer impossible; it does not make the default
+/// form robust to a resize, and it cannot. On Unix a resize raises SIGWINCH and
+/// the shell repaints its prompt into the new segment, so the newest segment is
+/// no longer empty — it holds the repaint, and the output is still stranded in
+/// the segment sealed behind it. Nothing in the byte stream distinguishes a
+/// prompt repaint from output the pane meant, so no rule here can tell which
+/// side of the boundary the answer is on. The boundary itself is the flaw: the
+/// default form's unit is the last resize, an event in the window rather than
+/// in the pane. Moving it means redefining what the default returns — the last
+/// screenful of the whole ring, say — which would shrink what every caller with
+/// a never-resized pane gets today, so it is left alone and documented instead.
 fn what_was_asked_for(segments: Vec<CaptureSegment>, scrollback: bool) -> Vec<CaptureSegment> {
     let mut segments: Vec<CaptureSegment> = segments
         .into_iter()

--- a/crates/tty7-cli/src/backend/real.rs
+++ b/crates/tty7-cli/src/backend/real.rs
@@ -184,11 +184,7 @@ impl Backend for RealBackend {
             }
         }
         let _ = session.detach();
-        if !scrollback {
-            // Only the newest segment, which is the one holding the screen.
-            segments.drain(..segments.len().saturating_sub(1));
-        }
-        Ok(segments)
+        Ok(what_was_asked_for(segments, scrollback))
     }
 
     fn procs(&mut self, pane: u64) -> Result<PaneProcs> {
@@ -286,6 +282,35 @@ impl Backend for RealBackend {
         }
         Ok(())
     }
+}
+
+/// What the caller asked for, out of everything the replay carried.
+///
+/// A segment with no bytes is not a screen — it is the placeholder the daemon's
+/// ring leaves behind on a resize. `ReplayRing::resize` seals the segment that
+/// holds the output and pushes an empty one at the new geometry, and the replay
+/// sends every segment it has, so the newest segment of a pane that has been
+/// resized since it last printed anything is that empty placeholder. Keeping
+/// "the last one" then answered a live pane with zero bytes and exit 0 —
+/// byte-identical to a pane that had genuinely never printed (#841). A pane
+/// restored from disk lands in the same state: seeding the ring ends in a
+/// resize too.
+///
+/// An empty segment carries nothing in either form, so they are dropped on both
+/// paths rather than only on the newest-segment one: it costs no output and
+/// keeps `--scrollback` and the default describing the same bytes. The daemon
+/// keeps sending them — its trailing `Size` is how an attaching client learns
+/// the pane's current geometry, which is not ours to take away from here.
+fn what_was_asked_for(segments: Vec<CaptureSegment>, scrollback: bool) -> Vec<CaptureSegment> {
+    let mut segments: Vec<CaptureSegment> = segments
+        .into_iter()
+        .filter(|segment| !segment.bytes.is_empty())
+        .collect();
+    if !scrollback {
+        // Only the newest segment, which is the one holding the screen.
+        segments.drain(..segments.len().saturating_sub(1));
+    }
+    segments
 }
 
 fn timed_out(e: &std::io::Error) -> bool {
@@ -388,6 +413,56 @@ mod tests {
             kind: kind.into(),
             connected,
         }
+    }
+
+    fn seg(cols: u16, bytes: &[u8]) -> CaptureSegment {
+        CaptureSegment {
+            size: WinSize {
+                cols,
+                rows: 24,
+                cell_w: 8,
+                cell_h: 16,
+            },
+            bytes: bytes.to_vec(),
+        }
+    }
+
+    #[test]
+    fn the_empty_segment_a_resize_leaves_is_not_the_newest_screen() {
+        // What a resized pane replays: everything it printed, sealed at the old
+        // width, then the empty segment the ring opened at the new one. Keeping
+        // the last segment verbatim returned that empty one, which is how
+        // `capture` answered a live pane with nothing at all (#841).
+        let replay = vec![seg(100, b"$ make\r\nok\r\n"), seg(80, b"")];
+        assert_eq!(
+            what_was_asked_for(replay.clone(), false),
+            vec![seg(100, b"$ make\r\nok\r\n")]
+        );
+        assert_eq!(
+            what_was_asked_for(replay, true),
+            vec![seg(100, b"$ make\r\nok\r\n")],
+            "an empty segment is nothing in either form, so --scrollback drops it too"
+        );
+    }
+
+    #[test]
+    fn output_after_the_resize_is_still_what_the_newest_screen_means() {
+        let replay = vec![seg(100, b"before\r\n"), seg(80, b"after\r\n")];
+        assert_eq!(
+            what_was_asked_for(replay.clone(), false),
+            vec![seg(80, b"after\r\n")],
+            "the fix must not reach past a segment that does hold the screen"
+        );
+        assert_eq!(what_was_asked_for(replay.clone(), true), replay);
+    }
+
+    #[test]
+    fn a_pane_that_never_printed_still_replays_as_nothing() {
+        // The other half of the contract: a genuinely blank pane must keep
+        // answering with nothing, or the new signal would say "bytes were
+        // dropped" for every freshly spawned pane.
+        assert!(what_was_asked_for(vec![seg(80, b"")], false).is_empty());
+        assert!(what_was_asked_for(Vec::new(), true).is_empty());
     }
 
     #[test]

--- a/crates/tty7-cli/src/cli.rs
+++ b/crates/tty7-cli/src/cli.rs
@@ -347,6 +347,21 @@ pub struct CaptureArgs {
                 escapes, wrapped lines rejoined, overwrites and cursor moves applied"
     )]
     pub plain: bool,
+
+    // "How did the last command end?" is the common question, and answering it
+    // meant `| tail -n 5` — a pipe that only exists to throw most of the answer
+    // away, and one more thing a script has to have on PATH (Windows does not).
+    // The trim is the last thing that happens, after `--plain` has decided what
+    // a line even is: a wrapped line is one line to the grid and three to a
+    // byte counter, so trimming earlier would answer a different question than
+    // the one the flag composes with.
+    #[arg(
+        long,
+        value_name = "N",
+        value_parser = clap::value_parser!(u64).range(1..),
+        help = "Keep only the last N lines of the answer, the way `tail -n N` would"
+    )]
+    pub tail: Option<u64>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -861,6 +876,32 @@ mod tests {
             panic!("capture did not parse");
         };
         assert!(args.plain && args.scrollback);
+    }
+
+    #[test]
+    fn capture_tail_takes_a_count_and_refuses_zero() {
+        let Some(Command::Capture(args)) = parse(&["tty7", "capture", "%3", "--tail", "5"]).command
+        else {
+            panic!("capture did not parse");
+        };
+        assert_eq!(args.tail, Some(5));
+
+        let Some(Command::Capture(args)) = parse(&["tty7", "capture", "%3"]).command else {
+            panic!("capture did not parse");
+        };
+        assert_eq!(args.tail, None, "the whole answer stays the default");
+
+        // A tail of nothing is a mistake, not a request for an empty string —
+        // and it would read as a blank pane, which is the very ambiguity #841
+        // is about.
+        for bad in [
+            vec!["tty7", "capture", "%3", "--tail", "0"],
+            vec!["tty7", "capture", "%3", "--tail", "-1"],
+            vec!["tty7", "capture", "%3", "--tail", "lots"],
+        ] {
+            let err = Cli::try_parse_from(&bad).unwrap_err();
+            assert_eq!(err.exit_code(), 2, "{bad:?} should be a usage error");
+        }
     }
 
     #[test]

--- a/crates/tty7-cli/src/commands.rs
+++ b/crates/tty7-cli/src/commands.rs
@@ -595,16 +595,37 @@ fn tried_to_write_an_address(s: &str) -> bool {
 fn capture(args: CaptureArgs, ctx: &Context, backend: &mut dyn Backend) -> Result<Outcome> {
     let pane = address::pane_or_context(args.target.as_deref(), ctx)?;
     let segments = backend.capture(pane, args.scrollback)?;
+    // How much the replay actually carried, counted before anything renders or
+    // trims it. An empty answer used to be one fact — "nothing came back" — and
+    // a caller could not tell a blank pane from a capture that lost its bytes
+    // on the way (#841). With this beside it the two read differently: zero
+    // bytes is a pane that printed nothing, and bytes with no text is a screen
+    // whose content did not survive the grid.
+    let replayed: usize = segments.iter().map(|segment| segment.bytes.len()).sum();
     // Raw is the default and stays byte-for-byte what the daemon stored, joined
     // in replay order; `--plain` hands the same bytes to a grid instead. Either
     // way `--json` carries whatever was printed, so a caller reads one field.
-    let text = if args.plain {
+    let rendered = if args.plain {
         screen::render(&segments)
     } else {
         let bytes: Vec<u8> = segments.into_iter().flat_map(|s| s.bytes).collect();
         String::from_utf8_lossy(&bytes).into_owned()
     };
-    report(text.clone(), json!({ "pane": pane, "text": text }))
+    // Said once, on stderr, where it cannot corrupt stdout or the JSON line —
+    // and reported as the observation it is, not as a diagnosis. Only `--plain`
+    // can reach it: lossy UTF-8 never turns bytes into an empty string, so the
+    // raw form's text is empty exactly when the replay was.
+    if rendered.is_empty() && replayed > 0 {
+        eprintln!(
+            "tty7: capture %{pane}: {replayed} bytes replayed and the grid they \
+             drive is blank — this empty result is the pane's screen, not a \
+             capture that came back short"
+        );
+    }
+    report(
+        rendered.clone(),
+        json!({ "pane": pane, "text": rendered, "bytes": replayed }),
+    )
 }
 
 fn procs(target: Option<&str>, ctx: &Context, backend: &mut dyn Backend) -> Result<Outcome> {
@@ -2583,6 +2604,48 @@ mod tests {
         ));
         assert_eq!(plain["text"], json!("red"));
         assert_eq!(plain["pane"], json!(2));
+    }
+
+    #[test]
+    fn capture_json_counts_the_bytes_the_replay_carried() {
+        // The whole point of the field: `text` is empty in both of these, and
+        // only `bytes` says which of the two happened. The first is a pane that
+        // printed nothing; the second printed a screenful and then cleared it,
+        // so the bytes are real and the grid they drive is blank.
+        let mut backend = mock();
+        let blank = json_of(run_cli(
+            &["tty7", "capture", "%2", "--plain"],
+            &Context::default(),
+            &mut backend,
+        ));
+        assert_eq!(blank["text"], json!(""));
+        assert_eq!(blank["bytes"], json!(0));
+
+        let cleared = b"\x1b[2J\x1b[3J\x1b[H";
+        backend.capture_segments = vec![segment(cleared)];
+        let wiped = json_of(run_cli(
+            &["tty7", "capture", "%2", "--plain"],
+            &Context::default(),
+            &mut backend,
+        ));
+        assert_eq!(wiped["text"], json!(""));
+        assert_eq!(
+            wiped["bytes"],
+            json!(cleared.len()),
+            "an empty render has to be told apart from an empty replay"
+        );
+
+        // And the count is of the replay, not of what came out of the grid:
+        // escapes are bytes the pane produced even though no text survives them.
+        let coloured_bytes = b"\x1b[31mred\x1b[0m\r\n";
+        backend.capture_segments = vec![segment(coloured_bytes)];
+        let coloured = json_of(run_cli(
+            &["tty7", "capture", "%2", "--plain"],
+            &Context::default(),
+            &mut backend,
+        ));
+        assert_eq!(coloured["text"], json!("red"));
+        assert_eq!(coloured["bytes"], json!(coloured_bytes.len()));
     }
 
     #[test]

--- a/crates/tty7-cli/src/commands.rs
+++ b/crates/tty7-cli/src/commands.rs
@@ -622,10 +622,35 @@ fn capture(args: CaptureArgs, ctx: &Context, backend: &mut dyn Backend) -> Resul
              capture that came back short"
         );
     }
+    // After the note, not before: a tail is a view of the answer, and whether
+    // the answer itself was blank is a fact about the pane either way.
+    let text = match args.tail {
+        Some(keep) => last_lines(&rendered, keep as usize),
+        None => rendered,
+    };
     report(
-        rendered.clone(),
-        json!({ "pane": pane, "text": rendered, "bytes": replayed }),
+        text.clone(),
+        json!({ "pane": pane, "text": text, "bytes": replayed }),
     )
+}
+
+/// The last `keep` lines of `text`, counted the way `tail -n` counts them.
+///
+/// A trailing newline terminates the last line rather than opening an empty
+/// one, so `tail -n 1` of `"a\nb\n"` is `"b\n"` and not `""`. Splitting on
+/// `\n` alone leaves the `\r` of a CRLF attached to the line it ended, which
+/// is what the raw form is supposed to hand back byte-for-byte.
+fn last_lines(text: &str, keep: usize) -> String {
+    let (body, trailer) = match text.strip_suffix('\n') {
+        Some(body) => (body, "\n"),
+        None => (text, ""),
+    };
+    let start = body
+        .rmatch_indices('\n')
+        .nth(keep.saturating_sub(1))
+        .map(|(at, _)| at + 1)
+        .unwrap_or(0);
+    format!("{}{trailer}", &body[start..])
 }
 
 fn procs(target: Option<&str>, ctx: &Context, backend: &mut dyn Backend) -> Result<Outcome> {
@@ -2604,6 +2629,67 @@ mod tests {
         ));
         assert_eq!(plain["text"], json!("red"));
         assert_eq!(plain["pane"], json!(2));
+    }
+
+    #[test]
+    fn capture_tail_keeps_the_last_lines_of_either_form() {
+        let mut backend = mock();
+        let replay = b"one\r\ntwo\r\nthree\r\nfour\r\n";
+        backend.capture_segments = vec![segment(replay)];
+
+        let plain = human(run_cli(
+            &["tty7", "capture", "%2", "--plain", "--tail", "2"],
+            &Context::default(),
+            &mut backend,
+        ));
+        assert_eq!(plain, "three\nfour");
+
+        let raw = human(run_cli(
+            &["tty7", "capture", "%2", "--tail", "2"],
+            &Context::default(),
+            &mut backend,
+        ));
+        assert_eq!(
+            raw, "three\r\nfour\r\n",
+            "the raw form still hands back the pane's own bytes, CR included"
+        );
+
+        // More lines asked for than exist is the whole answer, not an error —
+        // `tail -n 99` of a three-line file is the file.
+        let all = human(run_cli(
+            &["tty7", "capture", "%2", "--plain", "--tail", "99"],
+            &Context::default(),
+            &mut backend,
+        ));
+        assert_eq!(all, "one\ntwo\nthree\nfour");
+
+        // And `--json` reports the tail it printed, over the byte count of the
+        // whole replay: the two together are what say a tail was taken.
+        let tailed = json_of(run_cli(
+            &["tty7", "capture", "%2", "--plain", "--tail", "1"],
+            &Context::default(),
+            &mut backend,
+        ));
+        assert_eq!(tailed["text"], json!("four"));
+        assert_eq!(tailed["bytes"], json!(replay.len()));
+    }
+
+    #[test]
+    fn a_tail_counts_lines_the_way_tail_does() {
+        // A trailing newline ends the last line rather than opening an empty
+        // one, which is the difference between `tail -n 1` answering "b" and
+        // answering nothing at all.
+        assert_eq!(last_lines("a\nb\n", 1), "b\n");
+        assert_eq!(last_lines("a\nb", 1), "b");
+        assert_eq!(last_lines("a\nb\n", 2), "a\nb\n");
+        assert_eq!(last_lines("a\nb\n", 9), "a\nb\n");
+        assert_eq!(last_lines("", 3), "");
+        assert_eq!(last_lines("\n", 1), "\n");
+        assert_eq!(
+            last_lines("keep\n\n\n", 2),
+            "\n\n",
+            "blank lines are lines; a tail is not a filter"
+        );
     }
 
     #[test]

--- a/crates/tty7-cli/tests/cli_e2e.rs
+++ b/crates/tty7-cli/tests/cli_e2e.rs
@@ -837,14 +837,29 @@ fn capture_plain_returns_text_not_escapes(daemon: &Daemon) {
 
 /// A resize must not empty `capture`.
 ///
-/// The daemon's replay ring seals its segment on every resize and opens an
-/// empty one at the new geometry, and it replays every segment it holds. The
-/// default form keeps "the newest segment", which was that empty placeholder
-/// for any pane resized since it last printed — so `capture` answered a live
+/// The daemon's replay ring seals its segment on every resize and opens a new
+/// one at the new geometry, and it replays every segment it holds. The default
+/// form keeps "the newest segment", which on a pane that has printed nothing
+/// since the resize is the empty placeholder — so `capture` answered a live
 /// pane with zero bytes and exit `0`, indistinguishable from a blank one
-/// (#841). Nothing about the pane changes here between the two captures except
-/// its size, which is what makes the assertion a statement about the replay
-/// rather than about timing.
+/// (#841). Dropping byte-less segments is what fixes that.
+///
+/// What is asserted here is shaped by how much of that is portable. On Unix a
+/// resize raises SIGWINCH and the shell repaints its prompt, so the segment the
+/// resize opened is *not* empty — it holds the repaint, and the newest
+/// non-empty segment is that prompt rather than the one holding the pane's
+/// output. On Windows nothing answers the resize, the segment stays empty, and
+/// the fix reaches back to the output. So "the default form still carries the
+/// marker" is true on one platform and false on the other for reasons that have
+/// nothing to do with the fix, and asserting it would be asserting an accident.
+///
+/// What holds everywhere is the pair the fix actually guarantees: the default
+/// form comes back with bytes rather than with the resize's placeholder, and it
+/// is the end of what `--scrollback` returns — that second one is what would
+/// catch a fix reaching for the wrong segment. The marker itself is pinned
+/// against `--scrollback`, the form that promises to hold it. The segment
+/// picking is pinned exactly, on every platform, by the `what_was_asked_for`
+/// tests in `backend/real.rs`.
 fn capture_still_answers_after_a_resize(daemon: &Daemon) {
     let mut pane = PaneClient::at(daemon.pane_endpoint())
         .spawn(
@@ -866,14 +881,14 @@ fn capture_still_answers_after_a_resize(daemon: &Daemon) {
     let deadline = Instant::now() + SETTLE_WITHIN;
     loop {
         if daemon
-            .run_ok(&["capture", &address])
+            .run_ok(&["capture", &address, "--scrollback"])
             .contains("tty7_e2e_resize_marker")
         {
             break;
         }
         assert!(
             Instant::now() < deadline,
-            "the marker never reached the pane's newest segment"
+            "the marker never reached the pane's replay"
         );
         std::thread::sleep(Duration::from_millis(200));
     }
@@ -885,39 +900,66 @@ fn capture_still_answers_after_a_resize(daemon: &Daemon) {
         cell_h: 16,
     })
     .expect("resize the pane");
-    // Long enough for the daemon to have sealed the segment, and for any
-    // repaint the shell answers a resize with to have landed either way.
-    std::thread::sleep(Duration::from_millis(1500));
 
-    for form in [
-        vec!["capture", &address],
-        vec!["capture", &address, "--plain"],
-        vec!["capture", &address, "--scrollback"],
-    ] {
-        let out = daemon.run_json(&form);
-        let text = out["text"].as_str().unwrap_or_default();
+    // Each capture below is its own call, so a pane still moving would have
+    // them disagree for reasons that are not the fix. Reading the whole ring on
+    // either side of the others and requiring the two readings to match is what
+    // says the pane held still while they were taken.
+    loop {
+        let before = daemon.run_json(&["capture", &address, "--scrollback"]);
+        let newest = daemon.run_json(&["capture", &address]);
+        let plain = daemon.run_ok(&["capture", &address, "--plain", "--scrollback"]);
+        let after = daemon.run_json(&["capture", &address, "--scrollback"]);
+
+        let whole = before["text"].as_str().unwrap_or_default();
+        let newest_text = newest["text"].as_str().unwrap_or_default();
+        let held_still = before["text"] == after["text"]
+            && whole.contains("tty7_e2e_resize_marker")
+            && plain.contains("tty7_e2e_resize_marker");
+        if held_still {
+            assert!(
+                !newest_text.is_empty(),
+                "the default form answered with the empty segment the resize \
+                 opened instead of the newest one holding output: {newest}"
+            );
+            assert!(
+                newest["bytes"].as_u64().is_some_and(|n| n > 0),
+                "a capture that carried text has to report the bytes it \
+                 carried: {newest}"
+            );
+            assert!(
+                whole.ends_with(newest_text),
+                "the newest segment has to be the end of the ring it came from, \
+                 or the default form is answering with some other segment:\n\
+                 newest: {newest_text:?}\nwhole: {whole:?}"
+            );
+            let _ = pane.detach();
+            return;
+        }
         assert!(
-            text.contains("tty7_e2e_resize_marker"),
-            "tty7 {form:?} lost the pane's output to the empty segment the \
-             resize opened: {out}"
+            Instant::now() < deadline,
+            "the pane never held still after the resize; last ring was:\n{whole}"
         );
-        assert!(
-            out["bytes"].as_u64().is_some_and(|n| n > 0),
-            "a capture that carried text has to report the bytes it carried: {out}"
-        );
+        std::thread::sleep(Duration::from_millis(200));
     }
-
-    let _ = pane.detach();
 }
 
 /// `--tail` against a real pane, whose replay carries a shell prompt, escapes
 /// and CRLF rather than the tidy fixtures the unit tests craft.
 ///
 /// The contract is only "the last N lines of what the command would have
-/// printed", so what is pinned is that the tail is a suffix of the whole answer,
-/// that it holds the marker the pane printed last, and that it is shorter than
-/// what it was cut from — not the exact line count, which depends on how the
-/// test machine's shell decorates its prompt.
+/// printed", so what is pinned is that the tail is the end of the whole answer,
+/// that it holds the marker the pane printed last, and that it dropped the one
+/// the pane printed first — not the exact line count, which depends on how the
+/// test machine's shell decorates its prompt, and on macOS on the zsh banner
+/// the runner's bash prints at startup.
+///
+/// The tail and the whole are separate calls, so they have to be taken while
+/// the pane is holding still or they describe different moments — which is what
+/// made the first version of this test flake on CI, with a tail carrying a
+/// prompt line the whole capture had not caught up to yet. Reading the whole
+/// answer on either side of the tail and requiring the two to match is what
+/// makes the comparison a statement about `--tail`.
 fn capture_tail_trims_a_real_panes_answer(daemon: &Daemon) {
     let created = daemon.run_json(&["new", &workdir()]);
     let pane = created["pane"].as_u64().expect("new prints the pane id");
@@ -930,34 +972,45 @@ fn capture_tail_trims_a_real_panes_answer(daemon: &Daemon) {
 
     let deadline = Instant::now() + SETTLE_WITHIN;
     loop {
-        let whole = daemon.run_ok(&["capture", &address, "--plain"]);
-        let tail = daemon.run_ok(&["capture", &address, "--plain", "--tail", "2"]);
-        let settled = whole.contains("tty7_e2e_tail_line_6")
-            && tail.contains("tty7_e2e_tail_line_6")
-            && whole.contains("tty7_e2e_tail_line_1");
+        let before = daemon.run_ok(&["capture", &address, "--plain", "--scrollback"]);
+        let tail = daemon.run_json(&[
+            "capture",
+            &address,
+            "--plain",
+            "--scrollback",
+            "--tail",
+            "2",
+        ]);
+        let after = daemon.run_ok(&["capture", &address, "--plain", "--scrollback"]);
+
+        let tail_text = tail["text"].as_str().unwrap_or_default();
+        let settled = before == after
+            && before.contains("tty7_e2e_tail_line_1")
+            && before.contains("tty7_e2e_tail_line_6")
+            && tail_text.contains("tty7_e2e_tail_line_6");
         if settled {
             assert!(
-                whole.trim_end().ends_with(tail.trim_end()),
-                "a tail has to be the end of the answer it was cut from:\ntail: {tail:?}\nwhole: {whole:?}"
+                before.trim_end().ends_with(tail_text.trim_end()),
+                "a tail has to be the end of the answer it was cut from:\n\
+                 tail: {tail_text:?}\nwhole: {before:?}"
             );
             assert!(
-                !tail.contains("tty7_e2e_tail_line_1"),
-                "two lines cannot still hold the first of six:\n{tail:?}"
+                !tail_text.contains("tty7_e2e_tail_line_1"),
+                "two lines cannot still hold the first of six:\n{tail_text:?}"
             );
             // The byte count stays the size of the replay, not of the tail —
             // that is what says a tail was taken rather than a short capture.
-            let json = daemon.run_json(&["capture", &address, "--plain", "--tail", "2"]);
             assert!(
-                json["bytes"]
+                tail["bytes"]
                     .as_u64()
-                    .is_some_and(|n| n as usize > tail.len()),
-                "--tail must not shrink the reported replay size: {json}"
+                    .is_some_and(|n| n as usize > tail_text.len()),
+                "--tail must not shrink the reported replay size: {tail}"
             );
             return;
         }
         assert!(
             Instant::now() < deadline,
-            "the six echoes never settled; last capture was:\n{whole}"
+            "the six echoes never settled; last capture was:\n{before}"
         );
         std::thread::sleep(Duration::from_millis(200));
     }

--- a/crates/tty7-cli/tests/cli_e2e.rs
+++ b/crates/tty7-cli/tests/cli_e2e.rs
@@ -75,6 +75,10 @@ fn main() {
             "capture_plain_returns_text_not_escapes",
             capture_plain_returns_text_not_escapes,
         ),
+        (
+            "capture_still_answers_after_a_resize",
+            capture_still_answers_after_a_resize,
+        ),
     ];
 
     let mut failed = 0;
@@ -825,4 +829,79 @@ fn capture_plain_returns_text_not_escapes(daemon: &Daemon) {
         );
         std::thread::sleep(Duration::from_millis(200));
     }
+}
+
+/// A resize must not empty `capture`.
+///
+/// The daemon's replay ring seals its segment on every resize and opens an
+/// empty one at the new geometry, and it replays every segment it holds. The
+/// default form keeps "the newest segment", which was that empty placeholder
+/// for any pane resized since it last printed — so `capture` answered a live
+/// pane with zero bytes and exit `0`, indistinguishable from a blank one
+/// (#841). Nothing about the pane changes here between the two captures except
+/// its size, which is what makes the assertion a statement about the replay
+/// rather than about timing.
+fn capture_still_answers_after_a_resize(daemon: &Daemon) {
+    let mut pane = PaneClient::at(daemon.pane_endpoint())
+        .spawn(
+            None,
+            WinSize {
+                cols: 100,
+                rows: 24,
+                cell_w: 8,
+                cell_h: 16,
+            },
+            None,
+            Some("resize-capture-e2e".into()),
+            None,
+        )
+        .expect("spawn a pane to resize");
+    let address = format!("%{}", pane.pane_id());
+
+    daemon.run_ok(&["send", &address, "echo tty7_e2e_resize_marker", "--enter"]);
+    let deadline = Instant::now() + SETTLE_WITHIN;
+    loop {
+        if daemon
+            .run_ok(&["capture", &address])
+            .contains("tty7_e2e_resize_marker")
+        {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the marker never reached the pane's newest segment"
+        );
+        std::thread::sleep(Duration::from_millis(200));
+    }
+
+    pane.resize(WinSize {
+        cols: 80,
+        rows: 24,
+        cell_w: 8,
+        cell_h: 16,
+    })
+    .expect("resize the pane");
+    // Long enough for the daemon to have sealed the segment, and for any
+    // repaint the shell answers a resize with to have landed either way.
+    std::thread::sleep(Duration::from_millis(1500));
+
+    for form in [
+        vec!["capture", &address],
+        vec!["capture", &address, "--plain"],
+        vec!["capture", &address, "--scrollback"],
+    ] {
+        let out = daemon.run_json(&form);
+        let text = out["text"].as_str().unwrap_or_default();
+        assert!(
+            text.contains("tty7_e2e_resize_marker"),
+            "tty7 {form:?} lost the pane's output to the empty segment the \
+             resize opened: {out}"
+        );
+        assert!(
+            out["bytes"].as_u64().is_some_and(|n| n > 0),
+            "a capture that carried text has to report the bytes it carried: {out}"
+        );
+    }
+
+    let _ = pane.detach();
 }

--- a/crates/tty7-cli/tests/cli_e2e.rs
+++ b/crates/tty7-cli/tests/cli_e2e.rs
@@ -79,6 +79,10 @@ fn main() {
             "capture_still_answers_after_a_resize",
             capture_still_answers_after_a_resize,
         ),
+        (
+            "capture_tail_trims_a_real_panes_answer",
+            capture_tail_trims_a_real_panes_answer,
+        ),
     ];
 
     let mut failed = 0;
@@ -904,4 +908,57 @@ fn capture_still_answers_after_a_resize(daemon: &Daemon) {
     }
 
     let _ = pane.detach();
+}
+
+/// `--tail` against a real pane, whose replay carries a shell prompt, escapes
+/// and CRLF rather than the tidy fixtures the unit tests craft.
+///
+/// The contract is only "the last N lines of what the command would have
+/// printed", so what is pinned is that the tail is a suffix of the whole answer,
+/// that it holds the marker the pane printed last, and that it is shorter than
+/// what it was cut from — not the exact line count, which depends on how the
+/// test machine's shell decorates its prompt.
+fn capture_tail_trims_a_real_panes_answer(daemon: &Daemon) {
+    let created = daemon.run_json(&["new", &workdir()]);
+    let pane = created["pane"].as_u64().expect("new prints the pane id");
+    let address = format!("%{pane}");
+
+    for n in 1..=6 {
+        let line = format!("echo tty7_e2e_tail_line_{n}");
+        daemon.run_ok(&["send", &address, &line, "--enter"]);
+    }
+
+    let deadline = Instant::now() + SETTLE_WITHIN;
+    loop {
+        let whole = daemon.run_ok(&["capture", &address, "--plain"]);
+        let tail = daemon.run_ok(&["capture", &address, "--plain", "--tail", "2"]);
+        let settled = whole.contains("tty7_e2e_tail_line_6")
+            && tail.contains("tty7_e2e_tail_line_6")
+            && whole.contains("tty7_e2e_tail_line_1");
+        if settled {
+            assert!(
+                whole.trim_end().ends_with(tail.trim_end()),
+                "a tail has to be the end of the answer it was cut from:\ntail: {tail:?}\nwhole: {whole:?}"
+            );
+            assert!(
+                !tail.contains("tty7_e2e_tail_line_1"),
+                "two lines cannot still hold the first of six:\n{tail:?}"
+            );
+            // The byte count stays the size of the replay, not of the tail —
+            // that is what says a tail was taken rather than a short capture.
+            let json = daemon.run_json(&["capture", &address, "--plain", "--tail", "2"]);
+            assert!(
+                json["bytes"]
+                    .as_u64()
+                    .is_some_and(|n| n as usize > tail.len()),
+                "--tail must not shrink the reported replay size: {json}"
+            );
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the six echoes never settled; last capture was:\n{whole}"
+        );
+        std::thread::sleep(Duration::from_millis(200));
+    }
 }

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -93,6 +93,16 @@ stripping escapes yourself:
 
 Use `--plain` whenever a human would want to read the output.
 
+When all you want is how the last command ended, ask for that much:
+
+```bash
+tty7 capture %83 --plain --tail 5
+```
+
+`--tail N` keeps the last N lines of the answer, counted after `--plain` has
+resolved the wraps — so no pipe through `tail(1)`, which is one less thing to
+have on PATH.
+
 <Warning>
   A screen is a rectangle. Whatever scrolled off the top is gone, and an exit
   code was never on it. When you want the *answer* rather than the *view*, have

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -130,9 +130,9 @@ raw-mode TUI reads a sequence as a sequence rather than as a paste.
 
 JSON: `{"pane","sent","enter","keys"}`.
 
-### `tty7 capture [%PANE] [--plain] [--scrollback]`
+### `tty7 capture [%PANE] [--plain] [--scrollback] [--tail N]`
 
-The pane's replay. Two independent choices:
+The pane's replay. Three independent choices:
 
 **How much** — the newest scrollback segment by default, the whole ring with
 `--scrollback`. The ring splits into segments on resize, so for a pane that was
@@ -142,11 +142,20 @@ never resized the two are identical.
 decoded as UTF-8 (invalid bytes become U+FFFD). With `--plain`, those bytes
 replayed through a terminal grid and printed as the text they produced.
 
+**How many lines** — all of them by default, the last `N` with `--tail N`, which
+answers "how did the last command end?" without a pipe through `tail(1)` (a
+program Windows does not have). The trim happens last, after `--plain` has
+decided what a line is: a wrapped line is one line to the grid, so `--plain
+--tail 1` gives you the whole of the last line and not its final row. `N` must
+be at least 1 — a tail of nothing would read as a blank pane. The daemon still
+replays the ring in full; the saving is the pipe, not the wire.
+
 Either way it is a snapshot, not a stream: it collects the replay, settles for
 ~300 ms, and returns. Call it again for a newer one.
 
-JSON: `{"pane","text","bytes"}` — `bytes` is how much the replay carried, counted
-before `--plain` rendered it. It is what tells an empty `text` apart: `0` is a
+JSON: `{"pane","text","bytes"}` — `text` is what was printed, `--tail` included;
+`bytes` is how much the replay carried, counted before `--plain` rendered it or
+`--tail` trimmed it. It is what tells an empty `text` apart: `0` is a
 pane that has printed nothing, and a non-zero count with no text is a screen
 whose bytes produced nothing visible (a pane that was cleared, say). The same
 case also prints one line on stderr, so a script that never reads the JSON still

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -144,7 +144,13 @@ replayed through a terminal grid and printed as the text they produced.
 
 Either way it is a snapshot, not a stream: it collects the replay, settles for
 ~300 ms, and returns. Call it again for a newer one.
-JSON: `{"pane","text"}`.
+
+JSON: `{"pane","text","bytes"}` — `bytes` is how much the replay carried, counted
+before `--plain` rendered it. It is what tells an empty `text` apart: `0` is a
+pane that has printed nothing, and a non-zero count with no text is a screen
+whose bytes produced nothing visible (a pane that was cleared, say). The same
+case also prints one line on stderr, so a script that never reads the JSON still
+sees it.
 
 ### `tty7 procs [%PANE]`
 

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -138,6 +138,19 @@ The pane's replay. Three independent choices:
 `--scrollback`. The ring splits into segments on resize, so for a pane that was
 never resized the two are identical.
 
+<Warning>
+  The default form is bounded by the pane's last **resize**, which is an event in
+  the window rather than in the pane's output. A resize seals the segment holding
+  everything printed so far and opens a new one, and on Unix the shell answers
+  the SIGWINCH by repainting its prompt — so straight after a resize the newest
+  segment can hold that repaint and nothing else, while the command's output sits
+  in the segment behind it. Nothing in the byte stream tells a repaint apart from
+  real output, so `capture` cannot decide this for you. When you are reading a
+  pane whose window may have changed size — anything under the GUI — ask for
+  `--scrollback`, and reach for `--tail N` if you wanted the tail rather than the
+  ring.
+</Warning>
+
 **In what form** — without `--plain`, the stored bytes with ANSI escapes intact,
 decoded as UTF-8 (invalid bytes become U+FFFD). With `--plain`, those bytes
 replayed through a terminal grid and printed as the text they produced.

--- a/skills/tty7/references/commands.md
+++ b/skills/tty7/references/commands.md
@@ -136,11 +136,21 @@ Each keystroke goes out as its own event 200 ms after the last, which is what
 keeps a raw-mode TUI from reading the sequence as a paste; the first write is
 not delayed, so an interrupt is immediate.
 
-### `tty7 capture [%PANE] [--plain] [--scrollback]`
-The pane's replay. Two independent choices: **how much** — the newest scrollback
-segment by default, the whole ring with `--scrollback` (the ring splits into
-segments on resize, so for a pane that was never resized the two are identical)
-— and **in what form**.
+### `tty7 capture [%PANE] [--plain] [--scrollback] [--tail N]`
+The pane's replay. Three independent choices: **how much** — the newest
+scrollback segment by default, the whole ring with `--scrollback` (the ring
+splits into segments on resize, so for a pane that was never resized the two are
+identical) — **in what form**, and **how many lines**.
+
+The default's boundary is the pane's last *resize*, which is an event in the
+window rather than in the pane's output: a resize seals the segment holding
+everything printed so far, and on Unix the shell answers the SIGWINCH by
+repainting its prompt into the new one — so straight after a resize the newest
+segment can hold that repaint and nothing else, while the command's output sits
+in the segment behind it. Nothing in the byte stream tells a repaint apart from
+real output, so `capture` cannot decide it for you. When you are reading a pane
+whose window may have changed size — anything under the GUI — ask for
+`--scrollback`, and take the tail with `--tail N` if the tail is what you wanted.
 
 Without `--plain` you get the stored bytes, ANSI escapes intact, decoded as
 UTF-8 (invalid bytes become U+FFFD). That is the faithful form: it is exactly
@@ -163,9 +173,23 @@ Reach for it whenever a human would want to read the output. It is still a
 screen, though: what scrolled past the top is gone, and an exit code was never
 on screen — redirect to a file when you want the answer rather than the view.
 
+`--tail N` keeps the last N lines of the answer and drops the rest — "how did
+the last command end?" without a pipe through `tail(1)`, a program Windows does
+not have. It trims last, after `--plain` has decided what a line is, so a line
+the shell wrapped counts once: `--plain --tail 1` hands back the whole of the
+last line rather than its final row. `N` must be at least 1 — a tail of nothing
+would read as a blank pane. The server still replays the whole ring, so the
+saving is the pipe and not the wire.
+
 Either way it is a snapshot, not a stream: it collects the replay the server
 sends, settles for ~300 ms, and returns. Call it again for a newer one.
-JSON: `{"pane","text"}`, where `text` is whichever form was asked for.
+JSON: `{"pane","text","bytes"}`, where `text` is whichever form was asked for,
+`--tail` included, and `bytes` is how much the replay carried, counted before
+`--plain` rendered it or `--tail` trimmed it. `bytes` is what tells an empty
+`text` apart: `0` is a pane that has printed nothing, while a count with no text
+is a screen whose bytes produced nothing visible — a pane that was cleared, say.
+That second case also prints one line on stderr, so a script that reads only
+stdout still sees it.
 
 ### `tty7 procs [%PANE]`
 The process tree inside the pane, indented by depth, `*` on the foreground


### PR DESCRIPTION
Closes #841 — the two `capture` papercuts, handled separately because only one of them had a cause behind it.

## What changed

**`capture` can no longer answer a live pane with zero bytes.** `RealBackend::capture` now drops byte-less segments before it picks "the newest segment", so the empty placeholder a resize opens is never the answer. This is narrower than it first looks — see the second half of *Why*.

**An empty answer is now distinguishable from a failed one.** `--json` gains `bytes` — the size of the replay, counted before `--plain` renders it or `--tail` trims it. Zero bytes is a pane that printed nothing; a non-zero count with empty `text` is a screen whose bytes produced nothing visible. That second case also prints one line on stderr, so a script that only reads stdout still sees it.

**`capture --tail N`** keeps the last N lines of the answer. A third independent choice beside `--scrollback` (how much of the ring) and `--plain` (in what form), composing with both. `N < 1` is a usage error (exit 2).

Docs updated in `docs/cli/reference.mdx` and `docs/cli/overview.mdx`.

## Why

### The default form's silent-empty: cause established, and it is not the grid

The report suspected the replay grid. It is not the grid — it is the segment the grid was handed.

The daemon's replay ring splits on resize. `ReplayRing::resize` (`crates/tty7-core/src/daemon/pane.rs`) seals the segment holding the output and pushes an *empty* one at the new geometry; `ReplayRing::replay` then sends every segment it holds, empty tail included — unlike `ReplayRing::snapshot` right beside it, which filters empties out. `RealBackend::capture` kept the last segment for the default (non-`--scrollback`) form, so for a pane that had printed nothing since a resize, that last segment was the empty placeholder. A pane restored from disk lands in the same state: `ReplayRing::seeded` ends in a `resize` too.

Two measurements, both against a real daemon, before the fix:

- A unit probe on the ring: after `append(b"all the output")` + `resize(80x24)`, `replay` emits `Size(100x24), Snapshot("all the output"), Size(80x24), Snapshot([])`.
- End to end through the CLI on Windows, pane holding 954 bytes: `capture` → **0 bytes, exit 0**; `capture --plain` → **0 bytes, exit 0**; `capture --scrollback` → 954 bytes, exit 0. That is the reported symptom exactly, and it recovers on its own the moment the pane prints again — which is what "a later call recovered" looks like.

### The fix is narrower than that makes it sound, and CI is what showed it

The first round of this PR asserted end to end that after a resize the default form still carries the pane's output. That passed on Windows and **failed on Linux and macOS**, and the failure was the test telling me something true rather than being wrong about the test.

On Unix a resize raises SIGWINCH and the shell repaints its prompt, so the segment the resize opens is **not empty** — it holds the repaint. Dropping byte-less segments therefore leaves the newest non-empty segment being a bare prompt, with the output still stranded in the segment sealed behind it. On CI the default form came back as 174 bytes of prompt escapes and no marker (105 bytes on Darwin). On Windows nothing answers the resize, the segment stays empty, and the fix reaches past it to the output — which is the only reason the assertion held there. It was asserting an accident of the platform.

So, plainly: **this fix makes the zero-byte answer impossible, and that is all it does.** It does not make the default form robust to a resize, and it cannot. Nothing in the byte stream distinguishes a prompt repaint from output the pane meant, so no client-side rule can tell which side of the boundary the answer is on. The boundary itself is the flaw — the default form's unit is the last resize, an event in the *window* rather than in the pane's output, which under the GUI is close to arbitrary. Moving it means redefining what the default returns (the last screenful of the whole ring, say), and that would shrink what every caller with a never-resized pane gets today, where the default and `--scrollback` are identical. Out of scope here; said plainly instead, in `what_was_asked_for`'s doc comment and in a `<Warning>` in the CLI reference that tells anyone reading a pane under the GUI to ask for `--scrollback`.

Worth being explicit about the consequence for the reporter: on Unix, the residual case does not even trip the zero-byte signal — you get a prompt, not nothing. `bytes` and the stderr line answer the empty case, not this one.

### The other half of the report: not reproduced

I could not establish a cause for `--scrollback` also coming back empty, and could not reproduce it. Empty-segment filtering cannot produce it (`--scrollback` keeps every segment that has bytes). The other suspect was `REPLAY_SETTLE`, the 300 ms window `capture` allows between replay frames: if a `Size` arrives and its `Snapshot` does not land inside 300 ms, the loop breaks with nothing collected and returns `Ok("")`. Two stress runs failed to trigger it:

- 60 rounds of `capture` and `capture --scrollback` against a pane spewing 4000 escape-laden lines: **0 empty results**, slowest pair 777 ms.
- A ring filled to `RING_CAP` (8 MiB, the cap): every `capture --scrollback` returned all 8,388,609 bytes in ~400 ms including process startup, an order of magnitude inside the window.

Not disproved, only not reproduced. That is precisely why `bytes` and the stderr line are in this PR: they are what would let the next occurrence say which half happened, without a root cause to hang them on. **Deliberately not shipped: any retry loop, and any warning on a condition I have not established.** The stderr line fires only on a fact observable at the point of return — bytes came in, no text came out — and only `--plain` can reach it, since lossy UTF-8 never turns bytes into an empty string.

### Also left alone deliberately

- **The daemon's replay.** It keeps sending the empty segment; its trailing `Size` is how an attaching client learns the pane's current geometry. The fix is entirely client-side.
- **The wire cost of `--tail`.** The daemon still replays the whole ring on every observe, so `--tail` saves the pipe, not the wire. Bounding the wire means teaching `ClientMsg::Observe` a limit and versioning the protocol for it — far more than this papercut warrants, and the default form has always received the whole ring and discarded most of it. The docs say so rather than implying otherwise.

## Testing

Run on Windows 11 from this worktree's own `target/`:

- `cargo test -p tty7-cli` — 145 unit tests pass, including the new `what_was_asked_for` cases in `backend/real.rs` (a resize's empty segment is not the newest screen; output after a resize still is; a genuinely blank pane still answers with nothing), `capture_json_counts_the_bytes_the_replay_carried`, `capture_tail_keeps_the_last_lines_of_either_form`, `a_tail_counts_lines_the_way_tail_does`, and `capture_tail_takes_a_count_and_refuses_zero`. These are where the segment-picking logic is pinned exactly, on every platform.
- `cargo test -p tty7-cli --test cli_e2e` — the end-to-end suite against a real isolated daemon. Two new cases pass: `capture_still_answers_after_a_resize` and `capture_tail_trims_a_real_panes_answer`.
- `cargo test -p tty7-core` — 1157 pass, 4 fail: `remote_link::{a_local_stdio_child_round_trips_bytes, shutdown_closes_the_write_half_and_the_peer_sees_eof, dropping_the_link_kills_the_child}` and `router::a_successful_ack_names_the_transport`. Known pre-existing on a clean tree; this branch changes no `tty7-core` code.
- `cargo clippy -p tty7-cli --all-targets` — no warnings from `tty7-cli`.
- `cargo fmt` run; `Cargo.lock` verified unchanged.

**What the two e2e cases assert now**, after the CI round above:

- `capture_still_answers_after_a_resize` — the default form answers with bytes rather than with the resize's placeholder, and it is the end of what `--scrollback` returns (which is what would catch a fix reaching for the wrong segment). The marker is pinned against `--scrollback`, the form that promises to hold it, rather than against the default form, which as explained above legitimately may not. Neither assertion was weakened to go green: the one that was dropped was never guaranteed by the contract and only held on Windows by accident.
- `capture_tail_trims_a_real_panes_answer` — the CI failure here was a race in the test, not in `--tail`: the whole and the tail were separate calls and the pane advanced between them, so the tail carried a prompt line the whole capture had not caught up to. Both cases now read the whole answer on either side of the others and require the two readings to match before comparing anything. Both also read `--scrollback`, so neither depends on where a segment boundary falls, and neither pins exact pane content — the macOS runner prints a zsh banner into the pane.

One further pre-existing failure, environmental rather than known: `cli_e2e::config_dir_alone_resolves_both_endpoints` runs `tty7 run -- sh -c "exit 9"`, and this Windows box has no `sh` on PATH. It fails identically on an unmodified tree and is untouched by this branch; it is green on CI.

No Rust toolchain is available under WSL on this machine, so the Unix behaviour above is reasoned from the CI logs and validated by CI on this branch rather than locally.

The GUI was not built or launched.

https://claude.ai/code/session_01UUyWQXzcBAoBzaSX8pc7nU
