### PR TITLE
fix(files): put the tree on the panel's own left rail

### DIFF
--- a/src/ui/file_tree.rs
+++ b/src/ui/file_tree.rs
@@ -6,12 +6,12 @@ use std::sync::Arc;
 use crate::core::config::RightPanelTab;
 use crate::core::git::status::{DecoStatus, DirRollup, StatusIndex};
 use crate::terminal::git_data::index_of;
-use crate::ui::app::Tty7App;
+use crate::ui::app::{CONTENT_INSET, Tty7App};
 use crate::ui::file_copy;
 use crate::ui::host_ops::{ByHost, HostId, HostOps, InFlight, SharedHost, WatchSub};
 use crate::ui::host_registry::HostRegistry;
 use crate::ui::i18n::{L10nKey, t, t_fmt};
-use crate::ui::right_panel::{ROW_GLYPH, git_badge};
+use crate::ui::right_panel::{ROW_GLYPH, ROW_INSET, git_badge};
 use crate::ui::scm::status::{status_color, status_glyph};
 use gpui::prelude::*;
 use gpui::{
@@ -24,6 +24,18 @@ use gpui_component::{
     ActiveTheme as _, Icon, IconName, Sizable as _, WindowExt as _, h_flex, v_flex,
 };
 
+// The tree is laid out the way every other list in this panel is: the column
+// sits a `ROW_INSET` short of `CONTENT_INSET` and each row pads itself back
+// out, so a depth-0 name lands on the panel's 12px rail while the row's hover
+// and selection fill bleeds past it to 8. Depth is added on top of that inset,
+// so `INDENT` is the step between levels and nothing else.
+//
+// It used to run its own pair of numbers instead — a `px_1()` column and a 6px
+// row — which put the tree's names 2px left of the search field directly above
+// them and let a selected row's fill reach twice as close to the panel edge as
+// an Info or Source Control row's. Two adjacent left edges that disagree by
+// 2px is the one misalignment a reader can actually catch, because the search
+// glyph sits right there to compare against.
 const INDENT: f32 = 14.0;
 
 const REFRESH_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(200);
@@ -1579,7 +1591,7 @@ impl Tty7App {
             .min_h_0()
             .overflow_y_scroll()
             .track_scroll(&self.right_panel.tree_scroll)
-            .px_1()
+            .px(px(CONTENT_INSET - ROW_INSET))
             .pb_1()
             .track_focus(&self.file_tree.focus_handle)
             .on_key_down(cx.listener(|this, ev: &KeyDownEvent, window, cx| {
@@ -1718,9 +1730,9 @@ impl Tty7App {
             return vec![
                 h_flex()
                     // Aligned with the label column of a real row at this
-                    // depth: 6 for the row's own inset, INDENT for the depth,
-                    // then the width of the icon and its gap.
-                    .pl(px(6.0 + row.depth as f32 * INDENT + 20.0))
+                    // depth: ROW_INSET for the row's own inset, INDENT for the
+                    // depth, then the width of the icon and its gap.
+                    .pl(px(ROW_INSET + row.depth as f32 * INDENT + 20.0))
                     .py_1()
                     .items_center()
                     .text_xs()
@@ -1806,8 +1818,8 @@ impl Tty7App {
             .id(SharedString::from(format!("tree-{}", path.display())))
             .items_center()
             .gap_1()
-            .pl(px(6.0 + row.depth as f32 * INDENT))
-            .pr_1()
+            .pl(px(ROW_INSET + row.depth as f32 * INDENT))
+            .pr(px(ROW_INSET))
             .py_1()
             .rounded(cx.theme().radius)
             .cursor_pointer()
@@ -1903,8 +1915,8 @@ impl Tty7App {
                     h_flex()
                         .items_center()
                         .gap_1()
-                        .pl(px(6.0 + (row.depth + 1) as f32 * INDENT))
-                        .pr_1()
+                        .pl(px(ROW_INSET + (row.depth + 1) as f32 * INDENT))
+                        .pr(px(ROW_INSET))
                         .py_0p5()
                         .child(Input::new(&input).xsmall())
                         .into_any_element(),


### PR DESCRIPTION
Puts the file tree on the same left rail as every other list in the right panel.

`right_panel.rs` states the panel's geometry once: a list column sits `ROW_INSET` (4) short of `CONTENT_INSET` (12), and each row pads itself back out by `ROW_INSET`. A row's text therefore lands on the 12px rail while its hover and selection fill bleeds past it to 8. Info and Source Control both follow it. The Files tab ran its own pair of numbers instead — a `px_1()` column and a `pl(6.0 + depth * INDENT)` row.

| Measured from the panel edge | Before | After |
|---|---|---|
| Depth-0 name | 10 | 12 |
| Every deeper level | 10 + depth × 14 | 12 + depth × 14 |
| Hover / selection fill, left and right | 4 | 8 |
| Row content, right edge | 8 | 12 |
| Info and Source Control rows (unchanged) | 12 text, 8 fill | 12 text, 8 fill |

`INDENT` is untouched, so the step between levels is still 14.

## Why

Two of those disagreements are visible rather than merely inconsistent.

The tree renders directly under the panel's search field, so the root row's folder glyph and the search magnifier are two adjacent left edges 2px out of line — the one kind of misalignment a reader can actually catch, because the reference sits right above it.

And a selected row ran nearly edge to edge where the same row under Info or Source Control stops 8px short, so switching tabs changed how wide the panel's rows appeared to be. `ROW_INSET`'s own doc comment already argues this case: a fill that bleeds 4px under one tab and 6px under another is a panel whose rows visibly do not belong to each other.

## Testing

- `cargo build` clean, `cargo fmt --check` clean.
- Verified by hand in an isolated dev instance (`--config-dir /tmp/t7dev`, right panel seeded open on the Files tab over this repo): the root row's glyph now lines up with the search magnifier above it, the selection band pulls in from both edges, and cycling Info → Source Control → Files keeps the rows on one rail.
- No unit test: this is pure layout constants, and nothing in the tree's rendering is reachable without a `Window`.

https://claude.ai/code/session_01E4EPKzHg1fm9HMmHkUYpER
