### PR TITLE
fix(window): drop the dead window buttons from the title bar in fullscreen

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1166,6 +1166,22 @@ fn clear_window_override_values(config: &mut Config, backdrop_is_local: bool) {
     }
 }
 
+/// The id the fullscreen hint is pushed under, so that entering again replaces
+/// it and leaving takes it away.
+struct FullscreenHint;
+
+/// Whether fullscreen takes the title bar away on this platform.
+///
+/// Not on macOS, where fullscreen belongs to the system rather than to the app.
+/// The traffic lights live on that bar, and revealing the menu bar draws a
+/// translucent strip over the same band, which the bar absorbs; without it the
+/// strip lands on the terminal instead and covers its first row. There is also
+/// nothing there to fix: `WindowControls` draws no minimize, maximize or close
+/// on macOS — the three that are dead in fullscreen elsewhere are the system's
+/// there, and it hides them itself. So the bar is not broken chrome on macOS,
+/// it is part of how the system dresses a fullscreen window.
+const FULLSCREEN_TAKES_THE_TITLE_BAR: bool = !cfg!(target_os = "macos");
+
 impl Tty7App {
     pub fn for_workspace(
         id: Option<WorkspaceId>,
@@ -3526,6 +3542,46 @@ impl Tty7App {
         remember_leaf_in(&mut self.tabs, leaf);
     }
 
+    /// Toggle fullscreen, and say how to leave it on the way in.
+    ///
+    /// Only on the way in, and only from the action: entering is an instant in
+    /// which the title bar disappears, and a window that starts fullscreen
+    /// because the setting says so is not a surprise anybody needs explaining.
+    /// The chord comes from the keymap rather than from a string, because it is
+    /// `F11` on Windows and Linux, `Cmd+Enter` on macOS, and either of them may
+    /// have been rebound.
+    ///
+    /// The hint carries an id of its own, which is what keeps a held-down
+    /// `F11` to one notice rather than a column of identical ones: pushing
+    /// under an id already on screen replaces that one. Leaving through the
+    /// action takes it back too, so a quick in-and-out does not leave the way
+    /// out on screen after it has been taken. Leaving some other way — a
+    /// window manager with a chord of its own — just lets it time out, which
+    /// is a second or two of a stale notice and not worth watching every
+    /// frame for.
+    fn toggle_fullscreen(&self, window: &mut Window, cx: &mut App) {
+        let entering = !window.is_fullscreen();
+        window.toggle_fullscreen();
+        window.remove_notification::<FullscreenHint>(cx);
+        // Nothing disappeared where the bar stays, so there is nothing to
+        // explain.
+        if !entering || !FULLSCREEN_TAKES_THE_TITLE_BAR {
+            return;
+        }
+        let hint = match crate::ui::home::key_hint("ToggleFullscreen", cx) {
+            Some(chord) => t_fmt(L10nKey::AppFullscreenEntered, &[("key", &chord)]),
+            // Rebound to nothing at all: still worth saying the bar is gone,
+            // just without naming a key that would not work.
+            None => t(L10nKey::AppFullscreenEnteredNoKey).to_string(),
+        };
+        window.push_notification(
+            gpui_component::notification::Notification::new()
+                .id::<FullscreenHint>()
+                .message(hint),
+            cx,
+        );
+    }
+
     fn focus_leaf(&self, leaf: &PaneSlot, window: &mut Window, cx: &mut App) {
         let handle = leaf.focus_handle(cx);
         window.focus(&handle, cx);
@@ -5358,7 +5414,7 @@ impl Tty7App {
             NextTab => self.cycle_tab(true, window, cx),
             PrevTab => self.cycle_tab(false, window, cx),
             ToggleMaximizePane => self.toggle_maximize(window, cx),
-            ToggleFullscreen => window.toggle_fullscreen(),
+            ToggleFullscreen => self.toggle_fullscreen(window, cx),
             ToggleTabSidebar => self.toggle_tab_sidebar(cx),
             ToggleLeftPanel => self.toggle_left_panel(cx),
             ToggleRightPanel => self.toggle_right_panel(cx),
@@ -7609,11 +7665,22 @@ impl Render for Tty7App {
             }
         };
 
-        let title_bar = TitleBar::new()
-            .h(px(TITLE_BAR_HEIGHT))
-            .bg(cx.theme().transparent)
-            .border_color(cx.theme().transparent)
-            .child(strip);
+        // No title bar in fullscreen. The bar is window chrome — a caption to
+        // drag the window by and the three controls at its end — and a
+        // fullscreen window has none of that to offer: it has no caption for
+        // the platform to hit-test, so the buttons draw, light up under the
+        // pointer and do nothing at all when clicked. Drawing chrome that
+        // cannot work is worse than drawing none, and taking it away is also
+        // what the mode is for.
+        let fullscreen = window.is_fullscreen();
+        let bar_is_gone = fullscreen && FULLSCREEN_TAKES_THE_TITLE_BAR;
+        let title_bar = (!bar_is_gone).then(|| {
+            TitleBar::new()
+                .h(px(TITLE_BAR_HEIGHT))
+                .bg(cx.theme().transparent)
+                .border_color(cx.theme().transparent)
+                .child(strip)
+        });
         let body_area = div()
             .flex_1()
             .relative()
@@ -7717,9 +7784,9 @@ impl Render for Tty7App {
         let panel_below_title_bar =
             (right_panel.is_some() || document_column.is_some()) && !cfg!(target_os = "macos");
         let (column_title_bar, spanning_title_bar) = if panel_below_title_bar {
-            (None, Some(title_bar))
+            (None, title_bar)
         } else {
-            (Some(title_bar), None)
+            (title_bar, None)
         };
         let (column_overlays, hoisted_overlays) = if panel_below_title_bar {
             (Vec::new(), overlays)
@@ -8012,9 +8079,9 @@ impl Render for Tty7App {
                 .on_action(cx.listener(|this, _: &ToggleMaximizePane, window, cx| {
                     this.toggle_maximize(window, cx)
                 }))
-                .on_action(
-                    cx.listener(|_, _: &ToggleFullscreen, window, _cx| window.toggle_fullscreen()),
-                )
+                .on_action(cx.listener(|this, _: &ToggleFullscreen, window, cx| {
+                    this.toggle_fullscreen(window, cx)
+                }))
                 .on_action(cx.listener(|this, _: &ToggleTabSidebar, _window, cx| {
                     this.toggle_tab_sidebar(cx)
                 }))

--- a/src/ui/i18n/en.rs
+++ b/src/ui/i18n/en.rs
@@ -1577,6 +1577,10 @@ pub fn translate_en(key: L10nKey) -> &'static str {
         L10nKey::AppReopenTabFailed => "Could not reopen the tab: no terminal started",
         L10nKey::AppOpenTerminalFailed => "Could not open a terminal: {error}",
         L10nKey::AppTabsNotRestored => "{count} tabs from last time could not be reopened",
+        L10nKey::AppFullscreenEntered => "Fullscreen — press {key} to leave",
+        L10nKey::AppFullscreenEnteredNoKey => {
+            "Fullscreen — the title bar is hidden until you leave"
+        }
         L10nKey::LaunchWorkspacesLeftRunning => {
             "Only this window was restored — {count} workspaces are still running in the background. Reopen them from the sidebar."
         }

--- a/src/ui/i18n/ja.rs
+++ b/src/ui/i18n/ja.rs
@@ -1638,6 +1638,8 @@ pub fn translate_ja(key: L10nKey) -> Option<&'static str> {
         L10nKey::AppReopenTabFailed => "タブを開き直せませんでした: ターミナルが起動しませんでした",
         L10nKey::AppOpenTerminalFailed => "ターミナルを開けませんでした: {error}",
         L10nKey::AppTabsNotRestored => "前回のタブ {count} 個を開き直せませんでした",
+        L10nKey::AppFullscreenEntered => "全画面表示 — 解除するには {key}",
+        L10nKey::AppFullscreenEnteredNoKey => "全画面表示 — 解除するまでタイトルバーは非表示です",
         L10nKey::LaunchWorkspacesLeftRunning => {
             "このウィンドウだけを復元しました — あと {count} 個のワークスペースがバックグラウンドで実行中です。サイドバーから開き直せます。"
         }

--- a/src/ui/i18n/mod.rs
+++ b/src/ui/i18n/mod.rs
@@ -1276,6 +1276,8 @@ l10n_keys! {
     AppReopenTabFailed,
     AppOpenTerminalFailed,
     AppTabsNotRestored,
+    AppFullscreenEntered,
+    AppFullscreenEnteredNoKey,
     LaunchWorkspacesLeftRunning,
     AppSshConnectionFailed,
     AppSshReconnectFailed,

--- a/src/ui/i18n/zh.rs
+++ b/src/ui/i18n/zh.rs
@@ -1493,6 +1493,8 @@ pub fn translate_zh(key: L10nKey) -> Option<&'static str> {
         L10nKey::AppReopenTabFailed => "无法重新打开标签页：没有启动终端",
         L10nKey::AppOpenTerminalFailed => "无法打开终端：{error}",
         L10nKey::AppTabsNotRestored => "上次的 {count} 个标签页没能重新打开",
+        L10nKey::AppFullscreenEntered => "已进入全屏 —— 按 {key} 退出",
+        L10nKey::AppFullscreenEnteredNoKey => "已进入全屏 —— 标题栏在退出前会一直隐藏",
         L10nKey::LaunchWorkspacesLeftRunning => {
             "只恢复了这个窗口——还有 {count} 个工作区在后台运行，可从侧边栏重新打开。"
         }

--- a/src/ui/keymap.rs
+++ b/src/ui/keymap.rs
@@ -1339,6 +1339,55 @@ mod tests {
     use super::*;
     use gpui::Action as _;
 
+    /// Everything the title bar offers a button for stays reachable from the
+    /// keyboard, because on Windows and Linux the title bar is not drawn in
+    /// fullscreen at all — it is window chrome there, and a fullscreen window
+    /// has no chrome for the platform to hit-test, so its buttons would light
+    /// up under the pointer and do nothing when clicked. (On macOS the bar
+    /// stays: fullscreen is the system's there, and the bar is where it puts
+    /// the traffic lights.)
+    ///
+    /// Reachable means either a chord of its own or a seat in the palette,
+    /// which has one; both are hands-free, and the palette is how the sidebar
+    /// toggle is reached, since it ships without a chord. What this pins is
+    /// that a control on that bar is never mouse-only — if one ever is,
+    /// hiding the bar would take a feature away with it, and this is where
+    /// that should be noticed.
+    #[test]
+    fn what_the_title_bar_offers_is_reachable_without_it() {
+        let defaults = default_bindings();
+        let chord = |action: &str| {
+            defaults
+                .iter()
+                .any(|(name, keystroke)| *name == action && !keystroke.is_empty())
+        };
+        // The palette is the fallback, so it is the one that must not be.
+        assert!(
+            chord("TogglePalette"),
+            "the fallback needs a chord of its own"
+        );
+        for action in [
+            "NewTab",
+            "ToggleTabSidebar",
+            "OpenSettings",
+            "ToggleFullscreen",
+            "ToggleSwitcher",
+        ] {
+            assert!(
+                chord(action) || palette_lists(action),
+                "{action} would be mouse-only once the bar is hidden"
+            );
+        }
+    }
+
+    /// Whether the palette lists `action` under a name somebody wrote, which is
+    /// what having a real seat there means: `action_entry` answers for every
+    /// action, falling back to a name split on capitals, and a fallback name is
+    /// not evidence that anyone meant the action to be found.
+    fn palette_lists(action: &str) -> bool {
+        authored_entry(action).is_some()
+    }
+
     /// The actions a keymap built from `action_bindings` dispatches for `keys`
     /// typed in `context`, in precedence order — the same lookup gpui performs
     /// on a real keypress.


### PR DESCRIPTION
On Windows and Linux a fullscreen window has no caption, but the title bar was
drawn over it anyway — three window controls that light up under the pointer and
do nothing, and a bar that cannot be dragged. This takes the bar away where it is
the app's to draw, and leaves macOS alone, where it is not.

## What goes wrong today

Enter fullscreen on Windows and the minimize, maximize and close buttons are
still there. Hover styling works, because that is gpui's own dispatch. Clicking
does nothing, and neither does dragging the bar, because those go to the platform
through `WM_NCHITTEST` — and gpui answers that from the window control hitboxes
the frame registered, of which a fullscreen window has none.

Measured on a fullscreen tty7:

| | windowed | fullscreen |
| --- | --- | --- |
| `GetWindowLong` `WS_CAPTION` | set | clear |
| hit test along the top of the window | `HTCAPTION`, `HTMINBUTTON`, `HTCLOSE` | `HTCLIENT` everywhere |

`WindowControls` renders the three whenever the target is not macOS, without
asking whether the window is fullscreen, so they are drawn into a band the
platform no longer recognises.

## What this does

Fullscreen takes the title bar with it on Windows and Linux. The bar is the app's
own chrome there — a caption to move the window by and the controls at its end —
and a fullscreen window has neither. Drawing chrome that cannot work is worse
than drawing none.

Entering says how to leave, since entering is the instant the bar disappears.
Only entering, and only through the action: a window that starts fullscreen
because `startup_mode` says so needs no explaining, and the toggle does not write
`startup_mode` either way. The chord is read from the keymap rather than written
into a string, so it says whatever it has been bound to. The notice carries an
id, so holding the key down replaces one notice rather than stacking a column of
them.

## Not on macOS, and not because the bug is milder there

The premise does not hold at all. `WindowControls` draws none of the three on
macOS — the ones that go dead elsewhere are the system's traffic lights, and the
system hides them itself. What the bar does in fullscreen there is hold the band
the system reserves: the traffic lights land on it when the menu bar is revealed,
and so does the translucent strip drawn under the menu bar.

Take the bar away and that strip lands on the terminal and covers its first row.
Measured against an unmodified build under identical conditions, the difference is
exactly `TITLE_BAR_HEIGHT`. Fullscreen belongs to the system on macOS, and the bar
is part of how the system dresses the window rather than something broken, so the
change does not apply there and macOS behaviour is byte-for-byte what it was.

## Nothing on the bar becomes unreachable

Its controls are actions first, dispatched from the window's root rather than
from the bar, so hiding the bar takes away buttons and not features. Each has a
chord or a seat in the palette, which has one;
`what_the_title_bar_offers_is_reachable_without_it` pins that, and is where a
future mouse-only control on that bar would be noticed.

Worth flagging while you read it: `ToggleTabSidebar` ships with no default chord,
so in fullscreen the palette is how it is reached. That is pre-existing and not
touched here — claiming a chord for it felt like a decision for you rather than
for this PR.

## Testing

- `cargo test --bin tty7-app` — 1830 passed, 0 failed. `cargo fmt --all --check`
  clean.
- Windows 11 26200: hit-test table above, taken with `GetWindowLong` and
  `WM_NCHITTEST` rather than by eye; F11 in and out; the notice appears once for
  a held key; `startup_mode: fullscreen` starts with no bar and no notice;
  `Ctrl+T`, `Ctrl+Shift+P` and `Ctrl+,` all work while fullscreen.
- macOS 26.5.2, on a second machine: the change is inert there, verified by pixel
  comparison against a build without it — the menu-bar strip lands where it
  always did and the terminal's first row is not covered.
- **Linux is reasoned about rather than measured.** It draws its own chrome the
  way Windows does and answers the same question through gpui's window control
  hitboxes, so it takes the same branch — but I have no Linux machine to confirm
  it on, and would rather say so than imply otherwise.
