### PR TITLE
fix(terminal): report the terminal as the focused element

### DIFF
--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -6820,6 +6820,11 @@ impl Render for TerminalView {
 
         div()
             .id("terminal-surface")
+            // The surface, not the grid inside it, is what carries the role:
+            // a11y focus is only ever reported for a `div` that tracks a focus
+            // handle *and* has a node of its own, so a terminal with no role
+            // here is a window whose focused element is the window.
+            .role(gpui::Role::MultilineTextInput)
             .track_focus(&self.focus_handle)
             .key_context(self.key_context())
             .size_full()


### PR DESCRIPTION
A tty7 window reports no focused element to assistive clients. Not "an
element with no text" — no element: `FocusedElement` for a focused tty7
window is the top-level window itself.

## Why

gpui sets accessibility focus in exactly one place — a `div` that tracks a
focus handle *and* has an a11y node of its own:

```rust
// gpui/src/elements/div.rs
if let Some(focus_handle) = self.tracked_focus_handle.as_ref() {
    if window.a11y.is_active() {
        window.a11y.focus_ids.insert(node_id, focus_handle.id);
        if focus_handle.is_focused(window) && window.a11y.nodes.has_node(node_id) {
            window.a11y.nodes.set_focus(node_id);
        }
    }
}
```

A node exists only for an element whose `a11y_role()` is `Some`, and for a
`div` that means `.role(...)` was called. `#terminal-surface` tracks the
focus handle and never asks for a role, so `has_node` is false and
`set_focus` is never reached.

## Measured

Windows 11 26200, current `main`, with a UI Automation probe:

```
class                   : Zed::Window
UIA framework           : Win32
UIA patterns on window  : WindowPattern
UIA descendants         : 0
FocusedElement          : ControlType.Window
  ValuePattern          : NOT SUPPORTED
  TextPattern           : NOT SUPPORTED
```

With this patch:

```
UIA descendants         : 1
FocusedElement          : ControlType.Edit
  HasKeyboardFocus      : True
```

## What it breaks besides screen readers

A dictation tool pastes its transcript into the focused window and then
asks the focused element what it now says, to confirm the text arrived.
Against tty7 there is no element to ask, so it decides the paste failed
and hands the transcript back for the user to paste by hand — while the
bytes it sent are already in the pty and the text is on screen. Confirmed
end to end: with this one line the tool stops reporting a failure it never
had.

Screen readers are the same story with a worse outcome: they have nothing
to announce about a tty7 window at all.

## The role

`MultilineTextInput` rather than `Terminal`. `Terminal` maps to a document
that reports itself as not editable, and "can text be put here" is the
question these clients are actually asking. Happy to switch if you would
rather the tree said `Terminal` and the editability came from somewhere
else.

## Cost

None while nothing is listening. gpui builds the a11y tree only after a
client attaches (`window.a11y.is_active()`), so a window nobody is
inspecting builds nothing. The node carries no text of its own — reading
the grid out is a separate change with a real per-frame cost, and is not
needed for a client to find the focus.

The path this fixes is platform-independent. It was verified on Windows,
where the tool that surfaced it runs; I have no macOS or Linux assistive
client set up to check the other two.
